### PR TITLE
Order JdbcAutoConfiguration correctly for Datasource

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JdbcAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/JdbcAutoConfiguration.java
@@ -51,7 +51,13 @@ import javax.sql.DataSource;
  * @author Allard Buijze
  * @since 3.1
  */
-@AutoConfiguration(after = JpaAutoConfiguration.class)
+@AutoConfiguration(
+        after = JpaAutoConfiguration.class,
+        afterName = {
+                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+                "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
+        }
+)
 @ConditionalOnBean(DataSource.class)
 @ConditionalOnClass(SpringDataSourceConnectionProvider.class)
 @EnableConfigurationProperties(TokenStoreProperties.class)


### PR DESCRIPTION
During local testing with the PostgreSQL extension of Axoniq Framework I found that the beans were loaded in an incorrect order. This led the `DataSource` bean to not be known at the time of configuring the `JdbcAutoConfiguration`, leading to a missing `DataSource` bean for the `ConnectionProvider`, thus leading to a null `ConnectionProvider` on the `SpringTransactionManager`, leading to the Postgresql extension not being able to function due to a missing `ConnectionExecutor` in the `ProcessingContext`.

This PR resolves that by configuring the autoconfiguration after SB3 and SB4 configuration classes.