### PR TITLE
[#4455] Support a `null` `MessageStream.Entry` on the `AbstractMessageStream.FetchResult`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -693,9 +693,12 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
                                       : null;
         String flags = describeFlags();  // pipe separated
         String delegates = describeDelegates();  // comma separated, with the active prepended with asterisk
-        String statusDescription = Stream.of(status, (peekedEntry == null ? null : "P"), flags).filter(Objects::nonNull).collect(Collectors.joining("|"));
+        String statusDescription = Stream.of(status, (peekedEntry == null ? null : "P"), flags)
+                                         .filter(Objects::nonNull).collect(Collectors.joining("|"));
 
-        return getClass().getSimpleName().replace("MessageStream", "") + (statusDescription.isEmpty() ? "" : "[" + statusDescription + "]") + (delegates == null ? "" : "{" + delegates + "}");
+        return getClass().getSimpleName().replace("MessageStream", "")
+                + (statusDescription.isEmpty() ? "" : "[" + statusDescription + "]")
+                + (delegates == null ? "" : "{" + delegates + "}");
     }
 
     /**
@@ -706,6 +709,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      *
      * @return the flags that apply to this stream, or {@code null} if there are no relevant flags
      */
+    @Nullable
     protected String describeFlags() {
         return null;
     }
@@ -720,6 +724,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      *
      * @return the description of delegate streams, or {@code null} if there are no delegates
      */
+    @Nullable
     protected String describeDelegates() {
         return null;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -354,8 +354,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         switch (initialFetchResult) {
-            case FetchResult.Value(Entry<M> value) -> throw new IllegalArgumentException("Value fetchResult not supported during initialization");
-            case FetchResult.Error(Throwable error) -> completeExceptionally(error);
+            case FetchResult.Value(Entry<M> ignored) -> throw new IllegalArgumentException("Value fetchResult not supported during initialization");
+            case FetchResult.Error(Throwable throwable) -> completeExceptionally(throwable);
             case FetchResult.Completed() -> complete();
             case FetchResult.NotReady() -> awaitingData = true;
         }
@@ -531,8 +531,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
 
                 yield Optional.empty();
             }
