### PR TITLE
Adjust references to AxoniqFramework classes in the reference guide

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
@@ -340,7 +340,7 @@ Configuration API (using `InMemorySequencedDeadLetterQueue` for brevity; replace
 [source,java]
 ----
 import org.axonframework.messaging.core.configuration.MessagingConfigurer;
-import org.axonframework.messaging.deadletter.InMemorySequencedDeadLetterQueue;
+import io.axoniq.framework.messaging.deadletter.InMemorySequencedDeadLetterQueue;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
 
 public class AxonConfig {
@@ -423,8 +423,8 @@ Axon Framework 5::
 ----
 import org.axonframework.conversion.GeneralConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
-import org.axonframework.messaging.eventhandling.deadletter.SequencedDeadLetterQueueFactory;
-import org.axonframework.messaging.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue;
+import io.axoniq.framework.messaging.eventhandling.deadletter.SequencedDeadLetterQueueFactory;
+import io.axoniq.framework.messaging.eventhandling.deadletter.jpa.JpaSequencedDeadLetterQueue;
 import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
 import jakarta.persistence.EntityManagerFactory;
 import org.springframework.context.annotation.Bean;
@@ -580,7 +580,7 @@ Axon Framework 5::
 [source,java]
 ----
 import org.axonframework.common.configuration.Configuration;
-import org.axonframework.messaging.deadletter.SequencedDeadLetterProcessor;
+import io.axoniq.framework.messaging.deadletter.SequencedDeadLetterProcessor;
 import java.util.concurrent.TimeUnit;
 
 public class DeadLetterProcessor {

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -78,8 +78,8 @@ Configuration API::
 --
 [source,java]
 ----
-import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.axonframework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 
@@ -102,8 +102,8 @@ If you need to connect to another context, you should adjust the `connectionMana
 
 [source,java]
 ----
-import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.axonframework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 
@@ -129,8 +129,8 @@ Spring Boot::
 --
 [source,java]
 ----
-import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.axonframework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.springframework.context.annotation.Bean;
@@ -154,8 +154,8 @@ If you need to connect to another context, you should adjust the `connectionMana
 
 [source,java]
 ----
-import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.axonframework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.axonserver.connector.event.AggregateBasedAxonServerEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.springframework.beans.factory.annotation.Value;

--- a/docs/reference-guide/modules/migration/pages/understanding-architecture-principles.adoc
+++ b/docs/reference-guide/modules/migration/pages/understanding-architecture-principles.adoc
@@ -54,7 +54,7 @@ Instead of a monolithic configuration class, you now compose modular configurers
 [source,java]
 ----
 import io.axoniq.axonserver.connector.AxonServerConnection;
-import org.axonframework.axonserver.connector.event.AxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.event.AxonServerEventStorageEngine;
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
@@ -240,8 +240,8 @@ Infrastructure components now enforce the use of the appropriate converter due t
 
 [source,java]
 ----
-import org.axonframework.axonserver.connector.AxonServerConnectionManager;
-import org.axonframework.axonserver.connector.event.AxonServerEventStorageEngine;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.axonserver.connector.event.AxonServerEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.springframework.context.annotation.Bean;

--- a/docs/reference-guide/modules/testing/pages/basic-testing.adoc
+++ b/docs/reference-guide/modules/testing/pages/basic-testing.adoc
@@ -169,7 +169,7 @@ Inject it as a bean into your test for realistic integration testing:
 ----
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.test.fixture.AxonTestFixture;
-import org.axonframework.test.server.AxonServerContainer;
+import io.axoniq.framework.testcontainer.AxonServerContainer;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
This PR adjusts remaining references to classes and maven artifacts that have been moved to the AxoniqFramework repository.