### PR TITLE
Include Data Protection documentation in framework reference guide

### DIFF
--- a/docs/reference-guide/modules/ROOT/partials/nav.adoc
+++ b/docs/reference-guide/modules/ROOT/partials/nav.adoc
@@ -16,6 +16,10 @@ include::testing:partial$nav.adoc[]
 
 * xref:ROOT:conversion.adoc[]
 
+ifdef::data-protection[]
+include::data-protection:partial$nav.adoc[]
+endif::[]
+
 include::tuning:partial$nav.adoc[]
 
 include::monitoring:partial$nav.adoc[]


### PR DESCRIPTION
This PR integrates the data protection documentation into the reference guide main navigation.