### PR TITLE
Relocate the Kotlin module description to include it in the correct section

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/modules.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/modules.adoc
@@ -156,10 +156,6 @@ This extension provides basic implementations based on Dropwizard to collect mon
 This extension provides basic implementations based on Micrometer to collect monitoring information.
 https://micrometer.io/[Micrometer] is a dimensional-first metrics collection facade whose aim is to allow you to time, count, and gauge your code with a vendor neutral API.
 
-ifdef::advanced-framework[]
-include::ROOT:partial$modules-advanced-framework.adoc[]
-endif::[]
-
 === Axon Kotlin
 
 The Kotlin extension provides idiomatic Kotlin support for Axon Framework, reducing boilerplate and enabling natural Kotlin API usage through extension functions and reified generics.
@@ -171,6 +167,10 @@ Features include, among others:
 * Kotlin value class support for entity identifiers
 * reduced boilerplate in event sourcing handlers
 * test fixture support tailored for Kotlin (`axon-kotlin-test`)
+
+ifdef::advanced-framework[]
+include::ROOT:partial$modules-advanced-framework.adoc[]
+endif::[]
 
 == Axon Framework Bill of Materials
 


### PR DESCRIPTION
The module description for the Kotlin module has been placed after the include for the AxoniqFramework modules and appears at the end of the wrong section in the docs. This commit fixes that.