### PR TITLE
Remove image link about AxonIQ Console 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@
 
 Axon Framework is a framework for building evolutionary, event-driven microservice systems based on the principles of Domain-Driven Design (DDD), Command-Query Responsibility Separation (CQRS), and Event Sourcing.
 
-<img src="https://library.axoniq.io/axoniq-console-getting-started/main/ac-monitor-axon-framework-applications/_images/ac-message-dependency-diagram.png" alt="Bootstrap logo">
-
 Axon Framework provides you with the necessary building blocks to follow these principles.
 Examples of building blocks are aggregate design handles, aggregate repositories, command buses, saga design handles, event stores, query buses, and more.
 The framework provides sensible defaults for all of these components out of the box.


### PR DESCRIPTION
This pull request removes a link to an image showing AxonIQ Console monitoring. 
There's no need to "push" for Axoniq Console, or Axoniq Platform, in Axon Framework. 
If we'd reintroduce this, we will for Axoniq Framework.