### PR TITLE
[#4484] Fix 4.12 reference guide cross component references

### DIFF
--- a/docs/message-handler-customization-guide/modules/ROOT/pages/handler-enhancers.adoc
+++ b/docs/message-handler-customization-guide/modules/ROOT/pages/handler-enhancers.adoc
@@ -1,7 +1,7 @@
 :navtitle: Handler Enhancers
 = Handler Enhancers
 
-Handler Enhancers allow you to wrap handlers and add custom logic to the execution or eligibility of handlers for a specific message. Handler enhancers differ from xref:axon-framework-reference:messaging-concepts:message-intercepting.adoc[message handler interceptors] by the access they provide to the message handling component (for example, the aggregate member) at the resolution time. Hence, handler enhancers allow for more fine-grained control. You can use handler enhancers to intercept and perform checks on groups of `@MessageHandler` annotated methods, like a command, event, or query handler.
+Handler Enhancers allow you to wrap handlers and add custom logic to the execution or eligibility of handlers for a specific message. Handler enhancers differ from xref:4.12@axon-framework-reference:messaging-concepts:message-intercepting.adoc[message handler interceptors] by the access they provide to the message handling component (for example, the aggregate member) at the resolution time. Hence, handler enhancers allow for more fine-grained control. You can use handler enhancers to intercept and perform checks on groups of `@MessageHandler` annotated methods, like a command, event, or query handler.
 
 To create a handler enhancer, you implement the `HandlerEnhancerDefinition` interface and override the `wrapHandler()` method. All this method does is give you access to the `MessageHandlingMember<T>`, which is an object representing any handler specified in the system.
 

--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -3,7 +3,6 @@ title: Axon Framework
 version:
   axon-(?<version>+({0..9}).+({0..9})).*: $<version>
   master: development
-prerelease: false
 start_page: ROOT:index.adoc
 
 asciidoc:

--- a/docs/old-reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -21,7 +21,7 @@ When looking to provide a pull request, be sure to adjust link:https://github.co
 
 == PostgreSQL and large object storage
 
-When storing the serialized formats of, for example, xref:axon-framework-reference:events:event-processors/streaming.adoc#tracking-tokens[tokens], xref:axon-framework-reference:sagas:index.adoc[sagas], xref:axon-framework-reference:tuning:event-snapshots.adoc[snapshots], or xref:axon-framework-reference:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.
+When storing the serialized formats of, for example, xref:events:event-processors/streaming.adoc#tracking-tokens[tokens], xref:sagas:index.adoc[sagas], xref:tuning:event-snapshots.adoc[snapshots], or xref:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.
 
 This choice combined with link:https://www.postgresql.org/[PostgreSQL] and Hibernate, causes unexpected behavior for most.
 
@@ -36,7 +36,7 @@ However, even when using Axon Server, the predicament remains for tokens and sag
 
 For those cases, it would be wise to adjust the Hibernate mapping.
 The most straightforward way, is to enforce the use of the `BYTEA` column type; with some additional steps, of course.
-For a full explanation and walkthrough, please check the xref:axon-framework-reference:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
+For a full explanation and walkthrough, please check the xref:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
 
 == Sequence generation issues with JPA Entities
 
@@ -44,12 +44,12 @@ For the JPA entities that require a generated sequence, we decided to use the de
 In the pre-Hibernate-6 age, this typically resulted in the construction of a single sequence generator that would be reused by several tables.
 This can be regarded as suboptimal, as frequently, the sequence generator would be reused between tables.
 
-Especially given the nature of the `global_index` column on the `domain_event_entry` table, which is used to keep the progress in xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processors], a reused generator, causes unexpected gaps in event processing.
+Especially given the nature of the `global_index` column on the `domain_event_entry` table, which is used to keep the progress in xref:events:event-processors/streaming.adoc[streaming event processors], a reused generator, causes unexpected gaps in event processing.
 Although Axon Framework can deal with these gaps, they make the queries to the `domain_event_entry` table rather bulky.
 
 Just as with any event storage solution, using a dedicated event store implementation like xref:axon-server-reference::index.adoc[Axon Server] will solve the problem entirely.
 Instead of using Axon Server, it is also possible to define sequence generators manually for Axon's entities.
-The xref:axon-framework-reference:tuning:rdbms-tuning.adoc[Relational Database Tuning page] contains a section on how to do this, called xref:axon-framework-reference:tuning:rdbms-tuning.adoc#auto_increment_and_sequences[Auto-Increment and Sequences].
+The xref:tuning:rdbms-tuning.adoc[Relational Database Tuning page] contains a section on how to do this, called xref:tuning:rdbms-tuning.adoc#auto_increment_and_sequences[Auto-Increment and Sequences].
 
 As described earlier, the `@GeneratedValue` was introduced in 2016.
 With the recent move to Hibernate 6, which defaults the increment value to 50, the problem of gaps or unintended reuse between tables has only become bigger.

