### PR TITLE
Document PostgreSQL event storage engine

### DIFF
--- a/docs/changes-to-process.md
+++ b/docs/changes-to-process.md
@@ -36,6 +36,8 @@ The following files in `axon-5/` describe the API changes:
 - Documented extension modules organization
 - Updated dependency coordinates and groupIds
 - Added Axon Bill of Materials (BOM) recommendation
+- Added AxonIQ PostgreSQL extension coordinates for `io.axoniq.framework:axoniq-postgresql`
+- Documented `PostgresqlEventStorageEngine` as the PostgreSQL-backed DCB-capable event storage extension
 
 ### modules/ROOT/pages/serialization.adoc
 **Status:** ✅ COMPLETED
@@ -80,6 +82,7 @@ The following files in `axon-5/` describe the API changes:
 - Maintained relevant issues (PostgreSQL Large Object Storage, Sequence generation with JPA)
 - Updated cross-references to current module structure
 - Kept framework-agnostic issues that still apply
+- Updated PostgreSQL extension tip to reference `PostgresqlEventStorageEngine` and `axoniq-postgresql`
 
 ---
 
@@ -489,6 +492,11 @@ The following files in `axon-5/` describe the API changes:
 - **Updated Spring Boot auto-configuration note**: Removed JDBC references, kept only JPA
 - **Replaced DomainEventStream reference**: Changed to "transaction" in MongoEventStorageEngine description
 - **Updated EventStore introduction**: Changed "from aggregates" to "from entities", "based on aggregate identifier" to "based on given criteria"
+- **Added PostgreSQL event storage documentation**:
+  - Listed `PostgresqlEventStorageEngine` among available event storage engines
+  - Added a dedicated section before `InMemoryEventStorageEngine`
+  - Documented the `io.axoniq.framework:axoniq-postgresql` dependency
+  - Cross-referenced PostgreSQL event storage migration guidance
 - All imports updated to use correct Axon 5 packages
 
 ### modules/events/pages/event-processors/index.adoc
@@ -1049,6 +1057,25 @@ The following files in `axon-5/` describe the API changes:
 ### Old files removed:
 - commands-events.adoc (replaced by testing-with-axon-test-fixture.adoc)
 - sagas-1.adoc (sagas not available in Axon 5, alternatives covered in upgrading-from-axon-4.adoc)
+
+---
+
+## Migration Module
+
+### modules/migration/pages/why-upgrade.adoc
+**Status:** ✅ COMPLETED
+**Changes applied:**
+- Updated the PostgreSQL extension section to remove the placeholder marker
+- Described `PostgresqlEventStorageEngine` and the `axoniq-postgresql` artifact
+- Clarified that the extension supports PostgreSQL-backed DCB event storage
+
+### modules/migration/pages/paths/event-store.adoc
+**Status:** ✅ COMPLETED
+**Changes applied:**
+- Updated the event storage engine choice table to describe `PostgresqlEventStorageEngine` as available
+- Filled in the PostgreSQL event storage migration section
+- Added dependency coordinates for `io.axoniq.framework:axoniq-postgresql`
+- Documented when to choose PostgreSQL and how to approach migration from Axon Framework 4 storage
 
 ---
 

--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -24,8 +24,8 @@ When looking to provide a pull request, be sure to adjust link:https://github.co
 [TIP]
 .PostgreSQL Extension
 ====
-// TODO Axoniq feature
-You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution. For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
+If PostgreSQL is your preferred event store, consider the AxonIQ PostgreSQL extension.
+It provides the `PostgresqlEventStorageEngine` through the `io.axoniq.framework:axoniq-postgresql` artifact and supports DCB with PostgreSQL-backed event storage.
 ====
 
 When storing the serialized formats of, for example, xref:axon-framework-reference:events:event-processors/streaming.adoc#tracking_tokens[tokens], or xref:axon-framework-reference:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.
@@ -43,7 +43,7 @@ However, even when using Axon Server, the predicament remains for tokens and sag
 
 For those cases, it would be wise to adjust the Hibernate mapping.
 The most straightforward way, is to enforce the use of the `BYTEA` column type; with some additional steps, of course.
-For a full explanation and walkthrough, please check the xref:axon-framework-reference:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
+For a full explanation and walkthrough, please check the xref:axon-framework-reference:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostgreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
 
 == Sequence generation issues with JPA Entities
 

--- a/docs/reference-guide/modules/ROOT/pages/modules.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/modules.adoc
@@ -155,6 +155,25 @@ This extension provides basic implementations based on Dropwizard to collect mon
 This extension provides basic implementations based on Micrometer to collect monitoring information.
 https://micrometer.io/[Micrometer] is a dimensional-first metrics collection facade whose aim is to allow you to time, count, and gauge your code with a vendor neutral API.
 
