### PR TITLE
Ensure UnitOfWork recorded cause on `runErrorHandlers` is set

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
@@ -392,6 +392,7 @@ public class UnitOfWork implements ProcessingLifecycle {
 
         private CompletableFuture<Void> runErrorHandlers(Throwable e) {
             status.set(Status.COMPLETED_ERROR);
+            errorCause.compareAndSet(null, new CauseAndPhase(currentPhase.get(), e)); // fallback in case the error did not come from a phase handler
             CauseAndPhase recordedCause = errorCause.get();
 
             while (!errorHandlers.isEmpty()) {


### PR DESCRIPTION
Some paths can reach `runErrorHandlers` without ever having set up an `errorCause`. This then triggers a NPE there, and the original exception that is the real cause of the problem is lost. This PR fixes this by setting the `errorCause` to the current given `Throwable` if it wasn't set yet.