### PR TITLE
Snapshotting rework to allow snapshots to be part of event stream

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -19,31 +19,23 @@ package org.axonframework.eventsourcing;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
-import org.axonframework.eventsourcing.eventstore.Position;
-import org.axonframework.eventsourcing.eventstore.SourcingCondition;
-import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
-import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
+import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
+import org.axonframework.eventsourcing.handler.SimpleSourcingHandler;
+import org.axonframework.eventsourcing.handler.SourcingHandler;
 import org.axonframework.messaging.core.Context.ResourceKey;
-import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
-import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.modelling.EntityEvolver;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
@@ -60,48 +52,85 @@ import static java.util.Objects.requireNonNull;
  * @since 0.1
  */
 public class EventSourcingRepository<ID, E> implements Repository.LifecycleManagement<ID, E> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EventSourcingRepository.class);
-
     private final ResourceKey<Map<ID, CompletableFuture<EventSourcedEntity<ID, E>>>> managedEntitiesKey =
             ResourceKey.withLabel("managedEntities");
 
     private final Class<ID> idType;
     private final Class<E> entityType;
     private final EventStore eventStore;
-    private final CriteriaResolver<ID> criteriaResolver;
-    private final EntityEvolver<E> entityEvolver;
-    private final EventSourcedEntityFactory<ID, E> entityFactory;
-    private final Snapshotter<ID, E> snapshotter;
+    private final SourcingHandler<ID, E> sourcingHandler;
+    private final InitializingEntityEvolver<ID, E> initializingEntityEvolver;
+
+    private final EventSourcedEntityFactory<ID, E> entityFactory;  // only for describe
+    private final EntityEvolver<E> entityEvolver;  // only for describe
 
     /**
-     * Initialize the repository to load events from the given {@code eventStore} using the given {@code applier} to
+     * Initialize the repository to load events from the given {@code eventStore} using the given {@code entityEvolver} to
      * apply state transitions to the entity based on the events received, and given {@code criteriaResolver} to resolve
      * the {@link EventCriteria} of the given identifier type used to source an entity.
      *
-     * @param idType           The type of the identifier for the event sourced entity this repository serves.
-     * @param entityType       The type of the event sourced entity this repository serves.
-     * @param eventStore       The event store to load events from.
-     * @param entityFactory    A factory method to create new instances of the entity based on the entity's type and a
-     *                         provided identifier.
-     * @param criteriaResolver Converts the given identifier to an {@link EventCriteria} used to load a matching event
-     *                         stream.
-     * @param entityEvolver    The function used to evolve the state of loaded entities based on events.
-     * @param snapshotter      The optional snapshotter consulted for creating and retrieving snapshots.
+     * @param idType           the type of the identifier for the event sourced entity this repository serves
+     * @param entityType       the type of the event sourced entity this repository serves
+     * @param eventStore       the event store to load events from
+     * @param entityFactory    a factory method to create new instances of the entity based on the entity's type and a
+     *                         provided identifier
+     * @param criteriaResolver converts the given identifier to an {@link EventCriteria} used to load a matching event
+     *                         stream
+     * @param entityEvolver    the function used to evolve the state of loaded entities based on events
+     * @deprecated use {@link EventSourcingRepository#EventSourcingRepository(Class, Class, EventStore, EventSourcedEntityFactory, EntityEvolver, SourcingHandler)}
      */
+    @Deprecated
     public EventSourcingRepository(Class<ID> idType,
                                    Class<E> entityType,
                                    EventStore eventStore,
                                    EventSourcedEntityFactory<ID, E> entityFactory,
                                    CriteriaResolver<ID> criteriaResolver,
-                                   EntityEvolver<E> entityEvolver,
-                                   @Nullable Snapshotter<ID, E> snapshotter) {
+                                   EntityEvolver<E> entityEvolver
+    ) {
+        this(
+            requireNonNull(idType, "The id type must not be null."),
+            requireNonNull(entityType, "The entity type must not be null."),
+            requireNonNull(eventStore, "The event store must not be null."),
+            requireNonNull(entityFactory, "The entity factory must not be null."),
+            requireNonNull(entityEvolver, "The entity evolver must not be null."),
+            new SimpleSourcingHandler<>(
+                requireNonNull(eventStore, "The event store must not be null."),
+                requireNonNull(criteriaResolver, "The criteria resolver must not be null.")
+            )
+        );
+    }
+
+    /**
+     * Initialize the repository to load events from the given {@code eventStore} using the given {@code entityEvolver} to
+     * apply state transitions to the entity based on the events received, and given {@code sourcingHandler} to process
+     * the event stream.
+     *
+     * @param idType          the type of the identifier for the event sourced entity this repository serves
+     * @param entityType      the type of the event sourced entity this repository serves
+     * @param eventStore      the event store to load events from
+     * @param entityFactory   the entity factory to create new instances of the entity based on the entity's type and a
+     *                        provided identifier
+     * @param entityEvolver   the function used to evolve the state of loaded entities based on events
+     * @param sourcingHandler the handler which will source the actual events and convert them into an entity
+     */
+    public EventSourcingRepository(
+        Class<ID> idType,
+        Class<E> entityType,
+        EventStore eventStore,
+        EventSourcedEntityFactory<ID, E> entityFactory,
+        EntityEvolver<E> entityEvolver,
+        SourcingHandler<ID, E> sourcingHandler
+    ) {
         this.idType = requireNonNull(idType, "The id type must not be null.");
         this.entityType = requireNonNull(entityType, "The entity type must not be null.");
         this.eventStore = requireNonNull(eventStore, "The event store must not be null.");
-        this.entityFactory = requireNonNull(entityFactory, "The entity factory must not be null.");
-        this.criteriaResolver = requireNonNull(criteriaResolver, "The criteria resolver must not be null.");
-        this.entityEvolver = requireNonNull(entityEvolver, "The entity evolver must not be null.");
-        this.snapshotter = Objects.requireNonNullElse(snapshotter, Snapshotter.noSnapshotter());
+        this.initializingEntityEvolver = new InitializingEntityEvolver<>(
+            requireNonNull(entityFactory, "The entity factory must not be null."),
+            requireNonNull(entityEvolver, "The entity evolver must not be null.")
+        );
+        this.sourcingHandler = requireNonNull(sourcingHandler, "The sourcing handler must not be null.");
+        this.entityFactory = entityFactory;  // only for describe
+        this.entityEvolver = entityEvolver;  // only for describe
     }
 
     @Override
@@ -132,87 +161,31 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     @Override
     public CompletableFuture<ManagedEntity<ID, E>> load(ID identifier,
                                                         ProcessingContext context) {
-        var managedEntities = context.computeResourceIfAbsent(managedEntitiesKey, ConcurrentHashMap::new);
-
-        return managedEntities.computeIfAbsent(
-                identifier,
-                id -> doLoad(identifier, context)
-                        .whenComplete((entity, exception) -> updateActiveEntity(entity, context, exception))
-        ).thenApply(Function.identity());
+        return doLoad(identifier, false, context);
     }
 
     @Override
     public CompletableFuture<ManagedEntity<ID, E>> loadOrCreate(ID identifier,
                                                                 ProcessingContext context) {
+        return doLoad(identifier, true, context);
+    }
+
+    private CompletableFuture<ManagedEntity<ID, E>> doLoad(ID identifier,
+                                                           boolean create,
+                                                           ProcessingContext context) {
         var managedEntities = context.computeResourceIfAbsent(managedEntitiesKey, ConcurrentHashMap::new);
 
         return managedEntities.computeIfAbsent(
                 identifier,
-                id -> doLoad(identifier, context)
-                        .thenApply((entity) -> createEntityIfNullFromLoad(identifier, entity, context))
+                id -> sourcingHandler.source(identifier, initializingEntityEvolver, context)
+                        .thenApply(entity -> create && entity == null ? createIfRequested(identifier, context) : entity)
+                        .thenApply(e -> new EventSourcedEntity<>(identifier, e))
                         .whenComplete((entity, exception) -> updateActiveEntity(entity, context, exception))
         ).thenApply(Function.identity());
     }
 
