### PR TITLE
[#4484] Fix main branch reference guide cross component references

### DIFF
--- a/docs/message-handler-customization-guide/modules/ROOT/pages/handler-enhancers.adoc
+++ b/docs/message-handler-customization-guide/modules/ROOT/pages/handler-enhancers.adoc
@@ -1,7 +1,7 @@
 :navtitle: Handler Enhancers
 = Handler Enhancers
 
-Handler Enhancers allow you to wrap handlers and add custom logic to the execution or eligibility of handlers for a specific message. Handler enhancers differ from xref:axon-framework-reference:messaging-concepts:message-intercepting.adoc[message handler interceptors] by the access they provide to the message handling component (for example, the aggregate member) at the resolution time. Hence, handler enhancers allow for more fine-grained control. You can use handler enhancers to intercept and perform checks on groups of `@MessageHandler` annotated methods, like a command, event, or query handler.
+Handler Enhancers allow you to wrap handlers and add custom logic to the execution or eligibility of handlers for a specific message. Handler enhancers differ from xref:5.1@axon-framework-reference:messaging-concepts:message-intercepting.adoc[message handler interceptors] by the access they provide to the message handling component (for example, the aggregate member) at the resolution time. Hence, handler enhancers allow for more fine-grained control. You can use handler enhancers to intercept and perform checks on groups of `@MessageHandler` annotated methods, like a command, event, or query handler.
 
 To create a handler enhancer, you implement the `HandlerEnhancerDefinition` interface and override the `wrapHandler()` method. All this method does is give you access to the `MessageHandlingMember<T>`, which is an object representing any handler specified in the system.
 

--- a/docs/reference-guide/antora.yml
+++ b/docs/reference-guide/antora.yml
@@ -3,7 +3,7 @@ title: Axon Framework
 version:
   axon-(?<version>+({0..9}).+({0..9})).*: $<version>
   '*': development
-prerelease: false
+prerelease: true
 start_page: ROOT:index.adoc
 
 asciidoc:

--- a/docs/reference-guide/modules/ROOT/pages/conversion.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/conversion.adoc
@@ -15,7 +15,7 @@ Axon Framework uses a flexible approach to message identification and conversion
 
 === Message type vs Java class
 
-Messages in Axon Framework are identified by their `MessageType` (as described in the xref:axon-framework-reference:messaging-concepts:anatomy-message.adoc[Anatomy of a Message] chapter), which consists of:
+Messages in Axon Framework are identified by their `MessageType` (as described in the xref:messaging-concepts:anatomy-message.adoc[Anatomy of a Message] chapter), which consists of:
 
 * A `QualifiedName` - The fully qualified business name of the message, consisting of:
 ** A `namespace` (defaults to the package name of the message class)
@@ -28,7 +28,7 @@ This approach means that:
 * Different handlers can receive the same message in different Java types
 * The Java class is one possible representation of a message, not its sole identifier
 
-For example, a message with qualified name `com.example.events.UserRegistered` and version "1.0" is the same message regardless of whether it's represented as a `UserRegisteredEvent` class in one service or a `UserCreatedEvent` class in another, as long as both specify the same `MessageType`. When you want to learn more about how Axon resolves the `MessageType`, be sure to read xref:axon-framework-reference:messaging-concepts:anatomy-message.adoc#message_type_resolution[this] section.
+For example, a message with qualified name `com.example.events.UserRegistered` and version "1.0" is the same message regardless of whether it's represented as a `UserRegisteredEvent` class in one service or a `UserCreatedEvent` class in another, as long as both specify the same `MessageType`. When you want to learn more about how Axon resolves the `MessageType`, be sure to read xref:messaging-concepts:anatomy-message.adoc#message_type_resolution[this] section.
 
 === Payload conversion at handling time
 

--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -27,7 +27,7 @@ When looking to provide a pull request, be sure to adjust link:https://github.co
 You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution. For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
 ====
 
-When storing the serialized formats of, for example, xref:axon-framework-reference:events:event-processors/streaming.adoc#tracking_tokens[tokens], or xref:axon-framework-reference:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.
+When storing the serialized formats of, for example, xref:events:event-processors/streaming.adoc#tracking_tokens[tokens], or xref:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.
 
 This choice combined with link:https://www.postgresql.org/[PostgreSQL] and Hibernate, causes unexpected behavior for most.
 
@@ -42,7 +42,7 @@ However, even when using Axon Server, the predicament remains for tokens and sag
 
 For those cases, it would be wise to adjust the Hibernate mapping.
 The most straightforward way, is to enforce the use of the `BYTEA` column type; with some additional steps, of course.
-For a full explanation and walkthrough, please check the xref:axon-framework-reference:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
+For a full explanation and walkthrough, please check the xref:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
 
 == Sequence generation issues with JPA Entities
 
@@ -50,12 +50,12 @@ For the JPA entities that require a generated sequence, we decided to use the de
 In the pre-Hibernate-6 age, this typically resulted in the construction of a single sequence generator that would be reused by several tables.
 This can be regarded as suboptimal, as frequently, the sequence generator would be reused between tables.
 
-Especially given the nature of the `global_index` column on the `domain_event_entry` table, which is used to keep the progress in xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processors], a reused generator, causes unexpected gaps in event processing.
+Especially given the nature of the `global_index` column on the `domain_event_entry` table, which is used to keep the progress in xref:events:event-processors/streaming.adoc[streaming event processors], a reused generator, causes unexpected gaps in event processing.
 Although Axon Framework can deal with these gaps, they make the queries to the `domain_event_entry` table rather bulky.
 
 Just as with any event storage solution, using a dedicated event store implementation like xref:axon-server-reference::index.adoc[Axon Server] will solve the problem entirely.
 Instead of using Axon Server, it is also possible to define sequence generators manually for Axon's entities.