--- a/docs/old-reference-guide/modules/ROOT/pages/modules.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/modules.adoc
@@ -97,7 +97,7 @@ This module contains components that enable migration of older Axon projects to 
 
 === Axon Tracing OpenTelemetry
 
-This module contains the components needed to xref:axon-framework-reference:monitoring:tracing.adoc[enable tracing with OpenTelemetry].
+This module contains the components needed to xref:monitoring:tracing.adoc[enable tracing with OpenTelemetry].
 
 == Extension modules
 

--- a/docs/old-reference-guide/modules/events/pages/event-processors/dead-letter-queue.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/dead-letter-queue.adoc
@@ -1,6 +1,6 @@
 = Dead-Letter Queue
 
-When configuring xref:axon-framework-reference:events:event-processors/index.adoc#error-handling[error handling] for your event processors, you might want to consider a Dead-Letter Queue to park events that you were unable to handle.
+When configuring xref:events:event-processors/index.adoc#error-handling[error handling] for your event processors, you might want to consider a Dead-Letter Queue to park events that you were unable to handle.
 
 Instead of either logging the error and continuing, or infinitely retrying the current event, a Dead-Letter Queue will park the event in the queue so you can decide to try and handle it again later. In addition, it will prevent handling of later events in the same sequence until the failed event is successfully processed.
 

--- a/docs/old-reference-guide/modules/events/pages/event-processors/index.adoc
+++ b/docs/old-reference-guide/modules/events/pages/event-processors/index.adoc
@@ -323,7 +323,7 @@ If you instead propagate the exception so the event processor keeps retrying, th
 
 Although this behavior is sufficient on many occasions, sometimes it is beneficial if we can unblock event handling by parking the problematic event.
 This is where the Dead-letter Queue comes in. It is a mechanism to park events until they can be processed successfully.
-You can find more information in the xref:axon-framework-reference:events:event-processors/dead-letter-queue.adoc[] section.
+You can find more information in the xref:events:event-processors/dead-letter-queue.adoc[] section.
 
 [[general_processor_configuration]]
 == General processor configuration

--- a/docs/old-reference-guide/modules/queries/pages/index.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/index.adoc
@@ -8,16 +8,16 @@ These are messages that request information in a certain format. Any application
 
 There are multiple types of queries that cane be distinguished.
 
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#point-to-point-queries[Point-to-point queries]:
+. xref:queries:query-dispatchers.adoc#point-to-point-queries[Point-to-point queries]:
 They are routed to a single handler, which is expected to return a single result. This is the most common type of query.
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#scatter-gather-queries[Scatter-gather queries]:
+. xref:queries:query-dispatchers.adoc#scatter-gather-queries[Scatter-gather queries]:
 These queries are dispatched to all handlers that are capable of handling the query.
 The results of all handlers are then aggregated and returned to the client.
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#subscription-queries[Subscription queries]: These request an initial result and then continue to receive updates as long as the subscription is active.
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#streaming-queries[Streaming queries]: These queries are used to request a stream of results, which are returned as they become available.
+. xref:queries:query-dispatchers.adoc#subscription-queries[Subscription queries]: These request an initial result and then continue to receive updates as long as the subscription is active.
+. xref:queries:query-dispatchers.adoc#streaming-queries[Streaming queries]: These queries are used to request a stream of results, which are returned as they become available.
 
 
-You can find more about each type of query in the xref:axon-framework-reference:queries:query-dispatchers.adoc[Query Dispatchers] section.
+You can find more about each type of query in the xref:queries:query-dispatchers.adoc[Query Dispatchers] section.
 
 
 == Subsections

--- a/docs/old-reference-guide/modules/queries/pages/query-dispatchers.adoc
+++ b/docs/old-reference-guide/modules/queries/pages/query-dispatchers.adoc
@@ -1,7 +1,7 @@
 = Query Dispatchers
 :navtitle: Dispatching
 
-How to handle a query message has been covered in more detail in the xref:axon-framework-reference:queries:query-handlers.adoc[Query Handling section]. Queries have to be dispatched, just like any type of message, before they can be handled. To that end Axon provides two interfaces:
+How to handle a query message has been covered in more detail in the xref:queries:query-handlers.adoc[Query Handling section]. Queries have to be dispatched, just like any type of message, before they can be handled. To that end Axon provides two interfaces:
 
 . The Query Bus, and
 . The Query Gateway

