### PR TITLE
Add flattened pom files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/_playbook/build
 
 # just - console helper
 .justfile
+.flattened-pom.xml


### PR DESCRIPTION
After introducing the maven flatten plugin, maven generates `.flattened-pom.xml` for every pom during the build. We don't want that to be version controlled. 