### PR TITLE
Repository Transfer notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 > The team is actively constructing a several open-core licensed modules for Axon Framework.
 > These are best placed under the AxonIQ GitHub organization due to their licensing.
 >
-> User of the Axon Framework repository will not experience any disruptions from this transfer.
+> Users of the Axon Framework repository will not experience any disruptions from this transfer.
 > GitHub automatically redirects all links, clones, and references from the old location to the new one.
 > Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ our [Privacy Policy](https://www.axoniq.io/privacy-policy) for any privacy conce
 
 ## Repository Transferred
 
-The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
+The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [Axoniq GitHub organization](https://github.com/AxonIQ).
 This switch makes project management easier for the team, due to our active use of GitHub Project boards.
 
 GitHub Project boards do not allow merging repositories between different organizations in a single board.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 > The Axon Framework team decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
 > This switch makes project management easier for the team, following from our active use of GitHub Project boards.
 >
-> GitHub Project boards do not allow to merge repositories between different organizations in a single board.
+> GitHub Project boards do not allow merging repositories between different organizations in a single board.
 > The team is actively constructing several open-core licensed modules for Axon Framework.
 > These are best placed under the AxonIQ GitHub organization due to their licensing.
 >

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 > [!NOTE]
 > ## Repository Transferred
 >
-> The Axon Framework team decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
+> The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
 > This switch makes project management easier for the team, following from our active use of GitHub Project boards.
 >
 > GitHub Project boards do not allow merging repositories between different organizations in a single board.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,6 @@ Your existing forks, stars, and bookmarks will continue to work seamlessly, rega
 However, it is recommended to update existing local clones to the new repository URL.
 You can do this by using `git remote` on the command line:
 
-```
+```shell
 git remote set-url origin https://github.com/AxonIQ/AxonFramework.git
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 > This switch makes project management easier for the team, following from our active use of GitHub Project boards.
 >
 > GitHub Project boards do not allow to merge repositories between different organizations in a single board.
-> The team is actively constructing a several open-core licensed modules for Axon Framework.
+> The team is actively constructing several open-core licensed modules for Axon Framework.
 > These are best placed under the AxonIQ GitHub organization due to their licensing.
 >
 > Users of the Axon Framework repository will not experience any disruptions from this transfer.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ GitHub automatically redirects all links, clones, and references from the old lo
 Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
 
 However, it is recommended to update existing local clones to the new repository URL.
-You can do this by using git remote on the command line:
+You can do this by using `git remote` on the command line:
 
 ```
 git remote set-url origin https://github.com/AxonIQ/AxonFramework.git

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@
 
 </p>
 
+> [!NOTE]
+> ## Repository Transferred
+>
+> The Axon Framework team decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
+> This switch makes project management easier for the team, following from our active use of GitHub Project boards.
+>
+> GitHub Project boards do not allow to merge repositories between different organizations in a single board.
+> The team is actively constructing a several open-core licensed modules for Axon Framework.
+> These are best placed under the AxonIQ GitHub organization due to their licensing.
+>
+> User of the Axon Framework repository will not experience any disruptions from this transfer.
+> GitHub automatically redirects all links, clones, and references from the old location to the new one.
+> Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
+
 # Axon Framework
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.axonframework/axon-framework-bom)](https://central.sonatype.com/artifact/org.axonframework/axon-framework-bom)

--- a/README.md
+++ b/README.md
@@ -20,18 +20,9 @@
 </p>
 
 > [!NOTE]
-> ## Repository Transferred
->
-> The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
-> This switch makes project management easier for the team, due to our active use of GitHub Project boards.
->
-> GitHub Project boards do not allow merging repositories between different organizations in a single board.
-> The team is actively constructing several open-core licensed modules for Axon Framework.
-> These are best placed under the AxonIQ GitHub organization due to their licensing.
->
-> Users of the Axon Framework repository will not experience any disruptions from this transfer.
-> GitHub automatically redirects all links, clones, and references from the old location to the new one.
-> Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
+> This repository has moved from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ) to streamline project management.
+> All existing links, clones, forks, stars, and bookmarks will continue to work seamlessly thanks to GitHub's automatic redirects.
+> For more details, read [here](#repository-transferred) 
 
 # Axon Framework
 
@@ -124,3 +115,23 @@ why we collect this information, what you get in return, how to opt out, and why
 our [Privacy Policy](https://www.axoniq.io/privacy-policy) for any privacy concerns.
 
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=31ffe27e-667c-48ff-8a14-8029d44dfb66" />
+
+## Repository Transferred
+
+The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
+This switch makes project management easier for the team, due to our active use of GitHub Project boards.
+
+GitHub Project boards do not allow merging repositories between different organizations in a single board.
+The team is actively constructing several open-core licensed modules for Axon Framework.
+These are best placed under the AxonIQ GitHub organization due to their licensing.
+
+Users of the Axon Framework repository will not experience any disruptions from this transfer.
+GitHub automatically redirects all links, clones, and references from the old location to the new one.
+Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
+
+However, it is recommended to update existing local clones to the new repository URL.
+You can do this by using git remote on the command line:
+
+```
+git remote set-url origin https://github.com/AxonIQ/AxonFramework.git
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 > ## Repository Transferred
 >
 > The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ).
-> This switch makes project management easier for the team, following from our active use of GitHub Project boards.
+> This switch makes project management easier for the team, due to our active use of GitHub Project boards.
 >
 > GitHub Project boards do not allow merging repositories between different organizations in a single board.
 > The team is actively constructing several open-core licensed modules for Axon Framework.


### PR DESCRIPTION
This pull request adds a notice at the top of this projects `README.md`.
The notice explains that we have moved (although that will be done **after** this PR is merged) to the AxonIQ GitHub organization.
Furthermore, it explains why we move and that the impact for users is negligible.

We use GitHub's means to have the notice pop-out, through the `[!NOTE]` syntax.