### PR TITLE
fix(extensions/spring-boot): do not ignore `@Namespace` annotation on `@Component` with `@EventHandler` annotations if the matching `EventProcessorDefinition` is not present

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventHandlerSelectorTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventHandlerSelectorTest.java
@@ -171,6 +171,61 @@ class EventHandlerSelectorTest {
         }
     }
 
+    /**
+     * Tests that {@link Namespace} annotations are resolved automatically by
+     * {@link org.axonframework.extension.spring.config.DefaultProcessorModuleFactory} when no
+     * {@link EventProcessorDefinition} beans are registered. The processor name is derived directly from the
+     * {@code @Namespace} value on the handler type or its enclosing package, without requiring an explicit
+     * {@link EventProcessorDefinition#pooledStreamingMatching(String)} or custom selector definition.
+     */
+    @Nested
+    @SpringBootTest(
+            classes = {TestContext.class},
+            properties = {"axon.axonserver.enabled=false"},
+            webEnvironment = SpringBootTest.WebEnvironment.NONE
+    )
+    class AutomaticNamespaceResolutionTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        void handlerWithNamespaceOnTypeIsAssignedToNamespacedProcessorWithoutExplicitDefinition() {
+            QualifiedName expectedEventHandlerName = new QualifiedName("inventory-events");
+
+            AxonConfiguration axonConfiguration = context.getBean(AxonConfiguration.class);
+            Configuration moduleConfig = axonConfiguration.getModuleConfiguration(INVENTORY_PROCESSOR_NAME)
+                                                          .orElseThrow();
+
+            assertThat(moduleConfig.getComponents(EventProcessor.class)).isNotEmpty();
+            assertThat(
+                    moduleConfig.getOptionalComponent(EventProcessor.class, INVENTORY_PROCESSOR_NAME)
+            ).isPresent();
+            Map<String, EventHandlingComponent> ehcs = moduleConfig.getComponents(EventHandlingComponent.class);
+            assertThat(ehcs.size()).isEqualTo(1);
+            EventHandlingComponent ehc = ehcs.values().stream().toList().getFirst();
+            assertThat(ehc.supportedEvents()).contains(expectedEventHandlerName);
+        }
+
+        @Test
+        void handlerWithNamespaceOnPackageIsAssignedToNamespacedProcessorWithoutExplicitDefinition() {
+            QualifiedName expectedEventHandlerName = new QualifiedName("order-events");
+
+            AxonConfiguration axonConfiguration = context.getBean(AxonConfiguration.class);
+            Configuration moduleConfig = axonConfiguration.getModuleConfiguration(ORDERS_PROCESSOR_NAME)
+                                                          .orElseThrow();
+
+            assertThat(moduleConfig.getComponents(EventProcessor.class)).isNotEmpty();
+            assertThat(
+                    moduleConfig.getOptionalComponent(EventProcessor.class, ORDERS_PROCESSOR_NAME)
+            ).isPresent();
+            Map<String, EventHandlingComponent> ehcs = moduleConfig.getComponents(EventHandlingComponent.class);
+            assertThat(ehcs.size()).isEqualTo(1);
+            EventHandlingComponent ehc = ehcs.values().stream().toList().getFirst();
+            assertThat(ehc.supportedEvents()).contains(expectedEventHandlerName);
+        }
+    }
+
     @ContextConfiguration
     @EnableAutoConfiguration
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/DefaultProcessorModuleFactory.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/DefaultProcessorModuleFactory.java
@@ -17,8 +17,11 @@
 package org.axonframework.extension.spring.config;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.StringUtils;
+import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.extension.spring.BeanDefinitionUtils;
+import org.axonframework.messaging.core.annotation.Namespace;
 import org.axonframework.messaging.eventhandling.configuration.EventHandlingComponentsConfigurer;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
