### PR TITLE
[#4414] Fix Note for change in Jackson 3 converter default behaviour

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/conversion.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/conversion.adoc
@@ -230,9 +230,10 @@ TIP: If you have not migrated to Jackson 3 yet, Axon Framework also provides a `
 [IMPORTANT]
 ====
 Jackson 3 changed the default deserializing `final` fields (see https://github.com/FasterXML/jackson-databind/issues/4552[the original Jackson GitHub issue] for details).
-This prevents `final` fields from being deserialized, which—for example—affects any usage of Kotlin `val` properties for message payloads (because they are `final` by default).
+This prevents `final` fields from being deserialized, which—for example—might affect usages of Kotlin `val` properties for message payloads (because they are `final` by default).
 
-When upgrading to Jackson 3, be sure to check if any of your payloads that get serialized using the `JacksonConverter` (that is using Jackson 3 under the hood) are affected by this change. If so, you can either set the Jackson 3 feature `ALLOW_FINAL_FIELDS_AS_MUTATORS` to `false`, or adjust your payload representation in code as necessary.
+When upgrading to Jackson 3, be sure to check if any of your payloads that get serialized using the `JacksonConverter` (that is using Jackson 3 under the hood) are affected by this change.
+If so, you can either set the Jackson 3 feature `ALLOW_FINAL_FIELDS_AS_MUTATORS` to `true`, or adjust your payload representation in code as necessary.
 ====
 
 ==== XML support


### PR DESCRIPTION
Correct the suggestion for the workaround to use `true` instead of false.