### PR TITLE
Fix `add-to-project.yml` GHA URL

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/AxonFramework/projects/2
+          project-url: https://github.com/orgs/AxonIQ/projects/25
           github-token: ${{ secrets.ADD_PROJECT_TOKEN }}
           labeled: 'Type: Dependency Upgrade'


### PR DESCRIPTION
This pull request fixes the URL for the `add-to-project.yml` GitHub Action, inline with the repository transfer from the AxonFramework to AxonIQ GitHub organization.