### PR TITLE
[#4340] Break cyclic dependencies in spring autoconfiguration

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/AxonServerConfiguration.java
@@ -266,7 +266,7 @@ public class AxonServerConfiguration {
      * Properties describing the settings for the
      * {@link org.axonframework.axonserver.connector.event.AxonServerEventStorageEngine AxonServerEventStorageEngine}.
      */
-    private EventStoreConfiguration eventStoreConfiguration = new EventStoreConfiguration();
+    private EventStoreConfiguration eventStore = new EventStoreConfiguration();
 
     /**
      * The configuration of each of the persistent streams. The key is the identifier of the message source, the value
@@ -1097,18 +1097,17 @@ public class AxonServerConfiguration {
      *
      * @return The configured {@link EventStoreConfiguration} of this application for Axon Server.
      */
-    @ConfigurationProperties(prefix = "axon.axonserver.event-store")
-    public EventStoreConfiguration getEventStoreConfiguration() {
-        return eventStoreConfiguration;
+    public EventStoreConfiguration getEventStore() {
+        return eventStore;
     }
 
     /**
      * Set the {@link EventStoreConfiguration} of this application for Axon Server
      *
-     * @param eventStoreConfiguration The {@link EventStoreConfiguration} to set for this application.
+     * @param eventStore The {@link EventStoreConfiguration} to set for this application.
      */
-    public void setEventStoreConfiguration(EventStoreConfiguration eventStoreConfiguration) {
-        this.eventStoreConfiguration = eventStoreConfiguration;
+    public void setEventStore(EventStoreConfiguration eventStore) {
+        this.eventStore = eventStore;
     }
 
     /**

--- a/docs/reference-guide/modules/ROOT/pages/conversion.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/conversion.adoc
@@ -385,7 +385,7 @@ public class ConverterConfiguration {
 
 [source,properties]
 ----
-# Possible values: 'default', 'java', 'jackson', 'jackson2'
+# Possible values: 'default', 'jackson', 'jackson2', 'avro', 'cbor',
 # 'avro' can be used for 'events' and 'messages' only
 axon.converter.general=jackson
 axon.converter.messages=jackson
@@ -396,7 +396,7 @@ axon.converter.events=jackson
 
 [source,yaml]
 ----
-# Possible values: 'default', 'java', 'jackson', 'jackson2'
+# Possible values: 'default', 'jackson', 'jackson2', 'avro', 'cbor'
 # 'avro' can be used for 'events' and 'messages' only
 axon:
   converter:

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/ConverterProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/ConverterProperties.java
@@ -94,7 +94,7 @@ public class ConverterProperties {
      *
      * @return The {@link Converter} type to use for conversion of all kinds of objects
      */
-        public ConverterType getGeneral() {
+    public ConverterType getGeneral() {
         return general;
     }
 
@@ -122,7 +122,7 @@ public class ConverterProperties {
      *
      * @return The type of {@link Converter} to use for {@link Message#payload() Message payloads}.
      */
-        public ConverterType getMessages() {
+    public ConverterType getMessages() {
         return messages;
     }
 
@@ -155,7 +155,7 @@ public class ConverterProperties {
      *
      * @return The type of {@link Converter} to use for {@link EventMessage#payload() EventMessage payloads}.
      */
-        public ConverterType getEvents() {
+    public ConverterType getEvents() {
         return events;
     }
 

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroConverterAutoConfiguration.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.autoconfig;
+
+import org.apache.avro.message.SchemaStore;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.avro.AvroConverter;
+import org.axonframework.conversion.avro.AvroConverterConfiguration;
+import org.axonframework.conversion.avro.AvroConverterStrategy;
+import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Autoconfigures the {@link AvroConverter}, if configured via the {@link ConverterProperties}.
+ *
+ * @author Jakob Hatzl
+ * @since 5.1.0
+ */
+@AutoConfiguration
+@AutoConfigureBefore(ConverterAutoConfiguration.class)
+@ConditionalOnClass(name = {"org.apache.avro.message.SchemaStore"})
+@EnableConfigurationProperties(ConverterProperties.class)
+public class AvroConverterAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method to throw an {@link AxonConfigurationException}, indicating that the {@link AvroConverter} is
+     * not supported as general converter.
+     *
+     * @return always throws {@link AxonConfigurationException} to indicate misconfiguration
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "avro")
+    public Converter converter() {
+        throw new AxonConfigurationException(format(
+                "Invalid converter type [%s] configured as general converter. "
+                        + "The Avro Converter can be used as message or event converter only.",
+                ConverterProperties.ConverterType.AVRO
+        ));
+    }
+
+    /**
+     * Bean creation method constructing an {@link AvroConverter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param schemaStore         the Avro {@link SchemaStore} to be used
+     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "axon.converter.messages", havingValue = "avro")
+    public MessageConverter messageConverter(SchemaStore schemaStore,
+                                             Map<String, AvroConverterStrategy> converterStrategies) {
+        return new DelegatingMessageConverter(buildConverter(schemaStore, converterStrategies));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code avro}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code cbor}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' == 'avro'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing an {@link AvroConverter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param schemaStore         the Avro {@link SchemaStore} to be used
+     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' != 'avro'")
+    public EventConverter eventConverter(SchemaStore schemaStore,
+                                         Map<String, AvroConverterStrategy> converterStrategies) {
+        return new DelegatingEventConverter(buildConverter(schemaStore, converterStrategies));
+    }
+
+    private Converter buildConverter(SchemaStore schemaStore, Map<String, AvroConverterStrategy> converterStrategies) {
+        return new AvroConverter(
+                schemaStore,
+                (c) -> {
+                    AvroConverterConfiguration result = c;
+                    for (AvroConverterStrategy strategy : converterStrategies.values()) {
+                        result = result.addConverterStrategy(strategy);
+                    }
+                    return result;
+                },
+                new ChainingContentTypeConverter(classLoader)
+        );
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroConverterAutoConfiguration.java
@@ -97,7 +97,7 @@ public class AvroConverterAutoConfiguration implements BeanClassLoaderAware {
      * both use {@code avro}.
      *
      * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
-     *                         use {@code cbor}
+     *                         use {@code avro}
      * @return the {@link EventConverter} to be used by Axon Framework
      */
     @Bean(name = "eventConverter")
@@ -142,7 +142,7 @@ public class AvroConverterAutoConfiguration implements BeanClassLoaderAware {
      * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
      *
      * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}
      */
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroSchemaStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroSchemaStoreAutoConfiguration.java
@@ -18,11 +18,22 @@ package org.axonframework.extension.springboot.autoconfig;
 
 import org.apache.avro.Schema;
 import org.apache.avro.message.SchemaStore;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.conversion.ChainingContentTypeConverter;
 import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.avro.AvroConverter;
+import org.axonframework.conversion.avro.AvroConverterConfiguration;
+import org.axonframework.conversion.avro.AvroConverterStrategy;
 import org.axonframework.extension.spring.conversion.avro.AvroSchemaPackages;
 import org.axonframework.extension.spring.conversion.avro.AvroSchemaScan;
 import org.axonframework.extension.spring.conversion.avro.ClasspathAvroSchemaLoader;
 import org.axonframework.extension.spring.conversion.avro.SpecificRecordBaseClasspathAvroSchemaLoader;
+import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
@@ -30,16 +41,23 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ResourceLoader;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfigures required beans for the Avro {@link Converter}.
@@ -51,7 +69,89 @@ import java.util.stream.Collectors;
 @AutoConfiguration
 @AutoConfigureBefore(ConverterAutoConfiguration.class)
 @ConditionalOnClass(name = {"org.apache.avro.message.SchemaStore"})
-public class AvroSchemaStoreAutoConfiguration {
+@EnableConfigurationProperties(ConverterProperties.class)
+public class AvroSchemaStoreAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method to throw an {@link AxonConfigurationException}, indicating that the {@link AvroConverter} is
+     * not supported as general converter.
+     *
+     * @return always throws {@link AxonConfigurationException} to indicate misconfiguration
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "avro")
+    public Converter converter() {
+        throw new AxonConfigurationException(format(
+                "Invalid converter type [%s] configured as general converter. "
+                        + "The Avro Converter can be used as message or event converter only.",
+                ConverterProperties.ConverterType.AVRO
+        ));
+    }
+
+    /**
+     * Bean creation method constructing an {@link AvroConverter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param schemaStore         the Avro {@link SchemaStore} to be used
+     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "axon.converter.messages", havingValue = "avro")
+    public MessageConverter messageConverter(SchemaStore schemaStore,
+                                             Map<String, AvroConverterStrategy> converterStrategies) {
+        return new DelegatingMessageConverter(buildConverter(schemaStore, converterStrategies));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code avro}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code cbor}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' == 'avro'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing an {@link AvroConverter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param schemaStore         the Avro {@link SchemaStore} to be used
+     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' != 'avro'")
+    public EventConverter eventConverter(SchemaStore schemaStore,
+                                         Map<String, AvroConverterStrategy> converterStrategies) {
+        return new DelegatingEventConverter(buildConverter(schemaStore, converterStrategies));
+    }
+
+    private Converter buildConverter(SchemaStore schemaStore, Map<String, AvroConverterStrategy> converterStrategies) {
+        return new AvroConverter(
+                schemaStore,
+                (c) -> {
+                    AvroConverterConfiguration result = c;
+                    for (AvroConverterStrategy strategy : converterStrategies.values()) {
+                        result = result.addConverterStrategy(strategy);
+                    }
+                    return result;
+                },
+                new ChainingContentTypeConverter(classLoader)
+        );
+    }
 
     /**
      * Constructs a simple default in-memory schema store filled with schemas.
@@ -145,5 +245,17 @@ public class AvroSchemaStoreAutoConfiguration {
         static class SchemaStoreIsMissingCondition {
 
         }
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroSchemaStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/AvroSchemaStoreAutoConfiguration.java
@@ -18,22 +18,11 @@ package org.axonframework.extension.springboot.autoconfig;
 
 import org.apache.avro.Schema;
 import org.apache.avro.message.SchemaStore;
-import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.conversion.ChainingContentTypeConverter;
 import org.axonframework.conversion.Converter;
-import org.axonframework.conversion.avro.AvroConverter;
-import org.axonframework.conversion.avro.AvroConverterConfiguration;
-import org.axonframework.conversion.avro.AvroConverterStrategy;
 import org.axonframework.extension.spring.conversion.avro.AvroSchemaPackages;
 import org.axonframework.extension.spring.conversion.avro.AvroSchemaScan;
 import org.axonframework.extension.spring.conversion.avro.ClasspathAvroSchemaLoader;
 import org.axonframework.extension.spring.conversion.avro.SpecificRecordBaseClasspathAvroSchemaLoader;
-import org.axonframework.extension.springboot.ConverterProperties;
-import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
-import org.axonframework.messaging.core.conversion.MessageConverter;
-import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
-import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
@@ -41,23 +30,16 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ResourceLoader;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfigures required beans for the Avro {@link Converter}.
@@ -67,91 +49,9 @@ import static java.util.Objects.requireNonNull;
  * @since 4.11.0
  */
 @AutoConfiguration
-@AutoConfigureBefore(ConverterAutoConfiguration.class)
+@AutoConfigureBefore({ConverterAutoConfiguration.class, AvroConverterAutoConfiguration.class})
 @ConditionalOnClass(name = {"org.apache.avro.message.SchemaStore"})
-@EnableConfigurationProperties(ConverterProperties.class)
-public class AvroSchemaStoreAutoConfiguration implements BeanClassLoaderAware {
-
-    private ClassLoader classLoader;
-
-    /**
-     * Bean creation method to throw an {@link AxonConfigurationException}, indicating that the {@link AvroConverter} is
-     * not supported as general converter.
-     *
-     * @return always throws {@link AxonConfigurationException} to indicate misconfiguration
-     */
-    @Bean
-    @Primary
-    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
-    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "avro")
-    public Converter converter() {
-        throw new AxonConfigurationException(format(
-                "Invalid converter type [%s] configured as general converter. "
-                        + "The Avro Converter can be used as message or event converter only.",
-                ConverterProperties.ConverterType.AVRO
-        ));
-    }
-
-    /**
-     * Bean creation method constructing an {@link AvroConverter} as the {@link MessageConverter} to be used by Axon
-     * Framework.
-     *
-     * @param schemaStore         the Avro {@link SchemaStore} to be used
-     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
-     * @return the {@link MessageConverter} to be used by Axon Framework
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnProperty(name = "axon.converter.messages", havingValue = "avro")
-    public MessageConverter messageConverter(SchemaStore schemaStore,
-                                             Map<String, AvroConverterStrategy> converterStrategies) {
-        return new DelegatingMessageConverter(buildConverter(schemaStore, converterStrategies));
-    }
-
-    /**
-     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
-     * both use {@code avro}.
-     *
-     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
-     *                         use {@code cbor}
-     * @return the {@link EventConverter} to be used by Axon Framework
-     */
-    @Bean(name = "eventConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' == 'avro'")
-    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
-        return new DelegatingEventConverter(messageConverter);
-    }
-
-    /**
-     * Bean creation method constructing an {@link AvroConverter} as the {@link EventConverter} to be used by Axon
-     * Framework.
-     *
-     * @param schemaStore         the Avro {@link SchemaStore} to be used
-     * @param converterStrategies the {@link AvroConverterStrategy AvroConverterStrategies} to be used
-     * @return the {@link EventConverter} to be used by Axon Framework
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'avro' && '${axon.converter.messages}' != 'avro'")
-    public EventConverter eventConverter(SchemaStore schemaStore,
-                                         Map<String, AvroConverterStrategy> converterStrategies) {
-        return new DelegatingEventConverter(buildConverter(schemaStore, converterStrategies));
-    }
-
-    private Converter buildConverter(SchemaStore schemaStore, Map<String, AvroConverterStrategy> converterStrategies) {
-        return new AvroConverter(
-                schemaStore,
-                (c) -> {
-                    AvroConverterConfiguration result = c;
-                    for (AvroConverterStrategy strategy : converterStrategies.values()) {
-                        result = result.addConverterStrategy(strategy);
-                    }
-                    return result;
-                },
-                new ChainingContentTypeConverter(classLoader)
-        );
-    }
+public class AvroSchemaStoreAutoConfiguration {
 
     /**
      * Constructs a simple default in-memory schema store filled with schemas.
@@ -245,17 +145,5 @@ public class AvroSchemaStoreAutoConfiguration implements BeanClassLoaderAware {
         static class SchemaStoreIsMissingCondition {
 
         }
-    }
-
-    /**
-     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
-     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     */
-    @Override
-    public void setBeanClassLoader(ClassLoader classLoader) {
-        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORConverterAutoConfiguration.java
@@ -116,7 +116,7 @@ public class CBORConverterAutoConfiguration implements BeanClassLoaderAware {
      * by Axon Framework.
      *
      * @param cborMapper the {@link CBORMapper} to be used
-     * @return The {@link EventConverter} to be used by Axon Framework.
+     * @return the {@link EventConverter} to be used by Axon Framework
      */
     @Bean
     @ConditionalOnMissingBean
@@ -133,8 +133,8 @@ public class CBORConverterAutoConfiguration implements BeanClassLoaderAware {
      * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
      * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
      *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     * @param classLoader the class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}
      */
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORConverterAutoConfiguration.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.autoconfig;
+
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson.JacksonConverter;
+import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import tools.jackson.dataformat.cbor.CBORMapper;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Autoconfigures the CBOR based {@link JacksonConverter} if configured via the {@link ConverterProperties}.
+ *
+ * @author Jakob Hatzl
+ * @since 5.1.0
+ */
+@AutoConfiguration
+@AutoConfigureBefore(ConverterAutoConfiguration.class)
+@ConditionalOnClass(name = {"tools.jackson.dataformat.cbor.CBORMapper"})
+@EnableConfigurationProperties(value = ConverterProperties.class)
+public class CBORConverterAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the "general" {@link Converter} to be
+     * used by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "cbor")
+    public Converter converter(CBORMapper cborMapper) {
+        return buildConverter(cborMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code cbor}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code cbor}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' == 'cbor'")
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link MessageConverter} to be
+     * used by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' != 'cbor'")
+    public MessageConverter messageConverter(CBORMapper cborMapper) {
+        return new DelegatingMessageConverter(buildConverter(cborMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code cbor}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code cbor}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' == 'cbor'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link EventConverter} to be used
+     * by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return The {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' != 'cbor'")
+    public EventConverter eventConverter(CBORMapper cborMapper) {
+        return new DelegatingEventConverter(buildConverter(cborMapper));
+    }
+
+    private Converter buildConverter(CBORMapper cborMapper) {
+        return new JacksonConverter(cborMapper, new ChainingContentTypeConverter(classLoader));
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
@@ -46,7 +46,7 @@ public class CBORMapperAutoConfiguration {
      * <b>and</b> whenever the user specified the
      * {@link ConverterProperties.ConverterType#CBOR} {@code ConverterType}.
      *
-     * @return The default Axon Framework {@link CBORMapper}, if required.
+     * @return the default Axon Framework {@link CBORMapper}, if required
      */
     @Bean("defaultAxonCborMapper")
     @ConditionalOnMissingBean(CBORMapper.class)

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
@@ -16,15 +16,29 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Primary;
 import tools.jackson.dataformat.cbor.CBORMapper;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link CBORMapper}, typically to be used by a
@@ -37,7 +51,86 @@ import tools.jackson.dataformat.cbor.CBORMapper;
 @AutoConfigureBefore(ConverterAutoConfiguration.class)
 @ConditionalOnClass(name = {"tools.jackson.dataformat.cbor.CBORMapper"})
 @EnableConfigurationProperties(value = ConverterProperties.class)
-public class CBORMapperAutoConfiguration {
+public class CBORMapperAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the "general" {@link Converter} to be
+     * used by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "cbor")
+    public Converter converter(CBORMapper cborMapper) {
+        return buildConverter(cborMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code cbor}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code cbor}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' == 'cbor'")
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link MessageConverter} to be
+     * used by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' != 'cbor'")
+    public MessageConverter messageConverter(CBORMapper cborMapper) {
+        return new DelegatingMessageConverter(buildConverter(cborMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code cbor}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code cbor}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' == 'cbor'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link EventConverter} to be used
+     * by Axon Framework.
+     *
+     * @param cborMapper the {@link CBORMapper} to be used
+     * @return The {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' != 'cbor'")
+    public EventConverter eventConverter(CBORMapper cborMapper) {
+        return new DelegatingEventConverter(buildConverter(cborMapper));
+    }
+
+    private Converter buildConverter(CBORMapper cborMapper) {
+        return new JacksonConverter(cborMapper, new ChainingContentTypeConverter(classLoader));
+    }
 
     /**
      * Returns the default Axon Framework {@link CBORMapper}, if required.
@@ -50,8 +143,53 @@ public class CBORMapperAutoConfiguration {
      */
     @Bean("defaultAxonCborMapper")
     @ConditionalOnMissingBean(CBORMapper.class)
-    @ConditionalOnExpression("'${axon.converter.general}' == 'cbor' || '${axon.converter.events}' == 'cbor' || '${axon.converter.messages}' == 'cbor'")
+    @Conditional(CborConfiguredCondition.class)
     public CBORMapper defaultAxonCborMapper() {
         return CBORMapper.builder().findAndAddModules().build();
+    }
+
+    /**
+     * An {@link AnyNestedCondition} implementation, to support the following use cases:
+     * <ul>
+     *     <li>The {@code general} converter property is set to {@code cbor}</li>
+     *     <li>The {@code messages} converter property is set to {@code cbor}</li>
+     *     <li>The {@code events} converter property is set to {@code cbor}</li>
+     * </ul>
+     */
+    private static class CborConfiguredCondition extends AnyNestedCondition {
+
+        public CborConfiguredCondition() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+
+        @SuppressWarnings("unused")
+        @ConditionalOnProperty(name = "axon.converter.general", havingValue = "cbor")
+        static class GeneralJacksonCondition {
+
+        }
+
+        @SuppressWarnings("unused")
+        @ConditionalOnProperty(name = "axon.converter.messages", havingValue = "cbor")
+        static class MessagesJacksonCondition {
+
+        }
+
+        @SuppressWarnings("unused")
+        @ConditionalOnProperty(name = "axon.converter.events", havingValue = "cbor")
+        static class EventsJacksonCondition {
+
+        }
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/CBORMapperAutoConfiguration.java
@@ -16,29 +16,16 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
-import org.axonframework.conversion.ChainingContentTypeConverter;
-import org.axonframework.conversion.Converter;
-import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.extension.springboot.ConverterProperties;
-import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
-import org.axonframework.messaging.core.conversion.MessageConverter;
-import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
-import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Primary;
 import tools.jackson.dataformat.cbor.CBORMapper;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link CBORMapper}, typically to be used by a
@@ -48,89 +35,9 @@ import static java.util.Objects.requireNonNull;
  * @since 4.9.0
  */
 @AutoConfiguration
-@AutoConfigureBefore(ConverterAutoConfiguration.class)
+@AutoConfigureBefore({ConverterAutoConfiguration.class, CBORConverterAutoConfiguration.class})
 @ConditionalOnClass(name = {"tools.jackson.dataformat.cbor.CBORMapper"})
-@EnableConfigurationProperties(value = ConverterProperties.class)
-public class CBORMapperAutoConfiguration implements BeanClassLoaderAware {
-
-    private ClassLoader classLoader;
-
-    /**
-     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the "general" {@link Converter} to be
-     * used by Axon Framework.
-     *
-     * @param cborMapper the {@link CBORMapper} to be used
-     * @return the "general" {@link Converter} to be used by Axon Framework
-     */
-    @Bean
-    @Primary
-    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
-    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "cbor")
-    public Converter converter(CBORMapper cborMapper) {
-        return buildConverter(cborMapper);
-    }
-
-    /**
-     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
-     * case both use {@code cbor}.
-     *
-     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
-     *                         both use {@code cbor}
-     * @return the {@link MessageConverter} to be used by Axon Framework
-     */
-    @Bean(name = "messageConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' == 'cbor'")
-    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
-        return new DelegatingMessageConverter(generalConverter);
-    }
-
-    /**
-     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link MessageConverter} to be
-     * used by Axon Framework.
-     *
-     * @param cborMapper the {@link CBORMapper} to be used
-     * @return the {@link MessageConverter} to be used by Axon Framework
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.messages}' == 'cbor' && '${axon.converter.general}' != 'cbor'")
-    public MessageConverter messageConverter(CBORMapper cborMapper) {
-        return new DelegatingMessageConverter(buildConverter(cborMapper));
-    }
-
-    /**
-     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
-     * both use {@code cbor}.
-     *
-     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
-     *                         use {@code cbor}
-     * @return the {@link EventConverter} to be used by Axon Framework
-     */
-    @Bean(name = "eventConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' == 'cbor'")
-    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
-        return new DelegatingEventConverter(messageConverter);
-    }
-
-    /**
-     * Bean creation method constructing a CBOR based {@link JacksonConverter} as the {@link EventConverter} to be used
-     * by Axon Framework.
-     *
-     * @param cborMapper the {@link CBORMapper} to be used
-     * @return The {@link EventConverter} to be used by Axon Framework.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'cbor' && '${axon.converter.messages}' != 'cbor'")
-    public EventConverter eventConverter(CBORMapper cborMapper) {
-        return new DelegatingEventConverter(buildConverter(cborMapper));
-    }
-
-    private Converter buildConverter(CBORMapper cborMapper) {
-        return new JacksonConverter(cborMapper, new ChainingContentTypeConverter(classLoader));
-    }
+public class CBORMapperAutoConfiguration {
 
     /**
      * Returns the default Axon Framework {@link CBORMapper}, if required.
@@ -179,17 +86,5 @@ public class CBORMapperAutoConfiguration implements BeanClassLoaderAware {
         static class EventsJacksonCondition {
 
         }
-    }
-
-    /**
-     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
-     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     */
-    @Override
-    public void setBeanClassLoader(ClassLoader classLoader) {
-        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfiguration.java
@@ -30,9 +30,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 
 /**
- * Autoconfiguration class dedicated to configuring the {@link Converter}.
- * <p>
- * Users can influence the configuration through the {@link ConverterProperties}.
+ * Autoconfiguration class dedicated to configuring the delegation behaviour for default {@link MessageConverter}
+ * and {@link EventConverter}
  *
  * @author Steven van Beelen
  * @since 5.0.0

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfiguration.java
@@ -16,40 +16,18 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
-import org.apache.avro.message.SchemaStore;
-import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.conversion.ChainingContentTypeConverter;
-import org.axonframework.conversion.ContentTypeConverter;
 import org.axonframework.conversion.Converter;
-import org.axonframework.conversion.avro.AvroConverter;
-import org.axonframework.conversion.avro.AvroConverterConfiguration;
-import org.axonframework.conversion.avro.AvroConverterStrategy;
-import org.axonframework.conversion.jackson.JacksonConverter;
-import org.axonframework.conversion.jackson2.Jackson2Converter;
 import org.axonframework.extension.springboot.ConverterProperties;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.dataformat.cbor.CBORMapper;
-
-import java.util.Map;
-
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncludingAncestors;
 
 /**
  * Autoconfiguration class dedicated to configuring the {@link Converter}.
@@ -62,173 +40,35 @@ import static org.springframework.beans.factory.BeanFactoryUtils.beansOfTypeIncl
 @AutoConfiguration
 @AutoConfigureBefore(AxonAutoConfiguration.class)
 @EnableConfigurationProperties(ConverterProperties.class)
-public class ConverterAutoConfiguration implements ApplicationContextAware, BeanClassLoaderAware {
-
-    private ApplicationContext applicationContext;
-    private ClassLoader classLoader;
+public class ConverterAutoConfiguration {
 
     /**
-     * Bean creation method constructing the "general" {@link Converter} to be used by Axon Framework.
-     * <p>
-     * The type of {@code Converter} constructed depends on the given {@code converterProperties}.
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case it uses {@code default}.
      *
-     * @param converterProperties The properties dictating the type of {@link Converter} this bean creation method will
-     *                            construct.
-     * @return The "general" {@link Converter} to be used by Axon Framework.
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         it uses {@code default}
+     * @return the {@link MessageConverter} to be used by Axon Framework
      */
-    @Bean
-    @Primary
+    @Bean(name = "messageConverter")
     @ConditionalOnMissingBean
-    public Converter converter(ConverterProperties converterProperties) {
-        ConverterProperties.ConverterType generalConverterType = converterProperties.getGeneral();
-        if (ConverterProperties.ConverterType.AVRO == generalConverterType) {
-            throw new AxonConfigurationException(format(
-                    "Invalid converter type [%s] configured as general converter. "
-                            + "The Avro Converter can be used as message or event converter only.",
-                    generalConverterType.name()
-            ));
-        }
-        return buildConverter(generalConverterType);
+    @ConditionalOnProperty(name = "axon.converter.messages", havingValue = "default", matchIfMissing = true)
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
     }
 
     /**
-     * Bean creation method constructing the {@link MessageConverter} to be used by Axon Framework.
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * it uses {@code default}.
      *
-     * @param generalConverter    The "general" {@link Converter}, used to construct the {@link MessageConverter}
-     *                            whenever the {@link ConverterProperties#getMessages()} type equals the
-     *                            {@link ConverterProperties#getGeneral()} type.
-     * @param converterProperties The properties dictating the type of {@link MessageConverter} this bean creation
-     *                            method will construct.
-     * @return The {@link MessageConverter} to be used by Axon Framework.
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case it
+     *                         uses {@code default}
+     * @return the {@link EventConverter} to be used by Axon Framework.
      */
-    @Bean
+    @Bean(name = "eventConverter")
     @ConditionalOnMissingBean
-    public MessageConverter messageConverter(Converter generalConverter, ConverterProperties converterProperties) {
-        ConverterProperties.ConverterType messagesConverterType = converterProperties.getMessages();
-        if (ConverterProperties.ConverterType.DEFAULT == messagesConverterType
-                || converterProperties.getGeneral() == messagesConverterType) {
-            return new DelegatingMessageConverter(generalConverter);
-        } else {
-            return new DelegatingMessageConverter(buildConverter(messagesConverterType));
-        }
-    }
-
-    /**
-     * Bean creation method constructing the {@link EventConverter} to be used by Axon Framework.
-     *
-     * @param generalConverter    The "general" {@link Converter}, used to construct the {@link EventConverter} whenever
-     *                            the {@link ConverterProperties#getEvents()} type equals the
-     *                            {@link ConverterProperties#getGeneral()} type.
-     * @param messageConverter    The {@link MessageConverter}, used to construct the {@link EventConverter} whenever
-     *                            the {@link ConverterProperties#getEvents()} type equals the
-     *                            {@link ConverterProperties#getMessages()} type.
-     * @param converterProperties The properties dictating the type of {@link Converter} this bean creation method will
-     *                            construct.
-     * @return The {@link EventConverter} to be used by Axon Framework.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    public EventConverter eventConverter(Converter generalConverter,
-                                         MessageConverter messageConverter,
-                                         ConverterProperties converterProperties) {
-        ConverterProperties.ConverterType eventsConverterType = converterProperties.getEvents();
-        if (ConverterProperties.ConverterType.DEFAULT == eventsConverterType
-                || converterProperties.getMessages() == eventsConverterType) {
-            return new DelegatingEventConverter(messageConverter);
-        } else if (converterProperties.getGeneral() == eventsConverterType) {
-            return new DelegatingEventConverter(generalConverter);
-        }
-        return new DelegatingEventConverter(buildConverter(eventsConverterType));
-    }
-
-    private Converter buildConverter(ConverterProperties.ConverterType converterType) {
-        switch (converterType) {
-            case AVRO:
-                Map<String, SchemaStore> schemaStoreBeans =
-                        beansOfTypeIncludingAncestors(applicationContext, SchemaStore.class);
-                SchemaStore schemaStore = schemaStoreBeans.containsKey("defaultAxonSchemaStore")
-                        ? schemaStoreBeans.get("defaultAxonSchemaStore")
-                        : schemaStoreBeans.values()
-                                          .stream()
-                                          .findFirst()
-                                          .orElseThrow(() -> new NoSuchBeanDefinitionException(SchemaStore.class));
-
-                Map<String, AvroConverterStrategy> converterStrategies = beansOfTypeIncludingAncestors(
-                        applicationContext, AvroConverterStrategy.class);
-
-                return new AvroConverter(
-                        schemaStore,
-                        (c) -> {
-                            AvroConverterConfiguration result = c;
-                            for (AvroConverterStrategy strategy : converterStrategies.values()) {
-                                result = result.addConverterStrategy(strategy);
-                            }
-                            return result;
-                        },
-                        new ChainingContentTypeConverter(classLoader)
-                );
-
-            case CBOR:
-                Map<String, CBORMapper> cborMapperBeans =
-                        beansOfTypeIncludingAncestors(applicationContext, CBORMapper.class);
-                ObjectMapper cborMapper = cborMapperBeans.containsKey("defaultAxonCborObjectMapper")
-                        ? cborMapperBeans.get("defaultAxonCborObjectMapper")
-                        : cborMapperBeans.values()
-                                         .stream()
-                                         .findFirst()
-                                         .orElseThrow(() -> new NoSuchBeanDefinitionException(CBORMapper.class));
-                return new JacksonConverter(cborMapper, new ChainingContentTypeConverter(classLoader));
-            case JACKSON2:
-                Map<String, com.fasterxml.jackson.databind.ObjectMapper> jackson2MapperBeans =
-                        beansOfTypeIncludingAncestors(
-                                applicationContext, com.fasterxml.jackson.databind.ObjectMapper.class
-                        );
-                com.fasterxml.jackson.databind.ObjectMapper jackson2Mapper =
-                        jackson2MapperBeans.containsKey("defaultAxonJackson2Mapper")
-                                ? jackson2MapperBeans.get("defaultAxonJackson2Mapper")
-                                : jackson2MapperBeans.values()
-                                                     .stream()
-                                                     .findFirst()
-                                                     .orElseThrow(() -> new NoSuchBeanDefinitionException(
-                                                             com.fasterxml.jackson.databind.ObjectMapper.class
-                                                     ));
-                return new Jackson2Converter(jackson2Mapper, new ChainingContentTypeConverter(classLoader));
-            case JACKSON:
-            case DEFAULT:
-            default:
-                Map<String, ObjectMapper> objectMapperBeans =
-                        beansOfTypeIncludingAncestors(applicationContext, ObjectMapper.class);
-                ObjectMapper objectMapper = objectMapperBeans.containsKey("defaultAxonObjectMapper")
-                        ? objectMapperBeans.get("defaultAxonObjectMapper")
-                        : objectMapperBeans.values()
-                                           .stream()
-                                           .findFirst()
-                                           .orElseThrow(() -> new NoSuchBeanDefinitionException(ObjectMapper.class));
-                return new JacksonConverter(objectMapper, new ChainingContentTypeConverter(classLoader));
-        }
-    }
-
-    /**
-     * Sets the application context used to validate for the existence of other required properties to construct the
-     * specified {@link Converter Converters}.
-     *
-     * @param applicationContext The application context used to validate for the existence of other required properties
-     *                           to construct the specified {@link Converter Converters}.
-     */
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = requireNonNull(applicationContext, "The ApplicationContext cannot be null.");
-    }
-
-    /**
-     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
-     * {@link ContentTypeConverter ContentTypeConverters}.
-     *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link ContentTypeConverter ContentTypeConverters}.
-     */
-    @Override
-    public void setBeanClassLoader(ClassLoader classLoader) {
-        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
+    @ConditionalOnProperty(name = "axon.converter.events", havingValue = "default", matchIfMissing = true)
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
@@ -46,9 +46,11 @@ import static java.util.Objects.requireNonNull;
  * @since 5.1.0
  */
 @AutoConfiguration
-@AutoConfigureBefore({AxonAutoConfiguration.class,
+@AutoConfigureBefore({
+        AxonAutoConfiguration.class,
         ConverterAutoConfiguration.class,
-        CBORConverterAutoConfiguration.class})
+        CBORConverterAutoConfiguration.class
+})
 @AutoConfigureAfter(name = {
         "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
         "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
@@ -94,7 +94,7 @@ public class Jackson2ConverterAutoConfiguration implements BeanClassLoaderAware 
      * Framework.
      *
      * @param objectMapper the {@link ObjectMapper} to be used
-     * @return the {@link MessageConverter} to be used by Axon Framework.
+     * @return the {@link MessageConverter} to be used by Axon Framework
      */
     @Bean
     @ConditionalOnMissingBean
@@ -109,7 +109,7 @@ public class Jackson2ConverterAutoConfiguration implements BeanClassLoaderAware 
      *
      * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
      *                         use {@code jackson2}
-     * @return the {@link EventConverter} to be used by Axon Framework.
+     * @return the {@link EventConverter} to be used by Axon Framework
      */
     @Bean(name = "eventConverter")
     @ConditionalOnMissingBean
@@ -140,8 +140,8 @@ public class Jackson2ConverterAutoConfiguration implements BeanClassLoaderAware 
      * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
      * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
      *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     * @param classLoader the class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}
      */
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2ConverterAutoConfiguration.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.autoconfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson2.Jackson2Converter;
+import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Autoconfigures the {@link Jackson2Converter} if configured via the {@link ConverterProperties}.
+ *
+ * @author Jakob Hatzl
+ * @since 5.1.0
+ */
+@AutoConfiguration
+@AutoConfigureBefore({AxonAutoConfiguration.class,
+        ConverterAutoConfiguration.class,
+        CBORConverterAutoConfiguration.class})
+@AutoConfigureAfter(name = {
+        "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
+        "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
+})
+@ConditionalOnClass(name = "com.fasterxml.jackson.databind.ObjectMapper")
+@EnableConfigurationProperties(value = ConverterProperties.class)
+public class Jackson2ConverterAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the "general" {@link Converter} to be used by
+     * Axon Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2")
+    public Converter converter(ObjectMapper objectMapper) {
+        return buildConverter(objectMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code jackson2}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code jackson2}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' == 'jackson2'")
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' != 'jackson2'")
+    public MessageConverter messageConverter(ObjectMapper objectMapper) {
+        return new DelegatingMessageConverter(buildConverter(objectMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code jackson2}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code jackson2}
+     * @return the {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' == 'jackson2'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' != 'jackson2'")
+    public EventConverter eventConverter(ObjectMapper objectMapper) {
+        return new DelegatingEventConverter(buildConverter(objectMapper));
+    }
+
+    private Converter buildConverter(ObjectMapper objectMapper) {
+        return new Jackson2Converter(objectMapper, new ChainingContentTypeConverter(classLoader));
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
@@ -17,17 +17,29 @@
 package org.axonframework.extension.springboot.autoconfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson2.Jackson2Converter;
 import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Primary;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link ObjectMapper}, typically to be used by a
@@ -44,7 +56,86 @@ import org.springframework.context.annotation.Conditional;
 })
 @ConditionalOnClass(name = "com.fasterxml.jackson.databind.ObjectMapper")
 @EnableConfigurationProperties(value = ConverterProperties.class)
-public class Jackson2MapperAutoConfiguration {
+public class Jackson2MapperAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the "general" {@link Converter} to be used by
+     * Axon Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2")
+    public Converter converter(ObjectMapper objectMapper) {
+        return buildConverter(objectMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code jackson2}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code jackson2}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' == 'jackson2'")
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the {@link MessageConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' != 'jackson2'")
+    public MessageConverter messageConverter(ObjectMapper objectMapper) {
+        return new DelegatingMessageConverter(buildConverter(objectMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code jackson2}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code jackson2}
+     * @return the {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' == 'jackson2'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link Jackson2Converter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' != 'jackson2'")
+    public EventConverter eventConverter(ObjectMapper objectMapper) {
+        return new DelegatingEventConverter(buildConverter(objectMapper));
+    }
+
+    private Converter buildConverter(ObjectMapper objectMapper) {
+        return new Jackson2Converter(objectMapper, new ChainingContentTypeConverter(classLoader));
+    }
 
     /**
      * Returns the default Axon Framework {@link ObjectMapper}, if required.
@@ -66,8 +157,6 @@ public class Jackson2MapperAutoConfiguration {
     /**
      * An {@link AnyNestedCondition} implementation, to support the following use cases:
      * <ul>
-     *     <li>The {@code general} converter property is not set. This means Axon defaults to Jackson</li>
-     *     <li>The {@code general} converter property is set to {@code default}. This means Jackson will be used</li>
      *     <li>The {@code general} converter property is set to {@code jackson2}</li>
      *     <li>The {@code messages} converter property is set to {@code jackson2}</li>
      *     <li>The {@code events} converter property is set to {@code jackson2}</li>
@@ -80,13 +169,7 @@ public class Jackson2MapperAutoConfiguration {
         }
 
         @SuppressWarnings("unused")
-        @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2", matchIfMissing = true)
-        static class GeneralDefaultCondition {
-
-        }
-
-        @SuppressWarnings("unused")
-        @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2", matchIfMissing = true)
+        @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2")
         static class GeneralJacksonCondition {
 
         }
@@ -102,5 +185,17 @@ public class Jackson2MapperAutoConfiguration {
         static class EventsJacksonCondition {
 
         }
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
@@ -54,7 +54,7 @@ public class Jackson2MapperAutoConfiguration {
      * {@link ConverterProperties.ConverterType#DEFAULT} or {@link ConverterProperties.ConverterType#JACKSON}
      * {@code ConverterType}.
      *
-     * @return The default Axon Framework {@link ObjectMapper}, if required.
+     * @return the default Axon Framework {@link ObjectMapper}, if required
      */
     @Bean("defaultAxonJackson2Mapper")
     @ConditionalOnMissingBean

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/Jackson2MapperAutoConfiguration.java
@@ -17,29 +17,16 @@
 package org.axonframework.extension.springboot.autoconfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.axonframework.conversion.ChainingContentTypeConverter;
-import org.axonframework.conversion.Converter;
-import org.axonframework.conversion.jackson2.Jackson2Converter;
 import org.axonframework.extension.springboot.ConverterProperties;
-import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
-import org.axonframework.messaging.core.conversion.MessageConverter;
-import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
-import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Primary;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link ObjectMapper}, typically to be used by a
@@ -49,93 +36,15 @@ import static java.util.Objects.requireNonNull;
  * @since 5.0.3
  */
 @AutoConfiguration
-@AutoConfigureBefore({AxonAutoConfiguration.class, CBORMapperAutoConfiguration.class})
+@AutoConfigureBefore({AxonAutoConfiguration.class,
+        CBORMapperAutoConfiguration.class,
+        Jackson2ConverterAutoConfiguration.class})
 @AutoConfigureAfter(name = {
         "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
         "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
 })
 @ConditionalOnClass(name = "com.fasterxml.jackson.databind.ObjectMapper")
-@EnableConfigurationProperties(value = ConverterProperties.class)
-public class Jackson2MapperAutoConfiguration implements BeanClassLoaderAware {
-
-    private ClassLoader classLoader;
-
-    /**
-     * Bean creation method constructing a {@link Jackson2Converter} as the "general" {@link Converter} to be used by
-     * Axon Framework.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return the "general" {@link Converter} to be used by Axon Framework
-     */
-    @Bean
-    @Primary
-    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
-    @ConditionalOnProperty(name = "axon.converter.general", havingValue = "jackson2")
-    public Converter converter(ObjectMapper objectMapper) {
-        return buildConverter(objectMapper);
-    }
-
-    /**
-     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
-     * case both use {@code jackson2}.
-     *
-     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
-     *                         both use {@code jackson2}
-     * @return the {@link MessageConverter} to be used by Axon Framework
-     */
-    @Bean(name = "messageConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' == 'jackson2'")
-    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
-        return new DelegatingMessageConverter(generalConverter);
-    }
-
-    /**
-     * Bean creation method constructing a {@link Jackson2Converter} as the {@link MessageConverter} to be used by Axon
-     * Framework.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return the {@link MessageConverter} to be used by Axon Framework.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.messages}' == 'jackson2' && '${axon.converter.general}' != 'jackson2'")
-    public MessageConverter messageConverter(ObjectMapper objectMapper) {
-        return new DelegatingMessageConverter(buildConverter(objectMapper));
-    }
-
-    /**
-     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
-     * both use {@code jackson2}.
-     *
-     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
-     *                         use {@code jackson2}
-     * @return the {@link EventConverter} to be used by Axon Framework.
-     */
-    @Bean(name = "eventConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' == 'jackson2'")
-    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
-        return new DelegatingEventConverter(messageConverter);
-    }
-
-    /**
-     * Bean creation method constructing a {@link Jackson2Converter} as the {@link EventConverter} to be used by Axon
-     * Framework.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return the {@link EventConverter} to be used by Axon Framework
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson2' && '${axon.converter.messages}' != 'jackson2'")
-    public EventConverter eventConverter(ObjectMapper objectMapper) {
-        return new DelegatingEventConverter(buildConverter(objectMapper));
-    }
-
-    private Converter buildConverter(ObjectMapper objectMapper) {
-        return new Jackson2Converter(objectMapper, new ChainingContentTypeConverter(classLoader));
-    }
+public class Jackson2MapperAutoConfiguration {
 
     /**
      * Returns the default Axon Framework {@link ObjectMapper}, if required.
@@ -185,17 +94,5 @@ public class Jackson2MapperAutoConfiguration implements BeanClassLoaderAware {
         static class EventsJacksonCondition {
 
         }
-    }
-
-    /**
-     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
-     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     */
-    @Override
-    public void setBeanClassLoader(ClassLoader classLoader) {
-        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
@@ -45,9 +45,11 @@ import static java.util.Objects.requireNonNull;
  * @since 5.1.0
  */
 @AutoConfiguration
-@AutoConfigureBefore({AxonAutoConfiguration.class,
+@AutoConfigureBefore({
+        AxonAutoConfiguration.class,
         ConverterAutoConfiguration.class,
-        CBORConverterAutoConfiguration.class})
+        Jackson2ConverterAutoConfiguration.class
+})
 @AutoConfigureAfter(name = {
         "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
         "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.autoconfig;
+
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson.JacksonConverter;
+import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import tools.jackson.databind.ObjectMapper;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Autoconfigures the {@link JacksonConverter} if configured via the {@link ConverterProperties}.
+ *
+ * @author Jakob Hatzl
+ * @since 5.1.0
+ */
+@AutoConfiguration
+@AutoConfigureBefore({AxonAutoConfiguration.class,
+        ConverterAutoConfiguration.class,
+        CBORConverterAutoConfiguration.class})
+@AutoConfigureAfter(name = {
+        "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
+        "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
+})
+@ConditionalOnClass(name = "tools.jackson.databind.ObjectMapper")
+@EnableConfigurationProperties(value = ConverterProperties.class)
+public class JacksonConverterAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the "general" {@link Converter} to be used by
+     * Axon Framework.
+     * <p>
+     * This bean acts as fallback and gets created in case {@code axon.converter.general} is not set or set to
+     * {@code default}.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnExpression("'${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default'")
+    public Converter converter(ObjectMapper objectMapper) {
+        return buildConverter(objectMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code jackson/default}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code jackson/default}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("""
+            '${axon.converter.messages}' == 'jackson'
+            && ('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
+            """)
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return The {@link MessageConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("""
+            '${axon.converter.messages}' == 'jackson'
+            && !('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
+            """)
+    public MessageConverter messageConverter(ObjectMapper objectMapper) {
+        return new DelegatingMessageConverter(buildConverter(objectMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code jackson}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code jackson}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' == 'jackson'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return The {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' != 'jackson'")
+    public EventConverter eventConverter(ObjectMapper objectMapper) {
+        return new DelegatingEventConverter(buildConverter(objectMapper));
+    }
+
+    private Converter buildConverter(ObjectMapper objectMapper) {
+        return new JacksonConverter(objectMapper, new ChainingContentTypeConverter(classLoader));
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JacksonConverterAutoConfiguration.java
@@ -99,7 +99,7 @@ public class JacksonConverterAutoConfiguration implements BeanClassLoaderAware {
      * Framework.
      *
      * @param objectMapper the {@link ObjectMapper} to be used
-     * @return The {@link MessageConverter} to be used by Axon Framework.
+     * @return the {@link MessageConverter} to be used by Axon Framework
      */
     @Bean
     @ConditionalOnMissingBean
@@ -131,7 +131,7 @@ public class JacksonConverterAutoConfiguration implements BeanClassLoaderAware {
      * Framework.
      *
      * @param objectMapper the {@link ObjectMapper} to be used
-     * @return The {@link EventConverter} to be used by Axon Framework.
+     * @return the {@link EventConverter} to be used by Axon Framework
      */
     @Bean
     @ConditionalOnMissingBean
@@ -148,8 +148,8 @@ public class JacksonConverterAutoConfiguration implements BeanClassLoaderAware {
      * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
      * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
      *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     * @param classLoader the class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}
      */
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ObjectMapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ObjectMapperAutoConfiguration.java
@@ -16,24 +16,36 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.extension.spring.data.JacksonPageDeserializer;
 import org.axonframework.extension.springboot.ConverterProperties;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link ObjectMapper}, typically to be used by a
@@ -51,7 +63,96 @@ import tools.jackson.databind.module.SimpleModule;
 })
 @ConditionalOnClass(name = "tools.jackson.databind.ObjectMapper")
 @EnableConfigurationProperties(value = ConverterProperties.class)
-public class ObjectMapperAutoConfiguration {
+public class ObjectMapperAutoConfiguration implements BeanClassLoaderAware {
+
+    private ClassLoader classLoader;
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the "general" {@link Converter} to be used by
+     * Axon Framework.
+     * <p>
+     * This bean acts as fallback and gets created in case {@code axon.converter.general} is not set or set to
+     * {@code default}.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return the "general" {@link Converter} to be used by Axon Framework
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
+    @ConditionalOnExpression("'${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default'")
+    public Converter converter(ObjectMapper objectMapper) {
+        return buildConverter(objectMapper);
+    }
+
+    /**
+     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
+     * case both use {@code jackson/default}.
+     *
+     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
+     *                         both use {@code jackson/default}
+     * @return the {@link MessageConverter} to be used by Axon Framework
+     */
+    @Bean(name = "messageConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("""
+            '${axon.converter.messages}' == 'jackson'
+            && ('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
+            """)
+    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
+        return new DelegatingMessageConverter(generalConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the {@link MessageConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return The {@link MessageConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("""
+            '${axon.converter.messages}' == 'jackson'
+            && !('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
+            """)
+    public MessageConverter messageConverter(ObjectMapper objectMapper) {
+        return new DelegatingMessageConverter(buildConverter(objectMapper));
+    }
+
+    /**
+     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
+     * both use {@code jackson}.
+     *
+     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
+     *                         use {@code jackson}
+     * @return the {@link EventConverter} to be used by Axon Framework
+     */
+    @Bean(name = "eventConverter")
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' == 'jackson'")
+    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
+        return new DelegatingEventConverter(messageConverter);
+    }
+
+    /**
+     * Bean creation method constructing a {@link JacksonConverter} as the {@link EventConverter} to be used by Axon
+     * Framework.
+     *
+     * @param objectMapper the {@link ObjectMapper} to be used
+     * @return The {@link EventConverter} to be used by Axon Framework.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' != 'jackson'")
+    public EventConverter eventConverter(ObjectMapper objectMapper) {
+        return new DelegatingEventConverter(buildConverter(objectMapper));
+    }
+
+    private Converter buildConverter(ObjectMapper objectMapper) {
+        return new JacksonConverter(objectMapper, new ChainingContentTypeConverter(classLoader));
+    }
+
 
     /**
      * Returns the default Axon Framework {@link ObjectMapper}, if required.
@@ -66,6 +167,7 @@ public class ObjectMapperAutoConfiguration {
      * @return The default Axon Framework {@link ObjectMapper}, if required.
      */
     @Bean("defaultAxonObjectMapper")
+    @Primary
     @ConditionalOnMissingBean
     @Conditional(JacksonConfiguredCondition.class)
     public ObjectMapper defaultAxonObjectMapper(ObjectProvider<JacksonModule> modules) {
@@ -134,5 +236,17 @@ public class ObjectMapperAutoConfiguration {
         static class EventsJacksonCondition {
 
         }
+    }
+
+    /**
+     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
+     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     *
+     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
+     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
+     */
+    @Override
+    public void setBeanClassLoader(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ObjectMapperAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/ObjectMapperAutoConfiguration.java
@@ -16,26 +16,16 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
-import org.axonframework.conversion.ChainingContentTypeConverter;
-import org.axonframework.conversion.Converter;
-import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.extension.spring.data.JacksonPageDeserializer;
 import org.axonframework.extension.springboot.ConverterProperties;
-import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
-import org.axonframework.messaging.core.conversion.MessageConverter;
-import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
-import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Primary;
@@ -44,8 +34,6 @@ import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.module.SimpleModule;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Autoconfiguration that constructs a default {@link ObjectMapper}, typically to be used by a
@@ -56,103 +44,15 @@ import static java.util.Objects.requireNonNull;
  * @since 3.4.0
  */
 @AutoConfiguration
-@AutoConfigureBefore({AxonAutoConfiguration.class, CBORMapperAutoConfiguration.class})
+@AutoConfigureBefore({AxonAutoConfiguration.class,
+        CBORMapperAutoConfiguration.class,
+        JacksonConverterAutoConfiguration.class})
 @AutoConfigureAfter(name = {
         "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
         "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration"
 })
 @ConditionalOnClass(name = "tools.jackson.databind.ObjectMapper")
-@EnableConfigurationProperties(value = ConverterProperties.class)
-public class ObjectMapperAutoConfiguration implements BeanClassLoaderAware {
-
-    private ClassLoader classLoader;
-
-    /**
-     * Bean creation method constructing a {@link JacksonConverter} as the "general" {@link Converter} to be used by
-     * Axon Framework.
-     * <p>
-     * This bean acts as fallback and gets created in case {@code axon.converter.general} is not set or set to
-     * {@code default}.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return the "general" {@link Converter} to be used by Axon Framework
-     */
-    @Bean
-    @Primary
-    @ConditionalOnMissingBean(ignored = {MessageConverter.class, EventConverter.class})
-    @ConditionalOnExpression("'${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default'")
-    public Converter converter(ObjectMapper objectMapper) {
-        return buildConverter(objectMapper);
-    }
-
-    /**
-     * Bean creation method constructing a {@link MessageConverter} delegating to the "general" {@link Converter} in
-     * case both use {@code jackson/default}.
-     *
-     * @param generalConverter the "general" {@link Converter}, used to construct the {@link MessageConverter} in case
-     *                         both use {@code jackson/default}
-     * @return the {@link MessageConverter} to be used by Axon Framework
-     */
-    @Bean(name = "messageConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("""
-            '${axon.converter.messages}' == 'jackson'
-            && ('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
-            """)
-    public MessageConverter delegatingMessageConverter(Converter generalConverter) {
-        return new DelegatingMessageConverter(generalConverter);
-    }
-
-    /**
-     * Bean creation method constructing a {@link JacksonConverter} as the {@link MessageConverter} to be used by Axon
-     * Framework.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return The {@link MessageConverter} to be used by Axon Framework.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("""
-            '${axon.converter.messages}' == 'jackson'
-            && !('${axon.converter.general}' == 'jackson' || '${axon.converter.general:default}' == 'default')
-            """)
-    public MessageConverter messageConverter(ObjectMapper objectMapper) {
-        return new DelegatingMessageConverter(buildConverter(objectMapper));
-    }
-
-    /**
-     * Bean creation method constructing an {@link EventConverter} delegating to the {@link MessageConverter} in case
-     * both use {@code jackson}.
-     *
-     * @param messageConverter the {@link MessageConverter}, used to construct the {@link EventConverter} in case both
-     *                         use {@code jackson}
-     * @return the {@link EventConverter} to be used by Axon Framework
-     */
-    @Bean(name = "eventConverter")
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' == 'jackson'")
-    public EventConverter delegatingEventConverter(MessageConverter messageConverter) {
-        return new DelegatingEventConverter(messageConverter);
-    }
-
-    /**
-     * Bean creation method constructing a {@link JacksonConverter} as the {@link EventConverter} to be used by Axon
-     * Framework.
-     *
-     * @param objectMapper the {@link ObjectMapper} to be used
-     * @return The {@link EventConverter} to be used by Axon Framework.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("'${axon.converter.events}' == 'jackson' && '${axon.converter.messages}' != 'jackson'")
-    public EventConverter eventConverter(ObjectMapper objectMapper) {
-        return new DelegatingEventConverter(buildConverter(objectMapper));
-    }
-
-    private Converter buildConverter(ObjectMapper objectMapper) {
-        return new JacksonConverter(objectMapper, new ChainingContentTypeConverter(classLoader));
-    }
-
+public class ObjectMapperAutoConfiguration {
 
     /**
      * Returns the default Axon Framework {@link ObjectMapper}, if required.
@@ -236,17 +136,5 @@ public class ObjectMapperAutoConfiguration implements BeanClassLoaderAware {
         static class EventsJacksonCondition {
 
         }
-    }
-
-    /**
-     * Sets the class loader used by the {@link ChainingContentTypeConverter} to load
-     * {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     *
-     * @param classLoader The class loader used by the {@link ChainingContentTypeConverter} to load
-     *                    {@link org.axonframework.conversion.ContentTypeConverter ContentTypeConverters}.
-     */
-    @Override
-    public void setBeanClassLoader(ClassLoader classLoader) {
-        this.classLoader = requireNonNull(classLoader, "The ClassLoader cannot be null.");
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,17 +14,21 @@
 # limitations under the License.
 #
 
+org.axonframework.extension.springboot.autoconfig.AvroConverterAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.AvroSchemaStoreAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.AxonAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.AxonServerAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.AxonServerActuatorAutoConfiguration
 # TODO: include in config, see #3959 - org.axonframework.extension.springboot.autoconfig.AxonTimeoutAutoConfiguration
+org.axonframework.extension.springboot.autoconfig.CBORConverterAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.CBORMapperAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.ConverterAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.CorrelationDataProviderAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.EventProcessingAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.InfrastructureAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.InterceptorAutoConfiguration
+org.axonframework.extension.springboot.autoconfig.JacksonConverterAutoConfiguration
+org.axonframework.extension.springboot.autoconfig.Jackson2ConverterAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.Jackson2MapperAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.JdbcAutoConfiguration
 org.axonframework.extension.springboot.autoconfig.JdbcDeadLetterQueueAutoConfiguration

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -84,6 +84,15 @@ class AxonServerAutoConfigurationTest {
     }
 
     @Test
+    void disablingEventStoreViaProperty() {
+        testContext.withPropertyValues("axon.axonserver.event-store.enabled=false").run(
+                context -> {
+                    assertThat(context.getBean(AxonServerConfiguration.class).getEventStore().isEnabled())
+                            .isFalse();
+                });
+    }
+
+    @Test
     void axonServerConfigurationContainsApplicationIdAsComponentName() {
         String expectedComponentName = "my-awesome-app";
         testContext.withInitializer(context -> context.setId(expectedComponentName)).run(context -> {

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/ConverterAutoConfigurationTest.java
@@ -56,7 +56,9 @@ class ConverterAutoConfigurationTest {
 
     @BeforeEach
     void setUp() {
-        testContext = new ApplicationContextRunner().withUserConfiguration(TestContext.class);
+        testContext = new ApplicationContextRunner()
+                .withUserConfiguration(TestContext.class)
+                .withPropertyValues("axon.axonserver.enabled=false");
     }
 
     @Test
@@ -92,7 +94,6 @@ class ConverterAutoConfigurationTest {
     void defaultObjectMapperIsUsedForExpectedConverters() {
         // Jackson is used for all Converters.
         testContext.withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson",
                 "axon.converter.messages=jackson",
                 "axon.converter.events=jackson"
@@ -125,7 +126,6 @@ class ConverterAutoConfigurationTest {
     void customObjectMapperIsUsedForExpectedConverters() {
         // Jackson is used for general and events. CBOR for messages.
         testContext.withUserConfiguration(CustomMapperContext.class).withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson",
                 "axon.converter.messages=cbor",
                 "axon.converter.events=jackson"
@@ -155,7 +155,6 @@ class ConverterAutoConfigurationTest {
     void defaultCBORMapperIsUsedForExpectedConverters() {
         // Jackson is used for general, CBOR for messages and events.
         testContext.withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson",
                 "axon.converter.messages=cbor",
                 "axon.converter.events=cbor"
@@ -189,7 +188,6 @@ class ConverterAutoConfigurationTest {
     void customCBORMapperIsUsedForExpectedConverters() {
         // Jackson is used for general and events. CBOR for messages.
         testContext.withUserConfiguration(CustomMapperContext.class).withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson",
                 "axon.converter.messages=cbor",
                 "axon.converter.events=jackson"
@@ -218,7 +216,6 @@ class ConverterAutoConfigurationTest {
     void defaultAxonJackson2MapperIsUsedForExpectedConverters() {
         // Jackson is used for all Converters.
         testContext.withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson2",
                 "axon.converter.messages=jackson2",
                 "axon.converter.events=jackson2"
@@ -252,7 +249,6 @@ class ConverterAutoConfigurationTest {
     void customJackson2ObjectMapperIsUsedForExpectedConverters() {
         // Jackson is used for general and events. CBOR for messages.
         testContext.withUserConfiguration(CustomJackson2MapperContext.class).withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=jackson2",
                 "axon.converter.messages=cbor",
                 "axon.converter.events=jackson2"
@@ -296,7 +292,6 @@ class ConverterAutoConfigurationTest {
     @Test
     void noObjectMapperBeanIsCreatedIfNoJacksonConverterIsSpecified() {
         testContext.withUserConfiguration(JacksonlessTestContext.class).withPropertyValues(
-                "axon.axonserver.enabled=false",
                 "axon.converter.general=cbor",
                 "axon.converter.messages=avro",
                 "axon.converter.events=avro"
@@ -357,6 +352,7 @@ class ConverterAutoConfigurationTest {
     public static class CustomMapperContext {
 
         @Bean("testObjectMapper")
+        @Primary
         public ObjectMapper objectMapper() {
             return new ObjectMapper();
         }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/MessagingConfigurationDefaultsAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/MessagingConfigurationDefaultsAutoConfigurationTest.java
@@ -136,6 +136,10 @@ class MessagingConfigurationDefaultsAutoConfigurationTest {
     @EnableAutoConfiguration(
             exclude = {
                     ConverterAutoConfiguration.class,
+                    AvroConverterAutoConfiguration.class,
+                    CBORConverterAutoConfiguration.class,
+                    JacksonConverterAutoConfiguration.class,
+                    Jackson2ConverterAutoConfiguration.class,
                     JpaDeadLetterQueueAutoConfiguration.class,
                     JdbcDeadLetterQueueAutoConfiguration.class
             }
@@ -166,6 +170,10 @@ class MessagingConfigurationDefaultsAutoConfigurationTest {
     @EnableAutoConfiguration(
             exclude = {
                     ConverterAutoConfiguration.class,
+                    AvroConverterAutoConfiguration.class,
+                    CBORConverterAutoConfiguration.class,
+                    JacksonConverterAutoConfiguration.class,
+                    Jackson2ConverterAutoConfiguration.class,
                     JpaDeadLetterQueueAutoConfiguration.class,
                     JdbcDeadLetterQueueAutoConfiguration.class
             }


### PR DESCRIPTION
The `EventStoreConfiguration` inside `AxonServerConfiguration` caused a potential circular dependency by depending on configuration properties inside a configuration properties (making a circular dependency on `BoundConfigurationProperties`).

The `ConverterAutoConfiguration` led to a cyclic dependency on `BoundConfigurationProperties` due to triggering eager bean initialization when loading dependent beans through use of `BeanFactoryUtils.beansOfTypeIncludingAncestors`.

This PR aims to break these cyclic dependencies by restructuring the respective autoconfigurations:
* `AxonServerConfiguration`: remove the nested `ConfigurationProperties` (and fix the external configuration ability)
* `ConverterAutoConfiguration`: split the bean creation to the implementation specific autoconfiguration classes

While at it this adds a minor fix adjusting the config options for converters in the reference guide.

This fixes #4340 