### PR TITLE
Align `DistributedQueryBusConfiguration` with `DistributedCommandBusConfiguration`

### DIFF
--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryIT.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/query/StreamingQueryIT.java
@@ -149,7 +149,7 @@ class StreamingQueryIT {
         return new DistributedQueryBus(
                 localSegment,
                 payloadConvertingQueryBusConnector,
-                new DistributedQueryBusConfiguration()
+                DistributedQueryBusConfiguration.DEFAULT
         );
     }
 

--- a/docs/reference-guide/modules/queries/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/queries/pages/infrastructure.adoc
@@ -79,7 +79,7 @@ import org.axonframework.messaging.queryhandling.distributed.DistributedQueryBus
 public class AxonConfig {
     public void configureQueryBus(MessagingConfigurer configurer) {
         // Customize the configuration
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration()
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT
                 .queryThreads(20)                        // Set number of query processing threads
                 .queryQueueCapacity(2000)                // Set queue capacity
                 .preferLocalQueryHandler(true);         // Enable local handler shortcut (default)
@@ -94,7 +94,7 @@ To disable the local handler shortcut:
 
 [source,java]
 ----
-DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration()
+DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT
         .preferLocalQueryHandler(false);  // Force all queries through connector
 ----
 --
@@ -123,7 +123,7 @@ public class AxonConfig {
 
     @Bean
     public DistributedQueryBusConfiguration queryBusConfiguration() {
-        return new DistributedQueryBusConfiguration()
+        return DistributedQueryBusConfiguration.DEFAULT
                 .queryThreads(20)
                 .preferLocalQueryHandler(true);
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/QueryThreadingIntegrationTest.java
@@ -108,7 +108,7 @@ class QueryThreadingIntegrationTest {
         // The application having a query that depends on another one
         QueryBus localQueryBus = QueryBusTestUtils.aQueryBus();
         connector = new AxonServerQueryBusConnector(connectionManager.getConnection(), configuration);
-        DistributedQueryBusConfiguration queryBusConfig = new DistributedQueryBusConfiguration().queryThreads(5);
+        DistributedQueryBusConfiguration queryBusConfig = DistributedQueryBusConfiguration.DEFAULT.queryThreads(5);
         queryBus1 = new DistributedQueryBus(localQueryBus,
                                             new PayloadConvertingQueryBusConnector(connector,
                                                                                    messageConverter,

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfiguration.java
@@ -20,76 +20,80 @@ import org.axonframework.common.AxonThreadFactory;
 import org.axonframework.common.util.ExecutorServiceFactory;
 
 import java.util.Objects;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
+
+import static org.axonframework.common.BuilderUtils.assertStrictPositive;
 
 /**
  * Configuration for the {@link DistributedQueryBus}.
  * <p>
  * Can be used to modify non-critical settings of the bus, such as the query and query response thread pools.
  *
+ * @param queryThreads            The number of threads used by the {@link DistributedQueryBus}.
+ * @param queryQueueCapacity      The initial capacity of the priority queue used for query processing tasks.
+ * @param executorServiceFactory   The {@link ExecutorServiceFactory} constructing the priority-aware
+ *                                {@link ExecutorService} for the {@link DistributedQueryBus}.
+ * @param preferLocalQueryHandler Whether to use local query handlers directly when available, bypassing remote
+ *                                dispatch.
  * @author Steven van Beelen
+ * @author Allard Buijze
  * @since 5.0.0
  */
-public final class DistributedQueryBusConfiguration {
+public record DistributedQueryBusConfiguration(
+        int queryThreads,
+        int queryQueueCapacity,
+        ExecutorServiceFactory<DistributedQueryBusConfiguration> executorServiceFactory,
+        boolean preferLocalQueryHandler
+) {
 
     private static final int DEFAULT_QUERY_THREADS = 10;
     private static final int DEFAULT_QUERY_QUEUE_CAPACITY = 1000;
-    private static final Function<Integer, ExecutorServiceFactory<DistributedQueryBusConfiguration>> DEFAULT_QUERY_EXECUTOR_SERVICE_FACTORY =
-            (threads) -> (config, queue) -> new ThreadPoolExecutor(
-                    threads,
-                    threads,
+    private static final ExecutorServiceFactory<DistributedQueryBusConfiguration> DEFAULT_EXECUTOR_SERVICE_FACTORY =
+            (configuration, queue) -> new ThreadPoolExecutor(
+                    configuration.queryThreads(),
+                    configuration.queryThreads(),
                     0L,
                     TimeUnit.MILLISECONDS,
                     queue,
                     new AxonThreadFactory("QueryProcessor")
             );
-    private final ExecutorServiceFactory<DistributedQueryBusConfiguration> queryExecutorServiceFactory;
-    private final Supplier<BlockingQueue<Runnable>> queue;
-    private final boolean preferLocalQueryHandler;
-
-    private DistributedQueryBusConfiguration(
-            ExecutorServiceFactory<DistributedQueryBusConfiguration> queryExecutorServiceFactory,
-            Supplier<BlockingQueue<Runnable>> queue,
-            boolean preferLocalQueryHandler) {
-        this.queryExecutorServiceFactory = queryExecutorServiceFactory;
-        this.queue = queue;
-        this.preferLocalQueryHandler = preferLocalQueryHandler;
-    }
 
     /**
-     * Constructs a default {@code DistributedQueryBusConfiguration} with the following settings:
-     * <ul>
-     *     <li>Query threads: 10</li>
-     *     <li>Query queue capacity: 1000</li>
-     *     <li>Prefer local query handler: {@code true}</li>
-     * </ul>
+     * Compact constructor validating that the given {@code queryThreads} and {@code queryQueueCapacity} are strictly
+     * positive.
      */
-    public DistributedQueryBusConfiguration() {
-        this(DEFAULT_QUERY_EXECUTOR_SERVICE_FACTORY.apply(DEFAULT_QUERY_THREADS),
-             () -> new PriorityBlockingQueue<>(DEFAULT_QUERY_QUEUE_CAPACITY),
-             true);
+    @SuppressWarnings("MissingJavadoc")
+    public DistributedQueryBusConfiguration {
+        assertStrictPositive(queryThreads, "Number of query threads must be greater than 0.");
+        assertStrictPositive(queryQueueCapacity, "Query queue capacity must be greater than 0.");
     }
 
     /**
-     * Registers an Executor Service that uses a thread pool with the given amount of {@code queryThreads}.
+     * A default instance of the {@link DistributedQueryBusConfiguration}, setting the {@link #queryThreads()} to 10,
+     * the {@link #queryQueueCapacity()} to 1000, the {@link #executorServiceFactory()} to a priority-aware
+     * {@link ExecutorServiceFactory} using the configured number of threads, and {@link #preferLocalQueryHandler()} to
+     * {@code true}.
+     */
+    public static final DistributedQueryBusConfiguration DEFAULT = new DistributedQueryBusConfiguration(
+            DEFAULT_QUERY_THREADS, DEFAULT_QUERY_QUEUE_CAPACITY, DEFAULT_EXECUTOR_SERVICE_FACTORY, true
+    );
+
+    /**
+     * Sets the number of threads to use for the distributed query bus.
      * <p>
-     * Defaults to a pool with 10 threads.
+     * Defaults to 10.
      *
      * @param queryThreads the number of threads to use for the distributed query bus
      * @return the configuration itself, for fluent API usage
      */
     public DistributedQueryBusConfiguration queryThreads(int queryThreads) {
-        return new DistributedQueryBusConfiguration(DEFAULT_QUERY_EXECUTOR_SERVICE_FACTORY.apply(queryThreads),
-                                                    queue,
-                                                    preferLocalQueryHandler);
+        return new DistributedQueryBusConfiguration(
+                queryThreads, queryQueueCapacity, DEFAULT_EXECUTOR_SERVICE_FACTORY, preferLocalQueryHandler
+        );
     }
-
 
     /**
      * Sets the capacity of the priority queue used for query processing tasks.
@@ -100,9 +104,9 @@ public final class DistributedQueryBusConfiguration {
      * @return the configuration itself, for fluent API usage
      */
     public DistributedQueryBusConfiguration queryQueueCapacity(int queryQueueCapacity) {
-        return new DistributedQueryBusConfiguration(queryExecutorServiceFactory,
-                                                    () -> new PriorityBlockingQueue<>(queryQueueCapacity),
-                                                    preferLocalQueryHandler);
+        return new DistributedQueryBusConfiguration(
+                queryThreads, queryQueueCapacity, executorServiceFactory, preferLocalQueryHandler
+        );
     }
 
     /**
@@ -115,9 +119,9 @@ public final class DistributedQueryBusConfiguration {
      */
     public DistributedQueryBusConfiguration queryExecutorService(ExecutorService executorService) {
         Objects.requireNonNull(executorService, "The ExecutorService may not be null.");
-        return new DistributedQueryBusConfiguration((config, queue) -> executorService,
-                                                    queue,
-                                                    preferLocalQueryHandler);
+        return new DistributedQueryBusConfiguration(
+                queryThreads, queryQueueCapacity, (config, queue) -> executorService, preferLocalQueryHandler
+        );
     }
 
     /**
@@ -136,17 +140,9 @@ public final class DistributedQueryBusConfiguration {
      * @return the updated instance of {@code DistributedQueryBusConfiguration}, allowing for fluent API usage
      */
     public DistributedQueryBusConfiguration preferLocalQueryHandler(boolean preferLocalQueryHandler) {
-        return new DistributedQueryBusConfiguration(queryExecutorServiceFactory, queue, preferLocalQueryHandler);
-    }
-
-    /**
-     * Indicates whether local query handlers are used directly when available, bypassing remote dispatch.
-     *
-     * @return {@code true} if local handlers are used directly when available, {@code false} if all queries are
-     * dispatched through the connector
-     */
-    public boolean preferLocalQueryHandler() {
-        return preferLocalQueryHandler;
+        return new DistributedQueryBusConfiguration(
+                queryThreads, queryQueueCapacity, executorServiceFactory, preferLocalQueryHandler
+        );
     }
 
     /**
@@ -156,6 +152,6 @@ public final class DistributedQueryBusConfiguration {
      * @return the {@link ExecutorService} for query processing
      */
     public ExecutorService queryExecutorService() {
-        return queryExecutorServiceFactory.createExecutorService(this, queue.get());
+        return executorServiceFactory.createExecutorService(this, new PriorityBlockingQueue<>(queryQueueCapacity));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfigurationEnhancer.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfigurationEnhancer.java
@@ -52,7 +52,7 @@ public class DistributedQueryBusConfigurationEnhancer implements ConfigurationEn
             componentRegistry
                     .registerIfNotPresent(
                             DistributedQueryBusConfiguration.class,
-                            (c) -> new DistributedQueryBusConfiguration(),
+                            c -> DistributedQueryBusConfiguration.DEFAULT,
                             SearchScope.ALL
                     )
                     .registerDecorator(forType(QueryBus.class).with(queryBusDecoratorDefinition())

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusConfigurationTest.java
@@ -36,7 +36,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void defaultConfigurationHasExpectedValues() {
         // Given / When
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // Then
         assertTrue(config.preferLocalQueryHandler(),
@@ -58,7 +58,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void queryThreadsCreatesExecutorWithCorrectThreadCount() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         DistributedQueryBusConfiguration customConfig = config.queryThreads(42);
@@ -82,7 +82,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void queryQueueCapacityCreatesQueueWithCorrectCapacity() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         DistributedQueryBusConfiguration customConfig = config.queryQueueCapacity(500);
@@ -105,7 +105,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void queryExecutorServiceUsesProvidedExecutor() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
         ExecutorService customExecutor = Executors.newSingleThreadExecutor();
 
         // When
@@ -123,7 +123,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void queryExecutorServiceRejectsNullExecutor() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When / Then
         //noinspection DataFlowIssue
@@ -135,7 +135,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void preferLocalQueryHandlerStoresCorrectValue() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         DistributedQueryBusConfiguration disabledConfig = config.preferLocalQueryHandler(false);
@@ -158,7 +158,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void fluentChainingPreservesAllSettings() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         DistributedQueryBusConfiguration customConfig = config
@@ -183,7 +183,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void configurationIsImmutable() {
         // Given
-        DistributedQueryBusConfiguration original = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration original = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         DistributedQueryBusConfiguration modified1 = original.queryThreads(5);
@@ -214,7 +214,7 @@ class DistributedQueryBusConfigurationTest {
     @Test
     void multipleCallsToQueryExecutorServiceReturnDifferentInstances() {
         // Given
-        DistributedQueryBusConfiguration config = new DistributedQueryBusConfiguration();
+        DistributedQueryBusConfiguration config = DistributedQueryBusConfiguration.DEFAULT;
 
         // When
         ExecutorService executor1 = config.queryExecutorService();

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/distributed/DistributedQueryBusTest.java
@@ -69,7 +69,7 @@ class DistributedQueryBusTest {
     void setUp() {
         localSegment = new SimpleQueryBus(UnitOfWorkTestUtils.SIMPLE_FACTORY);
         connector = new StubQueryBusConnector();
-        configuration = new DistributedQueryBusConfiguration();
+        configuration = DistributedQueryBusConfiguration.DEFAULT;
     }
 
     @Test


### PR DESCRIPTION
This pull request aligns the `DistributedQueryBusConfiguration` with the `DistributedCommandBusConfiguration` version. 
Low-hanging fruit, although mostly important for ease-of-use by Platform, to have a single approach for decorating both components.