### PR TITLE
Repository Transfer notice - 4.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@
 
 </p>
 
-
-
+> [!NOTE]
+> This repository has moved from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [AxonIQ GitHub organization](https://github.com/AxonIQ) to streamline project management.
+> All existing links, clones, forks, stars, and bookmarks will continue to work seamlessly thanks to GitHub's automatic redirects.
+> For more details, read [here](#repository-transferred)
 
 # Axon Framework
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.axonframework/axon/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.axonframework/axon)
@@ -98,3 +100,23 @@ When filing a feature or enhancement:
 * If you have any thoughts on where to plug this into the framework, that would be very helpful too.
 * Lastly, we value contributions to the framework highly. 
   So please provide a Pull Request as well!
+
+## Repository Transferred
+
+The Axon Framework team has decided to move the Axon Framework repository from the [Axon Framework GitHub organization](https://github.com/AxonFramework/) to the [Axoniq GitHub organization](https://github.com/AxonIQ).
+This switch makes project management easier for the team, due to our active use of GitHub Project boards.
+
+GitHub Project boards do not allow merging repositories between different organizations in a single board.
+The team is actively constructing several open-core licensed modules for Axon Framework.
+These are best placed under the AxonIQ GitHub organization due to their licensing.
+
+Users of the Axon Framework repository will not experience any disruptions from this transfer.
+GitHub automatically redirects all links, clones, and references from the old location to the new one.
+Your existing forks, stars, and bookmarks will continue to work seamlessly, regardless of the transfer.
+
+However, it is recommended to update existing local clones to the new repository URL.
+You can do this by using `git remote` on the command line:
+
+```shell
+git remote set-url origin https://github.com/AxonIQ/AxonFramework.git
+```


### PR DESCRIPTION
This pull request includes the repository transfer notice as present on `axon-5.1.x`, originally introduced in #4415.
The notice clarifies that the Axon Framework repository will move to the Axoniq GitHub organization to ease our project management. 
Furthermore, it explains the limited impact to users.