### PR TITLE
chore: use latest 2025.2.7 in docker-compose

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   axon-server:
-    image: docker.axoniq.io/axoniq/axonserver:2025.2.0
+    image: docker.axoniq.io/axoniq/axonserver:2025.2.7
     container_name: axon-framework-examples-axon-server
     ports:
       - "8024:8024"

--- a/examples/university-demo/docker-compose.yaml
+++ b/examples/university-demo/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   axon-server:
-    image: axoniq/axonserver:2025.2.0
+    image: axoniq/axonserver:2025.2.7
     hostname: axon-server
     ports:
       - "8024:8024"

--- a/extensions/spring/spring-boot-autoconfigure/test-docker-compose.yml
+++ b/extensions/spring/spring-boot-autoconfigure/test-docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   axonserver:
     container_name: axonserver-springboot
-    image: axoniq/axonserver:2025.2.0
+    image: axoniq/axonserver:2025.2.7
     hostname: axonserver
     ports:
       - 8024


### PR DESCRIPTION
Updating docker-compose files to use latest version of axon-server