### PR TITLE
Revert Workflows documentation inclusion from 5.1.x

### DIFF
--- a/docs/reference-guide/modules/ROOT/partials/nav.adoc
+++ b/docs/reference-guide/modules/ROOT/partials/nav.adoc
@@ -8,10 +8,6 @@ include::events:partial$nav.adoc[]
 
 include::queries:partial$nav.adoc[]
 
-ifdef::workflows[]
-include::workflows:partial$nav.adoc[]
-endif::[]
-
 include::testing:partial$nav.adoc[]
 
 * xref:ROOT:conversion.adoc[]


### PR DESCRIPTION
The Workflows documentation should currently only appear in the "development" version, thus we need to remove it from the 5.1.x branch again. 