### PR TITLE
[#4427] Re-enable Examples build 

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,12 +1,11 @@
 name: Axon Framework with Examples
 
-# TODO #4427 - enable once the first (RC) of Axon and Axoniq Framework is out
 # The module split makes the examples brittle to run at this point in time
-#on:
-#  workflow_dispatch:
-#  pull_request:
-#    paths-ignore:
-#      - 'docs/**'
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,17 +37,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- The axoniq-bom provides the framework-bom plus -->
+            <!-- additional components needed to run examples against axon-server -->
             <dependency>
-                <groupId>org.axonframework</groupId>
-                <artifactId>axon-framework-bom</artifactId>
-                <version>${project.version}</version>
+                <groupId>io.axoniq.framework</groupId>
+                <artifactId>axoniq-framework-bom</artifactId>
+                <version>5.1.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.axonframework</groupId>
-                <artifactId>axon-server-connector</artifactId>
-                <version>5.1.0-RC2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/examples/university-demo/pom.xml
+++ b/examples/university-demo/pom.xml
@@ -42,13 +42,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.axonframework</groupId>
-                <artifactId>axon-framework-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
@@ -87,7 +80,7 @@
         <!-- Event Store Dependencies -->
 
         <dependency>
-            <groupId>org.axonframework</groupId>
+            <groupId>io.axoniq.framework</groupId>
             <artifactId>axon-server-connector</artifactId>
         </dependency>
 
@@ -145,8 +138,13 @@
             <groupId>org.axonframework</groupId>
             <artifactId>axon-test</artifactId>
             <scope>test</scope>
-            <version>5.1.0-RC2</version>
         </dependency>
+        <dependency>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-testcontainer</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>

--- a/examples/university-demo/src/main/java/org/axonframework/examples/demo/university/UniversityAxonApplication.java
+++ b/examples/university-demo/src/main/java/org/axonframework/examples/demo/university/UniversityAxonApplication.java
@@ -1,5 +1,7 @@
 package org.axonframework.examples.demo.university;
 
+import io.axoniq.framework.axonserver.connector.api.AxonServerConfiguration;
+import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
 import org.axonframework.examples.demo.university.faculty.FacultyModuleConfiguration;
 import org.axonframework.examples.demo.university.faculty.write.enrollstudent.EnrollStudentInFaculty;
 import org.axonframework.examples.demo.university.faculty.write.subscribestudent.SubscribeStudentToCourse;
@@ -7,8 +9,6 @@ import org.axonframework.examples.demo.university.shared.ids.CourseId;
 import org.axonframework.examples.demo.university.faculty.write.createcourseplain.CreateCourse;
 import org.axonframework.examples.demo.university.faculty.write.renamecourse.RenameCourse;
 import org.axonframework.examples.demo.university.shared.ids.StudentId;
-import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.AxonServerConfigurationEnhancer;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.common.infra.FilesystemStyleComponentDescriptor;

--- a/examples/university-demo/src/test/java/org/axonframework/examples/demo/university/UniversityApplicationTest.java
+++ b/examples/university-demo/src/test/java/org/axonframework/examples/demo/university/UniversityApplicationTest.java
@@ -1,5 +1,6 @@
 package org.axonframework.examples.demo.university;
 
+import io.axoniq.framework.testcontainer.AxonServerContainerUtils;
 import org.axonframework.examples.demo.university.faculty.FacultyModuleConfiguration;
 import org.assertj.core.api.Assertions;
 import org.axonframework.common.configuration.AxonConfiguration;
@@ -10,7 +11,6 @@ import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.test.fixture.MessagesRecordingConfigurationEnhancer;
 import org.axonframework.test.fixture.RecordingComponentsRegistry;
-import org.axonframework.test.server.AxonServerContainerUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 

--- a/examples/university-demo/src/test/java/org/axonframework/examples/demo/university/faculty/FacultyAxonTestFixture.java
+++ b/examples/university-demo/src/test/java/org/axonframework/examples/demo/university/faculty/FacultyAxonTestFixture.java
@@ -1,12 +1,12 @@
 package org.axonframework.examples.demo.university.faculty;
 
+import io.axoniq.framework.testcontainer.AxonServerContainerUtils;
 import org.axonframework.examples.demo.university.ConfigurationProperties;
 import org.axonframework.examples.demo.university.UniversityAxonApplication;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.examples.demo.university.faculty.write.createcourse.CreateCourseConfiguration;
 import org.axonframework.test.extension.AxonTestFixtureProvider;
 import org.axonframework.test.fixture.AxonTestFixture;
-import org.axonframework.test.server.AxonServerContainerUtils;
 
 import java.io.IOException;
 import java.util.function.UnaryOperator;
@@ -38,7 +38,7 @@ public class FacultyAxonTestFixture {
         var configuration = ConfigurationProperties.load();
         var configurer = application.configurer(configuration, customization);
         purgeAxonServerIfEnabled(configuration);
-        return () -> AxonTestFixture.with(configurer, c -> configuration.axonServerEnabled() ? c : c.disableAxonServer());
+        return () -> AxonTestFixture.with(configurer, c -> configuration.axonServerEnabled() ? c.asIntegrationTest() : c);
     }
 
     public static AxonTestFixture slice(UnaryOperator<EventSourcingConfigurer> customization) {

--- a/examples/university-java-springboot-3/pom.xml
+++ b/examples/university-java-springboot-3/pom.xml
@@ -104,24 +104,26 @@
 
         <!-- Axon -->
         <dependency>
-            <groupId>org.axonframework.extensions.spring</groupId>
-            <artifactId>axon-spring-boot-starter</artifactId>
-            <version>5.1.0-RC2</version>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.axonframework</groupId>
+            <groupId>io.axoniq.framework</groupId>
             <artifactId>axon-server-connector</artifactId>
         </dependency>
         <dependency>
             <groupId>org.axonframework</groupId>
             <artifactId>axon-test</artifactId>
-            <version>5.1.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>org.axonframework.extensions.spring</groupId>
             <artifactId>axon-spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <version>5.1.0-RC2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-testcontainer</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/examples/university-java-springboot-3/src/test/java/org/axonframework/examples/university/UniversityTestApplicationITest.java
+++ b/examples/university-java-springboot-3/src/test/java/org/axonframework/examples/university/UniversityTestApplicationITest.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.examples.university;
 
-import org.axonframework.test.server.AxonServerContainer;
-import org.axonframework.test.server.AxonServerContainerUtils;
+import io.axoniq.framework.testcontainer.AxonServerContainer;
+import io.axoniq.framework.testcontainer.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -48,9 +48,9 @@ class UniversityTestApplicationITest {
     static void setContextUp() throws Exception {
       // Mainly needed to create DBC context now:
       AxonServerContainerUtils.purgeEventsFromAxonServer(axonServer.getHost(),
-        axonServer.getHttpPort(),
-        "default",
-        AxonServerContainerUtils.DCB_CONTEXT);
+                                                         axonServer.getHttpPort(),
+                                                         "default",
+                                                         AxonServerContainerUtils.DCB_CONTEXT);
     }
 
     @Test

--- a/examples/university-java-springboot-4/pom.xml
+++ b/examples/university-java-springboot-4/pom.xml
@@ -109,24 +109,28 @@
 
         <!-- Axon -->
         <dependency>
-            <groupId>org.axonframework.extensions.spring</groupId>
-            <artifactId>axon-spring-boot-starter</artifactId>
-            <version>5.1.0-RC2</version>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.axonframework</groupId>
+            <groupId>io.axoniq.framework</groupId>
             <artifactId>axon-server-connector</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.axonframework</groupId>
             <artifactId>axon-test</artifactId>
-            <version>5.1.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>org.axonframework.extensions.spring</groupId>
             <artifactId>axon-spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <version>5.1.0-RC2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-testcontainer</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Database -->

--- a/examples/university-java-springboot-4/src/test/java/org/axonframework/examples/university/UniversityTestApplicationITest.java
+++ b/examples/university-java-springboot-4/src/test/java/org/axonframework/examples/university/UniversityTestApplicationITest.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.examples.university;
 
-import org.axonframework.test.server.AxonServerContainer;
-import org.axonframework.test.server.AxonServerContainerUtils;
+import io.axoniq.framework.testcontainer.AxonServerContainer;
+import io.axoniq.framework.testcontainer.AxonServerContainerUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/examples/university-java/pom.xml
+++ b/examples/university-java/pom.xml
@@ -69,7 +69,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.axonframework</groupId>
+            <groupId>io.axoniq.framework</groupId>
             <artifactId>axon-server-connector</artifactId>
         </dependency>
 
@@ -106,7 +106,6 @@
             <groupId>org.axonframework</groupId>
             <artifactId>axon-test</artifactId>
             <scope>test</scope>
-            <version>5.1.0-RC2</version>
         </dependency>
 
     </dependencies>

--- a/examples/university-java/src/main/java/org/axonframework/examples/university/UniversityExampleApplication.java
+++ b/examples/university-java/src/main/java/org/axonframework/examples/university/UniversityExampleApplication.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.examples.university;
 
-import org.axonframework.axonserver.connector.AxonServerConfiguration;
-import org.axonframework.axonserver.connector.AxonServerConfigurationEnhancer;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConfiguration;
+import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.infra.FilesystemStyleComponentDescriptor;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;

--- a/examples/university-java/src/test/java/org/axonframework/examples/university/write/createcourse/CourseCreationTest.java
+++ b/examples/university-java/src/test/java/org/axonframework/examples/university/write/createcourse/CourseCreationTest.java
@@ -33,8 +33,7 @@ class CourseCreationTest {
 
     @ProvidedAxonTestFixture
     AxonTestFixtureProvider fixtureProvider = () -> AxonTestFixture.with(
-            CreateCourseConfiguration.configure(EventSourcingConfigurer.create()),
-            Customization::disableAxonServer
+            CreateCourseConfiguration.configure(EventSourcingConfigurer.create())
     );
 
     @Test


### PR DESCRIPTION
- removed all fixed 5.1.0-RC2 dependencies
- fixed code imports
- use axoniq-spring-boot-starter for spring itests

This PR resolves #4427.