### PR TITLE
Chore: Update axon server image version

### DIFF
--- a/docs/getting-started/modules/ROOT/pages/configure-axon-server.adoc
+++ b/docs/getting-started/modules/ROOT/pages/configure-axon-server.adoc
@@ -37,7 +37,7 @@ Create a `docker-compose.yml` file in your project root:
 ----
 services:
   axon-server:
-    image: docker.axoniq.io/axoniq/axonserver:2025.2.0
+    image: docker.axoniq.io/axoniq/axonserver:2026.0.0
     ports:
       - "8024:8024"
       - "8124:8124"

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   axon-server:
-    image: docker.axoniq.io/axoniq/axonserver:2025.2.7
+    image: docker.axoniq.io/axoniq/axonserver:2026.0.0
     container_name: axon-framework-examples-axon-server
     ports:
       - "8024:8024"

--- a/examples/university-demo-kotlin/docker-compose.yaml
+++ b/examples/university-demo-kotlin/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   axon-server:
-    image: docker.axoniq.io/axoniq/axonserver:2025.2.7
+    image: docker.axoniq.io/axoniq/axonserver:2026.0.0
     ports:
       - "8024:8024"
       - "8124:8124"


### PR DESCRIPTION
When merged, this PR updates the axon-server docker image version to the latest 2026.0.0.

It was only used in the docs and the server-based examples.

I also double checked: when using the axoniq-testcontainer in tests withput explicitly setting a version, it uses `latest` which should be fine.