### PR TITLE
Port documentation enhancements from 5.0.x to main

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/index.adoc
@@ -18,8 +18,9 @@ Whether you are performing a straightforward version bump or a deep architectura
 * xref:migration:paths/projectors-event-processors.adoc[Event Processor configuration]
 * xref:migration:paths/test-fixtures.adoc[Test Fixture migration]
 * xref:migration:paths/serializers.adoc[Serializer migration]
+* xref:migration:paths/interceptors.adoc[Interceptor migration]
+* xref:migration:paths/sequencing-policies.adoc[Sequencing Policy migration]
 * _ConfigurerModule to ConfigurationEnhancers (Coming soon)_
-* _Message Interceptors in Axon Framework 5 (Coming soon)_
 3. **What is not yet there**
 4. **Missing a Migration Path?**
 

--- a/docs/reference-guide/modules/migration/pages/paths/interceptors.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/interceptors.adoc
@@ -1,0 +1,322 @@
+= Interceptor Migration
+
+Axon Framework 5 introduces significant changes to how interceptors work, reflecting the broader shift to async-first APIs and the move away from ThreadLocal-based patterns.
+
+This path covers the migration of message interceptors from Axon Framework 4 to Axon Framework 5. For a complete understanding of how interceptors work in Axon Framework 5, see xref:messaging-concepts:message-intercepting.adoc[Message Intercepting].
+
+[NOTE]
+====
+The most significant changes are:
+
+* **Async-first design**: Interceptors now return `MessageStream<?>` instead of synchronous values
+* **Explicit ProcessingContext**: Replaces the ThreadLocal-based `UnitOfWork` pattern from AF4
+* **Simplified registration**: Unified registration approach across all message types
+
+While the interfaces have changed, the fundamental concepts and use cases remain the same.
+====
+== MessageDispatchInterceptor interface changes
+
+Dispatch interceptors are invoked when a message is dispatched/published on a bus, eventually even before a `ProcessingContext` is created.
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+public class MyDispatchInterceptor implements MessageDispatchInterceptor<CommandMessage<?>> {
+
+    @Override
+    public BiFunction<Integer, CommandMessage<?>, CommandMessage<?>> handle(
+            List<? extends CommandMessage<?>> messages) {
+        return (index, message) -> {
+            // Modify or enrich message
+            return message.andMetaData(Collections.singletonMap("dispatchTime", Instant.now()));
+        };
+    }
+}
+----
+
+Axon Framework 5::
++
+[source,java]
+----
+public class MyDispatchInterceptor implements MessageDispatchInterceptor<CommandMessage> {
+
+    @Override
+    public MessageStream<?> interceptOnDispatch(CommandMessage message,
+                                                @Nullable ProcessingContext context,
+                                                MessageDispatchInterceptorChain<CommandMessage> chain) {
+        // Modify or enrich message
+        CommandMessage enrichedMessage = message.andMetaData(
+            Collections.singletonMap("dispatchTime", Instant.now())
+        );
+
+        // Continue chain with modified message
+        return chain.proceed(enrichedMessage, context);
+    }
+}
+----
++
+Key changes:
++
+* **Method name**: `handle()` → `interceptOnDispatch()`
+* **Single message**: Processes one message at a time instead of batching
+* **Return type**: `MessageStream<?>` for async-first design
+* **ProcessingContext**: `@Nullable` - may not exist during dispatch
+* **Chain proceed**: Must pass (possibly modified) message to continue
+====
+
+[IMPORTANT]
+====
+The `ProcessingContext` parameter is `@Nullable` for dispatch interceptors because they run **before** message handling begins, potentially before any context exists.
+
+If dispatching from within a handler (where context exists), pass it along to propagate correlation data. If dispatching from outside a handler (for example, HTTP endpoint), context will be `null`.
+====
+
+== MessageHandlerInterceptor interface changes
+
+The `MessageHandlerInterceptor` interface has been redesigned to support async-first processing and explicit context management.
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+public class MyHandlerInterceptor implements MessageHandlerInterceptor<CommandMessage<?>> {
+
+    @Override
+    public Object handle(UnitOfWork<? extends CommandMessage<?>> unitOfWork,
+                        InterceptorChain interceptorChain) throws Exception {
+        // Pre-processing
+        unitOfWork.onCommit(uow -> {
+            // Post-commit logic
+        });
+
+        // Continue chain synchronously
+        return interceptorChain.proceed();
+    }
+}
+----
++
+Key characteristics:
++
+* `UnitOfWork` provided via ThreadLocal (`CurrentUnitOfWork.get()`)
+* Synchronous `proceed()` method
+* Direct return of handler result
+
+Axon Framework 5::
++
+[source,java]
+----
+public class MyHandlerInterceptor implements MessageHandlerInterceptor<CommandMessage> {
+
+    @Override
+    public MessageStream<?> interceptOnHandle(CommandMessage message,
+                                              ProcessingContext context,
+                                              MessageHandlerInterceptorChain<CommandMessage> chain) {
+        // Pre-processing
+        context.runOnAfterCommit(ctx -> {
+            // Post-commit logic
+        });
+
+        // Continue chain - returns MessageStream
+        return chain.proceed(message, context);
+    }
+}
+----
++
+Key changes:
++
+* **Method name**: `handle()` → `interceptOnHandle()`
+* **Parameters**: Receives `message` and `context` explicitly
+* **Return type**: `MessageStream<?>` instead of `Object`
+* **Chain proceed**: Must pass `message` and `context` to `chain.proceed()`
+* **ProcessingContext**: Mandatory parameter, never null during handling
++
+The `ProcessingContext` provides lifecycle hooks similar to `UnitOfWork`:
++
+* `runOnPreInvocation(Consumer<ProcessingContext>)` - Execute when context starts
+* `runOnAfterCommit(Consumer<ProcessingContext>)` - Execute after successful commit
+* `onError(ProcessingErrorHandler)` - Handle errors during processing
+====
+
+== Declarative interceptor registration
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+Configurer configurer = DefaultConfigurer.defaultConfiguration();
+
+configurer.registerCommandHandlerInterceptor(
+    config -> new MyCommandHandlerInterceptor()
+);
+
+configurer.registerDispatchInterceptor(
+    config -> new MyCommandDispatchInterceptor()
+);
+----
+
+Axon Framework 5::
++
+[source,java]
+----
+MessagingConfigurer configurer = MessagingConfigurer.create();
+
+// Register handler interceptor for commands
+configurer.registerCommandHandlerInterceptor(
+    config -> new MyCommandHandlerInterceptor()
+);
+
+// Register dispatch interceptor for commands
+configurer.registerCommandDispatchInterceptor(
+    config -> new MyCommandDispatchInterceptor()
+);
+----
+====
+
+The following registration methods are available:
+
+**Handler Interceptors:**
+
+* `registerMessageHandlerInterceptor(ComponentBuilder)` - All message types
+* `registerCommandHandlerInterceptor(ComponentBuilder)` - Commands only
+* `registerEventHandlerInterceptor(ComponentBuilder)` - Events only
+* `registerQueryHandlerInterceptor(ComponentBuilder)` - Queries only
+
+**Dispatch Interceptors:**
+
+* `registerDispatchInterceptor(ComponentBuilder)` - All message types
+* `registerCommandDispatchInterceptor(ComponentBuilder)` - Commands only
+* `registerEventDispatchInterceptor(ComponentBuilder)` - Events only
+* `registerQueryDispatchInterceptor(ComponentBuilder)` - Queries only
+
+[source,java]
+----
+MessagingConfigurer configurer = MessagingConfigurer.create();
+
+// Register for multiple message types
+configurer.registerCommandHandlerInterceptor(config -> new LoggingInterceptor("Command"))
+          .registerEventHandlerInterceptor(config -> new LoggingInterceptor("Event"))
+          .registerQueryHandlerInterceptor(config -> new LoggingInterceptor("Query"));
+
+Configuration configuration = configurer.build();
+----
+
+== Spring Boot interceptor registration
+
+Spring Boot auto-configuration automatically discovers and registers interceptors declared as Spring beans.
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+@Component
+public class MyCommandHandlerInterceptor implements MessageHandlerInterceptor<CommandMessage<?>> {
+    // Implementation
+}
+----
+
+Axon Framework 5::
++
+[source,java]
+----
+@Component
+public class MyCommandHandlerInterceptor implements MessageHandlerInterceptor<CommandMessage> {
+
+    @Override
+    public MessageStream<?> interceptOnHandle(CommandMessage message,
+                                              ProcessingContext context,
+                                              MessageHandlerInterceptorChain<CommandMessage> chain) {
+        logger.info("Handling command: {}", message.type().name());
+        return chain.proceed(message, context);
+    }
+}
+----
++
+[source,java]
+----
+@Component
+public class MyCommandDispatchInterceptor implements MessageDispatchInterceptor<CommandMessage> {
+
+    @Override
+    public MessageStream<?> interceptOnDispatch(CommandMessage message,
+                                                @Nullable ProcessingContext context,
+                                                MessageDispatchInterceptorChain<CommandMessage> chain) {
+        logger.info("Dispatching command: {}", message.type().name());
+        return chain.proceed(message, context);
+    }
+}
+----
+====
+
+Spring Boot's `InterceptorAutoConfiguration` automatically:
+
+1. Discovers all beans implementing `MessageHandlerInterceptor<T>`
+2. Discovers all beans implementing `MessageDispatchInterceptor<T>`
+3. Registers them with the appropriate components based on their generic `Message` type
+4. Applies them to the corresponding message buses
+
+[IMPORTANT]
+====
+Be aware that interceptors are registered on all applicable components based on their generic type.
+That means, defining a `MessageDispatchInterceptor<Message<?>>` or `MessageHandlerInterceptor<Message<?>>` with for
+example `Message` as the generic type will register the interceptor for commands, events and queries.
+====
+
+[TIP]
+====
+You can control interceptor application order using Spring's `@Order` annotation:
+
+[source,java]
+----
+@Component
+@Order(1)
+public class FirstInterceptor implements MessageHandlerInterceptor<CommandMessage> {
+    // Applied first
+}
+
+@Component
+@Order(2)
+public class SecondInterceptor implements MessageHandlerInterceptor<CommandMessage> {
+    // Applied second
+}
+----
+====
+
+== Component-specific interceptor registration
+
+For advanced scenarios where interceptors should only apply to specific components, use the factory pattern:
+
+[source,java]
+----
+configurer.registerCommandHandlerInterceptor(
+    HandlerInterceptorFactory.of(
+        (config, componentType, componentName) -> {
+            // Only intercept OrderAggregate commands
+            if (componentType.equals(OrderAggregate.class)) {
+                return new OrderValidationInterceptor();
+            }
+            return null; // No interceptor for other components
+        }
+    )
+);
+----
+
+The factory receives:
+
+* `Configuration config` - Access to framework configuration
+* `Class<?> componentType` - The component class (for example, entity, projection)
+* `String componentName` - The component's registered name (may be null)
+
+Return `null` to skip interceptor registration for that component.
+
+== Annotation-based interceptors
+
+Although the `@MessageHandlerInterceptor` annotation is present in Axon Framework 5, using it to declare interceptor methods directly within handler classes is not yet supported. This feature will be fully functional in **Axon Framework 5.2.0**.

