### PR TITLE
Use revision property for POM versioning

### DIFF
--- a/axon-framework-bom/pom.xml
+++ b/axon-framework-bom/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-framework-bom</artifactId>

--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/build/coverage-report/pom.xml
+++ b/build/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/conversion/pom.xml
+++ b/conversion/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -55,6 +55,20 @@
     </modules>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>org.axonframework.examples</groupId>

--- a/examples/university-demo/pom.xml
+++ b/examples/university-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>university-demo</artifactId>

--- a/examples/university-java-springboot-3/pom.xml
+++ b/examples/university-java-springboot-3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>university-java-springboot-3</artifactId>

--- a/examples/university-java-springboot-4/pom.xml
+++ b/examples/university-java-springboot-4/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>university-java-springboot-4</artifactId>

--- a/examples/university-java/pom.xml
+++ b/examples/university-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>university-java</artifactId>

--- a/extensions/metrics/metrics-dropwizard/pom.xml
+++ b/extensions/metrics/metrics-dropwizard/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.metrics</groupId>
         <artifactId>axon-metrics-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-metrics-dropwizard</artifactId>

--- a/extensions/metrics/metrics-micrometer/pom.xml
+++ b/extensions/metrics/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.metrics</groupId>
         <artifactId>axon-metrics-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-metrics-micrometer</artifactId>

--- a/extensions/metrics/pom.xml
+++ b/extensions/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions</groupId>
         <artifactId>axon-extensions</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>org.axonframework.extensions.metrics</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/extensions/reactor/axon-reactor/pom.xml
+++ b/extensions/reactor/axon-reactor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.reactor</groupId>
         <artifactId>axon-reactor-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-reactor</artifactId>

--- a/extensions/reactor/pom.xml
+++ b/extensions/reactor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions</groupId>
         <artifactId>axon-extensions</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>org.axonframework.extensions.reactor</groupId>

--- a/extensions/spring/pom.xml
+++ b/extensions/spring/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions</groupId>
         <artifactId>axon-extensions</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>org.axonframework.extensions.spring</groupId>

--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.spring</groupId>
         <artifactId>axon-spring-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-spring-boot-autoconfigure</artifactId>

--- a/extensions/spring/spring-boot-starter-test/pom.xml
+++ b/extensions/spring/spring-boot-starter-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.spring</groupId>
         <artifactId>axon-spring-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-spring-boot-starter-test</artifactId>

--- a/extensions/spring/spring-boot-starter/pom.xml
+++ b/extensions/spring/spring-boot-starter/pom.xml
@@ -20,11 +20,10 @@
     <parent>
         <groupId>org.axonframework.extensions.spring</groupId>
         <artifactId>axon-spring-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-spring-boot-starter</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
 
     <name>Axon Extension - Spring - SpringBoot Starter</name>
     <description>

--- a/extensions/spring/spring/pom.xml
+++ b/extensions/spring/spring/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.spring</groupId>
         <artifactId>axon-spring-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-spring</artifactId>

--- a/extensions/tracing/pom.xml
+++ b/extensions/tracing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions</groupId>
         <artifactId>axon-extensions</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <groupId>org.axonframework.extensions.tracing</groupId>

--- a/extensions/tracing/tracing-opentelemetry/pom.xml
+++ b/extensions/tracing/tracing-opentelemetry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework.extensions.tracing</groupId>
         <artifactId>axon-tracing-extension</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>axon-tracing-opentelemetry</artifactId>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/modelling/pom.xml
+++ b/modelling/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.axonframework</groupId>
     <artifactId>axon</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <modules>
         <module>build/parent</module>
@@ -70,6 +70,7 @@
     </organization>
 
     <properties>
+        <revision>5.1.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/stash/legacy-aggregate/pom.xml
+++ b/stash/legacy-aggregate/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/stash/legacy-saga/pom.xml
+++ b/stash/legacy-saga/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/stash/legacy/pom.xml
+++ b/stash/legacy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/stash/migration/pom.xml
+++ b/stash/migration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/stash/todo/pom.xml
+++ b/stash/todo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 

--- a/update/pom.xml
+++ b/update/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../build/parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Minor improvement to use the revision property for POM versioning and fix a build warning for the examples (inspired by @jangalinski). 