### PR TITLE
Replace the Slack notify GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,22 +72,9 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_ID }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASS }}
 
-      - name: Notify success to Slack
-        if: success()
+      - name: Notify run to Slack
+        uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v2
-        with:
-          channel_id: CAGSEC92A
-          status: SUCCESS
-          color: good
-
-      - name: Notify failure to Slack
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v2
-        with:
-          channel_id: CAGSEC92A
-          status: FAILED
-          color: danger
+          SLACK_CHANNEL: CAGSEC92A
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TOKEN:  ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
The Slack notifier we used in the `main.yml` has been deprecated since 2025. 
Let's switch to [action-slack-notify](https://github.com/marketplace/actions/slack-notify) instead. Added benefit, it automatically defines the color of the message based on the status, so we don't require two distinct steps.
Hit this while verifying the GHA, for which the Slack version was failing anyhow.