### PR TITLE
Fix flakey test in AbstractSubscriptionQueryTestSuite

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/queryhandling/AbstractSubscriptionQueryTestSuite.java
@@ -594,7 +594,7 @@ public abstract class AbstractSubscriptionQueryTestSuite extends AbstractQueryTe
         assertThat(result.next()).map(MessageStream.Entry::message).containsInstanceOf(GenericResultMessage.class);
 
         // Don't consume next element:
-        assertThat(result.hasNextAvailable()).isTrue();
+        await().untilAsserted(() -> assertThat(result.hasNextAvailable()).isTrue());
         assertThat(result.peek())
             .map(MessageStream.Entry::message)
             .map(GenericSubscriptionQueryUpdateMessage.class::cast)


### PR DESCRIPTION
Replace direct assertion with await until assertion for next element availability.