-    private EventSourcedEntity<ID, E> createEntityIfNullFromLoad(ID identifier, EventSourcedEntity<ID, E> entity,
-                                                                 ProcessingContext context) {
-        if (entity.entity() == null) {
-            E createdEntity = entityFactory.create(identifier, null, context);
-            if (createdEntity == null) {
-                throw new EntityMissingAfterLoadOrCreateException(identifier);
-            }
-            return new EventSourcedEntity<>(snapshotter, identifier, createdEntity);
-        }
-        return entity;
-    }
-
-    private CompletableFuture<EventSourcedEntity<ID, E>> doLoad(ID identifier, ProcessingContext pc) {
-        long startTime = System.currentTimeMillis();
-
-        return snapshotter.load(identifier)
-            .exceptionally(e -> {
-                LOGGER.warn("Snapshot loading failed, falling back to full reconstruction for: {}({}={})", entityType, idType, identifier, e);
-
-                return null;  // indicates no snapshot, should trigger full reconstruction in next step
-            })
-            .thenCompose(snapshot -> {
-                @SuppressWarnings("unchecked")
-                EventSourcedEntity<ID, E> initialEntity = new EventSourcedEntity<>(snapshotter, identifier, snapshot == null ? null : (E)snapshot.payload());
-
-                return sourceAndEvolve(initialEntity, snapshot == null ? Position.START : snapshot.position(), pc)
-                    .thenApply(entity -> {
-                        if (initialEntity.evolutionCount > 0) {
-                            snapshotter.onEvolutionCompleted(
-                                identifier,
-                                entity.entity(),
-                                entity.position,
-                                new EvolutionResult(
-                                    initialEntity.evolutionCount,
-                                    Duration.ofMillis(Math.max(0, System.currentTimeMillis() - startTime)),
-                                    initialEntity.snapshotRequested
-                                )
-                            );
-                        }
-
-                        return entity;
-                    });
-            });
-    }
-
-    private CompletableFuture<EventSourcedEntity<ID, E>> sourceAndEvolve(EventSourcedEntity<ID, E> initialEntity, Position position, ProcessingContext pc) {
-        EventStoreTransaction transaction = eventStore.transaction(pc);
-        SourcingCondition sourcingCondition = SourcingCondition.conditionFor(position, criteriaResolver.resolve(initialEntity.identifier, pc));
-        AtomicReference<Position> postionRef = new AtomicReference<>(position);
-        MessageStream<? extends EventMessage> source = transaction.source(sourcingCondition, postionRef::set);
-
-        return source
-            .onComplete(() -> initialEntity.updatePosition(postionRef.get()))
-            .reduce(initialEntity, (entity, entry) -> {
-                entity.ensureInitialState(() -> entityFactory.create(entity.identifier, entry.message(), pc));
-                entity.evolve(entry.message(), entityEvolver, pc);
-
-                return entity;
-            });
+    private E createIfRequested(ID identifier, ProcessingContext context) {
+        return initializingEntityEvolver.initialize(identifier, context);
     }
 
     @Override
@@ -222,7 +195,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
         var managedEntities = processingContext.computeResourceIfAbsent(managedEntitiesKey, ConcurrentHashMap::new);
 
         return managedEntities.computeIfAbsent(identifier, id -> {
-            EventSourcedEntity<ID, E> sourcedEntity = new EventSourcedEntity<>(snapshotter, identifier, entity);
+            EventSourcedEntity<ID, E> sourcedEntity = new EventSourcedEntity<>(identifier, entity);
             updateActiveEntity(sourcedEntity, processingContext);
             return CompletableFuture.completedFuture(sourcedEntity);
         }).resultNow();
@@ -246,14 +219,12 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      */
     private void updateActiveEntity(EventSourcedEntity<ID, E> entity, ProcessingContext processingContext) {
         eventStore.transaction(processingContext)
-                  .onAppend(event -> {
-                      if (entity.entity() == null) {
-                          entity.applyStateChange(e -> entityFactory.create(
-                                  entity.identifier(), event, processingContext));
-                      } else {
-                          entity.evolve(event, entityEvolver, processingContext);
-                      }
-                  });
+                  .onAppend(event -> entity.applyStateChange(e -> initializingEntityEvolver.evolve(
+                      entity.identifier(),
+                      entity.entity(),
+                      event,
+                      processingContext
+                  )));
     }
 
     @Override
@@ -262,9 +233,8 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
         descriptor.describeProperty("entityType", entityType);
         descriptor.describeProperty("eventStore", eventStore);
         descriptor.describeProperty("entityFactory", entityFactory);
-        descriptor.describeProperty("criteriaResolver", criteriaResolver);
         descriptor.describeProperty("entityEvolver", entityEvolver);
-        descriptor.describeProperty("snapshotter", snapshotter);
+        descriptor.describeProperty("sourcingHandler", sourcingHandler);
     }
 
     /**
@@ -275,29 +245,18 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      */
     private static class EventSourcedEntity<ID, M> implements ManagedEntity<ID, M> {
 
-        private final Snapshotter<ID, M> snapshotter;
         private final ID identifier;
         private final AtomicReference<M> currentState;
-        private boolean initialized;
-        private Position position = Position.START;
-        private int evolutionCount;
-        private boolean snapshotRequested;
 
-        private EventSourcedEntity(Snapshotter<ID, M> snapshotter, ID identifier, @Nullable M currentState) {
-            this.snapshotter = snapshotter;
+        private EventSourcedEntity(ID identifier, @Nullable M currentState) {
             this.identifier = identifier;
             this.currentState = new AtomicReference<>(currentState);
-            this.initialized = currentState != null;
         }
 
         private static <ID, T> EventSourcedEntity<ID, T> mapToEventSourcedEntity(ManagedEntity<ID, T> entity) {
             return entity instanceof EventSourcingRepository.EventSourcedEntity<ID, T> eventSourcedEntity
                     ? eventSourcedEntity
-                    : new EventSourcedEntity<>(Snapshotter.noSnapshotter(), entity.identifier(), entity.entity());
-        }
-
-        void updatePosition(Position position) {
-            this.position = Objects.requireNonNull(position, "The position cannot be null.");
+                    : new EventSourcedEntity<>(entity.identifier(), entity.entity());
         }
 
         @Override
@@ -313,40 +272,6 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
         @Override
         public M applyStateChange(UnaryOperator<M> change) {
             return currentState.updateAndGet(change);
-        }
-
-        /**
-         * Initialize this entity with an initial state if it has not been initialized yet. This method will set the
-         * current state to the value returned by the given {@code initialState} supplier, and mark the entity as
-         * initialized. After the first invocation, this entity will be considered initialized, and further invocations
-         * will have no effect.
-         *
-         * @param initialStateSupplier The supplier that provides the initial state of the entity.
-         */
-        public void ensureInitialState(Supplier<M> initialStateSupplier) {
-            if (!initialized) {
-                this.initialized = true;
-                M entityInitialState = initialStateSupplier.get();
-                if (entityInitialState == null) {
-                    throw new EntityMissingAfterFirstEventException(identifier);
-                }
-                this.currentState.set(entityInitialState);
-            }
-        }
-
-        private M evolve(EventMessage event,
-                         EntityEvolver<M> evolver,
-                         ProcessingContext processingContext) {
-            evolutionCount++;
-
-            this.initialized = true;
-            M result = currentState.updateAndGet(current -> evolver.evolve(current, event, processingContext));
-
-            if (!snapshotRequested) {
-                snapshotRequested = snapshotter.onEventApplied(identifier, result, event);
-            }
-
-            return result;
         }
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcedEntityModule.java
@@ -22,7 +22,7 @@ import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
-import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
@@ -30,7 +30,6 @@ import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.configuration.EntityMetamodelConfigurationBuilder;
 import org.axonframework.modelling.configuration.EntityModule;
-import org.axonframework.modelling.configuration.StateBasedEntityModule.EntityIdResolverPhase;
 import org.axonframework.modelling.entity.EntityCommandHandlingComponent;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.repository.Repository;
@@ -56,14 +55,13 @@ import org.axonframework.modelling.repository.Repository;
  * approach to building the event-sourced entity, where the user can provide the required components.
  * <p>
  * There are several phases of the building process of the declarative event-sourced entity module:
- *     <ul>
- *         <li> {@link MessagingModelPhase} - Provides the {@link EntityMetamodel} of the event-sourced entity being built.</li>
- *         <li> {@link EntityFactoryPhase} - Provides the {@link EventSourcedEntityFactory} for the event-sourced entity
- *         being built.</li>
- *         <li> {@link CriteriaResolverPhase} - Provides the {@link CriteriaResolver} for the event-sourced entity being
- *         built.</li>
- *         <li> {@link EntityIdResolverPhase} - Provides the {@link EntityIdResolver} for the event-sourced entity being
- *         built, or provides the user with a choice to not have a {@link EntityCommandHandlingComponent}.</li>
+ * <ul>
+ *     <li>{@link MessagingModelPhase} – configure the {@link EntityMetamodel} used to evolve and handle commands.</li>
+ *     <li>{@link EntityFactoryPhase} – provide the {@link EventSourcedEntityFactory} to create entities.</li>
+ *     <li>{@link CriteriaResolverPhase} – provide the {@link CriteriaResolver} used to source events from the
+ *         {@link org.axonframework.eventsourcing.eventstore.EventStore}.</li>
+ *     <li>{@link OptionalPhase} – configure optional parameters, such as {@link SnapshotPolicy} and
+ *         {@link EntityIdResolver}.</li>
  * </ul>
  *
  * <h2>Module hierarchy</h2>
@@ -76,6 +74,7 @@ import org.axonframework.modelling.repository.Repository;
  * @param <E>  The type of the event-sourced entity.
  * @author Steven van Beelen
  * @author Mitchell Herrijgers
+ * @author John Hendrikx
  * @since 5.0.0
  */
 public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
@@ -209,15 +208,14 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
         OptionalPhase<ID, E> entityIdResolver(ComponentBuilder<EntityIdResolver<ID>> entityIdResolver);
 
         /**
-         * Registers an optional {@link ComponentBuilder} of a {@link Snapshotter} as the snapshotter for the
-         * event-sourced entity being built. This snapshotter is responsible for storing snapshots when it
-         * is triggered during the loading of an entity.
-         * <p>
-         * If no {@link Snapshotter} is provided, there will be no snapshotting functionality.
+         * Registers an optional {@link ComponentBuilder} of a {@link SnapshotPolicy} for the
+         * event-sourced entity being built. The snapshot policy determines under which conditions
+         * the entity state should be snapshotted during sourcing.
          *
-         * @param snapshotter A {@link ComponentBuilder} constructing the {@link Snapshotter} for the event-sourced entity.
+         * @param snapshotPolicy A {@link ComponentBuilder} constructing the {@link SnapshotPolicy}
+         *                       for the event-sourced entity.
          * @return The {@link OptionalPhase} phase of this builder, for a fluent API.
          */
-        OptionalPhase<ID, E> snapshotter(ComponentBuilder<Snapshotter<ID, E>> snapshotter);
+        OptionalPhase<ID, E> snapshotPolicy(ComponentBuilder<SnapshotPolicy> snapshotPolicy);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModule.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.eventsourcing.configuration;
 
-import org.axonframework.messaging.commandhandling.CommandBus;
-import org.axonframework.messaging.commandhandling.CommandHandlingComponent;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.TypeReference;
 import org.axonframework.common.configuration.BaseModule;
@@ -25,12 +23,22 @@ import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.common.configuration.ComponentDefinition;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.LifecycleRegistry;
+import org.axonframework.common.lifecycle.Phase;
+import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.EventSourcingRepository;
 import org.axonframework.eventsourcing.eventstore.EventStore;
-import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
-import org.axonframework.common.lifecycle.Phase;
+import org.axonframework.eventsourcing.handler.SimpleSourcingHandler;
+import org.axonframework.eventsourcing.handler.SnapshottingSourcingHandler;
+import org.axonframework.eventsourcing.handler.SourcingHandler;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+import org.axonframework.eventsourcing.snapshot.store.StoreBackedSnapshotter;
+import org.axonframework.messaging.commandhandling.CommandBus;
+import org.axonframework.messaging.commandhandling.CommandHandlingComponent;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.configuration.EntityMetamodelConfigurationBuilder;
@@ -63,7 +71,7 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
     private ComponentBuilder<CriteriaResolver<ID>> criteriaResolver;
     private ComponentBuilder<EntityMetamodel<E>> entityModel;
     private ComponentBuilder<EntityIdResolver<ID>> entityIdResolver;
-    private ComponentBuilder<Snapshotter<ID, E>> snapshotter;
+    private ComponentBuilder<SnapshotPolicy> snapshotPolicy;
 
     SimpleEventSourcedEntityModule(Class<ID> idType,
                                    Class<E> entityType) {
@@ -101,8 +109,8 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
     }
 
     @Override
-    public OptionalPhase<ID, E> snapshotter(ComponentBuilder<Snapshotter<ID, E>> snapshotter) {
-        this.snapshotter = requireNonNull(snapshotter, "The snapshotter cannot be null.");
+    public OptionalPhase<ID, E> snapshotPolicy(ComponentBuilder<SnapshotPolicy> snapshotPolicy) {
+        this.snapshotPolicy = requireNonNull(snapshotPolicy, "The snapshotPolicy cannot be null.");
         return this;
     }
 
@@ -141,8 +149,8 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
                 cr.registerComponent(commandHandlingComponent());
             }
 
-            if (snapshotter != null) {
-                cr.registerComponent(snapshotter());
+            if (snapshotPolicy != null) {
+                cr.registerComponent(snapshotPolicy());
             }
         });
     }
