### PR TITLE
test(messaging): fix command-threads property test using wrong prefix and weak assertion

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/AxonServerAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/AxonServerAutoConfigurationTest.java
@@ -107,13 +107,14 @@ class AxonServerAutoConfigurationTest {
 
     @Test
     void distributedCommandBusThreadCountIsAdjustableThroughAxonServerConfiguration() {
-        testContext.withPropertyValues("axon.server.command-threads=42").run(context -> {
+        testContext.withPropertyValues("axon.axonserver.command-threads=42").run(context -> {
             assertThat(context).hasSingleBean(AxonServerConfiguration.class);
             assertThat(context).hasSingleBean(DistributedCommandBusConfiguration.class);
 
             int numberOfThreads = context.getBean(DistributedCommandBusConfiguration.class).commandThreads();
             int commandThreads = context.getBean(AxonServerConfiguration.class).getCommandThreads();
-            assertThat(numberOfThreads).isEqualTo(commandThreads);
+            assertThat(commandThreads).isEqualTo(42);
+            assertThat(numberOfThreads).isEqualTo(42);
         });
     }
 


### PR DESCRIPTION
The test for adjusting command bus thread count via AxonServerConfiguration used 'axon.server.command-threads' instead of 'axon.axonserver.command-threads', so the property was never applied. The assertion only checked that two default values (both 10) were equal, masking the failure. Fixed the prefix and asserted both values equal the configured 42.