### PR TITLE
Replace `AxonTestFixture` setting `axonServerEnabled` for `integrationEnabled`

### DIFF
--- a/extensions/spring/spring-boot-starter-test/src/main/java/org/axonframework/extension/springboot/test/AxonTestConfiguration.java
+++ b/extensions/spring/spring-boot-starter-test/src/main/java/org/axonframework/extension/springboot/test/AxonTestConfiguration.java
@@ -36,10 +36,11 @@ import org.springframework.core.env.Environment;
  *     {@link AxonConfiguration}.</li>
  * </ul>
  * <p>
- * The fixture's {@link AxonTestFixture.Customization} can be overridden by declaring a bean of that type in the
- * test class (e.g. in an inner {@code @TestConfiguration} class). When no such bean is present, a default
+ * The fixture's {@link AxonTestFixture.Customization} can be overridden by declaring a bean of that type in the test
+ * class (e.g. in an inner {@code @TestConfiguration} class). When no such bean is present, a default
  * {@code Customization} is derived from the Spring {@link org.springframework.core.env.Environment}: the
- * {@code axon.axonserver.enabled} property controls whether Axon Server is enabled in the fixture.
+ * {@code axon.axonserver.enabled} property controls whether
+ * {@link AxonTestFixture.Customization#integrationEnabled() integration is enabled} in the fixture.
  *
  * @author Mateusz Nowak
  * @since 5.1.0
@@ -63,19 +64,19 @@ class AxonTestConfiguration {
      * Registers an {@link AxonTestFixture} wired with the Spring-managed {@link AxonConfiguration}.
      * <p>
      * If the test context contains a {@link AxonTestFixture.Customization} bean (e.g. declared in an inner
-     * {@code @TestConfiguration} class), it is used to configure the fixture. Otherwise a default
-     * {@code Customization} is built by reading the {@code axon.axonserver.enabled} property from the
-     * Spring {@link Environment}:
+     * {@code @TestConfiguration} class), it is used to configure the fixture. Otherwise, a default
+     * {@code Customization} is built by reading the {@code axon.axonserver.enabled} property from the Spring
+     * {@link Environment}:
      * <ul>
-     *     <li>When the property is {@code false}, Axon Server is disabled via
-     *     {@link AxonTestFixture.Customization#disableAxonServer()}.</li>
-     *     <li>When the property is {@code true} or absent, Axon Server remains enabled (the default).</li>
+     *     <li>When the property is {@code true}, we mark the test as an
+     *     {@link AxonTestFixture.Customization#asIntegrationTest() integration test}.</li>
+     *     <li>When the property is {@code false} or absent, we keep the fixture as a regular test (the default).</li>
      * </ul>
      * A custom {@link AxonTestFixture.Customization} bean always takes full precedence over this default.
      *
-     * @param configuration  the Axon application configuration provided by the Spring context
-     * @param customization  optional provider for a {@link AxonTestFixture.Customization} bean
-     * @param environment    the Spring environment used to resolve the {@code axon.axonserver.enabled} property
+     * @param configuration the Axon application configuration provided by the Spring context
+     * @param customization optional provider for a {@link AxonTestFixture.Customization} bean
+     * @param environment   the Spring environment used to resolve the {@code axon.axonserver.enabled} property
      * @return a ready-to-use {@link AxonTestFixture}
      */
     @Bean(destroyMethod = "stop")
@@ -91,8 +92,8 @@ class AxonTestConfiguration {
     }
 
     private static AxonTestFixture.Customization defaultCustomization(Environment environment) {
-        boolean axonServerEnabled = environment.getProperty("axon.axonserver.enabled", Boolean.class, true);
+        boolean axonServerEnabled = environment.getProperty("axon.axonserver.enabled", Boolean.class, false);
         var customization = new AxonTestFixture.Customization();
-        return axonServerEnabled ? customization : customization.disableAxonServer();
+        return axonServerEnabled ? customization.asIntegrationTest() : customization;
     }
 }

--- a/extensions/spring/spring-boot-starter-test/src/test/java/org/axonframework/extension/springboot/test/AxonSpringBootTestAnnotationTest.java
+++ b/extensions/spring/spring-boot-starter-test/src/test/java/org/axonframework/extension/springboot/test/AxonSpringBootTestAnnotationTest.java
@@ -100,7 +100,7 @@ class AxonSpringBootTestAnnotationTest {
         customizationField.setAccessible(true);
         var customization = (AxonTestFixture.Customization) customizationField.get(fixture);
 
-        assertFalse(customization.axonServerEnabled(),
+        assertFalse(customization.integrationEnabled(),
                     "Axon Server should be disabled in the default Customization when axon.axonserver.enabled=false");
     }
 

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
@@ -16,12 +16,12 @@
 
 package org.axonframework.test.fixture;
 
-import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.common.configuration.AxonConfiguration;
-import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.eventhandling.EventSink;
 import org.axonframework.test.FixtureExecutionException;
 import org.axonframework.test.matchers.FieldFilter;
 import org.axonframework.test.matchers.IgnoreField;
@@ -201,14 +201,14 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
         Objects.requireNonNull(configurer, "Configurer may not be null");
         Objects.requireNonNull(customization, "Customization may not be null");
         var fixtureConfiguration = customization.apply(new Customization());
-        if (!fixtureConfiguration.axonServerEnabled()) {
+        if (!fixtureConfiguration.integrationEnabled()) {
             configurer = configurer.componentRegistry(cr -> cr.disableEnhancer(
-                    "org.axonframework.axonserver.connector.AxonServerConfigurationEnhancer"));
+                    "io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer"
+            ));
         }
         var recordingEnhancer = new MessagesRecordingConfigurationEnhancer();
-        var configuration =
-                configurer.componentRegistry(cr -> cr.registerEnhancer(recordingEnhancer))
-                          .start();
+        var configuration = configurer.componentRegistry(cr -> cr.registerEnhancer(recordingEnhancer))
+                                      .start();
         return new AxonTestFixture(configuration, fixtureConfiguration);
     }
 
@@ -244,14 +244,21 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
     }
 
     /**
-     * Allow customizing the fixture setup.
+     * Allow customizing the fixture setup, by {@link #integrationEnabled() enabling it as an integration test} or by
+     * including {@link #fieldFilters()}.
+     * <p>
+     * When the {@link #integrationEnabled()} is set to {@code false} (the default), certain
+     * {@link org.axonframework.common.configuration.ConfigurationEnhancer ConfigurationEnhancers} will be
+     * {@link org.axonframework.common.configuration.ComponentRegistry#disableEnhancer(String) disabled}. Example of
+     * this is the {@code AxonServerConfigurationEnhancer}.
      *
-     * @param axonServerEnabled True if Axon Server should be enabled, false otherwise. It's enabled by default.
-     * @param fieldFilters Collections of {@link FieldFilter FieldFilters} used to adjust the matchers for commands,
-     *                     events, and result messages.
+     * @param integrationEnabled toggle describing whether this fixture should integrate with infrastructure (e.g. Axon
+     *                           Server). Defaults to {@code false}
+     * @param fieldFilters       collections of {@link FieldFilter FieldFilters} used to adjust the matchers for
+     *                           commands, events, and result messages
      */
     public record Customization(
-            boolean axonServerEnabled,
+            boolean integrationEnabled,
             List<FieldFilter> fieldFilters
     ) {
 
@@ -259,12 +266,12 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
          * Creates a new instance of {@code Customization}.
          */
         public Customization() {
-            this(true, new ArrayList<>());
+            this(false, new ArrayList<>());
         }
 
         /**
-         * Registers the given {@code fieldFilter}, which is used to define which Fields are used when comparing
-         * objects.
+         * Registers the given {@code fieldFilter}, which is used to define which {@link java.lang.reflect.Field Fields}
+         * are used when comparing objects.
          * <p>
          * This filter is used by the following methods:
          * <ul>
@@ -276,18 +283,18 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
          * If you use custom assertions with methods like {@link AxonTestPhase.Then.Event#eventsSatisfy} or
          * {@link AxonTestPhase.Then.Event#eventsMatch}  this filter is not taken into account.
          * <p/>
-         * When multiple filters are registered, a Field must be accepted by all registered filters in order to be
+         * When multiple filters are registered, a {@code Field} must be accepted by all registered filters in order to be
          * accepted.
          * <p/>
-         * By default, all Fields are included in the comparison.
+         * By default, all {@code Fields} are included in the comparison.
          *
-         * @param fieldFilter The FieldFilter that defines which fields to include in the comparison.
-         * @return the current Customization, for fluent interfacing.
+         * @param fieldFilter the {@code FieldFilter} that defines which fields to include in the comparison
+         * @return the current {@code Customization}, for fluent interfacing
          */
         public Customization registerFieldFilter(FieldFilter fieldFilter) {
             List<FieldFilter> fieldFiltersCopy = new ArrayList<>(this.fieldFilters);
             fieldFiltersCopy.add(fieldFilter);
-            return new Customization(axonServerEnabled, fieldFiltersCopy);
+            return new Customization(integrationEnabled, fieldFiltersCopy);
         }
 
         /**
@@ -304,9 +311,9 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
          * If you use custom assertions with methods like {@link AxonTestPhase.Then.Event#eventsSatisfy} or
          * {@link AxonTestPhase.Then.Event#eventsMatch}  this filter is not taken into account.
          *
-         * @param declaringClass The class declaring the field.
-         * @param fieldName      The name of the field.
-         * @return the current Customization, for fluent interfacing
+         * @param declaringClass the class declaring the field
+         * @param fieldName      the name of the field
+         * @return the current {@code Customization}, for fluent interfacing
          * @throws FixtureExecutionException when no such field is declared
          */
         public Customization registerIgnoredField(Class<?> declaringClass, String fieldName) {
@@ -316,37 +323,21 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
         /**
          * Configured field filters.
          *
-         * @return The list of field filters.
+         * @return the list of field filters
          */
         public List<FieldFilter> fieldFilters() {
             return fieldFilters;
         }
 
         /**
-         * Configures Axon Server to be disabled.
+         * Configures the fixture to run as an integration test.
+         * <p>
+         * Toggles the {@link #integrationEnabled()} to {@code true}.
          *
-         * @return The current Customization, for fluent interfacing.
+         * @return the current {@code Customization}, for fluent interfacing
          */
-        public Customization disableAxonServer() {
-            return new Customization(false, fieldFilters);
-        }
-
-        /**
-         * Indicates whether Axon Server is enabled.
-         *
-         * @return True if Axon Server is enabled, false otherwise.
-         */
-        public boolean axonServerEnabled() {
-            return axonServerEnabled;
-        }
-
-        /**
-         * Indicates whether Axon Server is disabled.
-         *
-         * @return True if Axon Server is disabled, false otherwise.
-         */
-        public boolean axonServerDisabled() {
-            return! axonServerEnabled;
+        public Customization asIntegrationTest() {
+            return new Customization(true, fieldFilters);
         }
     }
 }

--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
@@ -249,7 +249,7 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
      * <p>
      * When the {@link #integrationEnabled()} is set to {@code false} (the default), certain
      * {@link org.axonframework.common.configuration.ConfigurationEnhancer ConfigurationEnhancers} will be
-     * {@link org.axonframework.common.configuration.ComponentRegistry#disableEnhancer(String) disabled}. Example of
+     * {@link org.axonframework.common.configuration.ComponentRegistry#disableEnhancer(String) disabled}. An example of
      * this is the {@code AxonServerConfigurationEnhancer}.
      *
      * @param integrationEnabled toggle describing whether this fixture should integrate with infrastructure (e.g. Axon
@@ -332,7 +332,10 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
         /**
          * Configures the fixture to run as an integration test.
          * <p>
-         * Toggles the {@link #integrationEnabled()} to {@code true}.
+         * This ensures certain
+         * {@link org.axonframework.common.configuration.ConfigurationEnhancer ConfigurationEnhancers} that introduce
+         * "heavy" infrastructure components (like the {@code AxonServerConfigurationEnhancer}) are kept in the given
+         * {@link ApplicationConfigurer}.
          *
          * @return the current {@code Customization}, for fluent interfacing
          */

--- a/test/src/test/java/org/axonframework/test/extension/AxonFrameworkExtensionTest.java
+++ b/test/src/test/java/org/axonframework/test/extension/AxonFrameworkExtensionTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
-public class AxonFrameworkExtensionTest {
+class AxonFrameworkExtensionTest {
 
     private static final AxonTestFixture mockedFixture = mock(AxonTestFixture.class);
 
@@ -50,7 +50,7 @@ public class AxonFrameworkExtensionTest {
 
         @ProvidedAxonTestFixture
         AxonTestFixtureProvider fixtureProvider = () -> AxonTestFixture.with(CourseEntity.configurer(),
-                                                                             Customization::disableAxonServer);
+                                                                             Customization::asIntegrationTest);
 
         @Test
         void creatingNewCourseIssuesEvent(@NonNull AxonTestFixture fixture) {
@@ -127,7 +127,7 @@ public class AxonFrameworkExtensionTest {
 
         @BeforeEach
         void setUp() {
-            fixture = AxonTestFixture.with(CourseEntity.configurer(), Customization::disableAxonServer);
+            fixture = AxonTestFixture.with(CourseEntity.configurer(), Customization::asIntegrationTest);
         }
 
         @AfterEach

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureDisableAxonServerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureDisableAxonServerTest.java
@@ -16,25 +16,25 @@
 
 package org.axonframework.test.fixture;
 
-import org.axonframework.messaging.core.configuration.MessagingConfigurer;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AxonTestFixtureDisableAxonServerTest {
+class AxonTestFixtureIntegrationTestCustomizationTest {
 
     @Test
-    void disablesAxonServerForMessagingConfigurerNeverThrows() {
+    void customizingAsIntegrationTestForMessagingConfigurerNeverThrows() {
         var configurer = MessagingConfigurer.create();
 
-        assertDoesNotThrow(() -> AxonTestFixture.with(configurer, AxonTestFixture.Customization::disableAxonServer));
+        assertDoesNotThrow(() -> AxonTestFixture.with(configurer, AxonTestFixture.Customization::asIntegrationTest));
     }
 
     @Test
-    void disablesAxonServerForEventSourcingConfigurerNeverThrows() {
+    void customizingAsIntegrationTestForEventSourcingConfigurerNeverThrows() {
         var configurer = EventSourcingConfigurer.create();
 
-        assertDoesNotThrow(() -> AxonTestFixture.with(configurer, AxonTestFixture.Customization::disableAxonServer));
+        assertDoesNotThrow(() -> AxonTestFixture.with(configurer, AxonTestFixture.Customization::asIntegrationTest));
     }
 }

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMonitoringTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMonitoringTest.java
@@ -134,7 +134,7 @@ public class AxonTestFixtureMonitoringTest {
         final var courseId = UUID.randomUUID().toString();
         final var fixture = AxonTestFixture.with(
                 configurer(report, false),
-                Customization::disableAxonServer
+                Customization::asIntegrationTest
         );
 
         fixture


### PR DESCRIPTION
The `AxonTestFixture.Customization` contained an `axonServerEnabled` toggle. 
This toggle made it so that a user could disable automatically wiring Axon Server whenever it was on the class path for a given `AxonTestFixture`.
However, with the Axon Server integration moved to Axoniq Framework, as per #4412, it makes less sense to contain this toggle in the `AxonTestFixture` as is. 

Hence, this pull request adjusts the toggle to a more generic `integrationEnabled` toggle.
With `integrationEnabled` set to `true`, the `AxonTestFixture` does nothing to the given `ApplicationConfigurer`.
With it set to `false`, it will disable `ConfigurationEnhancers` that introduce "heavy" infrastructure components.
An example of this, is the `AxonServerConfigurationEnhancer`.

Besides this switch, the property is now disabled by default. As such, `AxonTestFixtures` no longer will automatically construct Axon Server components.