-The xref:axon-framework-reference:tuning:rdbms-tuning.adoc[Relational Database Tuning page] contains a section on how to do this, called xref:axon-framework-reference:tuning:rdbms-tuning.adoc#auto_increment_and_sequences[Auto-Increment and Sequences].
+The xref:tuning:rdbms-tuning.adoc[Relational Database Tuning page] contains a section on how to do this, called xref:tuning:rdbms-tuning.adoc#auto_increment_and_sequences[Auto-Increment and Sequences].
 
 As described earlier, the `@GeneratedValue` was introduced in 2016.
 With the recent move to Hibernate 6, which defaults the increment value to 50, the problem of gaps or unintended reuse between tables has only become bigger.

--- a/docs/reference-guide/modules/commands/pages/command-dispatchers.adoc
+++ b/docs/reference-guide/modules/commands/pages/command-dispatchers.adoc
@@ -211,7 +211,7 @@ For most use cases, the asynchronous `send` methods are preferred.
 [TIP]
 .Reactive command dispatching
 ====
-If your application uses Project Reactor (for example, Spring WebFlux), the xref:axon-framework-reference:ROOT:modules.adoc#axon-reactor[Reactor extension] provides a `ReactorCommandGateway` that returns `Mono<R>` instead of `CompletableFuture`.
+If your application uses Project Reactor (for example, Spring WebFlux), the xref:ROOT:modules.adoc#axon-reactor[Reactor extension] provides a `ReactorCommandGateway` that returns `Mono<R>` instead of `CompletableFuture`.
 Reactive dispatch interceptors run inside the Reactor subscription, enabling access to Reactor context such as `ReactiveSecurityContextHolder`.
 ====
 