@@ -161,28 +169,60 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
                                   .withBuilder(entityIdResolver);
     }
 
-    private ComponentDefinition<Snapshotter<ID, E>> snapshotter() {
-        TypeReference<Snapshotter<ID, E>> type = new TypeReference<>() {};
-        return ComponentDefinition.ofTypeAndName(type, entityName())
-                                  .withBuilder(snapshotter);
+    private ComponentDefinition<SnapshotPolicy> snapshotPolicy() {
+        return ComponentDefinition.ofTypeAndName(SnapshotPolicy.class, entityName())
+                                  .withBuilder(snapshotPolicy);
     }
 
     private ComponentDefinition<Repository<ID, E>> repository() {
-        TypeReference<Repository<ID, E>> type = new TypeReference<>() {
-        };
+        TypeReference<Repository<ID, E>> type = new TypeReference<>() {};
+
         return ComponentDefinition
                 .ofTypeAndName(type, entityName())
                 .withBuilder(config -> {
-                    //noinspection unchecked
-                    return new EventSourcingRepository<ID, E>(
-                            idType,
-                            entityType,
-                            config.getComponent(EventStore.class),
-                            config.getComponent(EventSourcedEntityFactory.class, entityName()),
-                            config.getComponent(CriteriaResolver.class, entityName()),
-                            config.getComponent(EntityMetamodel.class, entityName()),
-                            config.getOptionalComponent(Snapshotter.class, entityName()).orElse(null)
+                    @SuppressWarnings("unchecked")
+                    CriteriaResolver<ID> criteriaResolver = config.getComponent(CriteriaResolver.class, entityName());
+                    EventStore eventStore = config.getComponent(EventStore.class);
+                    SnapshotPolicy snapshotPolicy = config.getOptionalComponent(SnapshotPolicy.class, entityName()).orElse(null);
+                    SourcingHandler<ID, E> sourcingHandler;
+
+                    if (snapshotPolicy == null) {
+                        sourcingHandler = new SimpleSourcingHandler<>(eventStore, criteriaResolver);
+                    }
+                    else {
+                        Converter converter = config.getOptionalComponent(Converter.class)
+                            .orElseThrow(() -> new IllegalStateException("A Converter must be configured to use snapshotting."));
+                        SnapshotStore snapshotStore = config.getOptionalComponent(SnapshotStore.class)
+                            .orElseThrow(() -> new IllegalStateException("A SnapshotStore must be configured to use snapshotting."));
+                        MessageType messageType = config.getOptionalComponent(MessageTypeResolver.class)
+                            .flatMap(mtr -> mtr.resolve(entityType))
+                            .orElseThrow(() -> new IllegalStateException("A MessageTypeResolver capable of resolving " + entityType + " must be configured to use snapshotting."));
+
+                        sourcingHandler = new SnapshottingSourcingHandler<>(
+                            eventStore,
+                            criteriaResolver,
+                            messageType,
+                            snapshotPolicy,
+                            new StoreBackedSnapshotter<>(
+                                snapshotStore,
+                                messageType,
+                                converter,
+                                entityType
+                            )
+                        );
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    var repository = new EventSourcingRepository<ID, E>(
+                        idType,
+                        entityType,
+                        eventStore,
+                        config.getComponent(EventSourcedEntityFactory.class, entityName()),
+                        config.getComponent(EntityMetamodel.class, entityName()),
+                        sourcingHandler
                     );
+
+                    return repository;
                 })
                 .onStart(Phase.LOCAL_MESSAGE_HANDLER_REGISTRATIONS,
                          (config, component) -> {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/InitializingEntityEvolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/InitializingEntityEvolver.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.handler;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.eventsourcing.EntityMissingAfterFirstEventException;
+import org.axonframework.eventsourcing.EntityMissingAfterLoadOrCreateException;
+import org.axonframework.eventsourcing.EventSourcedEntityFactory;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.modelling.EntityEvolver;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Combines an {@link EventSourcedEntityFactory} and an {@link EntityEvolver}
+ * to ensure an entity exists and apply state transitions.
+ * <p>
+ * If the given entity is {@code null}, a new instance is created using the
+ * factory. The resulting entity is then passed to the evolver to apply the
+ * given event (if any).
+ * <p>
+ * This effectively provides "initialize or evolve" semantics.
+ *
+ * @param <I> the type of the identifier of the entity to create
+ * @param <E> the type of the entity to create
+ * @since 5.1.0
+ * @author John Hendrikx
+ */
+@Internal
+public class InitializingEntityEvolver<I, E> {
+    private final EventSourcedEntityFactory<I, E> entityFactory;
+    private final EntityEvolver<E> entityEvolver;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param entityFactory an {@link EventSourcedEntityFactory}, cannot be {@code null}
+     * @param entityEvolver an {@link EntityEvolver}, cannot be {@code null}
+     */
+    public InitializingEntityEvolver(EventSourcedEntityFactory<I, E> entityFactory, EntityEvolver<E> entityEvolver) {
+        this.entityFactory = Objects.requireNonNull(entityFactory, "The entityFactory parameter must not be null.");
+        this.entityEvolver = Objects.requireNonNull(entityEvolver, "The entityEvolver parameter must not be null.");
+    }
+
+    /**
+     * Creates an empty entity {@code E}.
+     *
+     * @param identifier the entity's identifier, cannot be {@code null}
+     * @param context a {@link ProcessingContext}, cannot be {@code null}
+     * @return a new entity of type {@code E}
+     */
+    public E initialize(I identifier, ProcessingContext context) {
+        E entity = entityFactory.create(
+            Objects.requireNonNull(identifier, "The identifier parameter must not be null."),
+            null,
+            Objects.requireNonNull(context, "The context parameter must not be null.")
+        );
+
+        if (entity == null) {
+            throw new EntityMissingAfterLoadOrCreateException(identifier);
+        }
+
+        return entity;
+    }
+
+    /**
+     * Initializes or evolves the given entity using the given message. If the entity
+     * is {@code null}, creates the entity using the given message, otherwise evolves it.
+     *
+     * @param identifier the entity's identifier, cannot be {@code null}
+     * @param entity the current state, can be {@code null}
+     * @param message an event message to initialize or evolve the entity with, cannot be {@code null}
+     * @param context a {@link ProcessingContext}, cannot be {@code null}
+     * @return an entity in its new state, never {@code null}
+     */
+    public E evolve(I identifier, @Nullable E entity, EventMessage message, ProcessingContext context) {
+        return ensureInitializedThenEvolve(
+            Objects.requireNonNull(identifier, "The identifier parameter must not be null."),
+            entity,
+            Objects.requireNonNull(message, "The message parameter must not be null."),
+            Objects.requireNonNull(context, "The context parameter must not be null.")
+        );
+    }
+
+    private E ensureInitializedThenEvolve(I identifier, @Nullable E entity, EventMessage message, ProcessingContext context) {
+        if (entity == null) {
+            entity = entityFactory.create(identifier, message, context);
+
+            if (entity == null) {
+                throw new EntityMissingAfterFirstEventException(identifier);
+            }
+        }
+
+        return entityEvolver.evolve(entity, message, context);
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleSourcingHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleSourcingHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.handler;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.eventsourcing.CriteriaResolver;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
+import org.axonframework.eventsourcing.eventstore.SourcingCondition;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A simple implementation of {@link SourcingHandler} that reconstructs an entity
+ * by sourcing events directly from an {@link EventStore}.
+ * <p>
+ * This implementation retrieves all events for a given identifier according to the
+ * {@link CriteriaResolver} and applies them in order to construct or evolve the entity
+ * using the provided {@link InitializingEntityEvolver}.
+ * <p>
+ * This is a straightforward, non-snapshotting sourcing strategy and is suitable
+ * when all events must be applied sequentially from the event store.
+ *
+ * @param <I> the type of the entity identifier
+ * @param <E> the type of the entity
+ * @since 5.1.0
+ * @author John Hendrikx
+ */
+@Internal
+public class SimpleSourcingHandler<I, E> implements SourcingHandler<I, E> {
+
+    private final EventStore eventStore;
+    private final CriteriaResolver<I> criteriaResolver;
+
+    /**
+     * Creates a new {@code SimpleSourcingHandler}.
+     *
+     * @param eventStore the {@link EventStore} from which events are sourced, cannot be {@code null}
+     * @param criteriaResolver the resolver to use to create the {@link EventCriteria} for sourcing, cannot be {@code null}
+     * @throws NullPointerException when any argument is {@code null}
+     */
+    public SimpleSourcingHandler(EventStore eventStore, CriteriaResolver<I> criteriaResolver) {
+        this.eventStore = Objects.requireNonNull(eventStore, "The eventStore parameter must not be null.");
+        this.criteriaResolver = Objects.requireNonNull(criteriaResolver, "The criteriaResolver parameter must not be null.");
+    }
+
+    @Override
+    public CompletableFuture<E> source(I identifier, InitializingEntityEvolver<I, E> evolver, ProcessingContext pc) {
+        EventCriteria criteria = criteriaResolver.resolve(identifier, pc);
+        EventStoreTransaction transaction = eventStore.transaction(pc);
+        MessageStream<? extends EventMessage> source = transaction.source(SourcingCondition.conditionFor(criteria));
+
+        return source.reduce(
+            (E) null,
+            (entity, entry) -> evolver.evolve(identifier, entity, entry.message(), pc)
+        );
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("eventStore", eventStore);
+        descriptor.describeProperty("criteriaResolver", criteriaResolver);
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingSourcingHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingSourcingHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.handler;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.eventsourcing.CriteriaResolver;
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
+import org.axonframework.eventsourcing.eventstore.Position;
+import org.axonframework.eventsourcing.eventstore.SourcingCondition;
+import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
+import org.axonframework.eventsourcing.snapshot.api.Snapshot;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
+import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link SourcingHandler} implementation that reconstructs an entity using snapshots
+ * when available, falling back to a full sourcing of events from the {@link EventStore}
+ * if necessary.
+ * <p>
+ * This handler first attempts to load a snapshot of the entity via the provided {@link Snapshotter}.
+ * If a snapshot is present, reconstruction starts from the snapshot's state and position, reducing
+ * the number of events that need to be replayed. If loading the snapshot fails or none exists,
+ * the entity is fully reconstructed from the beginning of its event stream.
+ * <p>
+ * All events retrieved from the {@link EventStore} are applied sequentially using the
+ * provided {@link InitializingEntityEvolver}. After sourcing completes, a snapshot is created
+ * if the {@link SnapshotPolicy} indicated one was needed.
+ *
+ * @param <I> the type of the entity identifier
+ * @param <E> the type of the entity
+ * @since 5.1.0
+ * @author John Hendrikx
+ */
+@Internal
+public class SnapshottingSourcingHandler<I, E> implements SourcingHandler<I, E> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SnapshottingSourcingHandler.class);
+
+    private final EventStore eventStore;
+    private final CriteriaResolver<I> criteriaResolver;
+    private final MessageType messageType;
+    private final Snapshotter<I, E> snapshotter;
+    private final SnapshotPolicy snapshotPolicy;
+
+    /**
+     * Creates a new {@code SnapshottingSourcingHandler}.
+     *
+     * @param eventStore the {@link EventStore} used to source events, cannot be {@code null}
+     * @param criteriaResolver the resolver to use to create the {@link EventCriteria} for sourcing, cannot be {@code null}
+     * @param messageType the {@link MessageType}, cannot be {@code null}
+     * @param snapshotPolicy the {@link SnapshotPolicy}, cannot be {@code null}
+     * @param snapshotter the {@link Snapshotter} used to load and handle snapshots, cannot be {@code null}
+     * @throws NullPointerException when a non-null argument was {@code null}
+     */
+    public SnapshottingSourcingHandler(
+        EventStore eventStore,
+        CriteriaResolver<I> criteriaResolver,
+        MessageType messageType,
+        SnapshotPolicy snapshotPolicy,
+        Snapshotter<I, E> snapshotter
+    ) {
+        this.eventStore = Objects.requireNonNull(eventStore, "The eventStore parameter must not be null.");
+        this.criteriaResolver = Objects.requireNonNull(criteriaResolver, "The criteriaResolver parameter must not be null.");
+        this.messageType = Objects.requireNonNull(messageType, "The messageType parameter must not be null.");
+        this.snapshotPolicy = Objects.requireNonNull(snapshotPolicy, "The snapshotPolicy parameter must not be null.");
+        this.snapshotter = Objects.requireNonNull(snapshotter, "The snapshotter parameter must not be null.");
+    }
+
+    @Override
+    public CompletableFuture<E> source(I identifier, InitializingEntityEvolver<I, E> evolver, ProcessingContext pc) {
+        EventCriteria criteria = criteriaResolver.resolve(identifier, pc);
+        long startTime = System.currentTimeMillis();
+
+        return snapshotter.load(identifier)
+            .exceptionally(e -> {
+                LOGGER.warn("Snapshot loading failed, falling back to full reconstruction for: {} ({})", messageType, identifier, e);
+
+                return null;  // indicates no snapshot, should trigger full reconstruction in next step
+            })
+            .thenCompose(snapshot -> sourceAndEvolve(identifier, snapshot, criteria, startTime, evolver, pc));
+    }
+
+    private CompletableFuture<E> sourceAndEvolve(
+        I identifier,
+        @Nullable Snapshot snapshot,
+        EventCriteria criteria,
+        long startTime,
+        InitializingEntityEvolver<I, E> evolver,
+        ProcessingContext pc
+    ) {
+        @SuppressWarnings("unchecked")
+        E initialEntity = snapshot == null ? null : (E) snapshot.payload();
+        Position startPosition = snapshot == null ? Position.START : snapshot.position();
+        EventStoreTransaction transaction = eventStore.transaction(pc);
+        SourcingCondition sourcingCondition = SourcingCondition.conditionFor(startPosition, criteria);
+        AtomicReference<Position> postionRef = new AtomicReference<>(startPosition);
+        AtomicInteger evolutionCount = new AtomicInteger();
+        AtomicBoolean triggerSnapshot = new AtomicBoolean();
+        MessageStream<? extends EventMessage> source = transaction.source(sourcingCondition, postionRef::set);
+
+        return source
+            .reduce(initialEntity, (entity, entry) -> {
+                E evolvedEntity = evolver.evolve(identifier, entity, entry.message(), pc);
+
+                evolutionCount.incrementAndGet();
+
+                if (!triggerSnapshot.get() && snapshotPolicy.shouldSnapshot(entry.message())) {
+                    triggerSnapshot.set(true);
+                }
+
+                return evolvedEntity;
+            })
+            .thenApply(entity -> {
+                int ec = evolutionCount.get();
+
+                if (ec > 0) {
+                    Duration sourcingTime = Duration.ofMillis(Math.max(0, System.currentTimeMillis() - startTime));
+
+                    // Snapshot is made when specifically triggered by an event, or based on the statistics:
+                    if (triggerSnapshot.get() || snapshotPolicy.shouldSnapshot(new EvolutionResult(ec, sourcingTime))) {
+                        snapshotter.store(identifier, entity, postionRef.get());
+                    }
+                }
+
+                return entity;
+            });
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("eventStore", eventStore);
+        descriptor.describeProperty("criteriaResolver", criteriaResolver);
+        descriptor.describeProperty("messageType", messageType);
+        descriptor.describeProperty("snapshotPolicy", snapshotPolicy);
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SourcingHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SourcingHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.handler;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handles the sourcing of an entity from its historical event stream.
+ * <p>
+ * Implementations of this interface are responsible for retrieving all relevant events for a given
+ * identifier and applying them to construct or evolve the entity to its current state.
+ *
+ * @param <I> the type of the entity identifier
+ * @param <E> the type of the entity
+ * @since 5.1.0
+ * @author John Hendrikx
+ */
+@Internal
+public interface SourcingHandler<I, E> extends DescribableComponent {
+
+    /**
+     * Sources the entity identified by the given {@code identifier}.
+     * <p>
+     * The {@link InitializingEntityEvolver} is used to either create the entity (if it does not exist)
+     * or evolve it through the events retrieved from the underlying event stream.
+     * <p>
+     * This method returns a {@link CompletableFuture} that completes when the entity has been fully
+     * reconstructed or evolved to its latest state.
+     *
+     * @param identifier the identifier of the entity to source, cannot be {@code null}
+     * @param evolver the {@link InitializingEntityEvolver} used to initialize and evolve the entity, cannot be {@code null}
+     * @param processingContext the {@link ProcessingContext} associated with this sourcing operation, cannot be {@code null}
+     * @return a {@link CompletableFuture} that completes with the sourced entity, never {@code null}
+     */
+    CompletableFuture<E> source(I identifier, InitializingEntityEvolver<I, E> evolver, ProcessingContext processingContext);
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/package-info.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package for the sourcing handler API.
+ */
+@NullMarked
+package org.axonframework.eventsourcing.handler;
+
+import org.jspecify.annotations.NullMarked;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/EvolutionResult.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/EvolutionResult.java
@@ -33,11 +33,10 @@ import java.util.Objects;
  * @param eventsApplied the number of events applied while sourcing the entity,
  *                      never negative
  * @param sourcingTime the total time spent sourcing the entity, never {@code null}
- * @param snapshotRequested whether a snapshot was requested during sourcing
  * @author John Hendrikx
  * @since 5.1.0
  */
-public record EvolutionResult(long eventsApplied, Duration sourcingTime, boolean snapshotRequested) {
+public record EvolutionResult(long eventsApplied, Duration sourcingTime) {
 
     /**
      * Creates a new {@code EvolutionResult}.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/SnapshotPolicy.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/SnapshotPolicy.java
@@ -16,15 +16,24 @@
 
 package org.axonframework.eventsourcing.snapshot.api;
 
+import org.axonframework.messaging.eventhandling.EventMessage;
+
 import java.time.Duration;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Defines a policy for determining when an event-sourced entity should be snapshotted.
  * <p>
  * A {@code SnapshotPolicy} encapsulates the logic that decides whether a snapshot
- * is required based on metrics collected during sourcing, such as the number of events
- * applied since the last snapshot or the total time taken to source the entity.
+ * is required based on events seen and metrics collected during sourcing.
+ * <p>
+ * A {@code SnapshotPolicy} can trigger snapshotting in two ways:
+ * <ul>
+ *     <li>During sourcing, by inspecting each event through {@link #shouldSnapshot(EventMessage)}</li>
+ *     <li>After sourcing completes, by evaluating the {@link EvolutionResult} through
+ *         {@link #shouldSnapshot(EvolutionResult)}</li>
+ * </ul>
  * <p>
  * Policies are <strong>immutable and thread-safe</strong>, so a single instance
  * can be shared across multiple entities and asynchronous operations.
@@ -73,25 +82,48 @@ public interface SnapshotPolicy {
     }
 
     /**
-     * Creates a policy that triggers a snapshot when specifically requested
-     * by an {@link Snapshotter#onEventApplied(Object, Object, org.axonframework.messaging.eventhandling.EventMessage)}
-     * implementation. The {@link EvolutionResult#snapshotRequested()} will return {@code true} in that case.
+     * Creates a policy that triggers a snapshot when the predicate matches
+     * an event encountered during sourcing.
      *
-     * @return a snapshot policy that triggers when specifically requested, never {@code null}
-     * @see EvolutionResult#snapshotRequested()
+     * @param predicate an event message predicate, cannot be {@code null}
+     * @return a snapshot policy that triggers when the predicate matches, never {@code null}
+     * @throws NullPointerException when {@code predicate} is {@code null}
      */
-    static SnapshotPolicy whenRequested() {
-        return EvolutionResult::snapshotRequested;
+    static SnapshotPolicy whenEventMatches(Predicate<EventMessage> predicate) {
+        Objects.requireNonNull(predicate, "The predicate parameter must not be null.");
+
+        return new SnapshotPolicy() {
+            @Override
+            public boolean shouldSnapshot(EvolutionResult evolutionResult) {
+                return false;
+            }
+
+            @Override
+            public boolean shouldSnapshot(EventMessage event) {
+                return predicate.test(event);
+            }
+        };
     }
 
     /**
-     * Determines whether a snapshot is needed given an evolution result.
+     * Allows triggering a snapshot when sourcing completes, based on the final evolution result.
      *
      * @param evolutionResult information about the sourcing process to base the decision on, cannot be {@code null}
      * @return {@code true} if a snapshot should be made, {@code false} otherwise
      * @implNote implementations should be thread-safe and side-effect free
      */
-    boolean needsSnapshot(EvolutionResult evolutionResult);
+    boolean shouldSnapshot(EvolutionResult evolutionResult);
+
+    /**
+     * Allows triggering a snapshot when sourcing completes, based on an event seen during sourcing.
+     *
+     * @param event the event seen, never {@code null}
+     * @return {@code true} if a snapshot should be created when sourcing completes, otherwise {@code false}
+     * @implNote implementations should be thread-safe and side-effect free
+     */
+    default boolean shouldSnapshot(EventMessage event) {
+        return false;
+    }
 
     /**
      * Composes this policy with another policy using logical OR.
@@ -106,6 +138,16 @@ public interface SnapshotPolicy {
     default SnapshotPolicy or(SnapshotPolicy other) {
         Objects.requireNonNull(other, "The other parameter must not be null.");
 
-        return result -> this.needsSnapshot(result) || other.needsSnapshot(result);
+        return new SnapshotPolicy() {
+            @Override
+            public boolean shouldSnapshot(EventMessage event) {
+                return SnapshotPolicy.this.shouldSnapshot(event) || other.shouldSnapshot(event);
+            }
+
+            @Override
+            public boolean shouldSnapshot(EvolutionResult evolutionResult) {
+                return SnapshotPolicy.this.shouldSnapshot(evolutionResult) || other.shouldSnapshot(evolutionResult);
+            }
+        };
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/Snapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/api/Snapshotter.java
@@ -16,66 +16,21 @@
 
 package org.axonframework.eventsourcing.snapshot.api;
 
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.eventsourcing.eventstore.Position;
-import org.axonframework.messaging.eventhandling.EventMessage;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
- * A {@code Snapshotter} is responsible for managing snapshots of event-sourced entities.
- * <p>
- * Its primary responsibilities are:
- * <ul>
- *     <li>Retrieve the current snapshot for a given entity (if any).</li>
- *     <li>Observe the evolution of an entity as events are applied during replay, allowing the snapshotter
- *         to decide whether a snapshot should be created at the end of replay.</li>
- *     <li>Persist a snapshot if it determines one should be created, based on the signals received
- *         during evolution.</li>
- * </ul>
- * <p>
- * The snapshotter does not control sourcing; it only reacts to evolution signals and
- * decides if and when a snapshot should be created.</p>
+ * A {@code Snapshotter} is responsible for loading and storing snapshots of event-sourced entities.
  *
  * @param <I> the type of the entity identifier
  * @param <E> the type of the entity being snapshotted
  * @author John Hendrikx
  * @since 5.1.0
  */
+@Internal
 public interface Snapshotter<I, E> {
-
-    /**
-     * A {@link Snapshotter} which never loads snapshots and never creates
-     * snapshots.
-     */
-    static final Snapshotter<?, ?> NO_OP = new Snapshotter<>() {
-        @Override
-        public CompletableFuture<Snapshot> load(Object identifier) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
-        public void onEvolutionCompleted(
-            Object identifier,
-            Object entity,
-            Position position,
-            EvolutionResult loadStatistics
-        ) {
-            // do nothing when evolution completes for the no-op snapshotter
-        }
-    };
-
-    /**
-     * Creates a {@link Snapshotter} which never loads snapshots and never creates
-     * snapshots.
-     *
-     * @param <I> the type of the entity identifier
-     * @param <E> the type of the entity being snapshotted
-     * @return a {@link Snapshotter}, never {@code null}
-     */
-    @SuppressWarnings("unchecked")
-    static <I, E> Snapshotter<I, E> noSnapshotter() {
-        return (Snapshotter<I, E>) NO_OP;
-    }
 
     /**
      * Asynchronously retrieves the snapshot for the given {@code identifier}, if one exists.
@@ -90,39 +45,12 @@ public interface Snapshotter<I, E> {
     CompletableFuture<Snapshot> load(I identifier);
 
     /**
-     * Called after an event has been applied to the entity while sourcing it to its current state.
-     * <p>
-     * Implementations can use this callback to request a snapshot of the fully sourced entity
-     * once the sourcing is complete. The boolean return value is a latching signal:
-     * returning {@code true} indicates a snapshot should be taken at the end of sourcing.
+     * Stores the given entity as a snapshot asynchronously.
      *
      * @param identifier the identifier of the entity, cannot be {@code null}
-     * @param entity the entity state after the event has been applied, cannot be {@code null}
-     * @param event the event that was just applied, cannot be {@code null}
-     * @return {@code true} to request a snapshot at the end of sourcing, {@code false} otherwise
+     * @param entity the entity state, cannot be {@code null}
+     * @param position the position in the event stream for this entity state, cannot be {@code null}
      * @throws NullPointerException if any argument is {@code null}
      */
-    default boolean onEventApplied(I identifier, E entity, EventMessage event) {
-        return false;
-    }
-
-    /**
-     * Called immediately after an entity has been fully sourced from its snapshot and any subsequent events.
-     * <p>
-     * Implementations can use this callback to decide whether to create and persist a snapshot of the entity.
-     * At this point, the entity has reached its current state, and all evolution metrics are available
-     * in {@link EvolutionResult}. This method should not block; any I/O should be performed asynchronously.
-     *
-     * @param identifier the identifier of the entity, cannot be {@code null}
-     * @param entity the fully sourced entity state, cannot be {@code null}
-     * @param position the last processed position in the event stream, cannot be {@code null}
-     * @param evolutionResult the metrics and signals collected during sourcing, cannot be {@code null}
-     * @throws NullPointerException if any argument is {@code null}
-     */
-    void onEvolutionCompleted(
-        I identifier,
-        E entity,
-        Position position,
-        EvolutionResult evolutionResult
-    );
+    void store(I identifier, E entity, Position position);
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.store;
 
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.messaging.core.QualifiedName;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
  * @author John Hendrikx
  * @since 5.1.0
  */
+@Internal
 public interface SnapshotStore {
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/StoreBackedSnapshotter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/StoreBackedSnapshotter.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.store;
 
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.Position;
 import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
@@ -60,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author John Hendrikx
  * @since 5.1.0
  */
+@Internal
 public class StoreBackedSnapshotter<I, E> implements Snapshotter<I, E> {
     private static final Logger LOGGER = LoggerFactory.getLogger(StoreBackedSnapshotter.class);
 
@@ -67,7 +69,6 @@ public class StoreBackedSnapshotter<I, E> implements Snapshotter<I, E> {
     private final MessageType type;
     private final Converter converter;
     private final Class<?> entityType;
-    private final SnapshotPolicy snapshotPolicy;
     private final ConcurrentHashMap<I, Snapshot> inFlightSnapshots = new ConcurrentHashMap<>();
 
     /**
@@ -77,21 +78,18 @@ public class StoreBackedSnapshotter<I, E> implements Snapshotter<I, E> {
      * @param type a versioned type to distinguish the snapshot in the store, cannot be {@code null}
      * @param converter a {@link Converter} used to deserialize snapshots, cannot be {@code null}
      * @param entityType the entity type, cannot be {@code null}
-     * @param snapshotPolicy a {@link SnapshotPolicy} which determines when to create a new snapshot, cannot be {@code null}
      * @throws NullPointerException when any argument is {@code null}
      */
     public StoreBackedSnapshotter(
         SnapshotStore store,
         MessageType type,
         Converter converter,
-        Class<E> entityType,
-        SnapshotPolicy snapshotPolicy
+        Class<E> entityType
     ) {
         this.store = Objects.requireNonNull(store, "The store parameter must not be null.");
         this.type = Objects.requireNonNull(type, "The type parameter must not be null.");
         this.converter = Objects.requireNonNull(converter, "The converter parameter must not be null.");
         this.entityType = Objects.requireNonNull(entityType, "The entityType parameter must not be null.");
-        this.snapshotPolicy = Objects.requireNonNull(snapshotPolicy, "The snapshotPolicy parameter must not be null.");
     }
 
     @Override
@@ -121,29 +119,25 @@ public class StoreBackedSnapshotter<I, E> implements Snapshotter<I, E> {
     }
 
     @Override
-    public void onEvolutionCompleted(
+    public void store(
         I identifier,
         E entity,
-        Position position,
-        EvolutionResult evolutionResult
+        Position position
     ) {
         Objects.requireNonNull(identifier, "The identifier parameter must not be null.");
         Objects.requireNonNull(entity, "The entity parameter must not be null.");
         Objects.requireNonNull(position, "The position parameter must not be null.");
-        Objects.requireNonNull(evolutionResult, "The evolutionResult parameter must not be null.");
 
-        if (snapshotPolicy.needsSnapshot(evolutionResult)) {
-            Snapshot newSnapshot = new Snapshot(position, type.version(), entity, GenericEventMessage.clock.instant(), Map.of());
+        Snapshot newSnapshot = new Snapshot(position, type.version(), entity, GenericEventMessage.clock.instant(), Map.of());
 
-            inFlightSnapshots.put(identifier, newSnapshot);
-            store.store(type.qualifiedName(), identifier, newSnapshot).whenComplete((voidResult, ex) -> {
-                // note: only remove inflight snapshot from cache if not replaced concurrently
-                inFlightSnapshots.remove(identifier, newSnapshot);
+        inFlightSnapshots.put(identifier, newSnapshot);
+        store.store(type.qualifiedName(), identifier, newSnapshot).whenComplete((voidResult, ex) -> {
+            // note: only remove inflight snapshot from cache if not replaced concurrently
+            inFlightSnapshots.remove(identifier, newSnapshot);
 
-                if (ex != null) {
-                    LOGGER.warn("Snapshotting failed for {} with identifier {}", type, identifier, ex);
-                }
-            });
-        }
+            if (ex != null) {
+                LOGGER.warn("Snapshotting failed for {} with identifier {}", type, identifier, ex);
+            }
+        });
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -18,12 +18,9 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
-import org.axonframework.eventsourcing.eventstore.GlobalIndexPosition;
-import org.axonframework.eventsourcing.eventstore.Position;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
-import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
-import org.axonframework.eventsourcing.snapshot.api.Snapshot;
-import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
+import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
+import org.axonframework.eventsourcing.handler.SourcingHandler;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
@@ -31,46 +28,56 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
-import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.jspecify.annotations.NonNull;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class validating the {@link EventSourcingRepository}.
  *
  * @author Allard Buijze
+ * @author John Hendrikx
  */
 @ExtendWith(MockitoExtension.class)
 class EventSourcingRepositoryTest {
 
     private static final Set<Tag> TEST_TAGS = Set.of(new Tag("aggregateId", "id"));
-    private static final EventCriteria TEST_CRITERIA = EventCriteria.havingTags("aggregateId", "id");
 
     private EventStore eventStore = mock();
     private EventStoreTransaction eventStoreTransaction = mock();
-    private Snapshotter<String, String> snapshotter = mock();
+    private SourcingHandler<String, String> sourcingHandler = mock();
     private EventSourcedEntityFactory<String, String> factory;
 
     private EventSourcingRepository<String, String> testSubject;
+    private List<EventMessage> eventsToLoad = new ArrayList<>(List.of(createEvent(0), createEvent(1)));
 
     @BeforeEach
     void setUp() {
@@ -87,80 +94,44 @@ class EventSourcingRepositoryTest {
                 String.class,
                 eventStore,
                 (id, event, context) -> factory.create(id, event, context),
-                (identifier, ctx) -> TEST_CRITERIA,
                 (entity, event, context) -> entity + "-" + event.payload(),
-                snapshotter
+                sourcingHandler
         );
+
+        // Simulate event evolution:
+        when(sourcingHandler.source(eq("test"), any(), any())).thenAnswer(invocation -> {
+            if (invocation.getArgument(0) instanceof String id
+                && invocation.getArgument(1) instanceof InitializingEntityEvolver e
+                && invocation.getArgument(2) instanceof ProcessingContext pc
+            ) {
+                return CompletableFuture.supplyAsync(() -> {
+                    String result = null;
+
+                    for (EventMessage event : eventsToLoad) {
+                        @SuppressWarnings("unchecked")
+                        String evolved = (String) e.evolve(id, result, event, pc);
+
+                        result = evolved;
+                    }
+
+                    return result;
+                });
+            }
+
+            throw new AssertionError("Unexpected invocation: " + invocation);
+        });
     }
 
     @Test
     void loadEventSourcedEntity() {
         ProcessingContext processingContext = new StubProcessingContext();
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0), createEvent(1))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
+        ManagedEntity<String, String> result = testSubject.load("test", processingContext).join();
 
-        assertTrue(result.isDone());
-        assertFalse(result.isCompletedExceptionally(), () -> result.exceptionNow().toString());
-        verify(eventStore, times(2)).transaction(processingContext);
+        assertEquals("test(0)-0-1", result.entity());
+
+        verify(eventStore).transaction(processingContext);
         verify(eventStoreTransaction).onAppend(any());
-        verify(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-        verify(snapshotter).load("test");
-
-        assertEquals("test(0)-0-1", result.resultNow().entity());
-    }
-
-    @Test
-    void loadEventSourcedEntityFromSnapshot(@Captor ArgumentCaptor<EvolutionResult> evolutionResult) {
-        ProcessingContext processingContext = new StubProcessingContext();
-        EventMessage event1 = createEvent(0);
-        EventMessage event2 = createEvent(1);
-
-        doAnswer(m -> {
-            @SuppressWarnings("unchecked")
-            Consumer<Position> consumer = (Consumer<Position>)m.getArgument(1);
-
-            consumer.accept(new GlobalIndexPosition(10));
-
-            return MessageStream.fromStream(Stream.of(event1, event2));
-        })
-        .when(eventStoreTransaction)
-        .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-
-        when(snapshotter.load("test")).thenReturn(CompletableFuture.completedFuture(new Snapshot(
-            new GlobalIndexPosition(5),
-            "1",
-            "payload",
-            Instant.now(),
-            Map.of()
-        )));
-
-        CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
-
-        assertTrue(result.isDone());
-        assertFalse(result.isCompletedExceptionally(), () -> result.exceptionNow().toString());
-        verify(eventStore, times(2)).transaction(processingContext);
-        verify(eventStoreTransaction).onAppend(any());
-        verify(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-        verify(snapshotter).load("test");
-        verify(snapshotter).onEventApplied("test", "payload-0", event1);
-        verify(snapshotter).onEventApplied("test", "payload-0-1", event2);
-        verify(snapshotter).onEvolutionCompleted(
-            eq("test"),
-            eq("payload-0-1"),
-            eq(new GlobalIndexPosition(10)),
-            evolutionResult.capture()
-        );
-
-        assertThat(evolutionResult.getValue().eventsApplied()).isEqualTo(2);
-        assertThat(evolutionResult.getValue().sourcingTime()).isLessThan(Duration.ofSeconds(1));
-        assertThat(evolutionResult.getValue().snapshotRequested()).isFalse();
-
-        assertEquals("payload-0-1", result.resultNow().entity());
     }
 
     @Test
@@ -191,28 +162,23 @@ class EventSourcingRepositoryTest {
     void assigningEntityToOtherProcessingContextInExactFormat() throws Exception {
         ProcessingContext processingContext = new StubProcessingContext();
         ProcessingContext processingContext2 = new StubProcessingContext();
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0), createEvent(1))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
         ManagedEntity<String, String> result = testSubject.load("test", processingContext).get();
 
+        // Attaches entity of correct internal type:
         testSubject.attach(result, processingContext2);
 
         verify(eventStoreTransaction, times(2)).onAppend(any());
-        verify(snapshotter).load("test");
     }
 
     @Test
     void assigningEntityToOtherProcessingContextInOtherFormat() throws Exception {
         ProcessingContext processingContext = new StubProcessingContext();
         ProcessingContext processingContext2 = new StubProcessingContext();
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0), createEvent(1))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
         ManagedEntity<String, String> result = testSubject.load("test", processingContext).get();
 
+        // Attaches entity of incorrect internal type (which will then be recreated):
         testSubject.attach(new ManagedEntity<>() {
             @Override
             public String identifier() {
@@ -232,64 +198,54 @@ class EventSourcingRepositoryTest {
         }, processingContext2);
 
         verify(eventStoreTransaction, times(2)).onAppend(any());
-        verify(snapshotter).load("test");
     }
 
     @Test
     void updateLoadedEventSourcedEntity() {
         ProcessingContext processingContext = new StubProcessingContext();
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0), createEvent(1))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
+        ManagedEntity<String, String> result = testSubject.load("test", processingContext).join();
 
-        assertTrue(result.isDone());
-        assertFalse(result.isCompletedExceptionally());
-        verify(eventStore, times(2)).transaction(processingContext);
+        assertEquals("test(0)-0-1", result.entity());
+
+        verify(eventStore).transaction(processingContext);
         verify(eventStoreTransaction).onAppend(any());
-        verify(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-        verify(snapshotter).load("test");
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Consumer<EventMessage>> callback = ArgumentCaptor.forClass(Consumer.class);
         verify(eventStoreTransaction).onAppend(callback.capture());
-        assertEquals("test(0)-0-1", result.resultNow().entity());
 
         callback.getValue().accept(new GenericEventMessage(new MessageType("event"), "live"));
-        assertEquals("test(0)-0-1-live", result.resultNow().entity());
+        assertEquals("test(0)-0-1-live", result.entity());
     }
 
     @Test
     void loadOrCreateShouldLoadWhenEventsAreReturned() {
         ProcessingContext processingContext = new StubProcessingContext();
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0), createEvent(1))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
         CompletableFuture<ManagedEntity<String, String>> result =
                 testSubject.load("test", processingContext);
 
-        assertEquals("test(0)-0-1", result.resultNow().entity());
+        assertEquals("test(0)-0-1", result.join().entity());
     }
 
     @Test
     void loadOrCreateThrowsExceptionWhenEventStreamIsEmptyAndNullEntityIsCreated() {
         ProcessingContext processingContext = new StubProcessingContext();
+
+        eventsToLoad = List.of();
+
         factory = (id, event, ctx) -> {
             if (event != null) {
                 return id + "(" + event.payload() + ")";
             }
             return null; // Simulating a null entity creation
         };
-        doReturn(MessageStream.fromStream(Stream.of()))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> result = testSubject.loadOrCreate("test", processingContext);
-        assertTrue(result.isCompletedExceptionally());
-        assertInstanceOf(EntityMissingAfterLoadOrCreateException.class, result.exceptionNow());
+        assertThatThrownBy(() -> testSubject.loadOrCreate("test", processingContext).join())
+            .isInstanceOf(CompletionException.class)
+            .cause()
+            .isInstanceOf(EntityMissingAfterLoadOrCreateException.class);
     }
 
     @Test
@@ -298,56 +254,43 @@ class EventSourcingRepositoryTest {
         factory = (id, event, ctx) -> {
             return null; // Simulating a null entity creation
         };
-        doReturn(MessageStream.fromStream(Stream.of(createEvent(0))))
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext);
-
-        assertTrue(result.isCompletedExceptionally());
-        assertInstanceOf(EntityMissingAfterFirstEventException.class, result.exceptionNow());
+        assertThatThrownBy(() -> testSubject.load("test", processingContext).join())
+            .isInstanceOf(CompletionException.class)
+            .cause()
+            .isInstanceOf(EntityMissingAfterFirstEventException.class);
     }
 
     @Test
     void loadShouldReturnNullEntityWhenNoEventsAreReturned() {
         StubProcessingContext processingContext = new StubProcessingContext();
+
+        when(sourcingHandler.source(eq("test"), any(), eq(processingContext))).thenReturn(CompletableFuture.completedFuture(null));
+
         doReturn(MessageStream.empty())
                 .when(eventStoreTransaction)
                 .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> loaded =
-                testSubject.load("test", processingContext);
+        ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
 
-        assertTrue(loaded.isDone());
-        assertFalse(loaded.isCompletedExceptionally());
-        verify(eventStore, times(2)).transaction(processingContext);
+        assertNull(loaded.entity());
+
+        verify(eventStore).transaction(processingContext);
         verify(eventStoreTransaction).onAppend(any());
-        verify(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-        verify(snapshotter).load("test");
-
-        assertNull(loaded.resultNow().entity());
     }
 
     @Test
     void loadOrCreateShouldReturnNoEventMessageConstructorEntityWhenNoEventsAreReturned() {
         ProcessingContext processingContext = new StubProcessingContext();
-        doReturn(MessageStream.empty())
-                .when(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
 
-        CompletableFuture<ManagedEntity<String, String>> loaded =
-                testSubject.loadOrCreate("test", processingContext);
+        eventsToLoad = List.of();
 
-        assertTrue(loaded.isDone());
-        assertFalse(loaded.isCompletedExceptionally());
-        verify(eventStore, times(2)).transaction(processingContext);
+        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext).join();
+
+        assertEquals("test()", loaded.entity());
+
+        verify(eventStore).transaction(processingContext);
         verify(eventStoreTransaction).onAppend(any());
-        verify(eventStoreTransaction)
-                .source(argThat(EventSourcingRepositoryTest::conditionPredicate), any());
-        verify(snapshotter).load("test");
-
-        assertEquals("test()", loaded.resultNow().entity());
     }
 
     private static boolean conditionPredicate(SourcingCondition condition) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/InitializingEntityEvolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/InitializingEntityEvolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing;
+
+import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.modelling.EntityEvolver;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link InitializingEntityEvolver}.
+ *
+ * @author John Hendrikx
+ */
+class InitializingEntityEvolverTest {
+
+    private final EventSourcedEntityFactory<Integer, String> entityFactory = mock();
+    private final EntityEvolver<String> entityEvolver = mock();
+    private final InitializingEntityEvolver<Integer, String> evolver = new InitializingEntityEvolver<>(entityFactory, entityEvolver);
+
+    private final ProcessingContext context = new StubProcessingContext();
+    private final EventMessage event = createEvent(0);
+
+    @Test
+    void initializeShouldCreateEntity() {
+        when(entityFactory.create(1001, null, context)).thenReturn("entity(1001)");
+
+        assertThat(evolver.initialize(1001, context)).isEqualTo("entity(1001)");
+    }
+
+    @Test
+    void initializeShouldThrowExceptionWhenFactoryReturnsNull() {
+        assertThatThrownBy(() -> evolver.initialize(1001, context)).isInstanceOf(EntityMissingAfterLoadOrCreateException.class);
+    }
+
+    @Test
+    void evolveShouldCreateThenEvolveEntity() {
+        when(entityFactory.create(1001, event, context)).thenReturn("entity(1001)");
+        when(entityEvolver.evolve("entity(1001)", event, context)).thenReturn("entity(1001)-1");
+
+        assertThat(evolver.evolve(1001, null, event, context)).isEqualTo("entity(1001)-1");
+    }
+
+    @Test
+    void evolveShouldOnlyEvolveEntityWhenInitializedAlready() {
+        when(entityEvolver.evolve("entity(1001)", event, context)).thenReturn("entity(1001)-1");
+
+        assertThat(evolver.evolve(1001, "entity(1001)", event, context)).isEqualTo("entity(1001)-1");
+
+        verifyNoInteractions(entityFactory);
+    }
+
+    @Test
+    void evolveShouldThrowExceptionWhenFactoryReturnsNull() {
+        assertThatThrownBy(() -> evolver.evolve(1001, null, event, context)).isInstanceOf(EntityMissingAfterFirstEventException.class);
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/StoreBackedSnapshotterTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/StoreBackedSnapshotterTestSuite.java
@@ -95,7 +95,8 @@ public abstract class StoreBackedSnapshotterTestSuite {
             .build();
 
         DelegatingEventConverter eventConverter = new DelegatingEventConverter(new JacksonConverter(objectMapper));
-        SnapshotPolicy snapshotPolicy = SnapshotPolicy.afterEvents(5).or(SnapshotPolicy.whenRequested());
+        SnapshotPolicy snapshotPolicy = SnapshotPolicy.afterEvents(5)
+            .or(SnapshotPolicy.whenEventMatches(msg -> msg.type().qualifiedName().equals(new QualifiedName(AccountClosed.class))));
 
         AxonConfiguration configuration = EventSourcingConfigurer.create()
             .componentRegistry(cr -> cr.registerComponent(Converter.class, c -> eventConverter))
@@ -109,20 +110,7 @@ public abstract class StoreBackedSnapshotterTestSuite {
                         return new Account(ac.id, ac.name, 0);
                     })
                     .criteriaResolver(c -> (id, ctx) -> EventCriteria.havingTags(Tag.of("account", id)))
-                    .snapshotter(c ->
-                        new StoreBackedSnapshotter<>(
-                            c.getComponent(SnapshotStore.class),
-                            MessageType.fromString("my-snapshot#1"),
-                            new JacksonConverter(),
-                            Account.class,
-                            snapshotPolicy
-                        ) {
-                            @Override
-                            public boolean onEventApplied(String identifier, Account entity, EventMessage event) {
-                                return event instanceof GenericEventMessage gem ? gem.type().qualifiedName().equals(new QualifiedName(AccountClosed.class)) : false;
-                            }
-                        }
-                    )
+                    .snapshotPolicy(c -> snapshotPolicy)
                     .build()
             )
             .build();
@@ -239,8 +227,10 @@ public abstract class StoreBackedSnapshotterTestSuite {
             new FundsDeposited(ACCOUNT_ID, 10050)
         );
 
+        QualifiedName qualifiedName = new QualifiedName(Account.class);
+
         snapshotStore.store(
-            new QualifiedName("my-snapshot"),
+            qualifiedName,
             ACCOUNT_ID,
             new Snapshot(
                 new GlobalIndexPosition(3),
@@ -263,7 +253,7 @@ public abstract class StoreBackedSnapshotterTestSuite {
             assertThat(appender.getEvents())
                 .extracting(LogEvent::getMessage)
                 .extracting(Message::getFormattedMessage)
-                .containsExactly("Unsupported snapshot version. Snapshot of my-snapshot#1 for identifier " + ACCOUNT_ID + " had unsupported version: 42");
+                .containsExactly("Unsupported snapshot version. Snapshot of " + qualifiedName + "#0.0.1 for identifier " + ACCOUNT_ID + " had unsupported version: 42");
         }
 
         publish(
@@ -299,12 +289,14 @@ public abstract class StoreBackedSnapshotterTestSuite {
             new FundsDeposited(ACCOUNT_ID, 10050)
         );
 
+        QualifiedName qualifiedName = new QualifiedName(Account.class);
+
         snapshotStore.store(
-            new QualifiedName("my-snapshot"),
+            qualifiedName,
             ACCOUNT_ID,
             new Snapshot(
                 new GlobalIndexPosition(3),
-                "1",  // correct version
+                "0.0.1",  // correct version
                 "Junk",  // incorrect data, which leads to deserialization error
                 Instant.now(),
                 Map.of()
@@ -324,7 +316,7 @@ public abstract class StoreBackedSnapshotterTestSuite {
             assertThat(appender.getEvents())
                 .extracting(LogEvent::getMessage)
                 .extracting(Message::getFormattedMessage)
-                .containsExactly("Snapshot loading failed, falling back to full reconstruction for: class org.axonframework.eventsourcing.StoreBackedSnapshotterTestSuite$Account(class java.lang.String=" + ACCOUNT_ID + ")");
+                .containsExactly("Snapshot loading failed, falling back to full reconstruction for: " + qualifiedName + "#0.0.1 (" + ACCOUNT_ID + ")");
         }
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.eventsourcing.configuration;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.DefaultComponentRegistry;
 import org.axonframework.common.configuration.StubLifecycleRegistry;
@@ -29,12 +27,19 @@ import org.axonframework.eventsourcing.annotation.CriteriaResolverDefinition;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntityFactoryDefinition;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.handler.SourcingHandler;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.Repository;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -45,7 +50,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test class validating the {@link AnnotatedEventSourcedEntityModule}.
@@ -54,6 +62,7 @@ import static org.mockito.Mockito.*;
  * @author Steven van Beelen
  * @author Simon Zambrovski
  */
+@ExtendWith(MockitoExtension.class)
 class AnnotatedEventSourcedEntityModuleTest {
 
     private StubLifecycleRegistry lifecycleRegistry;
@@ -112,7 +121,9 @@ class AnnotatedEventSourcedEntityModuleTest {
     }
 
     @Test
-    void customCriteriaResolverIsPresentOnResultingEventSourcingRepository() {
+    void customCriteriaResolverIsPresentOnResultingEventSourcingRepository(
+        @Captor ArgumentCaptor<SourcingHandler<CourseId, CustomCriteriaResolverCourse>> sourcingHandlerCaptor
+    ) {
         componentRegistry.registerModule(
                 EventSourcedEntityModule.autodetected(CourseId.class, CustomCriteriaResolverCourse.class)
         );
@@ -128,6 +139,11 @@ class AnnotatedEventSourcedEntityModuleTest {
         assertThat(result).isNotNull()
                           .isInstanceOf(EventSourcingRepository.class);
         result.describeTo(componentDescriptor);
+
+        verify(componentDescriptor).describeProperty(eq("sourcingHandler"), sourcingHandlerCaptor.capture());
+
+        sourcingHandlerCaptor.getValue().describeTo(componentDescriptor);
+
         verify(componentDescriptor).describeProperty(eq("criteriaResolver"), isA(CustomCriteriaResolver.class));
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModuleTest.java
@@ -17,10 +17,12 @@
 package org.axonframework.eventsourcing.configuration;
 
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.EventSourcingRepository;
-import org.axonframework.eventsourcing.snapshot.api.Snapshotter;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.commandhandling.CommandHandlingComponent;
 import org.axonframework.messaging.core.MessageStream;
@@ -36,13 +38,20 @@ import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.entity.EntityCommandHandlingComponent;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.repository.Repository;
-import org.junit.jupiter.api.*;
-import org.mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test class validating the {@link SimpleEventSourcedEntityModule}.
@@ -55,12 +64,12 @@ class SimpleEventSourcedEntityModuleTest {
     private CriteriaResolver<CourseId> testCriteriaResolver;
     private EntityMetamodel<Course> testEntityModel;
     private EntityIdResolver<CourseId> testEntityIdResolver;
-    private Snapshotter<CourseId, Course> testSnapshotter;
+    private SnapshotPolicy testSnapshotPolicy;
     private AtomicBoolean constructedEntityModel = new AtomicBoolean(false);
     private AtomicBoolean constructedEntityFactory = new AtomicBoolean(false);
     private AtomicBoolean constructedCriteriaResolver = new AtomicBoolean(false);
     private AtomicBoolean constructedEntityIdResolver = new AtomicBoolean(false);
-    private AtomicBoolean constructedSnapshotter = new AtomicBoolean(false);
+    private AtomicBoolean constructedSnapshotPolicy = new AtomicBoolean(false);
 
     private EventSourcedEntityModule<CourseId, Course> testSubject;
 
@@ -77,7 +86,7 @@ class SimpleEventSourcedEntityModuleTest {
                                          .creationalCommandHandler(new QualifiedName("creational"),
                                                                    (command, context) -> MessageStream.empty().cast())
                                          .build();
-        testSnapshotter = Snapshotter.noSnapshotter();
+        testSnapshotPolicy = SnapshotPolicy.afterEvents(5);
 
         testSubject = EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                               .messagingModel((c, b) -> {
@@ -96,9 +105,9 @@ class SimpleEventSourcedEntityModuleTest {
                                                   constructedEntityIdResolver.set(true);
                                                   return testEntityIdResolver;
                                               })
-                                              .snapshotter(c -> {
-                                                  constructedSnapshotter.set(true);
-                                                  return testSnapshotter;
+                                              .snapshotPolicy(c -> {
+                                                  constructedSnapshotPolicy.set(true);
+                                                  return testSnapshotPolicy;
                                               })
                                               .build();
     }
@@ -154,13 +163,13 @@ class SimpleEventSourcedEntityModuleTest {
     }
 
     @Test
-    void snapshotterThrowsNullPointerExceptionForNullSnapshotter() {
+    void snapshotPolicyThrowsNullPointerExceptionForNullSnapshotPolicy() {
         assertThrows(NullPointerException.class,
             () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                           .messagingModel((c, b) -> testEntityModel)
                                           .entityFactory(c -> testEntityFactory)
                                           .criteriaResolver(c -> testCriteriaResolver)
-                                          .snapshotter(null)
+                                          .snapshotPolicy(null)
         );
     }
 
@@ -174,8 +183,9 @@ class SimpleEventSourcedEntityModuleTest {
     @Test
     void registersAnEventSourcingRepositoryWithTheStateManager() {
         AxonConfiguration configuration = EventSourcingConfigurer.create()
-                                                                 .componentRegistry(cr -> cr.registerModule(testSubject))
-                                                                 .start();
+            .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+            .componentRegistry(cr -> cr.registerModule(testSubject))
+            .start();
         Repository<CourseId, Course> result = configuration.getComponent(StateManager.class)
                                                            .repository(Course.class, CourseId.class);
 
@@ -184,7 +194,21 @@ class SimpleEventSourcedEntityModuleTest {
         assertTrue(constructedCriteriaResolver.get());
         assertTrue(constructedEntityModel.get());
         assertTrue(constructedEntityIdResolver.get());
-        assertTrue(constructedSnapshotter.get());
+        assertTrue(constructedSnapshotPolicy.get());
+    }
+
+    @Test
+    void shouldRejectIncompleteConfigurationWhenConfiguringSnapshotting() {
+        EventSourcingConfigurer configurer = EventSourcingConfigurer.create()
+            .componentRegistry(cr -> cr.registerModule(testSubject));
+
+        assertThatThrownBy(() -> configurer.start())
+            .isInstanceOf(LifecycleHandlerInvocationException.class)
+            .cause()
+            .isInstanceOf(ExecutionException.class)
+            .cause()
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("A SnapshotStore must be configured to use snapshotting.");
     }
 
     @Test
@@ -201,6 +225,7 @@ class SimpleEventSourcedEntityModuleTest {
                                .componentRegistry(cr -> cr.registerComponent(SequencingPolicy.class,
                                                                              MessagingConfigurationDefaults.COMMAND_SEQUENCING_POLICY,
                                                                              c -> NoOpSequencingPolicy.INSTANCE))
+                               .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
                                .componentRegistry(cr -> cr.registerModule(testSubject)
                                                           .registerComponent(CommandBus.class, c -> commandBus))
                                .start();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/SnapshotPolicyTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/SnapshotPolicyTest.java
@@ -18,6 +18,8 @@ package org.axonframework.eventsourcing.snapshot.store;
 
 import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
 import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -39,13 +41,17 @@ class SnapshotPolicyTest {
     }
 
     @Test
+    void whenEventMatchesPolicyShouldRejectInvalidParameters() {
+        assertThatThrownBy(() -> SnapshotPolicy.whenEventMatches(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void afterEventsPolicyShouldWorkWithValidParameters() {
         SnapshotPolicy policy = SnapshotPolicy.afterEvents(5);
 
-        assertThat(policy.needsSnapshot(new EvolutionResult(6, Duration.ZERO, false))).isTrue();
-        assertThat(policy.needsSnapshot(new EvolutionResult(5, Duration.ZERO, false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(5, Duration.ofDays(1), false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(5, Duration.ZERO, true))).isFalse();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(6, Duration.ZERO))).isTrue();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(5, Duration.ZERO))).isFalse();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(5, Duration.ofDays(1)))).isFalse();
     }
 
     @Test
@@ -57,19 +63,16 @@ class SnapshotPolicyTest {
     void whenSourcingTimeExceedsPolicyShouldWorkWithValidParameters() {
         SnapshotPolicy policy = SnapshotPolicy.whenSourcingTimeExceeds(Duration.ofSeconds(1));
 
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ofMillis(1001), false))).isTrue();
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ofMillis(1000), false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(1000, Duration.ofMillis(1000), false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ofMillis(1000), true))).isFalse();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(0, Duration.ofMillis(1001)))).isTrue();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(0, Duration.ofMillis(1000)))).isFalse();
+        assertThat(policy.shouldSnapshot(new EvolutionResult(1000, Duration.ofMillis(1000)))).isFalse();
     }
 
     @Test
     void whenRequestedPolicyShouldWork() {
-        SnapshotPolicy policy = SnapshotPolicy.whenRequested();
+        SnapshotPolicy policy = SnapshotPolicy.whenEventMatches(msg -> msg.payload() instanceof String s && s.equals("Hi"));
 
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ZERO, true))).isTrue();
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ZERO, false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(1000, Duration.ZERO, false))).isFalse();
-        assertThat(policy.needsSnapshot(new EvolutionResult(0, Duration.ofDays(1), false))).isFalse();
+        assertThat(policy.shouldSnapshot(new GenericEventMessage(MessageType.fromString("a#1"), "Hi"))).isTrue();
+        assertThat(policy.shouldSnapshot(new GenericEventMessage(MessageType.fromString("a#1"), "Bye"))).isFalse();
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/StoreBackedSnapshotterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/StoreBackedSnapshotterTest.java
@@ -23,9 +23,7 @@ import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.message.Message;
 import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.Position;
-import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
-import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
 import org.axonframework.messaging.core.MessageType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,13 +53,12 @@ class StoreBackedSnapshotterTest {
 
     @Mock private SnapshotStore store;
     @Mock private Converter converter;
-    @Mock private SnapshotPolicy policy;
 
     private StoreBackedSnapshotter<String, String> snapshotter;
 
     @BeforeEach
     void beforeEach() {
-        this.snapshotter = new StoreBackedSnapshotter<>(store, TYPE, converter, String.class, policy);
+        this.snapshotter = new StoreBackedSnapshotter<>(store, TYPE, converter, String.class);
     }
 
     @Test
@@ -108,40 +103,22 @@ class StoreBackedSnapshotterTest {
     }
 
     @Test
-    void shouldNotStoreSnapshotWhenNotRequestedByPolicy() {
-        EvolutionResult evolutionResult = new EvolutionResult(1, Duration.ZERO, false);
-
-        when(policy.needsSnapshot(evolutionResult)).thenReturn(false);
-
-        snapshotter.onEvolutionCompleted("1", "payload", Position.START, evolutionResult);
-
-        verifyNoInteractions(store);
-    }
-
-    @Test
-    void succesfulSnapshotStoreShouldLogNothing(@Named("TestAppender") ListAppender appender) {
-        EvolutionResult evolutionResult = new EvolutionResult(1, Duration.ZERO, false);
-
-        when(policy.needsSnapshot(evolutionResult)).thenReturn(true);
-
+    void successfulSnapshotStoreShouldLogNothing(@Named("TestAppender") ListAppender appender) {
         appender.clear();
 
-        snapshotter.onEvolutionCompleted("1", "payload", Position.START, evolutionResult);
+        snapshotter.store("1", "payload", Position.START);
 
         assertThat(appender.getEvents()).isEmpty();
     }
 
     @Test
     void failureToStoreSnapshotShouldOnlyLogWarning(@Named("TestAppender") ListAppender appender) {
-        EvolutionResult evolutionResult = new EvolutionResult(1, Duration.ZERO, false);
-
-        when(policy.needsSnapshot(evolutionResult)).thenReturn(true);
         when(store.store(eq(TYPE.qualifiedName()), eq("1"), any(Snapshot.class)))
             .thenReturn(CompletableFuture.failedFuture(new IOException("busy")));
 
         appender.clear();
 
-        snapshotter.onEvolutionCompleted("1", "payload", Position.START, evolutionResult);
+        snapshotter.store("1", "payload", Position.START);
 
         assertThat(appender.getEvents())
             .extracting(LogEvent::getMessage)

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -255,8 +255,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                                             Student.class,
                                             c.getComponent(EventConverter.class),
                                             c.getComponent(MessageTypeResolver.class)
-                                    ),
-                                    null
+                                    )
                             );
                             return SimpleStateManager.named("testfixture")
                                                      .register(repository);


### PR DESCRIPTION
This rework was done to make it possible that `EventStore` can (in the future) deliver a relevant snapshot directly from its `source` call. This makes it possible to have the storage engine directly deliver the snapshot + events, saving a roundtrip when snapshotting is in use.

Main changes:
- Introduce the concept of a sourcing handler (`SourcingHandler`). A sourcing handler is responsible for creating and evolving an entity based on an event stream. Implementations can decide to do this based on a snapshot, or by just loading all events.
- The `Snapshotter` is for now hidden inside the snapshotting sourcing handler; this will likely be completely removed soon.
- The `SnapshotPolicy` now has an integrated way to set a `Predicate` to trigger snapshotting based on events seen (and this functionality was removed from `Snapshotter`)
- Marked many things `@Internal` to make users aware that these types may still need more rework before becoming public concepts.

Likely to be removed or significantly reworked soon:
- Snapshotter interface
- SnapshotStore interface

Note:
- Support for having snapshots and events in different back-ends is likely to be removed soon, as the costs for doing so are a very good reason not to ever want this
- Snapshots are their own concept in AF5 still, and not considered events as was done in AF4. This will not change when a Snapshot is delivered as the first "event" by storage engines that support snapshotting when sourcing; it is merely wrapped as an event similar to how `ConsistencyMarker`'s are handled.