### PR TITLE
Fix race between AxonTimeLimitedTask and UnitOfWorkTimeoutInterceptor causing TEP shutdown

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/TrackingEventProcessorTest.java
@@ -50,6 +50,7 @@ import org.axonframework.integrationtests.utils.MockException;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.timeout.UnitOfWorkTimeoutInterceptor;
 import org.axonframework.serialization.SerializationException;
 import org.axonframework.tracing.TestSpanFactory;
 import org.hamcrest.CoreMatchers;
@@ -2217,6 +2218,50 @@ class TrackingEventProcessorTest {
         assertTrue(finished.await(5, TimeUnit.SECONDS), "Expected Unit of Work to have reached clean up phase");
         TrackingToken trackingToken = tokenStore.fetchToken(testSubject.getName(), 0);
         assertFalse(ReplayToken.isReplay(trackingToken), "Not a replay token: " + trackingToken);
+    }
+
+    @Test
+    @Timeout(value = 15)
+    void timeoutInterceptorRaceWithNonTimeoutExceptionDoesNotShutDownProcessor() throws Exception {
+        // Regression test for: https://github.com/AxonFramework/AxonFramework/issues/4456
+        // AxonTimeLimitedTask's scheduled interrupt lambda can fire after detectInterruptionInsteadOfException
+        // has already determined that the exception was NOT a timeout. The fix is that complete() is called
+        // early in the catch block and is synchronized with the lambda — so either the lambda never fires,
+        // or complete() clears the interrupt the lambda set before it can reach doSleepFor.
+        AtomicInteger handlerInvocations = new AtomicInteger();
+        CountDownLatch processedAfterError = new CountDownLatch(2);
+
+        doAnswer(invocation -> {
+            if (handlerInvocations.getAndIncrement() == 0) {
+                throw new MockException("Simulated handler failure");
+            }
+            processedAfterError.countDown();
+            return null;
+        }).when(mockHandler).handle(any());
+
+        TrackingEventProcessor processorWithRealSleep =
+                TrackingEventProcessor.builder()
+                                      .name("timeoutRaceTest")
+                                      .eventHandlerInvoker(eventHandlerInvoker)
+                                      .messageSource(eventBus)
+                                      .tokenStore(new InMemoryTokenStore())
+                                      .transactionManager(NoTransactionManager.INSTANCE)
+                                      .build();
+        // A 1ms timeout maximises the chance that the interrupt lambda fires concurrently with the
+        // exception-handling path, exercising the synchronized complete() + early-complete fix.
+        processorWithRealSleep.registerHandlerInterceptor(
+                new UnitOfWorkTimeoutInterceptor("timeoutRaceTest", 1, Integer.MAX_VALUE, 1)
+        );
+        processorWithRealSleep.start();
+
+        eventBus.publish(createEvents(2));
+
+        assertTrue(
+                processedAfterError.await(10, TimeUnit.SECONDS),
+                "Processor should continue running and handle events despite timeout/exception race"
+        );
+        assertTrue(processorWithRealSleep.isRunning(), "Processor should still be running");
+        processorWithRealSleep.shutDown();
     }
 
     private void waitForStatus(String description,

--- a/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/TrackingEventProcessor.java
@@ -879,8 +879,10 @@ public class TrackingEventProcessor extends AbstractEventProcessor implements St
                 Thread.sleep(Math.min(timeLeft, 100));
             }
         } catch (InterruptedException e) {
-            logger.warn("Thread interrupted. Preparing to shut down event processor");
-            shutDown();
+            if (isRunning()) {
+                logger.warn("Thread interrupted. Preparing to shut down event processor");
+                setShutdownState();
+            }
             Thread.currentThread().interrupt();
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/AxonTimeLimitedTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/AxonTimeLimitedTask.java
@@ -46,6 +46,7 @@ class AxonTimeLimitedTask {
     private final String taskName;
     private final ScheduledExecutorService scheduledExecutorService;
     private final Logger logger;
+    private final Object lock = new Object();
     private boolean completed = false;
     private boolean interrupted = false;
     private boolean interruptedExternally = false;
@@ -141,12 +142,22 @@ class AxonTimeLimitedTask {
 
     /**
      * Marks the task as completed. Cancels the current future warning or interrupt if any exists.
+     * <p>
+     * If the scheduled interrupt lambda won a race against this call — i.e., it already set the interrupt
+     * flag on the task thread before {@code complete()} could cancel it — the interrupt is cleared here so
+     * it does not leak into the caller's subsequent code.
      */
     public void complete() {
-        completed = true;
-        if (currentScheduledFuture != null) {
-            currentScheduledFuture.cancel(false);
-            currentScheduledFuture = null;
+        synchronized (lock) {
+            completed = true;
+            if (currentScheduledFuture != null) {
+                currentScheduledFuture.cancel(false);
+                currentScheduledFuture = null;
+            }
+            if (interrupted) {
+                interrupted = false;
+                Thread.interrupted(); // clear the spurious flag set by the racing lambda
+            }
         }
         if (logger.isTraceEnabled()) {
             logger.trace("{} completed", taskName);
@@ -285,14 +296,16 @@ class AxonTimeLimitedTask {
      */
     private void scheduleInterrupt(long remainingTimeout) {
         currentScheduledFuture = scheduledExecutorService.schedule(() -> {
-            if (!completed && !interrupted) {
-                logger.error(
-                        "{} has exceeded its timeout of [{}ms]. Interrupting thread.\nStacktrace of current thread:\n{}",
-                        taskName,
-                        timeout,
-                        getCurrentStackTrace());
-                interrupted = true;
-                thread.interrupt();
+            synchronized (lock) {
+                if (!completed && !interrupted) {
+                    logger.error(
+                            "{} has exceeded its timeout of [{}ms]. Interrupting thread.\nStacktrace of current thread:\n{}",
+                            taskName,
+                            timeout,
+                            getCurrentStackTrace());
+                    interrupted = true;
+                    thread.interrupt();
+                }
             }
         }, remainingTimeout, TimeUnit.MILLISECONDS);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/UnitOfWorkTimeoutInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/UnitOfWorkTimeoutInterceptor.java
@@ -126,7 +126,14 @@ public class UnitOfWorkTimeoutInterceptor implements MessageHandlerInterceptor<M
             task.ensureNoInterruptionWasSwallowed();
             return proceed;
         } catch (Exception e) {
-            throw task.detectInterruptionInsteadOfException(e);
+            Exception result = task.detectInterruptionInsteadOfException(e);
+            if (result == e) {
+                // The exception was not caused by this task's timeout, so complete it now.
+                // This cancels any still-pending interrupt and clears one that may have already fired,
+                // preventing it from leaking into the caller's retry sleep (e.g. in TrackingEventProcessor).
+                task.complete();
+            }
+            throw result;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #4456.

When a handler throws a non-timeout exception, `AxonTimeLimitedTask`'s scheduled interrupt lambda could fire after `detectInterruptionInsteadOfException` had already returned the original exception (no timeout detected), but before `onRollback` called `complete()`. The lingering interrupt flag then reached `doSleepFor` in `TrackingEventProcessor`, where `Thread.sleep` threw `InterruptedException` — previously treated unconditionally as a shutdown signal, causing the processor to stop.

## Changes

**`AxonTimeLimitedTask`** — root cause fix: synchronize the `scheduleInterrupt` lambda body and `complete()` on a shared lock. If the lambda wins the race and fires the interrupt before `complete()` acquires the lock, `complete()` detects `interrupted == true` and clears the thread interrupt flag so it cannot leak to the caller.

**`UnitOfWorkTimeoutInterceptor`** — close the race window: call `task.complete()` immediately in the catch block when `detectInterruptionInsteadOfException` confirms the exception was not caused by a timeout (`result == e`). This runs before the unit-of-work rollback phase, making the `onRollback` handler a harmless no-op in that path.

**`TrackingEventProcessor.doSleepFor`** — fix pre-existing issue: replace the deadlock-prone `shutDown()` call (which invoked `awaitTermination().join()` from the worker thread itself) with `setShutdownState()`, matching the pattern already used in `processBatch`. Any interrupt that reaches `doSleepFor` while the processor is still running is now treated as a legitimate external signal and triggers a clean state transition; spurious interrupts from the lambda no longer reach here thanks to the first two fixes.