### PR TITLE
[#3773]: phase 0 Replace thenRun + joinAndUnwrap with thenCompose in Coordinator#abortWorkPackage

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1363,10 +1363,10 @@ class Coordinator {
                                             name, generation, work.segment());
                            }
                        })
-                       .thenRun(() -> joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+                       .thenCompose(unused -> unitOfWorkFactory.create().executeWithResult(
                                context -> tokenStore.releaseClaim(name, segmentId, context)
-                                                    .thenCompose(unused -> segmentChangeListener.onSegmentReleased(work.segment()))
-                       )))
+                                                    .thenCompose(ignored -> segmentChangeListener.onSegmentReleased(work.segment()))
+                       ))
                        .exceptionally(throwable -> {
                            logger.warn(
                                    "Processor [{}] (Coordination Task [{}]). An exception occurred during the abort of work package [{}].",

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -817,6 +817,39 @@ class PooledStreamingEventProcessorTest {
             assertFalse(coordinatorExecutor.isShutdown());
             assertFalse(workerExecutor.isShutdown());
         }
+
+        @Test
+        void abortFlowWaitsForSegmentChangeListenerBeforeCompleting() {
+            // given - processor with a single segment and a listener that blocks release until a gate is opened
+            CompletableFuture<Void> releaseGate = new CompletableFuture<>();
+            AtomicReference<Segment> releasedSegment = new AtomicReference<>();
+
+            withTestSubject(List.of(), c -> c
+                    .initialSegmentCount(1)
+                    .addSegmentChangeListener(SegmentChangeListener.onRelease(segment -> {
+                        releasedSegment.set(segment);
+                        return releaseGate;
+                    })));
+            startEventProcessor();
+            assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().isEmpty()));
+
+            // when - shutdown is triggered while the release listener is still pending
+            CompletableFuture<Void> shutdownFuture = testSubject.shutdown();
+
+            // then - the listener is called with the correct segment before shutdown can proceed
+            await().atMost(1, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(releasedSegment.get())
+                           .isNotNull()
+                           .extracting(Segment::getSegmentId)
+                           .isEqualTo(0));
+
+            // then - shutdown is blocked as long as the listener future is not completed
+            assertThat(shutdownFuture).isNotCompleted();
+
+            // then - completing the gate unblocks the abort flow and shutdown finishes
+            releaseGate.complete(null);
+            assertWithin(1, TimeUnit.SECONDS, () -> assertThat(shutdownFuture).isCompleted());
+        }
     }
 
     @Nested


### PR DESCRIPTION
thenRun discarded the CompletableFuture returned by executeWithResult, causing the abort flow to complete before releaseClaim and onSegmentReleased had finished. thenCompose chains the futures correctly so the abort flow waits for both operations before completing. Added a test that verifies shutdown blocks until the SegmentChangeListener future completes. Refs [#3773](https://github.com/AxonIQ/AxonFramework/issues/3773).