### PR TITLE
Fix incorrect aggregate version cached in DCB mode when using AxonServer

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -43,6 +43,7 @@ import org.axonframework.eventhandling.TrackedEventData;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
 import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.eventsourcing.CachingEventSourcingRepository;
 import org.axonframework.eventsourcing.EventStreamUtils;
 import org.axonframework.eventsourcing.eventstore.AbstractEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.AbstractEventStore;
@@ -70,6 +71,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.Spliterators;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -405,6 +408,8 @@ public class AxonServerEventStore extends AbstractEventStore {
 
         private static final int ALLOW_SNAPSHOTS_MAGIC_VALUE = -42;
         private final String APPEND_EVENT_TRANSACTION = this + "/APPEND_EVENT_TRANSACTION";
+        private final String LAST_MESSAGE_ID_KEY_PREFIX = this + "/LastMessageId/";
+        private final String PREDICTED_SEQUENCE_KEY_PREFIX = this + "/PredictedSequence/";
         private static final boolean WITHOUT_SNAPSHOTS = false;
 
         private final AxonServerConfiguration configuration;
@@ -469,10 +474,78 @@ public class AxonServerEventStore extends AbstractEventStore {
             }
             for (EventMessage<?> eventMessage : events) {
                 sender.appendEvent(map(eventMessage, serializer));
+                if (CurrentUnitOfWork.isStarted() && eventMessage instanceof DomainEventMessage) {
+                    registerCommittedSequenceSupplier((DomainEventMessage<?>) eventMessage);
+                }
             }
             if (!CurrentUnitOfWork.isStarted()) {
                 commit(sender);
             }
+        }
+
+        /**
+         * Called for each {@link DomainEventMessage} appended in the current transaction. Keeps track of the last
+         * event's identifier and locally-predicted sequence number per aggregate, and lazily registers a
+         * {@link Supplier} under {@link CachingEventSourcingRepository#COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX} in the
+         * root UnitOfWork. The supplier is called by {@link CachingEventSourcingRepository} after commit to obtain
+         * the actual server-assigned sequence number for the cached aggregate entry.
+         */
+        private void registerCommittedSequenceSupplier(DomainEventMessage<?> event) {
+            String aggregateId = event.getAggregateIdentifier();
+            AtomicReference<String> lastIdRef = CurrentUnitOfWork.get().root()
+                    .getOrComputeResource(LAST_MESSAGE_ID_KEY_PREFIX + aggregateId, k -> new AtomicReference<>());
+            lastIdRef.set(event.getIdentifier());
+            AtomicLong predictedSeqRef = CurrentUnitOfWork.get().root()
+                    .getOrComputeResource(PREDICTED_SEQUENCE_KEY_PREFIX + aggregateId, k -> new AtomicLong());
+            predictedSeqRef.set(event.getSequenceNumber());
+            CurrentUnitOfWork.get().root()
+                    .<Supplier<Optional<Long>>>getOrComputeResource(
+                            CachingEventSourcingRepository.COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX + aggregateId,
+                            k -> () -> resolveCommittedSequence(aggregateId, lastIdRef, predictedSeqRef)
+                    );
+        }
+
+        /**
+         * Resolves the sequence number that was actually assigned to the last event committed for the given aggregate.
+         * <p>
+         * First asks the server for the current highest sequence number. If it matches the locally-predicted value,
+         * no concurrent commit occurred and the sequence is returned immediately (one roundtrip). If the value
+         * differs — as happens in DCB contexts where the server assigns global rather than per-aggregate sequence
+         * numbers — the event at that position is read and its message identifier is compared against the last event
+         * we sent. A match confirms the sequence belongs to our transaction; a mismatch indicates a concurrent commit
+         * and {@link Optional#empty()} is returned to signal that caching should be skipped.
+         */
+        private Optional<Long> resolveCommittedSequence(String aggregateId,
+                                                        AtomicReference<String> expectedLastIdRef,
+                                                        AtomicLong predictedSeqRef) {
+            try {
+                Optional<Long> lastSeq = lastSequenceNumberFor(aggregateId);
+                if (!lastSeq.isPresent()) {
+                    return Optional.empty();
+                }
+                long sequence = lastSeq.get();
+                if (sequence == predictedSeqRef.get()) {
+                    // Sequence matches the locally-predicted value; no concurrent commit occurred.
+                    return Optional.of(sequence);
+                }
+                // Sequence differs from prediction (DCB global sequences, or a concurrent commit).
+                // Read the event at that position and verify it belongs to our transaction.
+                AggregateEventStream stream = connectionManager.getConnection(context)
+                                                               .eventChannel()
+                                                               .openAggregateStream(aggregateId, sequence, sequence);
+                try {
+                    if (stream.hasNext() && expectedLastIdRef.get().equals(stream.next().getMessageIdentifier())) {
+                        return Optional.of(sequence);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stream.cancel();
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to resolve committed sequence for aggregate [{}]", aggregateId, e);
+            }
+            return Optional.empty();
         }
 
         private void commit(AppendEventsTransaction appendEventTransaction) {

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/AxonServerConnectionManagerTest.java
@@ -58,6 +58,7 @@ class AxonServerConnectionManagerTest {
     private StubServer stubServer;
     private StubServer secondNode;
     private AxonServerConfiguration testConfig;
+    private AxonServerConnectionManager testSubject;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -75,6 +76,10 @@ class AxonServerConnectionManagerTest {
 
     @AfterEach
     void tearDown() throws InterruptedException {
+        if (testSubject != null) {
+            testSubject.shutdown();
+            testSubject = null;
+        }
         stubServer.shutdown();
         secondNode.shutdown();
     }
@@ -83,7 +88,7 @@ class AxonServerConnectionManagerTest {
     void whetherConnectionPreferenceIsSent() {
         TagsConfiguration testTags = new TagsConfiguration(Collections.singletonMap("key", "value"));
 
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .tagsConfiguration(testTags)
                                                                              .build();
@@ -126,7 +131,7 @@ class AxonServerConnectionManagerTest {
                                                                     .connectTimeout(50)
                                                                     .build();
 
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 
@@ -145,7 +150,7 @@ class AxonServerConnectionManagerTest {
     @Test
     void enablingHeartbeatsEnsuresHeartbeatMessagesAreSent() {
         testConfig.getHeartbeat().setEnabled(true);
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
         testSubject.start();
@@ -162,7 +167,7 @@ class AxonServerConnectionManagerTest {
     @Test
     void enablingHeartbeatsEnsuresHeartbeatMessagesAreSentOnOtherContexts() {
         testConfig.getHeartbeat().setEnabled(true);
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
         testSubject.start();
@@ -183,7 +188,7 @@ class AxonServerConnectionManagerTest {
     @Test
     void disablingHeartbeatsEnsuresNoHeartbeatMessagesAreSent() {
         testConfig.getHeartbeat().setEnabled(false);
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
         testSubject.start();
@@ -224,7 +229,7 @@ class AxonServerConnectionManagerTest {
 
     @Test
     void isConnected() {
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 
@@ -264,7 +269,7 @@ class AxonServerConnectionManagerTest {
 
     @Test
     void disconnectClosesAllConnections() {
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 
@@ -289,7 +294,7 @@ class AxonServerConnectionManagerTest {
 
     @Test
     void disconnectSingleConnection() {
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 
@@ -314,7 +319,7 @@ class AxonServerConnectionManagerTest {
 
     @Test
     void connectionsReturnsConnectionStatus() {
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 
@@ -345,7 +350,7 @@ class AxonServerConnectionManagerTest {
         testConfig.setReconnectInterval(expectedReconnectInterval);
         testConfig.setForceReconnectThroughServers(false);
 
-        AxonServerConnectionManager testSubject = AxonServerConnectionManager.builder()
+        testSubject = AxonServerConnectionManager.builder()
                                                                              .axonServerConfiguration(testConfig)
                                                                              .build();
 

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -131,6 +131,8 @@ class ServerConnectorConfigurerModuleTest {
         await().pollDelay(Duration.ofMillis(50))
                .atMost(Duration.ofMillis(500))
                .untilAsserted(() -> verify(connectionManager).getConnection());
+
+        config.shutdown();
     }
 
     /**
@@ -169,5 +171,7 @@ class ServerConnectorConfigurerModuleTest {
         await().pollDelay(Duration.ofMillis(50))
                .atMost(Duration.ofMillis(500))
                .untilAsserted(() -> verify(connectionManager, times(2)).getConnection());
+
+        config.shutdown();
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/ServerConnectorConfigurerModuleTest.java
@@ -45,11 +45,20 @@ import static org.mockito.Mockito.*;
  */
 class ServerConnectorConfigurerModuleTest {
 
+    private Configuration testSubject;
+
+    @AfterEach
+    void tearDown() {
+        if (testSubject != null) {
+            testSubject.shutdown();
+        }
+    }
+
     @Test
     void axonServerConfiguredInDefaultConfiguration() {
-        Configuration testSubject = DefaultConfigurer.defaultConfiguration()
-                                                     .configureSerializer(c -> TestSerializer.xStreamSerializer())
-                                                     .buildConfiguration();
+        testSubject = DefaultConfigurer.defaultConfiguration()
+                                       .configureSerializer(c -> TestSerializer.xStreamSerializer())
+                                       .buildConfiguration();
 
         AxonServerConfiguration resultAxonServerConfig = testSubject.getComponent(AxonServerConfiguration.class);
 
@@ -78,26 +87,25 @@ class ServerConnectorConfigurerModuleTest {
 
     @Test
     void queryUpdateEmitterIsTakenFromConfiguration() {
-        Configuration configuration = DefaultConfigurer.defaultConfiguration()
-                                                       .configureSerializer(c -> TestSerializer.xStreamSerializer())
-                                                       .buildConfiguration();
+        testSubject = DefaultConfigurer.defaultConfiguration()
+                                       .configureSerializer(c -> TestSerializer.xStreamSerializer())
+                                       .buildConfiguration();
 
-        assertTrue(configuration.queryBus() instanceof AxonServerQueryBus);
-        assertSame(configuration.queryBus().queryUpdateEmitter(), configuration.queryUpdateEmitter());
-        assertSame(((AxonServerQueryBus) configuration.queryBus()).localSegment().queryUpdateEmitter(),
-                   configuration.queryUpdateEmitter());
+        assertTrue(testSubject.queryBus() instanceof AxonServerQueryBus);
+        assertSame(testSubject.queryBus().queryUpdateEmitter(), testSubject.queryUpdateEmitter());
+        assertSame(((AxonServerQueryBus) testSubject.queryBus()).localSegment().queryUpdateEmitter(),
+                   testSubject.queryUpdateEmitter());
     }
 
     @Test
     void customCommandLoadFactorProvider() throws NoSuchFieldException {
         CommandLoadFactorProvider expected = command -> 5000;
-        Configuration config =
-                DefaultConfigurer.defaultConfiguration()
-                                 .configureSerializer(c -> TestSerializer.xStreamSerializer())
-                                 .registerComponent(CommandLoadFactorProvider.class, c -> expected)
-                                 .buildConfiguration();
+        testSubject = DefaultConfigurer.defaultConfiguration()
+                                       .configureSerializer(c -> TestSerializer.xStreamSerializer())
+                                       .registerComponent(CommandLoadFactorProvider.class, c -> expected)
+                                       .buildConfiguration();
 
-        CommandBus commandBus = config.commandBus();
+        CommandBus commandBus = testSubject.commandBus();
         assertTrue(commandBus instanceof AxonServerCommandBus);
         CommandLoadFactorProvider result = ReflectionUtils.getFieldValue(
                 AxonServerCommandBus.class.getDeclaredField("loadFactorProvider"), commandBus

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/EventStoreImpl.java
@@ -123,9 +123,11 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
         if (snapshot != null) {
             responseObserver.onNext(snapshot);
         }
+        long maxSeq = request.getMaxSequence() > 0 ? request.getMaxSequence() : Long.MAX_VALUE;
         events.stream()
               .filter(e -> e.getAggregateIdentifier().equals(request.getAggregateId()))
               .filter(e -> e.getAggregateSequenceNumber() >= request.getInitialSequence()
+                      && e.getAggregateSequenceNumber() <= maxSeq
                       && (snapshot == null || snapshot.getAggregateSequenceNumber() < e.getAggregateSequenceNumber()))
               .forEach(responseObserver::onNext);
         responseObserver.onCompleted();
@@ -210,6 +212,12 @@ public class EventStoreImpl extends EventStoreGrpc.EventStoreImplBase {
     @Override
     public void readHighestSequenceNr(ReadHighestSequenceNrRequest request,
                                       StreamObserver<ReadHighestSequenceNrResponse> responseObserver) {
-        super.readHighestSequenceNr(request, responseObserver);
+        long highest = events.stream()
+                             .filter(e -> e.getAggregateIdentifier().equals(request.getAggregateId()))
+                             .mapToLong(Event::getAggregateSequenceNumber)
+                             .max()
+                             .orElse(-1L);
+        responseObserver.onNext(ReadHighestSequenceNrResponse.newBuilder().setToSequenceNr(highest).build());
+        responseObserver.onCompleted();
     }
 }

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactoryTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreFactoryTest.java
@@ -86,6 +86,11 @@ class AxonServerEventStoreFactoryTest {
                                                  .build();
     }
 
+    @AfterEach
+    void tearDown() {
+        connectionManager.shutdown();
+    }
+
     @Test
     void constructForContextUsesFactoryComponents() throws NoSuchFieldException {
         AxonServerEventStore result = testSubject.constructFor(TEST_CONTEXT);

--- a/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
+++ b/axon-server-connector/src/test/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStoreTest.java
@@ -32,10 +32,12 @@ import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
+import org.axonframework.eventsourcing.CachingEventSourcingRepository;
 import org.axonframework.eventsourcing.eventstore.DomainEventStream;
 import org.axonframework.eventsourcing.eventstore.EventStoreException;
 import org.axonframework.eventsourcing.snapshotting.SnapshotFilter;
 import org.axonframework.messaging.Message;
+import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
 import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.serialization.json.JacksonSerializer;
@@ -52,9 +54,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static org.axonframework.axonserver.connector.utils.AssertUtils.assertWithin;
@@ -246,7 +250,7 @@ class AxonServerEventStoreTest {
 
     @Test
     void lastSequenceNumberFor() {
-        assertThrows(EventStoreException.class, () -> testSubject.lastSequenceNumberFor("Agg1"));
+        assertFalse(testSubject.lastSequenceNumberFor("Agg1").isPresent());
     }
 
     @Test
@@ -491,6 +495,45 @@ class AxonServerEventStoreTest {
         assertEquals(testPayloadThree, thirdResultEvent.getPayload());
 
         assertFalse(resultStream.hasNext());
+    }
+
+    @Test
+    void lastSequenceNumberForReturnsSequenceAfterPublishingDomainEvent() throws Exception {
+        GenericDomainEventMessage<String> event =
+                new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 0, "Test1");
+
+        UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
+        testSubject.publish(event);
+        uow.commit();
+
+        DefaultUnitOfWork.startAndGet(null);
+        Optional<Long> lastSeq = testSubject.lastSequenceNumberFor(AGGREGATE_ID);
+        CurrentUnitOfWork.commit();
+
+        assertTrue(lastSeq.isPresent());
+        assertEquals(0L, lastSeq.get());
+    }
+
+    @Test
+    void committedSequenceSupplierReturnsTrueVersionWhenLastEventIsOurs() throws Exception {
+        GenericDomainEventMessage<String> event =
+                new GenericDomainEventMessage<>(AGGREGATE_TYPE, AGGREGATE_ID, 0, "Test1");
+
+        // Supplier registration happens during onPrepareCommit (inside commit()), not during publish().
+        UnitOfWork<Message<?>> uow = DefaultUnitOfWork.startAndGet(null);
+        testSubject.publish(event);
+        uow.commit();
+
+        @SuppressWarnings("unchecked")
+        Supplier<Optional<Long>> supplier =
+                (Supplier<Optional<Long>>) uow.root()
+                        .getResource(CachingEventSourcingRepository.COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX
+                                             + AGGREGATE_ID);
+        assertNotNull(supplier, "Supplier should be registered after commit");
+
+        Optional<Long> result = supplier.get();
+        assertTrue(result.isPresent());
+        assertEquals(0L, result.get());
     }
 }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateCacheEntry.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/AggregateCacheEntry.java
@@ -32,13 +32,30 @@ public class AggregateCacheEntry<T> implements Serializable {
     private final transient EventSourcedAggregate<T> aggregate;
 
     public AggregateCacheEntry(EventSourcedAggregate<T> aggregate) {
+        this(aggregate, aggregate.version());
+    }
+
+    /**
+     * Creates a cache entry with an explicit version. Intended for event stores that assign sequence numbers at
+     * transaction commit time rather than at event-apply time (e.g. DCB-mode AxonServer), where the
+     * locally-predicted sequence number on the aggregate may differ from the one actually stored.
+     */
+    public AggregateCacheEntry(EventSourcedAggregate<T> aggregate, Long version) {
         this.aggregate = aggregate;
         this.aggregateRoot = aggregate.getAggregateRoot();
-        this.version = aggregate.version();
+        this.version = version;
         this.deleted = aggregate.isDeleted();
         this.snapshotTrigger =
                 (aggregate.getSnapshotTrigger() instanceof Serializable) ? aggregate.getSnapshotTrigger() :
                         NoSnapshotTriggerDefinition.TRIGGER;
+    }
+
+    /**
+     * Returns the version (sequence number) stored in this cache entry. Used by
+     * {@link CachingEventSourcingRepository} to detect whether the entry has been superseded by a more recent commit.
+     */
+    Long getVersion() {
+        return version;
     }
 
     public EventSourcedAggregate<T> recreateAggregate(AggregateModel<T> model,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/CachingEventSourcingRepository.java
@@ -20,9 +20,13 @@ import org.axonframework.common.caching.Cache;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
+import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.modelling.command.Aggregate;
 import org.axonframework.modelling.command.RepositoryProvider;
 import org.axonframework.modelling.command.inspection.AggregateModel;
+
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
@@ -38,6 +42,14 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @since 0.3
  */
 public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T> {
+
+    /**
+     * UnitOfWork resource key prefix used to share a committed-sequence supplier between the event store and this
+     * repository. The event store appends the aggregate identifier to form the full key. When present, the supplier
+     * is called in {@code afterCommit} to obtain the actual sequence number assigned by the store, replacing the
+     * locally-predicted value that would otherwise be cached.
+     */
+    public static final String COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX = "CommittedSequenceSupplier/";
 
     private final EventStore eventStore;
     private final RepositoryProvider repositoryProvider;
@@ -84,16 +96,43 @@ public class CachingEventSourcingRepository<T> extends EventSourcingRepository<T
     protected void doSaveWithLock(EventSourcedAggregate<T> aggregate) {
         super.doSaveWithLock(aggregate);
         String key = aggregate.identifierAsString();
-        CurrentUnitOfWork.get().onRollback(u -> cache.remove(aggregate.identifierAsString()));
+        Long predictedVersion = aggregate.version();
         cache.put(key, new AggregateCacheEntry<>(aggregate));
+        CurrentUnitOfWork.get().onRollback(u -> cache.remove(key));
+        CurrentUnitOfWork.get().afterCommit(u -> maybeCorrectCachedVersion(u, key, aggregate, predictedVersion));
     }
 
     @Override
     protected void doDeleteWithLock(EventSourcedAggregate<T> aggregate) {
         super.doDeleteWithLock(aggregate);
         String key = aggregate.identifierAsString();
-        CurrentUnitOfWork.get().onRollback(u -> cache.remove(aggregate.identifierAsString()));
+        Long predictedVersion = aggregate.version();
         cache.put(key, new AggregateCacheEntry<>(aggregate));
+        CurrentUnitOfWork.get().onRollback(u -> cache.remove(key));
+        CurrentUnitOfWork.get().afterCommit(u -> maybeCorrectCachedVersion(u, key, aggregate, predictedVersion));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void maybeCorrectCachedVersion(UnitOfWork<?> unitOfWork, String key,
+                                           EventSourcedAggregate<T> aggregate, Long predictedVersion) {
+        Supplier<Optional<Long>> supplier =
+                unitOfWork.root().getResource(COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX + key);
+        if (supplier == null) {
+            // No committed-sequence supplier registered; the locally-predicted version is already correct.
+            return;
+        }
+        AggregateCacheEntry<?> current = cache.get(key);
+        if (current == null || !predictedVersion.equals(current.getVersion())) {
+            // Cache was cleared or a nested UoW already put a newer entry; leave it alone.
+            return;
+        }
+        Optional<Long> resolved = supplier.get();
+        if (!resolved.isPresent()) {
+            // A concurrent commit was detected; remove the stale entry.
+            cache.remove(key);
+            return;
+        }
+        cache.put(key, new AggregateCacheEntry<>(aggregate, resolved.get()));
     }
 
     /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/CachingEventSourcingRepositoryTest.java
@@ -45,6 +45,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -223,6 +225,45 @@ class CachingEventSourcingRepositoryTest {
             // great, that's what we expect
         }
         assertNull(cache.get("id1"));
+    }
+
+    @Test
+    void committedVersionFromSupplierIsUsedWhenPresent() throws Exception {
+        startAndGetUnitOfWork();
+        testSubject.newInstance(() -> new StubAggregate("aggregateId")).execute(StubAggregate::doSomething);
+        CurrentUnitOfWork.commit();
+
+        // Simulate a DCB-style event store that registers a corrected sequence supplier (e.g. global token 42).
+        startAndGetUnitOfWork();
+        CurrentUnitOfWork.get().resources()
+                         .put(CachingEventSourcingRepository.COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX + "aggregateId",
+                              (Supplier<Optional<Long>>) () -> Optional.of(42L));
+        testSubject.load("aggregateId").execute(StubAggregate::doSomething);
+        CurrentUnitOfWork.commit();
+
+        AggregateCacheEntry<?> updated = (AggregateCacheEntry<?>) cache.get("aggregateId");
+        assertNotNull(updated);
+        // Version should be 42 (from the supplier), not 1 (the locally-predicted sequence).
+        assertEquals(42L, updated.getVersion());
+    }
+
+    @Test
+    void aggregateNotCachedWhenSupplierSignalsConcurrentCommit() throws Exception {
+        startAndGetUnitOfWork();
+        testSubject.newInstance(() -> new StubAggregate("aggregateId")).execute(StubAggregate::doSomething);
+        CurrentUnitOfWork.commit();
+
+        cache.remove("aggregateId");
+
+        // Supplier returns empty — another node committed for this aggregate after ours.
+        startAndGetUnitOfWork();
+        CurrentUnitOfWork.get().resources()
+                         .put(CachingEventSourcingRepository.COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX + "aggregateId",
+                              (Supplier<Optional<Long>>) Optional::empty);
+        testSubject.load("aggregateId").execute(StubAggregate::doSomething);
+        CurrentUnitOfWork.commit();
+
+        assertNull(cache.get("aggregateId"));
     }
 
     private UnitOfWork<?> startAndGetUnitOfWork() {


### PR DESCRIPTION
## Summary

- In DCB mode, AxonServer assigns global sequence numbers at commit time rather than per-aggregate sequence numbers at event-apply time. This caused `CachingEventSourcingRepository` to cache the locally-predicted (wrong) version, leading to stale cache entries that would fail conflict detection on subsequent loads.
- Introduced a `COMMITTED_SEQUENCE_SUPPLIER_KEY_PREFIX` UnitOfWork resource contract: after appending events, `AxonServerEventStore` registers a lazy `Supplier<Optional<Long>>` on the root UoW per aggregate. In `afterCommit`, `CachingEventSourcingRepository` calls this supplier to obtain the actual server-assigned sequence number and replaces the cached entry.
- If the supplier returns `Optional.empty()` (concurrent commit detected via message-id mismatch), the stale cache entry is evicted rather than left with an incorrect version.
- Also fixed resource leaks in several test classes by ensuring `AxonServerConnectionManager` and `Configuration` instances are shut down in `@AfterEach`.