-            case FetchResult.Error(Throwable error) -> {
-                completeExceptionally(error);
+            case FetchResult.Error(Throwable throwable) -> {
+                completeExceptionally(throwable);
 
                 yield Optional.empty();
             }

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -86,7 +86,7 @@ import static org.axonframework.messaging.core.MessageStreamUtils.NO_OP_CALLBACK
  * All methods in this class are either {@code final}, {@code private}, {@code abstract} or empty to
  * protect its invariants.
  *
- * @param <M> The type of {@link Message} contained in the {@link MessageStream.Entry entries} of this stream.
+ * @param <M> the type of {@link Message} contained in the {@link MessageStream.Entry entries} of this stream
  * @author Jan Galinski
  * @author John Hendrikx
  * @since 5.1.0
@@ -109,16 +109,15 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      * This abstraction allows implementations to distinguish between a stream that is
      * temporarily out of elements and one that has been fully exhausted.
      *
-     * @param <T> The type of value returned when available
+     * @param <T> the type of value returned when available
      */
     public sealed interface FetchResult<T extends @Nullable Entry<?>> {
 
         /**
-         * Creates a {@link FetchResult} reflecting the current observable state of the given
-         * {@link MessageStream}.
+         * Creates a {@code FetchResult} reflecting the current observable state of the given {@link MessageStream}.
          * <p>
-         * This method inspects the provided {@code delegate} in a non-blocking manner and
-         * translates its state into a corresponding {@link FetchResult}:
+         * This method inspects the provided {@code delegate} in a non-blocking manner and translates its state into a
+         * corresponding {@code FetchResult}:
          * <ul>
          *     <li>If {@link MessageStream#hasNextAvailable()} returns {@code true}, this method
          *     retrieves the next entry via {@link MessageStream#next()} and returns a
@@ -131,16 +130,16 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          *     containing the reported error.</li>
          * </ul>
          * <p>
-         * This method effectively adapts a {@link MessageStream} to the {@link FetchResult}-based
+         * This method effectively adapts a {@link MessageStream} to the {@code FetchResult}-based
          * consumption model used by {@link AbstractMessageStream}.
          * <p>
          * Note that this method may consume an entry from the delegate when one is available,
          * as it invokes {@link MessageStream#next()}. As such, it should only be used in contexts
          * where advancing the delegate stream is intended.
          *
-         * @param <M> the message type contained in the stream
+         * @param <M>      the message type contained in the stream
          * @param delegate the {@link MessageStream} to inspect, must not be {@code null}
-         * @return a {@link FetchResult} representing the delegate's current state
+         * @return a {@code FetchResult} representing the delegate's current state
          * @throws NullPointerException if {@code delegate} is {@code null}
          */
         static <M extends Message> FetchResult<Entry<M>> of(MessageStream<M> delegate) {
@@ -158,9 +157,9 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * Creates a {@link FetchResult} representing a successfully fetched value.
+         * Creates a {@code FetchResult} representing a successfully fetched value.
          *
-         * @param <T> the entry type
+         * @param <T>   the entry type
          * @param value the non-{@code null} value
          * @return a {@link Value} containing the given value, never {@code null}
          */
@@ -169,9 +168,9 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * Creates a {@link FetchResult} representing a producer side error.
+         * Creates a {@code FetchResult} representing a producer side error.
          *
-         * @param <T> the entry type
+         * @param <T>   the entry type
          * @param error the non-{@code null} error
          * @return an {@link Error} representing the failure, never {@code null}
          */
@@ -180,8 +179,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * Returns a {@link FetchResult} indicating that no element is available and
-         * no further elements will be produced.
+         * Returns a {@code FetchResult} indicating that no element is available and no further elements will be
+         * produced.
          *
          * @param <T> the entry type
          * @return a {@link Completed} result
@@ -192,8 +191,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * Returns a {@link FetchResult} indicating that no element is currently available,
-         * but more elements may become available in the future.
+         * Returns a {@code FetchResult} indicating that no element is currently available, but more elements may become
+         * available in the future.
          *
          * @param <T> the entry type
          * @return a {@link NotReady} result
@@ -204,10 +203,10 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * A {@link FetchResult} containing a successfully fetched value. The value
-         * can be {@code null} to support {@link MessageStream#ignoreEntries()}.
+         * A {@link FetchResult} containing a successfully fetched value. The value can be {@code null} to support
+         * {@link MessageStream#ignoreEntries()}.
          *
-         * @param <T> the entry type
+         * @param <T>   the entry type
          * @param value the value
          */
         record Value<T extends Entry<?>>(@Nullable T value) implements FetchResult<T> {
@@ -216,18 +215,23 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         /**
          * A {@link FetchResult} representing a terminal error in the stream.
          *
-         * @param <T> the entry type
+         * @param <T>   the entry type
          * @param error the non-{@code null} error
          */
         record Error<T extends Entry<?>>(Throwable error) implements FetchResult<T> {
+
+            /**
+             * Compact constructor ensuring the given {@code error} is not {@code null}.
+             *
+             * @param error the non-{@code null} error
+             */
             public Error {
                 Objects.requireNonNull(error, "error");
             }
         }
 
         /**
-         * A {@link FetchResult} indicating that the stream is exhausted and no further
-         * elements will be produced.
+         * A {@link FetchResult} indicating that the stream is exhausted and no further elements will be produced.
          *
          * @param <T> the entry type
          */
@@ -236,8 +240,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         }
 
         /**
-         * A {@link FetchResult} indicating that no element is currently available,
-         * but the stream may produce more elements in the future.
+         * A {@link FetchResult} indicating that no element is currently available, but the stream may produce more
+         * elements in the future.
          *
          * @param <T> the entry type
          */

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -111,7 +111,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      *
      * @param <T> The type of value returned when available
      */
-    public sealed interface FetchResult<T extends Entry<?>> {
+    public sealed interface FetchResult<T extends @Nullable Entry<?>> {
 
         /**
          * Creates a {@link FetchResult} reflecting the current observable state of the given
@@ -164,7 +164,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param value the non-{@code null} value
          * @return a {@link Value} containing the given value, never {@code null}
          */
-        static <T extends Entry<?>> FetchResult<T> of(T value) {
+        static <T extends @Nullable Entry<?>> FetchResult<T> of(@Nullable T value) {
             return new Value<>(value);
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -521,7 +521,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         this.awaitingData = false;
 
         return switch (fetchNext()) {
-            case FetchResult.Value(Entry<M> v) -> Optional.of(v);
+            case FetchResult.Value(Entry<M> v) -> Optional.ofNullable(v);
             case FetchResult.NotReady() -> {
                 awaitingData = true;
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -152,8 +152,8 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
             }
 
             return delegate.error()
-                .map(FetchResult::<Entry<M>>error)
-                .orElse(FetchResult.completed());
+                           .map(FetchResult::<Entry<M>>error)
+                           .orElse(FetchResult.completed());
         }
 
         /**
@@ -210,6 +210,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param value the value
          */
         record Value<T extends Entry<?>>(@Nullable T value) implements FetchResult<T> {
+
         }
 
         /**
@@ -236,6 +237,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param <T> the entry type
          */
         record Completed<T extends Entry<?>>() implements FetchResult<T> {
+
             private static final Completed<?> INSTANCE = new Completed<>();
         }
 
@@ -246,6 +248,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param <T> the entry type
          */
         record NotReady<T extends Entry<?>>() implements FetchResult<T> {
+
             private static final NotReady<?> INSTANCE = new NotReady<>();
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
@@ -158,6 +158,13 @@ class AbstractMessageStreamTest {
         }
 
         @Test
+        void whenNullValueAvailableThenReturnsEmptyOptional() {
+            stream.enqueue(FetchResult.of((Entry<Message>) null));
+
+            assertThat(stream.next()).isEmpty();
+        }
+
+        @Test
         void whenNotReadyThenReturnsEmptyAndDoesNotComplete() {
             assertThat(stream.next()).isEmpty();
             assertThat(stream.isCompleted()).isFalse();

--- a/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
@@ -19,6 +19,7 @@ package org.axonframework.messaging.core;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.axonframework.messaging.core.AbstractMessageStream.FetchResult;
 import org.axonframework.messaging.core.MessageStream.Entry;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.*;
 
 import java.util.ArrayDeque;
@@ -66,6 +67,7 @@ class AbstractMessageStreamTest {
             thrownExceptionInOnCompleted = e;
         }
 
+        @NonNull
         @Override
         protected FetchResult<Entry<Message>> fetchNext() {
             FetchResult<Entry<Message>> result = results.poll();
@@ -327,6 +329,7 @@ class AbstractMessageStreamTest {
             assertThat(count.get()).isEqualTo(0);
         }
 
+        @SuppressWarnings("DataFlowIssue")
         @Test
         void withNullCallbackThenThrowsNullPointerException() {
             assertThatThrownBy(() -> stream.setCallback(null))
@@ -553,7 +556,7 @@ class AbstractMessageStreamTest {
              * The class doc says: "If the registered callback throws an exception, the stream is
              * completed exceptionally, unless the callback was called to signal completion."
              *
-             * When complete() fires the callback and it throws, completeExceptionally() is called
+             * When complete() fires the callback, and it throws, completeExceptionally() is called
              * but is a no-op because completed=true already. The stream remains normally completed.
              */
 


### PR DESCRIPTION
This pull request ensures the nullability of the `Value` record implementation of the `FetchResult` is adhered too during `fetchNext()` invocations.
It does so by using `Optional#ofNullable` instead of `Optional#of`.
Besides this minor fix, I have:

1. Added a test to validate `null` values for the `MessageStream.entry` are supported
2. Clarified that generic of the `FetchResult` may be null by marking them as `@Nullable`
3. Clean-up all other warnings and inconsistencies within the file while touching it.

In doing the above, this PR resolves #4455.