### PR TITLE
Adjust `AxonServerAutoConfiguration` import for Spring Boot autoconfig classes

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaEventStoreAutoConfiguration.java
@@ -53,9 +53,9 @@ import java.util.function.UnaryOperator;
  * @since 4.0
  */
 @AutoConfiguration(afterName = {
+        "io.axoniq.framework.springboot.autoconfig.AxonServerAutoConfiguration",
         "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration",
         "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration",
-        "org.axonframework.extension.springboot.autoconfig.AxonServerAutoConfiguration",
         "org.axonframework.extension.springboot.autoconfig.JpaAutoConfiguration"
 })
 @ConditionalOnBean({EntityManagerFactory.class, PlatformTransactionManager.class})

--- a/stash/todo/src/main/java/org/axonframework/springboot/autoconfig/AxonDbSchedulerAutoConfiguration.java
+++ b/stash/todo/src/main/java/org/axonframework/springboot/autoconfig/AxonDbSchedulerAutoConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.context.annotation.Bean;
         value = {AxonTracingAutoConfiguration.class},
         name = {
                 "com.github.kagkarlsson.scheduler.boot.autoconfigure.DbSchedulerAutoConfiguration",
-                "org.axonframework.extension.springboot.autoconfig.AxonServerAutoConfiguration"
+                "io.axoniq.framework.springboot.autoconfig.AxonServerAutoConfiguration"
         }
 )
 public class AxonDbSchedulerAutoConfiguration {


### PR DESCRIPTION
This pull request fixes two remaining import statement usages of `AxonServerAutoConfiguration`.
With the move of the `axon-server-connector` module and it's Spring Boot integration, as per #4412, I forgot to adjust these two import statements accordingly.