### PR TITLE
[#4453] Fix ReplayToken.wasProcessedBeforeReset() for tokens without gap-walkback lowerBound semantics

### DIFF
--- a/axon-server-connector/pom.xml
+++ b/axon-server-connector/pom.xml
@@ -126,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/eventsourcing/pom.xml
+++ b/eventsourcing/pom.xml
@@ -162,12 +162,12 @@
         <!-- Testing -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Other -->

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -154,7 +154,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -166,7 +166,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>oracle-xe</artifactId>
+            <artifactId>testcontainers-oracle-xe</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/ReplayToken.java
@@ -322,7 +322,8 @@ public class ReplayToken implements TrackingToken, WrappedToken, Serializable {
         TrackingToken resetLowerBound = WrappedToken.unwrapLowerBound(tokenAtReset);
         TrackingToken newTokenLowerBound = WrappedToken.unwrapLowerBound(newToken);
         TrackingToken resetTokenLowerNewToken = resetLowerBound.lowerBound(newTokenLowerBound);
-        return resetTokenLowerNewToken.samePositionAs(newTokenLowerBound);
+        return resetTokenLowerNewToken.samePositionAs(newTokenLowerBound)
+                || resetLowerBound.covers(newTokenLowerBound);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/ReplayTokenTest.java
@@ -234,6 +234,52 @@ class ReplayTokenTest {
         }
     }
 
+    /**
+     * Tests for {@link ReplayToken#advancedTo(TrackingToken)} with a windowed token whose {@code lowerBound()}
+     * computes a set-intersection (like {@code MongoTrackingToken}). When two tokens track disjoint event sets —
+     * e.g. a recent reset token vs. an old replayed event — the intersection is empty and
+     * {@code samePositionAs(empty, old)} returns {@code false}. Without the {@code covers()} fallback introduced
+     * in <a href="https://github.com/AxonFramework/AxonFramework/issues/4453">issue #4453</a>, every replayed event
+     * would be misclassified as "new", causing {@code tokenAtReset.upperBound(newToken)} to be called on every step
+     * and the stored token to grow without bound.
+     */
+    @Nested
+    class AdvancedToWithWindowedTrackingToken {
+
+        @Test
+        void replayedEventFromEarlierPeriodIsClassifiedAsReplay() {
+            // tokenAtReset tracks events from "now" (high position, recent event IDs)
+            WindowedTrackingToken tokenAtReset = new WindowedTrackingToken(1000, Set.of(900L, 950L, 1000L));
+            // old event: low position, event IDs fully disjoint from tokenAtReset's window
+            WindowedTrackingToken oldEvent = new WindowedTrackingToken(10, Set.of(5L, 8L, 10L));
+
+            // lowerBound(tokenAtReset, oldEvent) = intersection = {} — triggers the bug without the fix
+            ReplayToken replayToken = (ReplayToken) ReplayToken.createReplayToken(tokenAtReset, null);
+            TrackingToken result = replayToken.advancedTo(oldEvent);
+
+            assertInstanceOf(ReplayToken.class, result);
+            assertTrue(ReplayToken.isReplay(result),
+                       "Old event processed before reset must be classified as replay, not as new");
+        }
+
+        @Test
+        void tokenAtResetDoesNotGrowDuringReplay() {
+            // Without the fix every misclassified event triggers tokenAtReset.upperBound(newToken),
+            // merging ALL new event IDs into tokenAtReset on each step — unbounded growth.
+            WindowedTrackingToken tokenAtReset = new WindowedTrackingToken(1000, Set.of(900L, 950L, 1000L));
+
+            TrackingToken current = ReplayToken.createReplayToken(tokenAtReset, null);
+            for (long i = 1; i <= 50; i++) {
+                current = ((ReplayToken) current).advancedTo(new WindowedTrackingToken(i, Set.of(i)));
+            }
+
+            assertInstanceOf(ReplayToken.class, current);
+            assertTrue(ReplayToken.isReplay(current));
+            assertEquals(tokenAtReset, ((ReplayToken) current).getTokenAtReset(),
+                         "tokenAtReset must not grow during replay");
+        }
+    }
+
     @Nested
     class SamePositionAs {
 
@@ -315,6 +361,68 @@ class ReplayTokenTest {
             ReplayToken replayToken = new ReplayToken(tokenAtReset, currentToken, null);
 
             assertTrue(replayToken.samePositionAs(sameCurrentToken));
+        }
+    }
+
+    /**
+     * A {@link TrackingToken} whose {@code lowerBound()} returns the intersection of two event-ID sets (mirroring
+     * {@code MongoTrackingToken}). The intersection is empty when the two tokens track disjoint event sets, which
+     * is the scenario that triggers issue #4453.
+     * <p>
+     * {@code covers()} uses time/position semantics: {@code other} is covered if it is not newer than {@code this}
+     * and all its tracked events are either present in this token's window or predate the oldest event in it.
+     */
+    private static class WindowedTrackingToken implements TrackingToken {
+
+        private final long position;
+        private final Set<Long> trackedEvents;
+
+        WindowedTrackingToken(long position, Set<Long> trackedEvents) {
+            this.position = position;
+            this.trackedEvents = Collections.unmodifiableSet(new HashSet<>(trackedEvents));
+        }
+
+        @Override
+        public TrackingToken lowerBound(TrackingToken other) {
+            WindowedTrackingToken o = (WindowedTrackingToken) other;
+            Set<Long> intersection = new HashSet<>(trackedEvents);
+            intersection.retainAll(o.trackedEvents);
+            return new WindowedTrackingToken(Math.min(position, o.position), intersection);
+        }
+
+        @Override
+        public TrackingToken upperBound(TrackingToken other) {
+            WindowedTrackingToken o = (WindowedTrackingToken) other;
+            Set<Long> union = new HashSet<>(trackedEvents);
+            union.addAll(o.trackedEvents);
+            return new WindowedTrackingToken(Math.max(position, o.position), union);
+        }
+
+        @Override
+        public boolean covers(TrackingToken other) {
+            WindowedTrackingToken o = (WindowedTrackingToken) other;
+            long oldest = trackedEvents.stream().min(Comparator.naturalOrder()).orElse(0L);
+            return o.position <= this.position
+                    && o.trackedEvents.stream().allMatch(e -> trackedEvents.contains(e) || e < oldest);
+        }
+
+        @Override
+        public OptionalLong position() {
+            return OptionalLong.of(position);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof WindowedTrackingToken)) {
+                return false;
+            }
+            WindowedTrackingToken other = (WindowedTrackingToken) obj;
+            return position == other.position && trackedEvents.equals(other.trackedEvents);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(position, trackedEvents);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <junit4.version>4.13.2</junit4.version>
         <junit.jupiter.version>5.13.4</junit.jupiter.version>
         <mockito.version>4.11.0</mockito.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <!-- Validation -->
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hibernate-validator.8.version>8.0.2.Final</hibernate-validator.8.version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -239,12 +239,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Other -->


### PR DESCRIPTION
`ReplayToken.wasProcessedBeforeReset()` relied solely on `lowerBound()` + `samePositionAs()` to determine whether a replayed event had already been processed before the reset. This works correctly for `GapAwareTrackingToken`, whose `lowerBound()` walks back from gap positions, but breaks for token implementations whose `lowerBound()` computes a set-intersection — such as `MongoTrackingToken`.

When the reset token and the replayed event token are from completely different time periods, their event-ID sets are disjoint. The intersection is empty, and `samePositionAs(empty, other)` returns `false`, causing every replayed event to be misclassified as "new" instead of "replay". This has two observable effects:

1. `@DisallowReplay` handlers fire during a replay, and `ReplayToken.isReplay()` returns `false`.
2. `advancedTo()` falls into the "new event" branch and calls `tokenAtReset.upperBound(newToken)` for every replayed event, merging all event IDs into the stored token on every step. The token grows without bound until the backing store's size limit is exceeded.

The fix adds a `covers()` fallback: if `resetLowerBound.covers(newTokenLowerBound)` is true, the event was processed before the reset regardless of what `lowerBound()` returned. For `GapAwareTrackingToken` this fallback is dead code — whenever `covers()` would return `true`, the existing `lowerBound()` + `samePositionAs()` check already does. For set-intersection tokens it restores correct behaviour by using their time/position-based `covers()` implementation.

Two regression tests are added using a `WindowedTrackingToken` (an in-test stub whose `lowerBound()` returns the intersection of event-ID sets, mirroring `MongoTrackingToken`):
- one verifying that a replayed event from an earlier period is classified as a replay
- one verifying that `tokenAtReset` does not grow during replay

Also includes an unrelated bump of the TestContainers version to support running integration tests against more recent Docker installations.

Fixes #4453.