### PR TITLE
Fix fromFuture to return Empty stream when future completes with null

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/DelayedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/DelayedMessageStream.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.messaging.core;
 
-import org.axonframework.messaging.core.MessageStream.Entry;
-
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;

--- a/messaging/src/main/java/org/axonframework/messaging/core/EmptyMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/EmptyMessageStream.java
@@ -17,7 +17,7 @@
 package org.axonframework.messaging.core;
 
 import org.axonframework.common.FutureUtils;
-import org.axonframework.messaging.core.MessageStream.Entry;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
@@ -51,7 +51,8 @@ class EmptyMessageStream<M extends Message> extends AbstractMessageStream<M> imp
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(R identity, BiFunction<R, ? super Entry<M>, R> accumulator) {
+    public <R> CompletableFuture<@Nullable R> reduce(@Nullable R identity,
+                                                     BiFunction<@Nullable R, ? super Entry<M>, @Nullable R> accumulator) {
         return (error().isPresent())
                 ? CompletableFuture.failedFuture(error().get())
                 : CompletableFuture.completedFuture(identity);

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -675,7 +675,7 @@ public interface MessageStream<M extends Message> {
          * {@code null} if none were produced, or completed exceptionally if the stream fails.
          * @throws UnsupportedOperationException if this stream is unbounded
          */
-        default CompletableFuture<Entry<M>> asCompletableFuture() {
+        default CompletableFuture<@Nullable Entry<M>> asCompletableFuture() {
 
             /*
              * NOTE: We intentionally use full reduce-based consumption instead of a single next()
@@ -683,7 +683,6 @@ public interface MessageStream<M extends Message> {
              * value-suppressing (ignoreEntries). This ensures correct lifecycle execution
              * regardless of stream transformations.
              */
-            //noinspection NullableProblems
             return reduce(null, (accumulator, entry) -> accumulator != null ? accumulator : entry);
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -208,7 +208,7 @@ public interface MessageStream<M extends Message> {
      */
     static <M extends Message> Single<M> fromFuture(CompletableFuture<? extends M> future,
                                                     Function<M, Context> contextSupplier) {
-        return new DelayedMessageStream.Single<>(
+        return DelayedMessageStream.createSingle(
                 future.thenApply(message -> MessageStream.just(message, contextSupplier))
         );
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -28,6 +28,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents a stream of {@link Entry entries} containing {@link Message Messages} of type {@code M} that can be
  * consumed as they become available.
@@ -186,7 +188,7 @@ public interface MessageStream<M extends Message> {
      * @param <M>    The type of {@link Message} contained in the {@link Entry entries} of this stream.
      * @return A stream containing at most one {@link Entry entry} from the given {@code future}.
      */
-    static <M extends Message> Single<M> fromFuture(CompletableFuture<? extends M> future) {
+    static <M extends Message> Single<M> fromFuture(CompletableFuture<? extends @Nullable M> future) {
         return fromFuture(future, message -> Context.empty());
     }
 
@@ -206,7 +208,7 @@ public interface MessageStream<M extends Message> {
      * @return A stream containing at most one {@link Entry entry} from the given {@code future} with a {@link Context}
      * provided by the {@code contextSupplier}.
      */
-    static <M extends Message> Single<M> fromFuture(CompletableFuture<? extends M> future,
+    static <M extends Message> Single<M> fromFuture(CompletableFuture<? extends @Nullable M> future,
                                                     Function<M, Context> contextSupplier) {
         return DelayedMessageStream.createSingle(
                 future.thenApply(message -> MessageStream.just(message, contextSupplier))
@@ -216,11 +218,14 @@ public interface MessageStream<M extends Message> {
     /**
      * Create a stream containing the single given {@code message}, automatically wrapped in an {@link Entry}.
      * <p>
-     * Once the {@code Entry} is consumed, the stream is considered completed.
+     * Once the {@code Entry} is consumed, the stream is considered completed. If {@code message} is {@code null}, the
+     * returned stream contains no entries and behaves like {@link #empty()}.
      *
-     * @param message The {@link Message} to wrap in an {@link Entry} and return in the stream.
+     * @param message The {@link Message} to wrap in an {@link Entry} and return in the stream, or {@code null} to
+     *                produce an empty stream.
      * @param <M>     The type of {@link Message} given.
-     * @return A stream consisting of a single {@link Entry entry} wrapping the given {@code message}.
+     * @return A stream consisting of a single {@link Entry entry} wrapping the given {@code message}, or an
+     * {@link Empty empty stream} if {@code message} is {@code null}.
      */
     static <M extends Message> Single<M> just(@Nullable M message) {
         return just(message, m -> Context.empty());
@@ -229,21 +234,26 @@ public interface MessageStream<M extends Message> {
     /**
      * Create a stream containing the single given {@code message}, automatically wrapped in an {@link Entry}.
      * <p>
-     * Once the {@code Entry} is consumed, the stream is considered completed.
+     * Once the {@code Entry} is consumed, the stream is considered completed. If {@code message} is {@code null}, the
+     * returned stream contains no entries and behaves like {@link #empty()}; the {@code contextSupplier} is not
+     * invoked in that case.
      *
-     * @param message         The {@link Message} to wrap in an {@link Entry} and return in the stream.
+     * @param message         The {@link Message} to wrap in an {@link Entry} and return in the stream, or {@code null}
+     *                        to produce an empty stream.
      * @param contextSupplier A {@link Function} ingesting the given {@code message} returning the {@link Context} to
      *                        set for the {@link Entry} the {@code message} is wrapped in.
      * @param <M>             The type of {@link Message} given.
      * @return A stream consisting of a single {@link Entry entry} wrapping the given {@code message} with a
-     * {@link Context} provided by the {@code contextSupplier}.
+     * {@link Context} provided by the {@code contextSupplier}, or an {@link Empty empty stream} if {@code message}
+     * is {@code null}.
      */
     static <M extends Message> Single<M> just(@Nullable M message,
                                               Function<M, Context> contextSupplier) {
         if (message == null) {
             return empty().cast();
         }
-        return new SingleValueMessageStream<>(new SimpleEntry<>(message, contextSupplier.apply(message)));
+        var safeMsg = requireNonNull(message);
+        return new SingleValueMessageStream<>(new SimpleEntry<>(safeMsg, contextSupplier.apply(message)));
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -112,7 +112,7 @@ public interface MessageStream<M extends Message> {
     static <M extends Message> MessageStream<M> fromIterable(Iterable<? extends M> iterable,
                                                              Function<? super M, ? extends Context> contextSupplier) {
         return new IteratorMessageStream<>(StreamSupport.stream(iterable.spliterator(), false)
-                                                        .<Entry<M>>map(message -> new SimpleEntry<M>(
+                                                        .<Entry<M>>map(message -> new SimpleEntry<>(
                                                                 message,
                                                                 contextSupplier.apply(message)
                                                         ))
@@ -354,7 +354,7 @@ public interface MessageStream<M extends Message> {
      * The callback is called on an arbitrary thread, and it should keep work performed on this thread to a minimum
      * as this may interfere with other callbacks handled by the same thread. Any exception thrown by the callback
      * will result in the stream completing with this exception as the error, unless the callback was called to
-     * indicate completition.
+     * indicate completion.
      *
      * @param callback The callback to invoke when {@link Entry entries} are available for reading, or the stream
      *                 completes.
@@ -469,7 +469,8 @@ public interface MessageStream<M extends Message> {
      * stream.
      * @throws UnsupportedOperationException if this stream is unbounded
      */
-    default <R> CompletableFuture<R> reduce(R identity, BiFunction<R, ? super Entry<M>, R> accumulator) {
+    default <R> CompletableFuture<@Nullable R> reduce(@Nullable R identity,
+                                                      BiFunction<@Nullable R, ? super Entry<M>, @Nullable R> accumulator) {
         return MessageStreamUtils.reduce(this, identity, accumulator);
     }
 
@@ -682,7 +683,7 @@ public interface MessageStream<M extends Message> {
              * value-suppressing (ignoreEntries). This ensures correct lifecycle execution
              * regardless of stream transformations.
              */
-
+            //noinspection NullableProblems
             return reduce(null, (accumulator, entry) -> accumulator != null ? accumulator : entry);
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStreamUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStreamUtils.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.core;
 
 import org.axonframework.common.annotation.Internal;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,31 +71,31 @@ public abstract class MessageStreamUtils {
      * @param <R>         The type of result expected from the reduction operation.
      * @return A {@code CompletableFuture} that completes with the result of the reduction operation.
      */
-    public static <M extends Message, R> CompletableFuture<R> reduce(MessageStream<M> source,
-                                                                     R identity,
-                                                                     BiFunction<R, ? super MessageStream.Entry<M>, R> accumulator) {
-        Reducer<M, R> reducer = new Reducer<>(source, identity, accumulator);
+    public static <M extends Message, R> CompletableFuture<@Nullable R> reduce(MessageStream<M> source,
+                                                                               @Nullable R identity,
+                                                                               BiFunction<@Nullable R, ? super MessageStream.Entry<M>, @Nullable R> accumulator) {
+        var reducer = new Reducer<>(source, identity, accumulator);
         source.setCallback(reducer::process);
         return reducer.result();
     }
 
     private static class Reducer<M extends Message, R> {
 
-        private final CompletableFuture<R> result = new CompletableFuture<>();
+        private final CompletableFuture<@Nullable R> result = new CompletableFuture<>();
         private final MessageStream<M> source;
-        private final BiFunction<R, ? super MessageStream.Entry<M>, R> accumulator;
+        private final BiFunction<@Nullable R, ? super MessageStream.Entry<M>, @Nullable R> accumulator;
         private final AtomicBoolean processingGate = new AtomicBoolean(false);
 
-        private final AtomicReference<R> intermediateResult;
+        private final AtomicReference<@Nullable R> intermediateResult;
 
-        public Reducer(MessageStream<M> source, R identity,
-                       BiFunction<R, ? super MessageStream.Entry<M>, R> accumulator) {
+        public Reducer(MessageStream<M> source, @Nullable R identity,
+                       BiFunction<@Nullable R, ? super MessageStream.Entry<M>, @Nullable R> accumulator) {
             this.source = source;
             this.intermediateResult = new AtomicReference<>(identity);
             this.accumulator = accumulator;
         }
 
-        public CompletableFuture<R> result() {
+        public CompletableFuture<@Nullable R> result() {
             return result;
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.messaging.core;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,7 +71,7 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
     }
 
     @Override
-    public CompletableFuture<@Nullable Entry<M>> asCompletableFuture() {
+    public CompletableFuture<Entry<M>> asCompletableFuture() {
         return source;
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
@@ -16,9 +16,6 @@
 
 package org.axonframework.messaging.core;
 
-import org.axonframework.messaging.core.MessageStream.Entry;
-import org.jspecify.annotations.Nullable;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -47,7 +44,7 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
      *
      * @param entry The {@link Entry entry} which is the singular value contained in this {@link MessageStream stream}.
      */
-    SingleValueMessageStream(@Nullable Entry<M> entry) {
+    SingleValueMessageStream(Entry<M> entry) {
         this(CompletableFuture.completedFuture(entry));
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.messaging.core;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -75,7 +77,7 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
             return FetchResult.error(source.exceptionNow());
         }
 
-        Entry<M> current = source.getNow(null);
+        Entry<M> current = source.resultNow();
 
         return read.compareAndSet(false, true) ? FetchResult.of(current) : FetchResult.completed();
     }
@@ -93,8 +95,8 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
     }
 
     @Override
-    public <R> CompletableFuture<R> reduce(R identity,
-                                           BiFunction<R, ? super Entry<M>, R> accumulator) {
+    public <R> CompletableFuture<@Nullable R> reduce(@Nullable R identity,
+                                           BiFunction<@Nullable R, ? super Entry<M>, @Nullable R> accumulator) {
         return source.thenApply(message -> accumulator.apply(identity, message));
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
@@ -21,12 +21,13 @@ import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * A {@link MessageStream} implementation using a single {@link Entry entry} or {@link CompletableFuture} completing to
  * an entry as the source.
+ * <p>
+ * This stream does not permit {@code null} entries. Passing a {@code null} entry directly or providing a
+ * {@link CompletableFuture} that resolves to {@code null} will result in a {@link NullPointerException}.
  *
  * @param <M> The type of {@link Message} contained in the singular {@link Entry} of this stream.
  * @author Allard Buijze
@@ -45,7 +46,9 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
      * {@link CompletableFuture#completedFuture(Object) completed CompletableFuture} as the single entry in this
      * stream.
      *
-     * @param entry The {@link Entry entry} which is the singular value contained in this {@link MessageStream stream}.
+     * @param entry The {@link Entry entry} which is the singular value contained in this {@link MessageStream stream};
+     *              must not be {@code null}.
+     * @throws NullPointerException If {@code entry} is {@code null}.
      */
     SingleValueMessageStream(Entry<M> entry) {
         this(CompletableFuture.completedFuture(Objects.requireNonNull(entry, "The entry parameter must not be null.")));
@@ -54,9 +57,13 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
     /**
      * Constructs a {@link MessageStream stream} with the given {@code source} as the provider of the single
      * {@link Entry entry} in this stream.
+     * <p>
+     * The {@code source} future must not resolve to {@code null}. If it does, the stream will complete exceptionally
+     * with a {@link NullPointerException}.
      *
      * @param source The {@link CompletableFuture} resulting in the singular {@link Entry entry} contained in this
-     *               {@link MessageStream stream}.
+     *               {@link MessageStream stream}; must not be {@code null} and must not resolve to {@code null}.
+     * @throws NullPointerException If {@code source} is {@code null}.
      */
     SingleValueMessageStream(CompletableFuture<Entry<M>> source) {
         this.source = Objects.requireNonNull(source, "The source parameter must not be null.");
@@ -66,7 +73,7 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
     }
 
     @Override
-    public CompletableFuture<Entry<M>> asCompletableFuture() {
+    public CompletableFuture<@Nullable Entry<M>> asCompletableFuture() {
         return source;
     }
 
@@ -90,17 +97,6 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
         if (!source.isDone()) {
             source.cancel(false);
         }
-    }
-
-    @Override
-    public <RM extends Message> Single<RM> map(Function<Entry<M>, Entry<RM>> mapper) {
-        return new SingleValueMessageStream<>(source.thenApply(mapper));
-    }
-
-    @Override
-    public <R> CompletableFuture<@Nullable R> reduce(@Nullable R identity,
-                                           BiFunction<@Nullable R, ? super Entry<M>, @Nullable R> accumulator) {
-        return source.thenApply(message -> accumulator.apply(identity, message));
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
@@ -91,7 +91,7 @@ public class MessageStreamResolverUtils {
         return switch (result) {
             case MessageStream<?> messageStream -> messageStream;
             case CompletableFuture<?> future -> MessageStream.fromFuture(
-                    future.thenApply(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r))
+                    future.thenApply(r -> r == null ? null : new GenericMessage(typeResolver.resolveOrThrow(r), r))
             );
             case Optional<?> optional when optional.isPresent() -> {
                 Object r = optional.get();

--- a/messaging/src/test/java/org/axonframework/messaging/core/SingleValueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/SingleValueMessageStreamTest.java
@@ -47,8 +47,7 @@ class SingleValueMessageStreamTest extends MessageStreamTest<Message> {
 
     @Override
     protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
-        Assumptions.abort("DelayedMessageStream does not support empty streams");
-        return null;
+        return (MessageStream.Empty<Message>) MessageStream.fromFuture(CompletableFuture.completedFuture(null));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </organization>
 
     <properties>
-        <revision>5.1.0-SNAPSHOT</revision>
+        <revision>5.2.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
## What

`MessageStream.fromFuture` previously wrapped its result in a `DelayedMessageStream.Single` unconditionally, even when the future resolved to `null`. This produced a `Single<M>` wrapping an `EmptyMessageStream` rather than returning an `Empty<M>` directly. As a consequence, the `Empty<M>` short-circuit overrides (`map`, `mapMessage`, `onNext`, `onComplete`, etc.) never fired on a null-completing future, and all empty-stream tests in `SingleValueMessageStreamTest` were skipped via `Assumptions.abort`.

A related gap existed in `MessageStreamResolverUtils`: when a `CompletableFuture` handler returned `null`, the resolver wrapped it in a `GenericMessage` with a null payload before passing it to `fromFuture`, bypassing the null check entirely.

## How

Switch `fromFuture` to use `DelayedMessageStream.createSingle` instead of `new DelayedMessageStream.Single`. `createSingle` already has the early-return optimisation: when the delegate future is already done it returns the inner stream directly. A completed-null future therefore returns `MessageStream.empty()` — a true `Empty<M>` — rather than a delayed wrapper.

Fix `MessageStreamResolverUtils` to pass `null` through to `fromFuture` when the handler result is `null`, so the null check in `fromFuture` fires as intended.

Remove the `Assumptions.abort` in `SingleValueMessageStreamTest.completedEmptyStreamTestSubject` and implement it using `fromFuture(completedFuture(null))`, enabling all previously skipped empty-stream tests to run.

Document the null-to-empty-stream behaviour in the Javadoc of both `MessageStream.just` overloads, resolving the TODO that was left there.