--- a/docs/reference-guide/modules/events/pages/event-publishing.adoc
+++ b/docs/reference-guide/modules/events/pages/event-publishing.adoc
@@ -244,7 +244,7 @@ public CompletableFuture<Void> publishEvent() {
 [TIP]
 .Reactive event publishing
 ====
-If your application uses Project Reactor, the xref:axon-framework-reference:ROOT:modules.adoc#axon-reactor[Reactor extension] provides a `ReactorEventGateway` that returns `Mono<Void>` and supports reactive dispatch interceptors with access to Reactor context.
+If your application uses Project Reactor, the xref:ROOT:modules.adoc#axon-reactor[Reactor extension] provides a `ReactorEventGateway` that returns `Mono<Void>` and supports reactive dispatch interceptors with access to Reactor context.
 ====
 
 [#low_level_event_publication]

--- a/docs/reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/message-intercepting.adoc
@@ -442,7 +442,7 @@ public void registerQueryHandlerInterceptor(MessagingConfigurer configurer) {
 [[reactive-dispatch-interceptors]]
 == Reactor dispatch interceptors
 
-When using the xref:axon-framework-reference:ROOT:modules.adoc#axon-reactor[Reactor extension], reactor gateways provide their own interceptor type: `ReactorMessageDispatchInterceptor`.
+When using the xref:ROOT:modules.adoc#axon-reactor[Reactor extension], reactor gateways provide their own interceptor type: `ReactorMessageDispatchInterceptor`.
 Unlike the standard `MessageDispatchInterceptor`, the reactor variant runs inside the Reactor subscription chain.
 This means interceptors can access Reactor context using `Mono.deferContextual()`, enabling integration with reactive context holders such as Spring Security's `ReactiveSecurityContextHolder`.
 

--- a/docs/reference-guide/modules/migration/pages/paths/serializers.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/serializers.adoc
@@ -151,7 +151,7 @@ Available types for properties are:
 
 * `jackson` - using jackson latest version 3 as propagated by Spring Boot 4
 * `jackson2` - fallback for legacy jackson version 2 (Spring Boot 2/3)
-* `avro` - https://avro.apache.org/[Apache Avro] schema based, see the xref:axon-framework-reference:ROOT:conversion.adoc#avro_converter[AvroConverter] section
+* `avro` - https://avro.apache.org/[Apache Avro] schema based, see the xref:ROOT:conversion.adoc#avro_converter[AvroConverter] section
 * `cbor` - uses Jackson/CBORMapper to convert objects into the Concise Binary Object Representation.
 
 Note that `avro` can only be used for `messages` or `events`, not as a `general` converter.

--- a/docs/reference-guide/modules/queries/pages/index.adoc
+++ b/docs/reference-guide/modules/queries/pages/index.adoc
@@ -10,12 +10,12 @@ Query handling is fully async-native, with all query dispatching operations retu
 
 There are multiple types of queries that can be distinguished:
 
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#point-to-point-queries[Point-to-point queries]:
+. xref:queries:query-dispatchers.adoc#point-to-point-queries[Point-to-point queries]:
 These are routed to a single handler, which is expected to return a single result. This is the most common type of query.
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#subscription-queries[Subscription queries]: These request an initial result and then continue to receive updates as long as the subscription is active. The initial result and updates are combined in a single `Publisher` stream.
-. xref:axon-framework-reference:queries:query-dispatchers.adoc#streaming-queries[Streaming queries]: These queries are used to request a stream of results as a `Publisher`, which are returned as they become available. This is ideal for large result sets.
+. xref:queries:query-dispatchers.adoc#subscription-queries[Subscription queries]: These request an initial result and then continue to receive updates as long as the subscription is active. The initial result and updates are combined in a single `Publisher` stream.
+. xref:queries:query-dispatchers.adoc#streaming-queries[Streaming queries]: These queries are used to request a stream of results as a `Publisher`, which are returned as they become available. This is ideal for large result sets.
 
-You can find more about each type of query in the xref:axon-framework-reference:queries:query-dispatchers.adoc[Query dispatchers] section.
+You can find more about each type of query in the xref:queries:query-dispatchers.adoc[Query dispatchers] section.
 
 
 == Subsections

--- a/docs/reference-guide/modules/queries/pages/query-dispatchers.adoc
+++ b/docs/reference-guide/modules/queries/pages/query-dispatchers.adoc
@@ -292,7 +292,7 @@ Axon Framework uses Project Reactor internally to build the `Publisher` for subs
 [TIP]
 .Reactive query gateway
 ====
-Since subscription queries already require `reactor-core`, consider using the xref:axon-framework-reference:ROOT:modules.adoc#axon-reactor[Reactor extension]'s `ReactorQueryGateway`.
+Since subscription queries already require `reactor-core`, consider using the xref:ROOT:modules.adoc#axon-reactor[Reactor extension]'s `ReactorQueryGateway`.
 It returns `Flux<R>` for subscription queries natively and provides reactor dispatch interceptors with access to Reactor context (for example, `ReactiveSecurityContextHolder` in Spring WebFlux applications).
 ====
 
@@ -413,7 +413,7 @@ However, it is a compile time dependency and is not required for other Axon feat
 [TIP]
 .Reactive query gateway
 ====
-Since streaming queries already require `reactor-core`, consider using the xref:axon-framework-reference:ROOT:modules.adoc#axon-reactor[Reactor extension]'s `ReactorQueryGateway`.
+Since streaming queries already require `reactor-core`, consider using the xref:ROOT:modules.adoc#axon-reactor[Reactor extension]'s `ReactorQueryGateway`.
 It provides `streamingQuery()` returning `Flux<R>` directly, along with `query()` returning `Mono<R>` for point-to-point queries.
 Reactor dispatch interceptors enable access to Reactor context at the gateway boundary.
 ====

--- a/docs/reference-guide/modules/tuning/pages/rdbms-tuning.adoc
+++ b/docs/reference-guide/modules/tuning/pages/rdbms-tuning.adoc
@@ -66,14 +66,14 @@ Here, again, a shorter (but variable) length field should suffice.
 [#auto_increment_and_sequences]
 :navtitle: Auto-Increment and Sequences
 
-When using a relational database as an event store, Axon Framework relies on an auto-increment value to allow xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processors] to read all events roughly in the order they were inserted.
+When using a relational database as an event store, Axon Framework relies on an auto-increment value to allow xref:events:event-processors/streaming.adoc[streaming event processors] to read all events roughly in the order they were inserted.
 We say "roughly", because "insert-order" and "commit-order" are different things.
 
 While auto-increment values are (generally) generated at insert-time, these values only become visible at commit-time.
 This means another process may observe these sequence numbers arriving in a different order.
 While Axon Framework has mechanisms to ensure that eventually all events are handled, even when they become visible in a different order, there are limitations and performance aspects to consider.
 
-When a xref:axon-framework-reference:events:event-processors/streaming.adoc[streaming event processor] reads events, it uses the "global sequence" to track its progress.
+When a xref:events:event-processors/streaming.adoc[streaming event processor] reads events, it uses the "global sequence" to track its progress.
 When events become available in a different order than they were inserted, Axon Framework will encounter a "gap." Axon Framework will remember these "gaps" to verify that data has become available since the last read.
 These gaps may be the result of events becoming visible in a different order, but also because a transaction was rolled back.
 It is highly recommended to ensure that no gaps exist because of over eagerly increasing the sequence number.
@@ -153,7 +153,7 @@ Thus, the dedicate large object storage solution will be used if you are using P
 As events and snapshots are frequently read, the overhead predicament discussed earlier will be hit.
 Arguably more problematic is issue two, especially for the `token_entry` table.
 
-The "claim" on a token is frequently updated to allow correct collaboration in a distributed Axon setup (please read our xref:axon-framework-reference:events:event-processors/streaming.adoc#tracking_tokens[Tracking Tokens] section for more details).
+The "claim" on a token is frequently updated to allow correct collaboration in a distributed Axon setup (please read our xref:events:event-processors/streaming.adoc#tracking_tokens[Tracking Tokens] section for more details).
 As the large object table is **not** automatically cleared, it will eventually overflow through all the updates.
 
 Hence, it would be best to avoid the Large Object Storage behavior and instead opt for the transparent TOAST feature.


### PR DESCRIPTION
We are using `xref:axon-framework-reference:...` type references in the reference guide at several places which makes Antora referencing to the latest version of the component instead of the same version (when specifying the component part in an xref, Antora defaults to the latest version, omitting the component part defaults to the same version).

After restructuring the documentation in #4420 some parts of the documentation moved to the Axoniq Framework repository and are not available anymore once 5.1 becomes the latest (non-prerelease) version, which will break the build of the axoniq-library-site.

To fix that, we need to replace all unintentional "cross-version" references in all release branches (4.10, 4.11, 4.12, 4.13, 5.0, 5.1) to omit the antora component name, so they reference the same version instead.

relates to #4484