### PR TITLE
[#4323] fix(messaging): `PooledStreamingEventProcessor`/`WorkPackage` - TrackingToken in `ProcessingContext` per event, not per batch

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/ReplayStatusChangedHandlerIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/ReplayStatusChangedHandlerIT.java
@@ -162,7 +162,7 @@ public abstract class ReplayStatusChangedHandlerIT extends AbstractStudentIT {
                 ))
                 .customized(
                         (config, psep) -> psep.initialSegmentCount(2)
-                                              .batchSize(1)
+                                              .batchSize(3)
                 );
         return configurer.messaging(
                 messaging -> messaging.eventProcessing(

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -80,24 +80,41 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
 
 
     /**
-     * Processes a batch of events in the processing context.
+     * Processes a batch of events in the given processing context.
      * <p>
-     * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that the events with same
+     * For each entry, a per-event sub-{@link ProcessingContext} is derived by reading the
+     * {@link TrackingToken} stored in the entry's {@link org.axonframework.messaging.core.Context} under
+     * {@link TrackingToken#RESOURCE_KEY} and overriding that key on the batch context via
+     * {@link ProcessingContext#withResource}. This ensures that per-event replay detection (
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#isReplay} and
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#concludesReplay}) observes
+     * the correct position for each individual event rather than the shared batch-end token. The batch-end token
+     * remains accessible under {@link TrackingToken#BATCH_END_RESOURCE_KEY} on the parent context.
+     * <p>
+     * The sub-context delegates all {@link ProcessingContext} lifecycle hooks (commit, rollback, etc.) to the parent,
+     * so transaction semantics are unaffected. When an entry carries no per-event token (e.g. from a
+     * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor} which has no
+     * stream position), the parent context is used as-is.
+     * <p>
+     * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that events with the same
      * {@link #sequenceIdentifiersFor(EventMessage, ProcessingContext)} value are processed by a single component in the
-     * order they are received, but the sequencing of event processing is not preserved between different event handling
-     * components. This is intentional, as they may have different sequencing policies.
+     * order they are received, but sequencing is not preserved across different event handling components — this is
+     * intentional, as they may have different sequencing policies.
      *
-     * @param events  The batch of event messages to be processed.
-     * @param context The processing context in which the event messages are processed.
-     * @return A stream of messages resulting from the processing of the event messages.
+     * @param entries the batch of message stream entries to be processed
+     * @param context the processing context in which the event messages are processed
+     * @return a stream of messages resulting from the processing of the event messages
      */
     public MessageStream.Empty<Message> handle(
-            List<? extends EventMessage> events,
+            List<MessageStream.Entry<? extends EventMessage>> entries,
             ProcessingContext context
     ) {
         MessageStream<Message> batchResult = MessageStream.empty().cast();
-        for (var event : events) {
-            var eventResult = handle(event, context);
+        for (var entry : entries) {
+            ProcessingContext perEventContext = TrackingToken.fromContext(entry)
+                    .map(token -> context.withResource(TrackingToken.RESOURCE_KEY, token))
+                    .orElse(context);
+            var eventResult = handle(entry.message(), perEventContext);
             batchResult = batchResult.concatWith(eventResult.cast());
         }
         return batchResult.ignoreEntries()

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -82,19 +82,21 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     /**
      * Processes a batch of events in the given processing context.
      * <p>
-     * For each entry, a per-event sub-{@link ProcessingContext} is derived by reading the
-     * {@link TrackingToken} stored in the entry's {@link org.axonframework.messaging.core.Context} under
-     * {@link TrackingToken#RESOURCE_KEY} and overriding that key on the batch context via
-     * {@link ProcessingContext#withResource}. This ensures that per-event replay detection (
-     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#isReplay} and
-     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#concludesReplay}) observes
-     * the correct position for each individual event rather than the shared batch-end token. The batch-end token
-     * remains accessible under {@link TrackingToken#BATCH_END_RESOURCE_KEY} on the parent context.
+     * Each entry carries its own {@link TrackingToken} in its {@link org.axonframework.messaging.core.Context} under
+     * {@link TrackingToken#RESOURCE_KEY}. Before invoking the event handling components for a given entry, that
+     * per-event token is written into the shared {@code context} under the same key, overriding the batch-end token
+     * that the caller placed there. The {@code context} itself — including its transaction lifecycle and all other
+     * resources — is the same object for every event in the batch; only {@link TrackingToken#RESOURCE_KEY} is
+     * temporarily overridden for the duration of each event's handling. The batch-end token remains accessible under
+     * {@link TrackingToken#BATCH_END_RESOURCE_KEY} throughout.
      * <p>
-     * The sub-context delegates all {@link ProcessingContext} lifecycle hooks (commit, rollback, etc.) to the parent,
-     * so transaction semantics are unaffected. When an entry carries no per-event token (e.g. from a
+     * This ensures that per-event replay detection (
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#isReplay(TrackingToken)} and
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#concludesReplay(TrackingToken)}) observes
+     * the correct position for each individual event rather than the shared batch-end token. When an entry carries no
+     * per-event token (e.g. from a
      * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor} which has no
-     * stream position), the parent context is used as-is.
+     * stream position), the context is used as-is.
      * <p>
      * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that events with the same
      * {@link #sequenceIdentifiersFor(EventMessage, ProcessingContext)} value are processed by a single component in the

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -435,13 +435,13 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
                           .build();
     }
 
-    private MessageStream.Empty<Message> processWithErrorHandling(List<? extends EventMessage> events,
+    private MessageStream.Empty<Message> processWithErrorHandling(List<MessageStream.Entry<? extends EventMessage>> entries,
                                                                   ProcessingContext context) {
-        return eventHandlingComponents.handle(events, context)
+        return eventHandlingComponents.handle(entries, context)
                                       .onErrorContinue(ex -> {
                                           try {
                                               configuration.errorHandler()
-                                                           .handleError(new ErrorContext(name, ex, events, context));
+                                                           .handleError(new ErrorContext(name, ex, entries.stream().map(MessageStream.Entry::message).toList(), context));
                                           } catch (RuntimeException re) {
                                               return MessageStream.failed(re);
                                           } catch (Exception e) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -412,7 +412,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     }
 
     private WorkPackage spawnWorker(Segment segment, TrackingToken initialToken) {
-        WorkPackage.BatchProcessor batchProcessor = (events, context) -> processWithErrorHandling(events, context);
+        WorkPackage.BatchProcessor batchProcessor = (entries, context) -> processWithErrorHandling(entries, context);
         var batchSize = configuration.batchSize();
         var claimExtensionThreshold = configuration.claimExtensionThreshold();
         var clock = configuration.clock();
@@ -435,8 +435,10 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
                           .build();
     }
 
-    private MessageStream.Empty<Message> processWithErrorHandling(List<MessageStream.Entry<? extends EventMessage>> entries,
-                                                                  ProcessingContext context) {
+    private MessageStream.Empty<Message> processWithErrorHandling(
+            List<MessageStream.Entry<? extends EventMessage>> entries,
+            ProcessingContext context
+    ) {
         return eventHandlingComponents.handle(entries, context)
                                       .onErrorContinue(ex -> {
                                           try {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -582,13 +582,13 @@ class WorkPackage {
     interface BatchProcessor {
 
         /**
-         * Processes a batch of events in the processing context.
+         * Processes a batch of entries in the processing context.
          *
-         * @param events  The batch of event messages to be processed.
+         * @param entries  The batch of event messages to be processed.
          * @param context The processing context in which the event messages are processed.
          * @return A stream of messages resulting from the processing of the event messages.
          */
-        MessageStream.Empty<Message> process(List<MessageStream.Entry<? extends EventMessage>> events,
+        MessageStream.Empty<Message> process(List<MessageStream.Entry<? extends EventMessage>> entries,
                                              ProcessingContext context);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -259,11 +260,11 @@ class WorkPackage {
      * a specialized {@link ProcessingContext} from the event entry to evaluate if the event should be processed by this
      * work package's {@link Segment}.
      * <p>
-     * The method extracts resources from the {@code eventEntry} that were set by the
-     * {@link StreamableEventSource} to make filtering decisions. Example: These
-     * resources include data like {@link LegacyResources#AGGREGATE_IDENTIFIER_KEY}, which
-     * might be essential (while using the Aggreate based approach) for event sequencing since Axon Framework 5.0.0 no
-     * longer embeds aggregate identifiers directly in event messages.
+     * The method extracts resources from the {@code eventEntry} that were set by the {@link StreamableEventSource} to
+     * make filtering decisions. Example: These resources include data like
+     * {@link LegacyResources#AGGREGATE_IDENTIFIER_KEY}, which might be essential (while using the Aggreate based
+     * approach) for event sequencing since Axon Framework 5.0.0 no longer embeds aggregate identifiers directly in
+     * event messages.
      * <p>
      * The temporary {@link EventSchedulingProcessingContext} created here has limitations - it cannot access
      * configuration components or register lifecycle hooks. Its sole purpose is to provide resource access during event
@@ -358,11 +359,11 @@ class WorkPackage {
     }
 
     private void processEvents() {
-        List<EventMessage> eventBatch = new ArrayList<>();
+        List<MessageStream.Entry<? extends EventMessage>> eventBatch = new ArrayList<>();
         while (!isAbortTriggered() && eventBatch.size() < batchSize && !processingQueue.isEmpty()) {
             ProcessingEntry entry = processingQueue.poll();
             lastConsumedToken = WrappedToken.advance(lastConsumedToken, entry.trackingToken());
-            entry.addToBatch(eventBatch);
+            entry.addToBatch(eventBatch, lastConsumedToken);
         }
 
         // Make sure all subsequent events with the same token (if non-null) as the last are added as well.
@@ -376,7 +377,7 @@ class WorkPackage {
                 var unitOfWork = unitOfWorkFactory.create();
                 unitOfWork.runOnPreInvocation(ctx -> {
                     ctx.putResource(Segment.RESOURCE_KEY, segment);
-                    ctx.putResource(TrackingToken.RESOURCE_KEY, lastConsumedToken);
+                    ctx.putResource(TrackingToken.BATCH_END_RESOURCE_KEY, lastConsumedToken);
                 });
 
                 unitOfWork.onInvocation(ctx -> batchProcessor.process(eventBatch, ctx).asCompletableFuture());
@@ -481,8 +482,8 @@ class WorkPackage {
      * Indicates whether an abort has been triggered for this {@code WorkPackage}. When {@code true}, any events
      * scheduled for processing by this {@code WorkPackage} are likely to be ignored.
      * <p>
-     * Use {@link WorkPackage#abort(Exception)} (possibly with a {@code null} reason) to obtain a {@link CompletableFuture} with a
-     * reference to the abort reason.
+     * Use {@link WorkPackage#abort(Exception)} (possibly with a {@code null} reason) to obtain a
+     * {@link CompletableFuture} with a reference to the abort reason.
      *
      * @return {@code true} if an abort was scheduled, otherwise {@code false}
      */
@@ -587,7 +588,8 @@ class WorkPackage {
          * @param context The processing context in which the event messages are processed.
          * @return A stream of messages resulting from the processing of the event messages.
          */
-        MessageStream.Empty<Message> process(List<? extends EventMessage> events, ProcessingContext context);
+        MessageStream.Empty<Message> process(List<MessageStream.Entry<? extends EventMessage>> events,
+                                             ProcessingContext context);
     }
 
     /**
@@ -757,8 +759,7 @@ class WorkPackage {
          * this {@code WorkPackage}. The provided {@code ProcessingContext} is enriched with resources from the
          * {@link MessageStream.Entry} to evaluate whether the event can be handled by this package's {@link Segment}.
          * Currently, the only usage of the context is for
-         * {@link EventHandlingComponent#sequenceIdentifierFor(EventMessage,
-         * ProcessingContext)} execution.
+         * {@link EventHandlingComponent#sequenceIdentifierFor(EventMessage, ProcessingContext)} execution.
          *
          * @param schedulingProcessingContextProvider The {@link ProcessingContext} provider.
          * @return The current Builder instance, for fluent interfacing.
@@ -796,12 +797,28 @@ class WorkPackage {
         TrackingToken trackingToken();
 
         /**
-         * Add this entry's events to the {@code eventBatch}. Since tracking is handled at the UnitOfWork level, we only
-         * need to add the actual event messages to the batch.
+         * Add this entry's events to the {@code eventBatch}, overriding the raw stream token already present in the
+         * entry's context with the given {@code wrappedToken}.
+         * <p>
+         * The raw token stored in the entry's context is the position as reported by the event source (e.g. a plain
+         * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken}).
+         * That raw value is insufficient for correct per-event processing: {@code wrappedToken} is the result of
+         * {@link WrappedToken#advance(TrackingToken, TrackingToken)} applied to the previous batch position and this
+         * entry's raw token, so it encodes additional state — most importantly, during a replay it is a
+         * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken} wrapping the raw
+         * position. Without this override, replay-detection logic such as
+         * {@link
+         * org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#isReplay(TrackingToken)} and
+         * {@link
+         * org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#concludesReplay(TrackingToken)}
+         * would always see a plain token and never recognise the replay boundary, causing all events in a batch to be
+         * mis-classified.
          *
-         * @param eventBatch The list of events to add this entry's events to.
+         * @param eventBatch   the list of events to add this entry's events to
+         * @param wrappedToken the result of {@link WrappedToken#advance} for this specific event; replaces the raw
+         *                     stream token in each event's context
          */
-        void addToBatch(List<EventMessage> eventBatch);
+        void addToBatch(List<MessageStream.Entry<? extends EventMessage>> eventBatch, TrackingToken wrappedToken);
     }
 
     /**
@@ -825,9 +842,12 @@ class WorkPackage {
         }
 
         @Override
-        public void addToBatch(List<EventMessage> eventBatch) {
+        public void addToBatch(
+                List<MessageStream.Entry<? extends EventMessage>> eventBatch,
+                TrackingToken wrappedToken
+        ) {
             if (canHandle) {
-                eventBatch.add(eventEntry.message());
+                eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
             }
         }
     }
@@ -854,8 +874,11 @@ class WorkPackage {
         }
 
         @Override
-        public void addToBatch(List<EventMessage> eventBatch) {
-            processingEntries.forEach(entry -> entry.addToBatch(eventBatch));
+        public void addToBatch(
+                List<MessageStream.Entry<? extends EventMessage>> eventBatch,
+                TrackingToken wrappedToken
+        ) {
+            processingEntries.forEach(entry -> entry.addToBatch(eventBatch, wrappedToken));
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingToken.java
@@ -73,28 +73,6 @@ public interface TrackingToken {
     }
 
     /**
-     * Adds the given {@code token} to the given {@code context} using the {@link #BATCH_END_RESOURCE_KEY}.
-     *
-     * @param context The {@link Context} to add the batch-end {@code token} to.
-     * @param token   The {@link TrackingToken} representing the position of the last event in the batch.
-     * @return The resulting context.
-     */
-    static Context addBatchEndToContext(Context context, TrackingToken token) {
-        return context.withResource(BATCH_END_RESOURCE_KEY, token);
-    }
-
-    /**
-     * Returns an {@link Optional} of {@link TrackingToken} keyed under {@link #BATCH_END_RESOURCE_KEY} in the given
-     * {@code context}, representing the token of the last event in the current batch.
-     *
-     * @param context The {@link Context} to retrieve the batch-end {@link TrackingToken} from, if present.
-     * @return An {@link Optional} of {@link TrackingToken} representing the last position in the current batch.
-     */
-    static Optional<TrackingToken> batchEndFromContext(Context context) {
-        return Optional.ofNullable(context.getResource(BATCH_END_RESOURCE_KEY));
-    }
-
-    /**
      * A special {@link TrackingToken} that indicates the very beginning of an event stream.
      * <p>
      * Used to explicitly represent the first position in a stream instead of using {@code null}.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingToken.java
@@ -31,11 +31,23 @@ import java.util.OptionalLong;
  * @since 3.0.0
  */
 public interface TrackingToken {
-
     /**
-     * The {@link ResourceKey} used whenever a {@link Context} would contain a {@link TrackingToken}.
+     * The {@link ResourceKey} used to store the per-event {@link TrackingToken} in a {@link Context}.
+     * <p>
+     * During batch processing, each event's handler receives a {@link org.axonframework.messaging.core.unitofwork.ProcessingContext}
+     * with this key set to the token of that specific event.
      */
     ResourceKey<TrackingToken> RESOURCE_KEY = ResourceKey.withLabel("trackingToken");
+
+    /**
+     * The {@link ResourceKey} used to expose the batch-end {@link TrackingToken} in a batch
+     * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext}.
+     * <p>
+     * This key holds the token of the <em>last</em> event in the current batch, i.e. the position that will be stored
+     * in the {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore} when the
+     * batch commits. Per-event tokens are available under {@link #RESOURCE_KEY}.
+     */
+    ResourceKey<TrackingToken> BATCH_END_RESOURCE_KEY = ResourceKey.withLabel("batchEndTrackingToken");
 
     /**
      * Adds the given {@code token} to the given {@code context} using the {@link #RESOURCE_KEY}.
@@ -58,6 +70,28 @@ public interface TrackingToken {
      */
     static Optional<TrackingToken> fromContext(Context context) {
         return Optional.ofNullable(context.getResource(RESOURCE_KEY));
+    }
+
+    /**
+     * Adds the given {@code token} to the given {@code context} using the {@link #BATCH_END_RESOURCE_KEY}.
+     *
+     * @param context The {@link Context} to add the batch-end {@code token} to.
+     * @param token   The {@link TrackingToken} representing the position of the last event in the batch.
+     * @return The resulting context.
+     */
+    static Context addBatchEndToContext(Context context, TrackingToken token) {
+        return context.withResource(BATCH_END_RESOURCE_KEY, token);
+    }
+
+    /**
+     * Returns an {@link Optional} of {@link TrackingToken} keyed under {@link #BATCH_END_RESOURCE_KEY} in the given
+     * {@code context}, representing the token of the last event in the current batch.
+     *
+     * @param context The {@link Context} to retrieve the batch-end {@link TrackingToken} from, if present.
+     * @return An {@link Optional} of {@link TrackingToken} representing the last position in the current batch.
+     */
+    static Optional<TrackingToken> batchEndFromContext(Context context) {
+        return Optional.ofNullable(context.getResource(BATCH_END_RESOURCE_KEY));
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
@@ -23,6 +23,8 @@ import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.lifecycle.Phase;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.SimpleEntry;
+import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -157,7 +159,7 @@ public class SubscribingEventProcessor implements EventProcessor {
 
     private MessageStream.Empty<Message> processWithErrorHandling(List<EventMessage> events,
                                                                   ProcessingContext context) {
-        List<EventMessage> supportedEvents =
+        List<MessageStream.Entry<? extends EventMessage>> supportedEntries =
                 events.stream()
                       .filter(event -> {
                           boolean supported = eventHandlingComponents.supports(event.type().qualifiedName());
@@ -166,8 +168,8 @@ public class SubscribingEventProcessor implements EventProcessor {
                           }
                           return supported;
                       })
-                      .toList();
-        return eventHandlingComponents.handle(supportedEvents, context)
+                      .<MessageStream.Entry<? extends EventMessage>>map(event -> new SimpleEntry<>(event, Context.empty())).toList();
+        return eventHandlingComponents.handle(supportedEntries, context)
                                       .onErrorContinue(ex -> {
                                           try {
                                               errorHandler.handleError(new ErrorContext(name, ex, events, context));

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/EventProcessorMonitoringTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/EventProcessorMonitoringTest.java
@@ -33,6 +33,8 @@ import org.axonframework.messaging.monitoring.interception.MonitoringEventHandle
 import org.junit.jupiter.api.*;
 
 import java.util.HashSet;
+import org.axonframework.messaging.core.SimpleEntry;
+import org.axonframework.messaging.core.Context;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -128,7 +130,7 @@ class EventProcessorMonitoringTest {
                 throws ExecutionException, InterruptedException, TimeoutException {
             var unitOfWork = UnitOfWorkTestUtils.aUnitOfWork();
             unitOfWork.executeWithResult(ctx -> processorEventHandlingComponents
-                    .handle(eventMessages, ctx)
+                    .handle(eventMessages.stream().<MessageStream.Entry<? extends EventMessage>>map(e -> new SimpleEntry<>(e, Context.empty())).toList(), ctx)
                     .asCompletableFuture()
             ).get(2, TimeUnit.SECONDS);
         }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -1090,6 +1090,224 @@ class PooledStreamingEventProcessorTest {
             // then - verify no events processed during replay
             assertThat(recordedEvents).isEmpty();
         }
+
+        @Test
+        void replayBlockingEventHandlingComponentCorrectlySkipsEventsWithBatchSizeGreaterThanOne() {
+            // given
+            List<EventMessage> recordedEvents = new CopyOnWriteArrayList<>();
+
+            var innerComponent = SimpleEventHandlingComponent.create("test");
+            innerComponent.subscribe(new QualifiedName(String.class), (event, ctx) -> {
+                recordedEvents.add(event);
+                return MessageStream.empty();
+            });
+            var replayBlockingComponent = new ReplayBlockingEventHandlingComponent<>(innerComponent);
+
+            // do not clear event source after close
+            stubMessageSource = new AsyncInMemoryStreamableEventSource(false, false);
+            withTestSubject(
+                    List.of(replayBlockingComponent),
+                    c -> c.initialSegmentCount(1).batchSize(5)
+            );
+
+            // when - publish 5 events and process normally (not during replay)
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            EventMessage event4 = EventTestUtils.asEventMessage("event-4");
+            EventMessage event5 = EventTestUtils.asEventMessage("event-5");
+            stubMessageSource.publishMessage(event1);
+            stubMessageSource.publishMessage(event2);
+            stubMessageSource.publishMessage(event3);
+            stubMessageSource.publishMessage(event4);
+            stubMessageSource.publishMessage(event5);
+
+            startEventProcessor();
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedEvents).containsOnly(event1, event2, event3, event4, event5));
+
+            joinAndUnwrap(testSubject.shutdown());
+            recordedEvents.clear();
+
+            // Reset tokens to trigger a replay from the beginning
+            joinAndUnwrap(testSubject.resetTokens(source -> source.firstToken(null)));
+
+            // when - restart; with batchSize=5 all 5 replay events land in a single batch
+            startEventProcessor();
+
+            // then - wait for the processor to catch up to position 5
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> {
+                       long currentPosition = testSubject.processingStatus().get(0).getCurrentPosition().orElse(0);
+                       assertThat(currentPosition).isEqualTo(5);
+                   });
+
+            // then - replay-blocking component must have skipped all events: each event in the batch must have
+            // had isReplaying=true (i.e. its per-event ReplayToken was correctly injected, not the plain
+            // batch-end GlobalSequenceTrackingToken)
+            assertThat(recordedEvents).isEmpty();
+        }
+
+        @Test
+        void perEventTokenIsCorrectWhenBatchCrossesReplayBoundaryInMiddle() {
+            // given
+            // batchSize=5, 3 events processed before reset (tokenAtReset=3), then 5 more events added.
+            // Batch 1 (full, size 5): tokens 1-3 are replay, tokens 4-5 are post-replay — boundary in middle.
+            // Batch 2 (partial, size 3): tokens 6-8 are post-replay.
+            // The batch-end of batch 1 is the plain GST(5).
+            Map<EventMessage, TrackingToken> recordedTokens = Collections.synchronizedMap(new HashMap<>());
+
+            var innerComponent = SimpleEventHandlingComponent.create("test");
+            innerComponent.subscribe(new QualifiedName(String.class), (event, ctx) -> {
+                TrackingToken.fromContext(ctx).ifPresent(t -> recordedTokens.put(event, t));
+                return MessageStream.empty();
+            });
+            innerComponent.subscribe((ResetHandler) (resetContext, ctx) -> MessageStream.empty());
+
+            stubMessageSource = new AsyncInMemoryStreamableEventSource(false, false);
+            withTestSubject(
+                    List.of(innerComponent),
+                    c -> c.initialSegmentCount(1).batchSize(5)
+            );
+
+            // publish 3 events (tokens 1-3) — these will become replay events
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            stubMessageSource.publishMessage(event1);
+            stubMessageSource.publishMessage(event2);
+            stubMessageSource.publishMessage(event3);
+
+            startEventProcessor();
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedTokens).containsKeys(event1, event2, event3));
+            joinAndUnwrap(testSubject.shutdown());
+            recordedTokens.clear();
+
+            // reset to replay from the start; tokenAtReset = GST(3)
+            joinAndUnwrap(testSubject.resetTokens(source -> source.firstToken(null)));
+
+            // publish 5 more events (tokens 4-8) — tokens 4-5 land in batch 1 (post-replay), tokens 6-8 in batch 2
+            EventMessage event4 = EventTestUtils.asEventMessage("event-4");
+            EventMessage event5 = EventTestUtils.asEventMessage("event-5");
+            EventMessage event6 = EventTestUtils.asEventMessage("event-6");
+            EventMessage event7 = EventTestUtils.asEventMessage("event-7");
+            EventMessage event8 = EventTestUtils.asEventMessage("event-8");
+            stubMessageSource.publishMessage(event4);
+            stubMessageSource.publishMessage(event5);
+            stubMessageSource.publishMessage(event6);
+            stubMessageSource.publishMessage(event7);
+            stubMessageSource.publishMessage(event8);
+
+            // when - restart
+            startEventProcessor();
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedTokens)
+                           .containsKeys(event1, event2, event3, event4, event5, event6, event7, event8));
+
+            // then — each event must carry its own per-event token
+            TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(3);
+
+            // events 1-2: replay, not concluding
+            assertPerEventReplayToken(recordedTokens.get(event1), tokenAtReset, new GlobalSequenceTrackingToken(1), false);
+            assertPerEventReplayToken(recordedTokens.get(event2), tokenAtReset, new GlobalSequenceTrackingToken(2), false);
+            // event3: replay boundary — still a ReplayToken, concludesReplay = true
+            assertPerEventReplayToken(recordedTokens.get(event3), tokenAtReset, new GlobalSequenceTrackingToken(3), true);
+
+            // events 4-8: post-replay — plain GlobalSequenceTrackingToken
+            assertEquals(new GlobalSequenceTrackingToken(4), recordedTokens.get(event4));
+            assertEquals(new GlobalSequenceTrackingToken(5), recordedTokens.get(event5));
+            assertEquals(new GlobalSequenceTrackingToken(6), recordedTokens.get(event6));
+            assertEquals(new GlobalSequenceTrackingToken(7), recordedTokens.get(event7));
+            assertEquals(new GlobalSequenceTrackingToken(8), recordedTokens.get(event8));
+        }
+
+        @Test
+        void perEventTokenIsCorrectWhenReplayEndsAtBatchBoundary() {
+            // given
+            // batchSize=5, 5 events processed before reset (tokenAtReset=5), then 3 more events added.
+            // Batch 1 (full, size 5): tokens 1-5 are all replay — boundary falls at the very end of the batch.
+            // Batch 2 (partial, size 3): tokens 6-8 are post-replay.
+            // The batch-end of batch 1 is ReplayToken(current=5, atReset=5) — still a ReplayToken.
+            Map<EventMessage, TrackingToken> recordedTokens = Collections.synchronizedMap(new HashMap<>());
+
+            var innerComponent = SimpleEventHandlingComponent.create("test");
+            innerComponent.subscribe(new QualifiedName(String.class), (event, ctx) -> {
+                TrackingToken.fromContext(ctx).ifPresent(t -> recordedTokens.put(event, t));
+                return MessageStream.empty();
+            });
+            innerComponent.subscribe((ResetHandler) (resetContext, ctx) -> MessageStream.empty());
+
+            stubMessageSource = new AsyncInMemoryStreamableEventSource(false, false);
+            withTestSubject(
+                    List.of(innerComponent),
+                    c -> c.initialSegmentCount(1).batchSize(5)
+            );
+
+            // publish 5 events (tokens 1-5) — these will become replay events
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            EventMessage event4 = EventTestUtils.asEventMessage("event-4");
+            EventMessage event5 = EventTestUtils.asEventMessage("event-5");
+            stubMessageSource.publishMessage(event1);
+            stubMessageSource.publishMessage(event2);
+            stubMessageSource.publishMessage(event3);
+            stubMessageSource.publishMessage(event4);
+            stubMessageSource.publishMessage(event5);
+
+            startEventProcessor();
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedTokens)
+                           .containsKeys(event1, event2, event3, event4, event5));
+            joinAndUnwrap(testSubject.shutdown());
+            recordedTokens.clear();
+
+            // reset to replay from the start; tokenAtReset = GST(5)
+            joinAndUnwrap(testSubject.resetTokens(source -> source.firstToken(null)));
+
+            // publish 3 more events (tokens 6-8) — these land in batch 2 (post-replay)
+            EventMessage event6 = EventTestUtils.asEventMessage("event-6");
+            EventMessage event7 = EventTestUtils.asEventMessage("event-7");
+            EventMessage event8 = EventTestUtils.asEventMessage("event-8");
+            stubMessageSource.publishMessage(event6);
+            stubMessageSource.publishMessage(event7);
+            stubMessageSource.publishMessage(event8);
+
+            // when - restart
+            startEventProcessor();
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedTokens)
+                           .containsKeys(event1, event2, event3, event4, event5, event6, event7, event8));
+
+            // then — each event must carry its own per-event token
+            TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(5);
+
+            // events 1-4: replay, not concluding — before the fix all saw ReplayToken(current=5, atReset=5)
+            assertPerEventReplayToken(recordedTokens.get(event1), tokenAtReset, new GlobalSequenceTrackingToken(1), false);
+            assertPerEventReplayToken(recordedTokens.get(event2), tokenAtReset, new GlobalSequenceTrackingToken(2), false);
+            assertPerEventReplayToken(recordedTokens.get(event3), tokenAtReset, new GlobalSequenceTrackingToken(3), false);
+            assertPerEventReplayToken(recordedTokens.get(event4), tokenAtReset, new GlobalSequenceTrackingToken(4), false);
+            // event5: replay boundary — still a ReplayToken, concludesReplay = true
+            assertPerEventReplayToken(recordedTokens.get(event5), tokenAtReset, new GlobalSequenceTrackingToken(5), true);
+
+            // events 6-8: post-replay — plain GlobalSequenceTrackingToken
+            assertEquals(new GlobalSequenceTrackingToken(6), recordedTokens.get(event6));
+            assertEquals(new GlobalSequenceTrackingToken(7), recordedTokens.get(event7));
+            assertEquals(new GlobalSequenceTrackingToken(8), recordedTokens.get(event8));
+        }
+
+        private void assertPerEventReplayToken(TrackingToken token,
+                                               TrackingToken expectedAtReset,
+                                               TrackingToken expectedCurrent,
+                                               boolean expectedConcludesReplay) {
+            assertInstanceOf(ReplayToken.class, token);
+            ReplayToken replayToken = (ReplayToken) token;
+            assertEquals(expectedCurrent, replayToken.getCurrentToken());
+            assertEquals(expectedAtReset, replayToken.getTokenAtReset());
+            assertTrue(ReplayToken.isReplay(token));
+            assertEquals(expectedConcludesReplay, ReplayToken.concludesReplay(token));
+        }
     }
 
     @Nested

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventTestUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
@@ -559,6 +560,90 @@ class WorkPackageTest {
         });
     }
 
+
+    @Nested
+    class WhenProcessingBatch {
+
+        @Test
+        void processBatchSurfacesPerEventTokenInEntryContext() {
+            // given
+            WorkPackage subject = testSubjectBuilder.batchSize(3).build();
+
+            // when
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+
+            await().atMost(TIMEOUT).untilAsserted(() -> assertEquals(3, batchProcessor.getProcessedEvents().size()));
+
+            // then — each entry's context must carry its own token, not the batch-end token
+            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(0).context()))
+                    .hasValue(new GlobalSequenceTrackingToken(1L));
+            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(1).context()))
+                    .hasValue(new GlobalSequenceTrackingToken(2L));
+            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(2).context()))
+                    .hasValue(new GlobalSequenceTrackingToken(3L));
+        }
+
+        @Test
+        void processBatchSurfacesPerEventReplayTokenInEntryContext() {
+            // given — reset at position 3, so events at 1, 2, 3 are all replay events
+            TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(3L);
+            WorkPackage subject = testSubjectBuilder
+                    .initialToken(ReplayToken.createReplayToken(tokenAtReset))
+                    .batchSize(3)
+                    .build();
+
+            // when
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+
+            await().atMost(TIMEOUT).untilAsserted(() -> assertEquals(3, batchProcessor.getProcessedEvents().size()));
+
+            // then — each entry's context must carry a ReplayToken advanced to its own position
+            TrackingToken t0 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(0).context()).get();
+            TrackingToken t1 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(1).context()).get();
+            TrackingToken t2 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(2).context()).get();
+
+            assertInstanceOf(ReplayToken.class, t0);
+            assertEquals(new GlobalSequenceTrackingToken(1L), ((ReplayToken) t0).getCurrentToken());
+            assertEquals(tokenAtReset, ((ReplayToken) t0).getTokenAtReset());
+
+            assertInstanceOf(ReplayToken.class, t1);
+            assertEquals(new GlobalSequenceTrackingToken(2L), ((ReplayToken) t1).getCurrentToken());
+            assertEquals(tokenAtReset, ((ReplayToken) t1).getTokenAtReset());
+
+            assertInstanceOf(ReplayToken.class, t2);
+            assertEquals(new GlobalSequenceTrackingToken(3L), ((ReplayToken) t2).getCurrentToken());
+            assertEquals(tokenAtReset, ((ReplayToken) t2).getTokenAtReset());
+        }
+
+        @Test
+        void processBatchExposesBatchEndTokenViaResourceKey() {
+            // given
+            List<TrackingToken> capturedBatchEndTokens = new ArrayList<>();
+            WorkPackage subject = testSubjectBuilder
+                    .batchSize(3)
+                    .batchProcessor((events, ctx) -> {
+                        capturedBatchEndTokens.add(ctx.getResource(TrackingToken.BATCH_END_RESOURCE_KEY));
+                        return MessageStream.empty();
+                    })
+                    .build();
+
+            // when
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+
+            // then — regardless of how many batches the events span, the final batch-end token must equal the last event's token
+            await().atMost(TIMEOUT).untilAsserted(() -> {
+                assertThat(capturedBatchEndTokens.getLast())
+                        .isEqualTo(new GlobalSequenceTrackingToken(3L));
+            });
+        }
+    }
+
     private static Context globalTrackingTokenContext(long globalIndex) {
         return trackingTokenContext(new GlobalSequenceTrackingToken(globalIndex));
     }
