### PR TITLE
Provide `default` `ResetHandler#handle(ResetContext, ProcessingContext)` for `EventHandlingComponent`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventHandlingComponent.java
@@ -90,6 +90,11 @@ public interface EventHandlingComponent
     }
 
     @Override
+    default MessageStream.Empty<Message> handle(ResetContext resetContext, ProcessingContext context) {
+        return MessageStream.empty();
+    }
+
+    @Override
     default MessageStream.Empty<Message> handle(ReplayStatusChanged statusChange, ProcessingContext context) {
         return MessageStream.empty();
     }


### PR DESCRIPTION
Provide default implementation for `ResetHandler#handle(ResetContext, ProcessingContext)`. 
Otherwise, users that have their own `EventHandlingComponent` implementation will break when moving to 5.1.0.