### PR TITLE
Run tests only for examples on the examples build

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,9 +37,15 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
-      - name: Regular Build including examples
+      - name: Build whole project (tests skipped)
         run: |
-          ./mvnw -B -U -ntp -Pintegration-test -Pexamples clean verify \
+          ./mvnw -B -U -ntp -Pintegration-test -Pexamples clean install -DskipTests \
+          -Dstyle.color=always
+
+      - name: Run tests for examples only
+        run: |
+          ./mvnw -B -ntp -Pexamples verify \
+          -pl examples,examples/university-demo,examples/university-java,examples/university-java-springboot-3,examples/university-java-springboot-4 \
           -Dcoverage \
           -Dstyle.color=always \
           -Dsurefire.rerunFailingTestsCount=5 \


### PR DESCRIPTION
To save build time, we could only run the examples tests in the exmaples build. 