### PR TITLE
Add Visual indicator for features moved to Axoniq Framework

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -24,7 +24,6 @@ When looking to provide a pull request, be sure to adjust link:https://github.co
 [TIP]
 .PostgreSQL Extension
 ====
-// TODO Axoniq feature
 You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution. For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
 ====
 

--- a/docs/reference-guide/modules/ROOT/pages/modules.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/modules.adoc
@@ -161,14 +161,15 @@ endif::[]
 
 == Axon Framework Bill of Materials
 
-In addition to the base framework modules and extensions and advanced framework modules, Axon also provides two https://en.wikipedia.org/wiki/Software_bill_of_materials[Bills of Materials], or BOM for both base and advanced framework.
+In addition to the Axon Framework modules and extensions and Axoniq Framework modules, Axon also provides two https://en.wikipedia.org/wiki/Software_bill_of_materials[Bills of Materials], or BOM for both Axon Framework and Axoniq Framework.
 The BOM is provided to ensure the use of compatible framework and extension dependencies inside an Axon application.
 As such, it is the recommended approach towards defining the overall Axon version used inside of an application.
 
-[#base-framework-bom]
-=== Base Axon Framework Bill of Materials
+// TODO anchor
+[#axon-framework-bom]
+=== Axon Framework Bill of Materials
 
-For the base framework and extensions, we provide a BOM under the `org.axonframework` Group id as follows:
+For the Axon Framework and extensions, we provide a BOM under the `org.axonframework` Group id as follows:
 
 [cols="<,<,<,^"]
 |===

--- a/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
@@ -1,5 +1,5 @@
+[.axoniq-feature]
 = Dead-Letter Queue Migration
-//TODO Axoniq feature
 
 Axon Framework 5 introduces slight changes to how the Dead-Letter Queue (DLQ) works, reflecting the broader shift to async-first APIs and finer-grained component model in Axon Framework 5.
 

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -463,8 +463,8 @@ axon.eventstorage.jpa.polling-interval=1000
 --
 ====
 
+[.axoniq-feature]
 == PostgreSQL event storage migration
-// TODO Axoniq feature
 
 If you are using PostgreSQL as your database for event storage—whether through the `JpaEventStorageEngine` or `JdbcEventStorageEngine` in Axon Framework 4—you would benefit from migrating to the dedicated `PostgresqlEventStorageEngine`.
 

--- a/docs/reference-guide/modules/migration/pages/prerequisites.adoc
+++ b/docs/reference-guide/modules/migration/pages/prerequisites.adoc
@@ -11,8 +11,8 @@ Axon Framework 5.0 represents a significant change for event-sourced application
 
 **What This Means for You** - The minimum Java version required for Axon Framework 4.x was Java 8. The Java ecosystem has matured significantly since then, and Java 21 provides a wealth of features that make event-sourced systems more resilient, reliable, modern, and performant. Therefore, If you're currently running your Axon Framework 4.x applications on any Java version before Java 21, then you need to upgrade before performing a migration to Axon Framework 5.
 
+[.axoniq-feature]
 == 2. Axon Server compatibility (optional)
-// TODO Axoniq feature
 
 **Requirement** - Your Axon Server infrastructure needs to align with your Axon Framework 5.0 migration approach.
 

--- a/docs/reference-guide/modules/migration/pages/understanding-architecture-principles.adoc
+++ b/docs/reference-guide/modules/migration/pages/understanding-architecture-principles.adoc
@@ -48,9 +48,6 @@ This breaks down into specific layer configurers:
 
 Instead of a monolithic configuration class, you now compose modular configurers:
 
-// TODO other Storage engine example or
-// TODO Axoniq feature
-
 [source,java]
 ----
 import io.axoniq.axonserver.connector.AxonServerConnection;

--- a/docs/reference-guide/modules/migration/pages/why-upgrade.adoc
+++ b/docs/reference-guide/modules/migration/pages/why-upgrade.adoc
@@ -92,8 +92,8 @@ In Axon Framework 4.x, extensions existed, but they often felt like companions r
 With Axon Framework 5, the story changes.
 The extensions aren't afterthoughts or legacy components—they're integral to the ecosystem, rebuilt from the ground up to embrace the async-native architecture and all the philosophical improvements that Axon Framework 5 introduces.
 
+[.axoniq-feature]
 === Why this matters: the PostgreSQL extension for Axon Framework 5
-// TODO Axoniq feature
 
 Not every organization runs specialized event stores.
 Many teams have PostgreSQL at their core—a battle-tested, reliable relational database that's already part of their infrastructure.

--- a/docs/reference-guide/modules/monitoring/pages/message-tracking.adoc
+++ b/docs/reference-guide/modules/monitoring/pages/message-tracking.adoc
@@ -7,7 +7,7 @@ There are several ways to track messages in your system.
 ifdef::advanced-framework[]
 A clear solution to this, is xref:tracing:index.adoc[tracing], albeit slightly involved.
 endif::[]
-Among the options you have through the base framework, there are xref:messaging-concepts:message-correlation.adoc[correlation data providers] or straight out logging in xref:messaging-concepts:message-intercepting.adoc[interceptors]
+Among the options you have through the Axon Framework, there are xref:messaging-concepts:message-correlation.adoc[correlation data providers] or straight out logging in xref:messaging-concepts:message-intercepting.adoc[interceptors]
 You can correlate messages to each other with a Correlation Data Provider or log the messages being handled and dispatched.
 
 == Correlation data

--- a/docs/reference-guide/modules/release-notes/pages/index.adoc
+++ b/docs/reference-guide/modules/release-notes/pages/index.adoc
@@ -5,7 +5,7 @@
 The release notes section for the Axon framework for all major/minor releases.
 You can switch the documentation to other major version on the right side of the header, right above the every chapter.
 
-== Base framework and extensions
+== Axon Framework and extensions
 
 [cols="<,<"]
 |===


### PR DESCRIPTION
To make it easy for users to distinguish between Axon Framework and Axoniq Framework features, we add visual indication based on an antora role that renders as css-class in the rendered docs that we can style. 

In addition this PR also straightens the wording of Axon Framework / Axoniq Framework which was referred to as base and advanced framework in the beginning of the split.