### PR TITLE
Chore: fix duplicate archunit dependency management

### DIFF
--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -353,11 +353,6 @@
             </dependency>
             <!-- Testing -->
             <dependency>
-                <groupId>com.tngtech.archunit</groupId>
-                <artifactId>archunit-junit5</artifactId>
-                <version>${archunit.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>


### PR DESCRIPTION
The archunit dependency management is duplicated in the axon-parent pom, leading to a maven build warning