### PR TITLE
Remove DLQ entity registration in `JpaAutoConfiguration`

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JpaAutoConfiguration.java
@@ -54,7 +54,6 @@ import javax.sql.DataSource;
 @EnableConfigurationProperties(TokenStoreProperties.class)
 @RegisterDefaultEntities(packages = {
         "org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa",
-        "org.axonframework.messaging.eventhandling.deadletter.jpa",
 })
 public class JpaAutoConfiguration {
 


### PR DESCRIPTION
We do not need to register entities from the `org.axonframework.messaging.eventhandling.deadletter.jpa` package anymore, as the `DeadLetterEntry`, and all other sequenced DLQ logic, moved to Axoniq Framework as per #4408.
Marked this bug as a should, as it does not break anything. It's just a clean-up.