@@ -589,9 +674,10 @@ class WorkPackageTest {
         private final List<ContextMessage> processedEvents = new ArrayList<>();
 
         @Override
-        public MessageStream.Empty<Message> process(@NonNull List<? extends EventMessage> events, @NonNull ProcessingContext context) {
-            if (batchProcessorPredicate.test(events, TrackingToken.fromContext(context).orElse(null))) {
-                processedEvents.addAll(events.stream().map(m -> new ContextMessage(m, context)).toList());
+        public MessageStream.Empty<Message> process(@NonNull List<MessageStream.Entry<? extends EventMessage>> entries, @NonNull ProcessingContext context) {
+            List<? extends EventMessage> events = entries.stream().map(MessageStream.Entry::message).toList();
+            if (batchProcessorPredicate.test(events, TrackingToken.batchEndFromContext(context).orElse(null))) {
+                processedEvents.addAll(entries.stream().map(e -> new ContextMessage(e.message(), e)).toList());
             }
             return MessageStream.empty();
         }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -625,7 +625,7 @@ class WorkPackageTest {
             List<TrackingToken> capturedBatchEndTokens = new ArrayList<>();
             WorkPackage subject = testSubjectBuilder
                     .batchSize(3)
-                    .batchProcessor((events, ctx) -> {
+                    .batchProcessor((entries, ctx) -> {
                         capturedBatchEndTokens.add(ctx.getResource(TrackingToken.BATCH_END_RESOURCE_KEY));
                         return MessageStream.empty();
                     })

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -566,28 +566,77 @@ class WorkPackageTest {
 
         @Test
         void processBatchSurfacesPerEventTokenInEntryContext() {
-            // given
+            // given — defer worker so all three scheduleEvent calls populate the queue before processing starts
+            List<Runnable> deferredWorkerTasks = new ArrayList<>();
+            doAnswer(inv -> {
+                deferredWorkerTasks.add(inv.getArgument(0));
+                return CompletableFuture.completedFuture(null);
+            }).when(executorService).submit(any(Runnable.class));
+
             WorkPackage subject = testSubjectBuilder.batchSize(3).build();
 
             // when
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+            runDeferred(deferredWorkerTasks);
 
-            await().atMost(TIMEOUT).untilAsserted(() -> assertEquals(3, batchProcessor.getProcessedEvents().size()));
+            assertEquals(3, batchProcessor.getProcessedEvents().size());
+            ContextMessage event0 = batchProcessor.getProcessedEvents().get(0);
+            ContextMessage event1 = batchProcessor.getProcessedEvents().get(1);
+            ContextMessage event2 = batchProcessor.getProcessedEvents().get(2);
 
             // then — each entry's context must carry its own token, not the batch-end token
-            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(0).context()))
+            assertThat(TrackingToken.fromContext(event0.context()))
                     .hasValue(new GlobalSequenceTrackingToken(1L));
-            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(1).context()))
+            assertThat(TrackingToken.fromContext(event1.context()))
                     .hasValue(new GlobalSequenceTrackingToken(2L));
-            assertThat(TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(2).context()))
+            assertThat(TrackingToken.fromContext(event2.context()))
                     .hasValue(new GlobalSequenceTrackingToken(3L));
+        }
+
+        @Test
+        void processBatchExposesBatchEndTokenAsLastEventTokenInBatchContext() {
+            // given — defer worker so all three scheduleEvent calls populate the queue before processing starts
+            List<Runnable> deferredWorkerTasks = new ArrayList<>();
+            doAnswer(inv -> {
+                deferredWorkerTasks.add(inv.getArgument(0));
+                return CompletableFuture.completedFuture(null);
+            }).when(executorService).submit(any(Runnable.class));
+
+            List<TrackingToken> capturedBatchEndTokens = new ArrayList<>();
+            WorkPackage subject = testSubjectBuilder
+                    .batchSize(3)
+                    .batchProcessor((entries, ctx) -> {
+                        // capture the batch-end token once per event — all three must see the same value
+                        entries.forEach(e -> capturedBatchEndTokens.add(ctx.getResource(TrackingToken.BATCH_END_RESOURCE_KEY)));
+                        return MessageStream.empty();
+                    })
+                    .build();
+
+            // when
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
+            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+            runDeferred(deferredWorkerTasks);
+
+            // then — each event in the batch sees the same batch-end token: the last event's position
+            TrackingToken expectedBatchEnd = new GlobalSequenceTrackingToken(3L);
+            assertThat(capturedBatchEndTokens)
+                    .hasSize(3)
+                    .containsOnly(expectedBatchEnd);
         }
 
         @Test
         void processBatchSurfacesPerEventReplayTokenInEntryContext() {
             // given — reset at position 3, so events at 1, 2, 3 are all replay events
+            // defer worker so all three events are in the queue before processing begins
+            List<Runnable> deferredWorkerTasks = new ArrayList<>();
+            doAnswer(inv -> {
+                deferredWorkerTasks.add(inv.getArgument(0));
+                return CompletableFuture.completedFuture(null);
+            }).when(executorService).submit(any(Runnable.class));
+
             TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(3L);
             WorkPackage subject = testSubjectBuilder
                     .initialToken(ReplayToken.createReplayToken(tokenAtReset))
@@ -598,10 +647,10 @@ class WorkPackageTest {
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
             subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
-
-            await().atMost(TIMEOUT).untilAsserted(() -> assertEquals(3, batchProcessor.getProcessedEvents().size()));
+            runDeferred(deferredWorkerTasks);
 
             // then — each entry's context must carry a ReplayToken advanced to its own position
+            assertEquals(3, batchProcessor.getProcessedEvents().size());
             TrackingToken t0 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(0).context()).get();
             TrackingToken t1 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(1).context()).get();
             TrackingToken t2 = TrackingToken.fromContext(batchProcessor.getProcessedEvents().get(2).context()).get();
@@ -621,7 +670,8 @@ class WorkPackageTest {
 
         @Test
         void processBatchExposesBatchEndTokenViaResourceKey() {
-            // given
+            // given — use scheduleEvents (plural) to guarantee all three events are wrapped in one
+            // BatchProcessingEntry and therefore processed as a single batch
             List<TrackingToken> capturedBatchEndTokens = new ArrayList<>();
             WorkPackage subject = testSubjectBuilder
                     .batchSize(3)
@@ -631,16 +681,29 @@ class WorkPackageTest {
                     })
                     .build();
 
-            // when
-            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), globalTrackingTokenContext(1L)));
-            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), globalTrackingTokenContext(2L)));
-            subject.scheduleEvent(new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), globalTrackingTokenContext(3L)));
+            TrackingToken sharedToken = new GlobalSequenceTrackingToken(3L);
+            Context sharedContext = trackingTokenContext(sharedToken);
 
