### PR TITLE
[#4437] Fix consistency marker when sourcing an empty stream in the AggregateBasedJpaEventStorageEngine

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -297,7 +297,9 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                                          entry -> setMarkerAndBuildContext(entry, markerReference))
                              // Defaults the marker when the aggregate stream was empty
                              .onComplete(() -> markerReference.compareAndSet(
-                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, 0)
+                                     // making sequence number (=last seen event) -1 makes the position in the Consistency Marker 0
+                                     // this ensures 0-based sequence numbers, as they are derived from the marker when appending
+                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, -1)
                              ))
                              .cast();
         return new AggregateSource(markerReference, source);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -482,8 +483,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     @Test
     void sourcingAnEmptyEventStoreReturnsAnExpectedConsistencyMarker() {
         // given...
-        ConsistencyMarker testAggregateMarker = new AggregateBasedConsistencyMarker(TEST_AGGREGATE_ID, 0);
-        ConsistencyMarker otherAggregateMarker = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 0);
+        ConsistencyMarker testAggregateMarker = new AggregateBasedConsistencyMarker(TEST_AGGREGATE_ID, -1);
+        ConsistencyMarker otherAggregateMarker = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, -1);
         ConsistencyMarker expectedMarker = testAggregateMarker.upperBound(otherAggregateMarker);
         // when...
         SourcingCondition testCondition =

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -498,6 +498,27 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
                     .verifyComplete();
     }
 
+    /**
+     * Regression test for <a href="https://github.com/AxonIQ/AxonFramework/issues/4437">#4437</a>
+     */
+    @Test
+    void appendingFirstEventAfterSourcingEmptyStreamSucceeds() {
+        // given
+        SourcingCondition sourcingCondition = SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA);
+        AtomicReference<ConsistencyMarker> markerFromSource = new AtomicReference<>();
+        StepVerifier.create(FluxUtils.of(testSubject.source(sourcingCondition)))
+                    .assertNext(entry -> markerFromSource.set(entry.getResource(ConsistencyMarker.RESOURCE_KEY)))
+                    .verifyComplete();
+
+        // when
+        AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA)
+                                                         .withMarker(markerFromSource.get());
+        assertDoesNotThrow(
+                () -> appendEvents(appendCondition, taggedEventMessage("event-0", TEST_AGGREGATE_TAGS))
+        );
+    }
+
+
     @Test
     void transactionRejectedWithConflictingEventsInStore() {
         ConsistencyMarker consistencyMarker = appendEvents(


### PR DESCRIPTION
This PR adjusts the behaviour of the AggregateBasedJpaEventStorageEngine when sourcing an empty event stream to make sure the consistency marker included in the context of the Terminal message is pointing to position 0, resulting in 0-based sequence numbers for aggregates in the AggregateBasedJpaEventStorageEngine.

In AF5, when sourcing an empty event stream in the AggregateBasedJpaEventStorageEngine, the consistency marker included in the context of the Terminal message was pointing to position 1, resulting in 1-based sequence numbers for aggregates in the AggregateBasedJpaEventStorageEngine.

While this is technically acceptable for appending events to the AggregateBasedJpaEventStorageEngine, it is inconsistent with the behaviour of the AF4 JpaEventStorageEngine (aggregate based), which produced 0 based sequence numbers.

This inconsistency was discovered while investigating #4437, so it's related. Moreover, the regression test added to the `AggregateBasedStorageEngineTestSuite` also acts as a basis for a fix towards the Axon Server based event storage engine in AxoniqFramework.

Changes included:
* fix empty stream behaviour in AggregateBasedJpaEventStorageEngine to point to position 0 in the consistency marker
* add a regression test to make sure appending events based on an append condition derived from a consistency marker returned from sourcing an empty aggregate event stream yields no exception

Note: if we do not want to change the behaviour of the JpaEventStorage engine we can just keep the second commit of this PR and move the adjustments on `org.axonframework.eventsourcing.eventstore.AggregateBasedStorageEngineTestSuite#sourcingAnEmptyEventStoreReturnsAnExpectedConsistencyMarker` to the axon server specific implementation of this test suite.