### PR TITLE
[#4355] `ConcatenatingMessageStream` ensures it interacts with its first stream before calling `isCompleted`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
@@ -52,7 +52,8 @@ class ConcatenatingMessageStream<M extends Message> implements MessageStream<M> 
 
     @Override
     public Optional<Entry<M>> next() {
-        if (first.isCompleted() && first.error().isEmpty()) {
+        if (!first.hasNextAvailable()  // this may trigger a completition state change, so call **before** isCompleted
+                && first.isCompleted() && first.error().isEmpty()) {
             return second.next();
         }
         return first.next();

--- a/messaging/src/test/java/org/axonframework/messaging/core/ConcatenatingMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/ConcatenatingMessageStreamTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.core;
 
+import org.axonframework.messaging.core.MessageStream.Entry;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
@@ -24,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -197,5 +199,20 @@ class ConcatenatingMessageStreamTest extends MessageStreamTest<Message> {
 
             assertTrue(callbackCalled.getAndSet(false));
         }
+    }
+
+    @Test
+    void transitionToSecondaryStreamShouldBeImmediate() {
+        Message msg1 = createRandomMessage();
+        Message msg2 = createRandomMessage();
+
+        ConcatenatingMessageStream<Message> ms = new ConcatenatingMessageStream<>(
+            MessageStream.fromIterable(List.of(msg1)),
+            MessageStream.fromIterable(List.of(msg2))
+        );
+
+        assertThat(ms.next()).map(Entry::message).contains(msg1);
+        assertThat(ms.next()).map(Entry::message).contains(msg2);
+        assertThat(ms.next()).isEmpty();
     }
 }


### PR DESCRIPTION
Resolves #4355 