-            // then — regardless of how many batches the events span, the final batch-end token must equal the last event's token
+            // when — three events sharing one token are atomically enqueued as one batch
+            subject.scheduleEvents(List.of(
+                    new SimpleEntry<>(EventTestUtils.asEventMessage("event-1"), sharedContext),
+                    new SimpleEntry<>(EventTestUtils.asEventMessage("event-2"), sharedContext),
+                    new SimpleEntry<>(EventTestUtils.asEventMessage("event-3"), sharedContext)
+            ));
+
+            // then — exactly one batch is processed and its BATCH_END equals the shared token
             await().atMost(TIMEOUT).untilAsserted(() -> {
-                assertThat(capturedBatchEndTokens.getLast())
-                        .isEqualTo(new GlobalSequenceTrackingToken(3L));
+                assertThat(capturedBatchEndTokens).hasSize(1);
+                assertThat(capturedBatchEndTokens.getFirst()).isEqualTo(sharedToken);
             });
+        }
+    }
+
+    private static void runDeferred(List<Runnable> tasks) {
+        while (!tasks.isEmpty()) {
+            List<Runnable> snapshot = new ArrayList<>(tasks);
+            tasks.clear();
+            snapshot.forEach(Runnable::run);
         }
     }
 
@@ -676,7 +739,7 @@ class WorkPackageTest {
         @Override
         public MessageStream.Empty<Message> process(@NonNull List<MessageStream.Entry<? extends EventMessage>> entries, @NonNull ProcessingContext context) {
             List<? extends EventMessage> events = entries.stream().map(MessageStream.Entry::message).toList();
-            if (batchProcessorPredicate.test(events, TrackingToken.batchEndFromContext(context).orElse(null))) {
+            if (batchProcessorPredicate.test(events, context.getResource(TrackingToken.BATCH_END_RESOURCE_KEY))) {
                 processedEvents.addAll(entries.stream().map(e -> new ContextMessage(e.message(), e)).toList());
             }
             return MessageStream.empty();


### PR DESCRIPTION
I introduced this bug in one of my first PRs :/ 
https://github.com/AxonIQ/AxonFramework/pull/3456#discussion_r2126082536

I reverted to almost what we had here in AxonFramework4 - so TrackingToken as a parameter of addToBatch. 

In doing so, this PR resolves #4323.