--- a/docs/old-reference-guide/modules/release-notes/pages/major-releases.adoc
+++ b/docs/old-reference-guide/modules/release-notes/pages/major-releases.adoc
@@ -553,14 +553,14 @@ For an exhaustive list of all adjustments made for release 4.5 you can check out
 * A new type of `EventProcessor` has been introduced in pull request https://github.com/AxonFramework/AxonFramework/pull/1712[#1712], called the `PooledStreamingEventProcessor`.
  This `EventProcessor` allows the same set of operations as the `TrackingEventProcessor`, but uses a different threading approach for handling events and processing operations.
  In all, this solution provides a more straightforward processor implementation and configuration, allowing for enhanced event processing in general.
- For specifics on how to configure it, check out xref:axon-framework-reference:events:event-processors/streaming.adoc[this] section.
+ For specifics on how to configure it, check out xref:events:event-processors/streaming.adoc[this] section.
 
-* Sagas support the use of xref:axon-framework-reference:deadlines:deadline-managers.adoc#_handling_a_deadline[Deadline Handlers], but an `@DeadlineHandler` annotated method couldn't automatically close a Saga with the `@EndSaga` annotation.
+* Sagas support the use of xref:deadlines:deadline-managers.adoc#_handling_a_deadline[Deadline Handlers], but an `@DeadlineHandler` annotated method couldn't automatically close a Saga with the `@EndSaga` annotation.
  This enhancement has been described in https://github.com/AxonFramework/AxonFramework/issues/1469[#1469] and resolved in pull request https://github.com/AxonFramework/AxonFramework/pull/1656[#1656].
  As such, as of Axon 4.5, an `@DeadlineHandler` annotated can also be annotated with `@EndSaga`, to automatically close the Saga whenever the given deadline is handled.
 
 * Whenever an application uses snapshots, the point arises that old snapshot versions need to be invalidated when loading an Aggregate.
- To that end the xref:axon-framework-reference:tuning:event-snapshots.adoc#_filtering_snapshot_events[`SnapshotFilter`] can be configured.
+ To that end the xref:tuning:event-snapshots.adoc#_filtering_snapshot_events[`SnapshotFilter`] can be configured.
  As a simplified solution, the `@Revision` annotation can now be placed on the Aggregate class to automatically configure a revision based `SnapshotFilter`.
  Due to this, old snapshots will be filtered out automatically when an Aggregate is reconstructed from the `EventStore`.
  For those interested, the implementation of this feature can be found https://github.com/AxonFramework/AxonFramework/pull/1657[here].
@@ -598,7 +598,7 @@ For an exhaustive list of all adjustments made for release 4.5 you can check out
  This annotation allows you to introduce a specific bit of logic to be invoked _prior_ to entering the message handling function or after invocation.
  It for example allows the additional introduction of a `@ExceptionHandler` annotation, allowing you to specifically deal with the exceptions thrown from your message handlers.
  The original pull request can be found under https://github.com/AxonFramework/AxonFramework/pull/1394[#1394].
- For more specifics on using this annotation, check out the xref:axon-framework-reference:messaging-concepts:message-intercepting.adoc#annotated-MessageHandlerInterceptor[@MessageHandlerInterceptor] section.
+ For more specifics on using this annotation, check out the xref:messaging-concepts:message-intercepting.adoc#annotated-MessageHandlerInterceptor[@MessageHandlerInterceptor] section.
 
 * Configuring a `Snapshotter` and `SnapshotFilter` have been simplified in this release.
  Pull request https://github.com/AxonFramework/AxonFramework/pull/1447[#1447] shares the load of allowing for distinct `Snapshotter` configuration.
@@ -641,7 +641,7 @@ For a full list of all the feature request and enhancements done for release 4.4
 
 * The `TrackingEventProcessor#processingStatus` method as of 4.3 exposes more status information.
  The current token position, token-at-reset, is-merging and merge-completed position have been added to the set.
- Read the xref:axon-framework-reference:monitoring:processors.adoc#event-tracker-status[Event Tracker Status] section for more specifics on this.
+ Read the xref:monitoring:processors.adoc#event-tracker-status[Event Tracker Status] section for more specifics on this.
 
 === _Bug fixes_
 