--- a/docs/reference-guide/modules/migration/pages/paths/sequencing-policies.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/sequencing-policies.adoc
@@ -1,0 +1,183 @@
+= Sequencing Policy Migration
+
+Axon Framework 5 refines the `SequencingPolicy` concept, moving it from event-only processing to a shared abstraction for both events and commands.
+This path covers the migration of sequencing policies from Axon Framework 4 to Axon Framework 5.
+For a complete understanding of how sequencing policies work in Axon Framework 5, see xref:events:event-processors/streaming.adoc#sequencing_policies[Sequencing Policies].
+
+[NOTE]
+====
+The most notable changes are:
+
+* **Package move**: Policies moved from `org.axonframework.eventhandling.async` to `org.axonframework.messaging.core.sequencing`
+* **Method signature**: The signature of `Object SequencingPolicy#getSequenceIdentifierFor(T event)` changed to `Optional<Object> SequencingPolicy#sequenceIdentifierFor(M message, ProcessingContext context)`, the semantics stay the same: messages with the same identifier are processed sequentially, `null` / `Optional#empty()` indicates no sequencing requirements for the message
+* **Changed default**: If you are using the aggregate-based event storage engines, the sequencing policy for event handlers still defaults to `SequentialPerAggregatePolicy`.
+However, if you are using DCB support, the default policy falls back to the `SequentialPolicy`, which processes **all events sequentially**.
+In that case it is highly recommended to explicitly configure a suitable `SequencingPolicy`.
+====
+
+== API changes
+
+The `SequencingPolicy` interface has been redesigned to be reusable for message sequencing in general (not only event sequencing) and fit the context-aware architecture of Axon Framework 5.
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+package org.axonframework.eventhandling.async;
+
+public interface SequencingPolicy<T> {
+
+    Object getSequenceIdentifierFor(T event);
+}
+----
++
+Key characteristics:
++
+* The type parameter `T` refers to the event type directly
+* Returns `null` to indicate no sequencing requirement (full concurrency for that message)
+* No access to processing context
+
+Axon Framework 5::
++
+[source,java]
+----
+package org.axonframework.messaging.core.sequencing;
+
+public interface SequencingPolicy<M extends Message> {
+
+    Optional<Object> sequenceIdentifierFor(M message, ProcessingContext context);
+}
+----
++
+Key changes:
++
+* The type parameter `M` is bound to `Message`, making the policy applicable to any message type
+* Returns `Optional.empty()` instead of `null` to indicate no need for sequencing
+* Receives an explicit `ProcessingContext` for resource access
+
+====
+
+When migrating a custom `SequencingPolicy`, apply the following changes:
+
+[tabs]
+====
+Axon Framework 4::
++
+[source,java]
+----
+public class CustomerIdSequencingPolicy implements SequencingPolicy<EventMessage<?>> {
+
+    @Override
+    public Object getSequenceIdentifierFor(EventMessage<?> event) {
+        if (event.getPayload() instanceof CustomerEvent customerEvent) {
+            return customerEvent.getCustomerId();
+        }
+        return null;
+    }
+}
+----
+
+Axon Framework 5::
++
+[source,java]
+----
+public class CustomerIdSequencingPolicy implements SequencingPolicy<EventMessage> {
+
+    @Override
+    public Optional<Object> sequenceIdentifierFor(EventMessage message, ProcessingContext context) {
+        if (message.payload() instanceof CustomerEvent customerEvent) {
+            return Optional.of(customerEvent.customerId());
+        }
+        return Optional.empty();
+    }
+}
+----
+====
+
+== Changed default: from `SequentialPerAggregatePolicy` to `HierarchicalSequencingPolicy`
+
+In Axon Framework 4, the default sequencing policy for streaming event processors was `SequentialPerAggregatePolicy`.
+This policy groups events by aggregate identifier, so events from the same aggregate are processed sequentially, while events from different aggregates can be processed concurrently.
+For non-domain events (events without an aggregate identifier), the policy returned `null`, resulting in full concurrency for those events.
+
+In Axon Framework 5, the default is a `HierarchicalSequencingPolicy` that wraps `SequentialPerAggregatePolicy` as its primary policy, with `SequentialPolicy` as the fallback.
+This means that when the primary policy returns `Optional.empty()`—which happens when no aggregate identifier is found in the processing context—the fallback `SequentialPolicy` is applied instead.
+
+The practical impact depends on your event store solution:
+
+* **Aggregate-based event store solution**: Events carry an aggregate identifier that is placed in the processing context.
+`SequentialPerAggregatePolicy` can find it, so the behavior is identical to Axon Framework 4—events from the same aggregate are handled sequentially, events from different aggregates can be processed concurrently.
+Users migrating from Axon Framework 4 without migrating their event store to DCB should observe no behavioral difference.
+
+* **DCB (tag-based) event store solution**: Events are stored using tags rather than aggregate identifiers.
+No aggregate identifier is placed in the processing context, so `SequentialPerAggregatePolicy` returns `Optional.empty()` for every event.
+The `HierarchicalSequencingPolicy` then falls back to `SequentialPolicy`, processing all events sequentially within a single segment (allowing no concurrency at all within the processing segment).
+This is the safe default, but limits parallelism—see the section below on defining an explicit policy.
+
+== Define an explicit event sequencing policy
+
+Because the default policy adapts automatically to your event store type, it can introduce unexpected performance implications when migrating to a DCB-based event store.
+We therefore strongly recommend always defining a sequencing policy that explicitly matches your application's ordering requirements.
+
+For the available built-in policies and configuration options, see xref:events:event-processors/streaming.adoc#sequencing_policies[Sequencing Policies].
+The two main configuration approaches are shown below.
+
+=== Annotation-based configuration
+
+Use `@SequencingPolicy` on an event handling component class or on individual `@EventHandler` methods.
+Method-level annotations take precedence over class-level ones.
+
+[source,java]
+----
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.core.annotation.SequencingPolicy;
+import org.axonframework.messaging.core.sequencing.PropertySequencingPolicy;
+
+@SequencingPolicy(type = PropertySequencingPolicy.class, parameters = {"customerId"})
+class OrderEventHandler {
+
+    @EventHandler
+    public void on(OrderPlacedEvent event) {
+        // handled sequentially per customerId
+    }
+}
+----
+
+=== Declarative configuration
+
+Register the sequencing policy programmatically through the `MessagingConfigurer`.
+
+[source,java]
+----
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.core.sequencing.PropertySequencingPolicy;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+
+public void configureEventProcessing(MessagingConfigurer configurer) {
+    configurer.eventProcessing(eventConfigurer ->
+            eventConfigurer.pooledStreaming(pooledStreamingConfigurer ->
+                    pooledStreamingConfigurer.processor("order-processor", customizer ->
+                                    customizer.eventHandlingComponents(ehc ->
+                                            ehc.declarative(cfg ->
+                                                    SimpleEventHandlingComponent.create("orders",
+                                                            new PropertySequencingPolicy<>(Order.class, "customerId")
+                                                    )
+                                            )
+                                    ).notCustomized()
+                    )
+            )
+    );
+}
+----
+
+== Sequencing policies for commands
+
+In Axon Framework 4, sequencing policies exclusively applied to event processing.
+
+In Axon Framework 5, the `SequencingPolicy` abstraction is also used for command handling.
+By default, the `RoutingKeySequencingPolicy` sequences commands by their routing key, ensuring that commands targeting the same entity are handled sequentially and eliminating optimistic locking failures in high-throughput scenarios.
+
+This change does not introduce migration issues for existing applications, as command sequencing is new functionality that operates transparently in the background and reflects the aggregate locking behaviour that was the default in Axon Framework 4.
+If you need to customize or disable command sequencing, see xref:tuning:command-processing.adoc#command-sequencing[Command sequencing].

--- a/docs/reference-guide/modules/migration/partials/nav.adoc
+++ b/docs/reference-guide/modules/migration/partials/nav.adoc
@@ -14,3 +14,5 @@
 *** xref:migration:paths/event-store.adoc[]
 *** xref:migration:paths/test-fixtures.adoc[]
 *** xref:migration:paths/serializers.adoc[]
+*** xref:migration:paths/interceptors.adoc[]
+*** xref:migration:paths/sequencing-policies.adoc[]


### PR DESCRIPTION
porting
* interceptors migration path
* sequencing policies migration path
* query refguide improvements

(no conflicts)