### PR TITLE
Restructure Release Notes navigation in framework reference

### DIFF
--- a/docs/reference-guide/modules/release-notes/partials/nav.adoc
+++ b/docs/reference-guide/modules/release-notes/partials/nav.adoc
@@ -1,6 +1,7 @@
 * xref:release-notes:README.adoc[]
-** xref:release-notes:major-releases.adoc[]
-** xref:release-notes:minor-releases.adoc[]
+** Axon Framework
+*** xref:release-notes:major-releases.adoc[]
+*** xref:release-notes:minor-releases.adoc[]
 ifdef::advanced-framework[]
 include::advanced-release-notes:partial$nav.adoc[]
 endif::[]


### PR DESCRIPTION
To better allow for separate release from different repositories, we restructure the navigation for the release notes section in the framework reference guide to have separate sections per released artifact, currently planning for
* Axon Framework
* Axoniq Framework
* Axoniq Data Protection
* Axoniq Workflow Engine