### PR TITLE
Align Sonar settings with repository organization transfer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,8 @@ jobs:
         if: matrix.sonar-enabled
         run: |
           ./mvnw -B -ntp -Dstyle.color=always org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.projectKey=AxonFramework_AxonFramework \
-          -Dsonar.organization=axonframework \
+          -Dsonar.projectKey=AxonIQ_AxonFramework \
+          -Dsonar.organization=axoniq \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
         env:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -55,8 +55,8 @@ jobs:
         if: ${{ success() && matrix.sonar-enabled && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           ./mvnw -B -ntp -Dstyle.color=always org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.projectKey=AxonFramework_AxonFramework \
-          -Dsonar.organization=axonframework \
+          -Dsonar.projectKey=AxonIQ_AxonFramework \
+          -Dsonar.organization=axoniq \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
         env:


### PR DESCRIPTION
This pull request adjusts the `projectKey` and `organization` variables for our Sonar settings.
This is inline with the Axon Framework repository transfer from the AxonFramework GitHub organization to the Axoniq GitHub organization.