### PR TITLE
[#4437] Fix consistency marker when sourcing an empty stream in the AggregateBasedJpaEventStorageEngine and AggregateBasedAxonServerEventStorageEngine

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/AggregateBasedAxonServerEventStorageEngine.java
@@ -211,7 +211,10 @@ public class AggregateBasedAxonServerEventStorageEngine implements EventStorageE
                                                                            markerReference))
                              // Defaults the marker when the aggregate stream was empty
                              .onComplete(() -> markerReference.compareAndSet(
-                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, 0)
+                                     // making sequence number (=last seen event) -1 makes the position in the Consistency Marker 0
+                                     // this ensures 0-based sequence numbers, as they are derived from the marker when appending
+                                     // Axon Server enforces 0-based sequence numbers
+                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, -1)
                              ))
                              .cast();
         return new AggregateSource(markerReference, source);

--- a/build/coverage-report/pom.xml
+++ b/build/coverage-report/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon-parent</artifactId>
-        <version>5.0.4-SNAPSHOT</version>
+        <version>5.0.5-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -299,7 +299,9 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                                          entry -> setMarkerAndBuildContext(entry, markerReference))
                              // Defaults the marker when the aggregate stream was empty
                              .onComplete(() -> markerReference.compareAndSet(
-                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, 0)
+                                     // making sequence number (=last seen event) -1 makes the position in the Consistency Marker 0
+                                     // this ensures 0-based sequence numbers, as they are derived from the marker when appending
+                                     null, new AggregateBasedConsistencyMarker(aggregateIdentifier, -1)
                              ))
                              .cast();
         return new AggregateSource(markerReference, source);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -475,8 +476,8 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     @Test
     void sourcingAnEmptyEventStoreReturnsAnExpectedConsistencyMarker() {
         // given...
-        ConsistencyMarker testAggregateMarker = new AggregateBasedConsistencyMarker(TEST_AGGREGATE_ID, 0);
-        ConsistencyMarker otherAggregateMarker = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 0);
+        ConsistencyMarker testAggregateMarker = new AggregateBasedConsistencyMarker(TEST_AGGREGATE_ID, -1);
+        ConsistencyMarker otherAggregateMarker = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, -1);
         ConsistencyMarker expectedMarker = testAggregateMarker.upperBound(otherAggregateMarker);
         // when...
         SourcingCondition testCondition =

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -491,6 +491,27 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
                     .verifyComplete();
     }
 
+    /**
+     * Regression test for <a href="https://github.com/AxonIQ/AxonFramework/issues/4437">#4437</a>
+     */
+    @Test
+    void appendingFirstEventAfterSourcingEmptyStreamSucceeds() {
+        // given
+        SourcingCondition sourcingCondition = SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA);
+        AtomicReference<ConsistencyMarker> markerFromSource = new AtomicReference<>();
+        StepVerifier.create(FluxUtils.of(testSubject.source(sourcingCondition)))
+                    .assertNext(entry -> markerFromSource.set(entry.getResource(ConsistencyMarker.RESOURCE_KEY)))
+                    .verifyComplete();
+
+        // when
+        AppendCondition appendCondition = AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA)
+                                                         .withMarker(markerFromSource.get());
+        assertDoesNotThrow(
+                () -> appendEvents(appendCondition, taggedEventMessage("event-0", TEST_AGGREGATE_TAGS))
+        );
+    }
+
+
     @Test
     void transactionRejectedWithConflictingEventsInStore() {
         ConsistencyMarker consistencyMarker = appendEvents(

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework</groupId>
         <artifactId>axon</artifactId>
-        <version>5.0.4-SNAPSHOT</version>
+        <version>5.0.5-SNAPSHOT</version>
     </parent>
 
     <groupId>org.axonframework.examples</groupId>

--- a/examples/university-demo/pom.xml
+++ b/examples/university-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.0.4-SNAPSHOT</version>
+        <version>5.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>university-demo</artifactId>

--- a/examples/university-java-springboot/pom.xml
+++ b/examples/university-java-springboot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.0.4-SNAPSHOT</version>
+        <version>5.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>university-java-springboot</artifactId>

--- a/examples/university-java/pom.xml
+++ b/examples/university-java/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.axonframework.examples</groupId>
         <artifactId>axon-framework-examples</artifactId>
-        <version>5.0.4-SNAPSHOT</version>
+        <version>5.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>university-java</artifactId>


### PR DESCRIPTION
This PR adjusts the behaviour of the aggregate based event storage engines when sourcing an empty event stream to make sure the consistency marker included in the context of the Terminal message is pointing to position 0, resulting in 0-based sequence numbers for aggregates.

### AggregateBasedAxonServerEventStorageEngine
Up to now in Axon Framework 5 when sourcing an empty event stream in the AggregateBasedAxonServerEventStorageEngine, the consistency marker included in the context of the Terminal message was pointing to position 1, resulting in the sequence number to be generated when the event is appended based on this consistency marker being 1.

Axon Server does not allow to start an empty aggregate event stream with sequence number 1 (for optimization reasons), so doing this leads to a misleading `AppendEventsTransactionRejectedException` stating `Event matching append criteria have been detected beyond provided consistency marker`. 

### AggregateBasedJpaEventStorageEngine

Up to now in AF5, when sourcing an empty event stream in the AggregateBasedJpaEventStorageEngine, the consistency marker included in the context of the Terminal message was pointing to position 1, resulting in 1-based sequence numbers for aggregates in the AggregateBasedJpaEventStorageEngine.

While this is technically acceptable for appending events to the AggregateBasedJpaEventStorageEngine, it is inconsistent with the behaviour of the AF4 JpaEventStorageEngine (aggregate based), which produced 0 based sequence numbers.

This inconsistency was discovered while investigating #4437, so it's related.

### Changes included
* fix empty stream behaviour in AggregateBasedJpaEventStorageEngine to point to position 0 in the consistency marker
* fix empty stream behaviour in AggregateBasedAxonServerEventStorageEngine to point to position 0 in the consistency marker
* add a regression test to make sure appending events based on an append condition derived from a consistency marker returned from sourcing an empty aggregate event stream yields no exception