### PR TITLE
Change code owners to align with new team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @AxonFramework/framework-developers
+*   @AxonIQ/framework-developers


### PR DESCRIPTION
This PR changes code owners to align with new team name. Hence, we only have to replace the organization name.