### PR TITLE
[#4414] Add Note for change in Jackson 3 converter default behaviour

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/conversion.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/conversion.adoc
@@ -226,6 +226,15 @@ public Converter customJacksonConverter() {
 
 TIP: If you have not migrated to Jackson 3 yet, Axon Framework also provides a `Jackson2Converter` in the `org.axonframework.conversion.jackson2` package. This converter uses the Jackson 2 library (`com.fasterxml.jackson`) and works identically to the `JacksonConverter`.
 
+[#jackson3_converter_final_fields_note]
+[IMPORTANT]
+====
+Jackson 3 changed the default deserializing `final` fields (see https://github.com/FasterXML/jackson-databind/issues/4552[the original Jackson GitHub issue] for details).
+This prevents `final` fields from being deserialized, which—for example—affects any usage of Kotlin `val` properties for message payloads (because they are `final` by default).
+
+When upgrading to Jackson 3, be sure to check if any of your payloads that get serialized using the `JacksonConverter` (that is using Jackson 3 under the hood) are affected by this change. If so, you can either set the Jackson 3 feature `ALLOW_FINAL_FIELDS_AS_MUTATORS` to `false`, or adjust your payload representation in code as necessary.
+====
+
 ==== XML support
 
 If you need to serialize to XML format instead of JSON, you can configure the `JacksonConverter` with an `XmlMapper`:

--- a/docs/reference-guide/modules/migration/pages/paths/serializers.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/serializers.adoc
@@ -154,7 +154,9 @@ Available types for properties are:
 * `avro` - https://avro.apache.org/[Apache Avro] schema based, see the xref:ROOT:conversion.adoc#avro_converter[AvroConverter] section
 * `cbor` - uses Jackson/CBORMapper to convert objects into the Concise Binary Object Representation.
 
-Note that `avro` can only be used for `messages` or `events`, not as a `general` converter.
+NOTE: The `avro` converter can only be used for `messages` or `events`, not as a `general` converter.
+
+IMPORTANT: Jackson 3 changed the default for deserializing `final` fields. If your upgrade from Jackson 2 to Jackson 3, check the xref:ROOT:conversion.adoc#jackson3_converter_final_fields_note[additional information in the conversion reference].
 
 
 


### PR DESCRIPTION
As of Jackson 3, the default for ALLOW_FINAL_FIELDS_AS_MUTATORS defaults to `false` , which avoids `final` fields to be deserialized. This for example affects usages of Kotlin val properties, which are final.

This commit adds a note to the Conversion page and the Serializer migration path to make users aware of that.

resolves https://github.com/AxonIQ/AxonFramework/issues/4414