### PR TITLE
fix(test): disable `PostgresqlConfigurationEnhancer` in `AxonTestFixture` to prevent using Postgres db in non-integration tests

### DIFF
--- a/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
+++ b/test/src/main/java/org/axonframework/test/fixture/AxonTestFixture.java
@@ -205,6 +205,9 @@ public class AxonTestFixture implements AxonTestPhase.Setup {
             configurer = configurer.componentRegistry(cr -> cr.disableEnhancer(
                     "io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer"
             ));
+            configurer = configurer.componentRegistry(cr -> cr.disableEnhancer(
+                    "io.axoniq.framework.postgresql.PostgresqlConfigurationEnhancer"
+            ));
         }
         var recordingEnhancer = new MessagesRecordingConfigurationEnhancer();
         var configuration = configurer.componentRegistry(cr -> cr.registerEnhancer(recordingEnhancer))


### PR DESCRIPTION
For now I don't see better solution (to do not need changes here in case of new extensions). 