@@ -161,7 +164,15 @@ public class DefaultProcessorModuleFactory implements ProcessorModuleFactory {
      * <p>
      * This method evaluates the handler against all processor definitions. If exactly one definition matches, the
      * handler is assigned to that processor. If no definitions match, the handler is assigned to a processor named
-     * after its package. If multiple definitions match, an {@link AxonConfigurationException} is thrown.
+     * after its {@link Namespace} annotation value, or after its package if no namespace is present. If multiple
+     * definitions match, an {@link AxonConfigurationException} is thrown.
+     * <p>
+     * The resolution order is:
+     * <ol>
+     *     <li>Explicit {@link EventProcessorDefinition} selector match</li>
+     *     <li>{@link Namespace} annotation on the handler's type, enclosing classes, package, or module</li>
+     *     <li>Package name derived from the bean definition</li>
+     * </ol>
      *
      * @param handler The event handler descriptor.
      * @return The name of the processor this handler should be assigned to.
@@ -175,8 +186,10 @@ public class DefaultProcessorModuleFactory implements ProcessorModuleFactory {
             }
         }
         if (matches.isEmpty()) {
-            // we try to detect the package from the bean definition
-            return BeanDefinitionUtils.extractPackageName(handler.beanDefinition());
+            // First, check if the handler type has a @Namespace annotation
+            return resolveNamespace(handler)
+                    // Fall back to the package name derived from the bean definition
+                    .orElseGet(() -> BeanDefinitionUtils.extractPackageName(handler.beanDefinition()));
         }
         if (matches.size() == 1) {
             return matches.iterator().next();
@@ -184,6 +197,33 @@ public class DefaultProcessorModuleFactory implements ProcessorModuleFactory {
         throw new AxonConfigurationException(
                 "Handler [" + handler.beanName() + " (of type " + handler.beanDefinition().getBeanClassName()
                         + ")] matched with multiple processors selectors: " + matches);
+    }
+
+    /**
+     * Resolves the {@link Namespace} value from the handler's bean type.
+     * <p>
+     * The {@code Namespace} annotation is searched for on several levels in the following order:
+     * <ol>
+     *     <li>On the bean type itself</li>
+     *     <li>The enclosing classes (from innermost to outermost)</li>
+     *     <li>The package (via {@code package-info.java})</li>
+     *     <li>The module</li>
+     * </ol>
+     *
+     * @param handler The event handler descriptor.
+     * @return An Optional containing the namespace value if found, or empty if not found.
+     */
+    private Optional<String> resolveNamespace(EventProcessorDefinition.EventHandlerDescriptor handler) {
+        Class<?> type = handler.beanType();
+        if (type == null) {
+            return Optional.empty();
+        }
+        return AnnotationUtils.findAnnotationAttributesOnType(
+                                       type,
+                                       Namespace.class,
+                                       attrs -> !StringUtils.emptyOrNull((String) attrs.get("namespace"))
+                               )
+                               .map(attrs -> (String) attrs.get("namespace"));
     }
 
     /**


### PR DESCRIPTION
## Spring Boot: `@Namespace` annotation ignored without explicit `EventProcessorDefinition`

### Problem

When a Spring `@Component` with `@EventHandler` methods is annotated with `@Namespace("my-processor")`, the processor name is only derived from the namespace if an `EventProcessorDefinition` bean with a matching `matchesNamespaceOnType()` selector is registered. Without such a definition, `DefaultProcessorModuleFactory` silently falls back to the handler's package name, effectively ignoring the `@Namespace` annotation.

This forces users to always register boilerplate `EventProcessorDefinition` beans like:

```java
@Bean
EventProcessorDefinition myProcessor() {
    return EventProcessorDefinition.pooledStreamingMatching("my-processor").notCustomized();
}
```

even when they don't need any custom processor configuration — just a readable processor name.

In Axon Framework 4 this was achieved with `@ProcessingGroup("my-processor")` alone, with no additional configuration needed.

### Solution

Modified `DefaultProcessorModuleFactory.assignedProcessor()` to resolve `@Namespace` before falling back to the package name.

**Resolution order (updated):**
1. Explicit `EventProcessorDefinition` selector match (unchanged)
2. **`@Namespace` annotation** on the handler's type, enclosing classes, package, or module (**new**)
3. Package name derived from the bean definition (unchanged)

The new `resolveNamespace()` method reuses the same `AnnotationUtils.findAnnotationAttributesOnType()` lookup that `EventHandlerSelector.matchesNamespaceOnType()` already uses, ensuring consistent annotation search order (type → enclosing classes → package → module).

### Example

Before (required boilerplate):
```java
@Namespace("ReadModel_GetAllDwellings")
@Component
class DwellingReadModelProjector { ... }

// Required — otherwise @Namespace is ignored:
@Bean
EventProcessorDefinition dwellingProcessor() {
    return EventProcessorDefinition.pooledStreamingMatching("ReadModel_GetAllDwellings").notCustomized();
}
```

After (annotation alone is sufficient):
```java
@Namespace("ReadModel_GetAllDwellings")
@Component
class DwellingReadModelProjector { ... }

// No EventProcessorDefinition needed — processor is named "ReadModel_GetAllDwellings" automatically
```

YAML configuration references the namespace name directly:
```yaml
axon:
  eventhandling:
    processors:
      ReadModel_GetAllDwellings:
        dlq:
          enabled: true
```