--- a/docs/old-reference-guide/modules/release-notes/pages/minor-releases.adoc
+++ b/docs/old-reference-guide/modules/release-notes/pages/minor-releases.adoc
@@ -779,7 +779,7 @@ For an exhaustive list of all the changes, check out the https://github.com/Axon
 === Release 4.5.3
 
 * One new feature has been introduced in 4.5.3: the `PropertySequencingPolicy` by contributor `nils-christian`.
- This xref:axon-framework-reference:events:event-processors/streaming.adoc#sequential-processing[sequencing policy] can be configured to look for a common property in the events.
+ This xref:events:event-processors/streaming.adoc#sequential-processing[sequencing policy] can be configured to look for a common property in the events.
 
 * The version of the `axonserver-connector-java` has been updated to 4.5.2.
  This update resolves a troublesome issue around permit updates for subscription queries, which exhausted the number of queries an application could have running.
@@ -1112,7 +1112,7 @@ For a complete list of all resolved bugs we refer to the https://github.com/Axon
 
 === Release 4.1.1
 
-* Query Dispatch Interceptors were not called correctly when a xref:axon-framework-reference:queries:query-dispatchers.adoc#subscription-queries[subscription query] was performed when Axon Server was used as the `QueryBus`.
+* Query Dispatch Interceptors were not called correctly when a xref:queries:query-dispatchers.adoc#subscription-queries[subscription query] was performed when Axon Server was used as the `QueryBus`.
 
 This issue was marked https://github.com/AxonFramework/AxonFramework/issues/1013[here] and resolved in pull request https://github.com/AxonFramework/AxonFramework/pull/1042[#1042].
 

--- a/docs/old-reference-guide/modules/tuning/pages/rdbms-tuning.adoc
+++ b/docs/old-reference-guide/modules/tuning/pages/rdbms-tuning.adoc
@@ -66,14 +66,14 @@ Here, again, a shorter (but variable) length field should suffice.
 [#auto_increment_and_sequences]
 :navtitle: Auto-Increment and Sequences
 
-When using a relational database as an event store, Axon Framework relies on an auto-increment value to allow xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processors] to read all events roughly in the order they were inserted.
+When using a relational database as an event store, Axon Framework relies on an auto-increment value to allow xref:events:event-processors/streaming.adoc[streaming event processors] to read all events roughly in the order they were inserted.
 We say "roughly", because "insert-order" and "commit-order" are different things.
 
 While auto-increment values are (generally) generated at insert-time, these values only become visible at commit-time.
 This means another process may observe these sequence numbers arriving in a different order.
 While Axon Framework has mechanisms to ensure that eventually all events are handled, even when they become visible in a different order, there are limitations and performance aspects to consider.
 
-When a xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processor] reads events, it uses the "global sequence" to track its progress.
+When a xref:events:event-processors/streaming.adoc[streaming event processor] reads events, it uses the "global sequence" to track its progress.
 When events become available in a different order than they were inserted, Axon Framework will encounter a "gap." Axon Framework will remember these "gaps" to verify that data has become available since the last read.
 These gaps may be the result of events becoming visible in a different order, but also because a transaction was rolled back.
 It is highly recommended to ensure that no gaps exist because of over eagerly increasing the sequence number.
@@ -153,7 +153,7 @@ Thus, the dedicate large object storage solution will be used if you are using P
 As events and snapshots are frequently read, the overhead predicament discussed earlier will be hit.
 Arguably more problematic is issue two, especially for the `token_entry` table.
 
-The "claim" on a token is frequently updated to allow correct collaboration in a distributed Axon setup (please read our xref:axon-framework-reference:events:event-processors/streaming.adoc#tracking-tokens[Tracking Tokens] section for more details).
+The "claim" on a token is frequently updated to allow correct collaboration in a distributed Axon setup (please read our xref:events:event-processors/streaming.adoc#tracking-tokens[Tracking Tokens] section for more details).
 As the large object table is **not** automatically cleared, it will eventually overflow through all the updates.
 
 Hence, it would be best to avoid the Large Object Storage behavior and instead opt for the transparent TOAST feature.


### PR DESCRIPTION
We are using `xref:axon-framework-reference:...` type references in the reference guide at several places which makes Antora referencing to the latest version of the component instead of the same version (when specifying the component part in an xref, Antora defaults to the latest version, omitting the component part defaults to the same version).

After restructuring the documentation in #4420 some parts of the documentation moved to the Axoniq Framework repository and are not available anymore once 5.1 becomes the latest (non-prerelease) version, which will break the build of the axoniq-library-site.

To fix that, we need to replace all unintentional "cross-version" references in all release branches (4.10, 4.11, 4.12, 4.13, 5.0, 5.1) to omit the antora component name, so they reference the same version instead.

relates to #4484