+[#external_extensions]
+== External extensions
+
+External extensions are maintained outside the main Axon Framework repository and provide integrations for specific infrastructure choices.
+The AxonIQ PostgreSQL extension is one such extension.
+
+[cols="<,<,<,^"]
+|===
+|Module |Artifact Id |Group Id |Maven Central
+
+|<<Axon PostgreSQL>> |`axoniq-postgresql` |`io.axoniq.framework` |https://central.sonatype.com/search?q=a:axoniq-postgresql[available]
+|===
+
+=== Axon PostgreSQL
+
+This module provides the `PostgresqlEventStorageEngine`, a storage solution optimized for link:https://www.postgresql.org/[PostgreSQL].
+It supports xref:events:event-store-internals.adoc#dynamic_consistency_boundaries_dcb[Dynamic Consistency Boundaries (DCB)] with event tagging and criteria-based querying.
+Use this extension when PostgreSQL is your chosen event store and you want a database-backed DCB-capable alternative to Axon Server.
+
 ifdef::advanced-framework[]
 include::ROOT:partial$modules-advanced-framework.adoc[]
 endif::[]

--- a/docs/reference-guide/modules/events/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/events/pages/infrastructure.adoc
@@ -83,6 +83,9 @@ endif::[]
 * **`AggregateBasedJpaEventStorageEngine`** - Stores events in a JPA-compatible database.
 Organizes events by aggregate identifier and sequence number.
 Useful when Axon Server is not available.
+* **`PostgresqlEventStorageEngine`** - Stores events in PostgreSQL through the AxonIQ PostgreSQL extension.
+Provides DCB support with event tagging and criteria-based querying.
+Useful when PostgreSQL is your chosen operational event store.
 * **`InMemoryEventStorageEngine`** - Stores events in memory.
 Ideal for testing and short-lived tools.
 Not suitable for production use.
@@ -261,6 +264,37 @@ You can use JPA's `SELECT new SomeClass(parameters) FROM ...` style queries to w
 Alternatively, call `EntityManager.flush()` and `EntityManager.clear()` after fetching a batch of events.
 Failure to do so might result in `OutOfMemoryException`s when loading large streams of events.
 ====
+
+[#postgresqleventstorageengine]
+==== `PostgresqlEventStorageEngine`
+
+The `PostgresqlEventStorageEngine` stores events in link:https://www.postgresql.org/[PostgreSQL] through the AxonIQ PostgreSQL extension.
+It is optimized for PostgreSQL and supports xref:event-store-internals.adoc#dynamic_consistency_boundaries_dcb[Dynamic Consistency Boundaries (DCB)].
+This means events can be stored with several tags and queried through criteria, instead of only being organized by aggregate identifier and sequence number.
+
+Use this storage engine when PostgreSQL is the preferred persistence technology for your application and you want to use Axon Framework 5's DCB model without running Axon Server.
+If you already use PostgreSQL for application data, this option can keep your operational footprint small while still providing a persistent event store.
+
+Declare the AxonIQ PostgreSQL extension alongside the event sourcing module:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.axoniq.framework</groupId>
+    <artifactId>axoniq-postgresql</artifactId>
+    <version>${axon.version}</version>
+</dependency>
+<dependency>
+    <groupId>org.axonframework</groupId>
+    <artifactId>axon-eventsourcing</artifactId>
+    <version>${axon.version}</version>
+</dependency>
+----
+
+The extension contributes PostgreSQL-specific configuration infrastructure.
+After adding the dependency, configure your PostgreSQL connection according to the extension documentation and register the provided `PostgresqlEventStorageEngine` as your application's `EventStorageEngine`.
+
+For migration guidance from Axon Framework 4 event storage solutions, see xref:migration:paths/event-store.adoc#postgresql_event_storage_migration[PostgreSQL event storage migration].
 
 ==== `InMemoryEventStorageEngine`
 

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -35,7 +35,7 @@ Some of these support DCB, while others are tailored towards the previous aggreg
 | No
 
 | `PostgresqlEventStorageEngine`
-| Optimized PostgreSQL integration (coming 2026 Q1)
+| Optimized PostgreSQL integration
 | Yes
 
 | `InMemoryEventStorageEngine`
@@ -463,16 +463,57 @@ axon.eventstorage.jpa.polling-interval=1000
 --
 ====
 
+[#postgresql_event_storage_migration]
 == PostgreSQL event storage migration
-// TODO Axoniq feature
 
-If you are using PostgreSQL as your database for event storage—whether through the `JpaEventStorageEngine` or `JdbcEventStorageEngine` in Axon Framework 4—you would benefit from migrating to the dedicated `PostgresqlEventStorageEngine`.
+If you are using PostgreSQL as your database for event storage, consider migrating to the dedicated `PostgresqlEventStorageEngine`.
+This applies whether your Axon Framework 4 application used `JpaEventStorageEngine`, `JdbcEventStorageEngine`, or a custom PostgreSQL-backed storage component.
 
 This storage engine is optimized specifically for PostgreSQL and provides full support for xref:events:event-store-internals.adoc#dynamic_consistency_boundaries_dcb[DCB].
 As such, unlike the `AggregateBasedJpaEventStorageEngine`, the `PostgresqlEventStorageEngine` allows you to leverage the flexible consistency boundaries with event tagging and criteria-based querying.
 
-[NOTE]
+=== When to choose PostgreSQL
+
+Choose the `PostgresqlEventStorageEngine` when all of the following apply:
+
+* PostgreSQL is your intended long-term event store.
+* You want to use DCB with event tags, event criteria, and consistency markers.
+* You want a database-backed alternative to Axon Server for event storage.
+
+If you only want to keep an existing aggregate-oriented JPA event table running during the first upgrade step, the `AggregateBasedJpaEventStorageEngine` is the closer migration target.
+It keeps the aggregate identifier and sequence number model, but does not support DCB.
+
+=== Dependency
+
+The PostgreSQL event storage engine is provided by the AxonIQ PostgreSQL artifact:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.axoniq.framework</groupId>
+    <artifactId>axoniq-postgresql</artifactId>
+    <version>${axon.version}</version>
+</dependency>
+----
+
+=== Migration approach
+
+Migrating to the `PostgresqlEventStorageEngine` is a storage-engine migration.
+Do not treat it as a simple table rename of Axon Framework 4's `domain_event_entry` table.
+The PostgreSQL engine is designed for Axon Framework 5's tag-based event model, so the migration should preserve the event payload and metadata while adding the tag information needed for DCB.
+
+A typical migration consists of these steps:
+
+1. Add the `axoniq-postgresql` dependency and configure a PostgreSQL data source for the event store.
+2. Decide how events will receive tags in Axon Framework 5.
+This can be done through annotations such as `@EventTag` or through a custom `TagResolver`.
+3. Create the PostgreSQL event storage schema required by the extension.
+4. Migrate existing events from the Axon Framework 4 storage table into the PostgreSQL engine's schema.
+During this step, keep the original event identifiers, message type information, payload, metadata, timestamp, and ordering information intact.
+5. Validate event sourcing and streaming processors against a copy of production data before switching the application.
+
+[IMPORTANT]
 ====
-The `PostgresqlEventStorageEngine` is scheduled for release in Q1 2026.
-This section will be updated with detailed migration instructions, schema changes, and configuration examples once the extension is available.
+Always perform the migration on a copy of production data first.
+PostgreSQL migrations should preserve event ordering and message identity, and DCB migrations should also verify that tags and criteria match the way your entities are sourced in Axon Framework 5.
 ====

--- a/docs/reference-guide/modules/migration/pages/why-upgrade.adoc
+++ b/docs/reference-guide/modules/migration/pages/why-upgrade.adoc
@@ -93,7 +93,6 @@ With Axon Framework 5, the story changes.
 The extensions aren't afterthoughts or legacy components—they're integral to the ecosystem, rebuilt from the ground up to embrace the async-native architecture and all the philosophical improvements that Axon Framework 5 introduces.
 
 === Why this matters: the PostgreSQL extension for Axon Framework 5
-// TODO Axoniq feature
 
 Not every organization runs specialized event stores.
 Many teams have PostgreSQL at their core—a battle-tested, reliable relational database that's already part of their infrastructure.
@@ -102,8 +101,10 @@ The PostgreSQL Extension for Axon Framework 5 provides a fully compatible event 
 
 This extension:
 
-* Leverages Jakarta Persistence with modern, clean configuration
+* Provides the `PostgresqlEventStorageEngine` through the `axoniq-postgresql` artifact
+* Uses PostgreSQL as a persistent, operational event store
 * Supports Axon Framework 5's message type system natively
+* Supports Dynamic Consistency Boundaries (DCB) with event tags and criteria
 * Provides optimized querying through PostgreSQL's rich feature set
 * Integrates seamlessly with the async-native architecture for non-blocking event operations
 * Simplifies your infrastructure footprint by consolidating event storage into your existing database layer


### PR DESCRIPTION
Add reference guide coverage for the AxonIQ PostgreSQL event storage engine so users can discover it from infrastructure, migration, and module documentation.

## Summary

- Documents `PostgresqlEventStorageEngine` as a DCB-capable PostgreSQL event storage option.
- Adds the `io.axoniq.framework:axoniq-postgresql` artifact to the Modules page.
- Fills in the PostgreSQL event storage migration guidance and links it from the event infrastructure docs.

## Related issue

Fixes #4442

## Verification

- Checked changed docs for linter issues.
- Ran `git diff --check`.