### PR TITLE
[#3773]: phase 1 Make ClaimTask, SplitTask and MergeTask fully async

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTask.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 /**
  * A {@link CoordinatorTask} implementation dedicated to claiming a token so that the {@link Coordinator} can start a
@@ -104,32 +103,25 @@ class ClaimTask extends CoordinatorTask {
             return CompletableFuture.completedFuture(true);
         }
         releasesDeadlines.remove(segmentId);
-        List<Segment> segments = joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+        return unitOfWorkFactory.create().executeWithResult(
                 context -> tokenStore.fetchAvailableSegments(name, context)
-        ));
-        if (segments == null) {
-            logger.info("Processor [{}] cannot claim segment {}. It is not available.", name, segmentId);
-            return CompletableFuture.completedFuture(false);
-        }
+        ).thenCompose(segments -> {
+            Optional<Segment> segmentToClaim = segments.stream()
+                                                       .filter(segment -> segment.getSegmentId() == segmentId)
+                                                       .findFirst();
+            if (segmentToClaim.isEmpty()) {
+                logger.info("Processor [{}] cannot claim segment {}. It is not available.", name, segmentId);
+                return CompletableFuture.completedFuture(false);
+            }
 
-        Optional<Segment> segmentToClaim = segments.stream()
-                                                   .filter(segment -> segment.getSegmentId() == segmentId)
-                                                   .findFirst();
-        if (segmentToClaim.isEmpty()) {
-            logger.info("Processor [{}] cannot claim segment {}. It is not available.", name, segmentId);
-            return CompletableFuture.completedFuture(false);
-        }
-
-        try {
-            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+            return unitOfWorkFactory.create().executeWithResult(
                     context -> tokenStore.fetchToken(name, segmentId, context)
-            ));
-        } catch (Exception e) {
-            logger.warn("Processor [{}] cannot claim segment {} due to an error.", name, segmentId, e);
-            return CompletableFuture.completedFuture(false);
-        }
-
-        return CompletableFuture.completedFuture(true);
+            ).thenApply(token -> true)
+             .exceptionally(e -> {
+                 logger.warn("Processor [{}] cannot claim segment {} due to an error.", name, segmentId, e);
+                 return false;
+             });
+        });
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -150,22 +150,21 @@ class MergeTask extends CoordinatorTask {
 
     private CompletableFuture<Boolean> mergeSegments(Segment thisSegment, TrackingToken thisToken,
                                                      Segment thatSegment, TrackingToken thatToken) {
-        Segment mergedSegment = thisSegment.mergedWith(thatSegment);
-        TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
-                ? MergedTrackingToken.merged(thatToken, thisToken)
-                : MergedTrackingToken.merged(thisToken, thatToken);
-
-        return unitOfWorkFactory.create().executeWithResult(
-                context -> tokenStore.deleteToken(name, thisSegment.getSegmentId(), context)
-                                     .thenCompose(result -> tokenStore.deleteToken(name, thatSegment.getSegmentId(), context))
-                                     .thenCompose(result -> tokenStore.initializeSegment(mergedToken, name, mergedSegment, context))
-                                     .thenCompose(result -> tokenStore.releaseClaim(name, mergedSegment.getSegmentId(), context))
-        ).thenApply(unused -> {
-            logger.info("Processor [{}] successfully merged {} with {} into {}.",
-                        name, thisSegment, thatSegment, mergedSegment);
-            return true;
+        return unitOfWorkFactory.create().executeWithResult(context -> {
+            Segment mergedSegment = thisSegment.mergedWith(thatSegment);
+            TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
+                    ? MergedTrackingToken.merged(thatToken, thisToken)
+                    : MergedTrackingToken.merged(thisToken, thatToken);
+            return tokenStore.deleteToken(name, thisSegment.getSegmentId(), context)
+                             .thenCompose(result -> tokenStore.deleteToken(name, thatSegment.getSegmentId(), context))
+                             .thenCompose(result -> tokenStore.initializeSegment(mergedToken, name, mergedSegment, context))
+                             .thenCompose(result -> tokenStore.releaseClaim(name, mergedSegment.getSegmentId(), context))
+                             .thenApply(unused -> {
+                                 logger.info("Processor [{}] successfully merged {} with {} into {}.",
+                                             name, thisSegment, thatSegment, mergedSegment);
+                                 return true;
+                             });
         }).whenComplete((result, throwable) -> {
-            // Remove both segments from the releases deadlines to allow the Coordinator to claim the merged segment
             releasesDeadlines.remove(thisSegment.getSegmentId());
             releasesDeadlines.remove(thatSegment.getSegmentId());
         });

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -29,7 +29,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 /**
  * A {@link CoordinatorTask} implementation dedicated to merging two {@link Segment}s.
@@ -106,27 +105,27 @@ class MergeTask extends CoordinatorTask {
     protected CompletableFuture<Boolean> task() {
         logger.debug("Processor [{}] will perform merge instruction for segment {}.", name, segmentId);
 
-        Segment thisSegment = joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-            context -> tokenStore.fetchSegment(name, segmentId, context)
-        ));
+        return unitOfWorkFactory.create().executeWithResult(
+                context -> tokenStore.fetchSegment(name, segmentId, context)
+        ).thenCompose(thisSegment -> {
+            if (segmentId == thisSegment.mergeableSegmentId()) {
+                logger.debug("Processor [{}] cannot merge segment {}. "
+                                     + "A merge request can only be fulfilled if there is more than one segment.",
+                             name, segmentId);
+                return CompletableFuture.completedFuture(false);
+            }
 
-        if (segmentId == thisSegment.mergeableSegmentId()) {
-            logger.debug("Processor [{}] cannot merge segment {}. "
-                                 + "A merge request can only be fulfilled if there is more than one segment.",
-                         name, segmentId);
-            return CompletableFuture.completedFuture(false);
-        }
-
-        Segment thatSegment = joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-            context -> tokenStore.fetchSegment(name, thisSegment.mergeableSegmentId(), context)
-        ));
-
-        CompletableFuture<TrackingToken> thisTokenFuture = tokenFor(thisSegment.getSegmentId());
-        CompletableFuture<TrackingToken> thatTokenFuture = tokenFor(thatSegment.getSegmentId());
-        return thisTokenFuture.thenCombine(
-                thatTokenFuture,
-                (thisToken, thatToken) -> mergeSegments(thisSegment, thisToken, thatSegment, thatToken)
-        );
+            return unitOfWorkFactory.create().executeWithResult(
+                    context -> tokenStore.fetchSegment(name, thisSegment.mergeableSegmentId(), context)
+            ).thenCompose(thatSegment -> {
+                CompletableFuture<TrackingToken> thisTokenFuture = tokenFor(thisSegment.getSegmentId());
+                CompletableFuture<TrackingToken> thatTokenFuture = tokenFor(thatSegment.getSegmentId());
+                return thisTokenFuture
+                        .thenCombine(thatTokenFuture,
+                                     (thisToken, thatToken) -> mergeSegments(thisSegment, thisToken, thatSegment, thatToken))
+                        .thenCompose(f -> f);
+            });
+        });
     }
 
     private CompletableFuture<TrackingToken> tokenFor(int segmentId) {
@@ -149,38 +148,27 @@ class MergeTask extends CoordinatorTask {
         );
     }
 
-    private Boolean mergeSegments(Segment thisSegment, TrackingToken thisToken,
-                                  Segment thatSegment, TrackingToken thatToken) {
-        try {
-            Segment mergedSegment = thisSegment.mergedWith(thatSegment);
-            TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
-                    ? MergedTrackingToken.merged(thatToken, thisToken)
-                    : MergedTrackingToken.merged(thisToken, thatToken);
+    private CompletableFuture<Boolean> mergeSegments(Segment thisSegment, TrackingToken thisToken,
+                                                     Segment thatSegment, TrackingToken thatToken) {
+        Segment mergedSegment = thisSegment.mergedWith(thatSegment);
+        TrackingToken mergedToken = thatSegment.getSegmentId() < thisSegment.getSegmentId()
+                ? MergedTrackingToken.merged(thatToken, thisToken)
+                : MergedTrackingToken.merged(thisToken, thatToken);
 
-            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-                    context -> tokenStore.deleteToken(name, thisSegment.getSegmentId(), context)
-                                         .thenCompose(result -> tokenStore.deleteToken(name, thatSegment.getSegmentId(), context))
-                                         .thenCompose(result -> tokenStore.initializeSegment(
-                                             mergedToken,
-                                             name,
-                                             mergedSegment,
-                                             context
-                                         ))
-                                         .thenCompose(result -> tokenStore.releaseClaim(
-                                             name,
-                                             mergedSegment.getSegmentId(),
-                                             context
-                                         ))
-            ));
-
+        return unitOfWorkFactory.create().executeWithResult(
+                context -> tokenStore.deleteToken(name, thisSegment.getSegmentId(), context)
+                                     .thenCompose(result -> tokenStore.deleteToken(name, thatSegment.getSegmentId(), context))
+                                     .thenCompose(result -> tokenStore.initializeSegment(mergedToken, name, mergedSegment, context))
+                                     .thenCompose(result -> tokenStore.releaseClaim(name, mergedSegment.getSegmentId(), context))
+        ).thenApply(unused -> {
             logger.info("Processor [{}] successfully merged {} with {} into {}.",
                         name, thisSegment, thatSegment, mergedSegment);
-        } finally {
+            return true;
+        }).whenComplete((result, throwable) -> {
             // Remove both segments from the releases deadlines to allow the Coordinator to claim the merged segment
             releasesDeadlines.remove(thisSegment.getSegmentId());
             releasesDeadlines.remove(thatSegment.getSegmentId());
-        }
-        return true;
+        });
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
@@ -30,7 +30,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 /**
  * A {@link CoordinatorTask} implementation dedicated to splitting a {@link Segment}.
@@ -116,30 +115,25 @@ class SplitTask extends CoordinatorTask {
 
     private CompletableFuture<Boolean> abortAndSplit(WorkPackage workPackage) {
         return workPackage.abort(null)
-                          .thenApply(e -> splitAndRelease(workPackage.segment()));
+                          .thenCompose(e -> splitAndRelease(workPackage.segment()));
     }
 
     private CompletableFuture<Boolean> fetchSegmentAndSplit(int segmentId) {
         return unitOfWorkFactory.create().executeWithResult(
                 context -> tokenStore.fetchSegment(name, segmentId, context)
-                                     .thenApply(this::splitAndRelease)
-        );
+        ).thenCompose(this::splitAndRelease);
     }
 
-    private boolean splitAndRelease(Segment segmentToSplit) {
-        try {
-            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-                    context -> tokenStore.fetchToken(name, segmentToSplit.getSegmentId(), context)
-                                         .thenApply(tokenToSplit -> TrackerStatus.split(segmentToSplit, tokenToSplit))
-                                         .thenCompose(splitStatuses -> splitAndRelease(
-                                                 splitStatuses, segmentToSplit, context
-                                         ))
-            ));
-        } finally {
-            // Remove the segment from the releases deadlines to allow the Coordinator to claim the split segments
-            releasesDeadlines.remove(segmentToSplit.getSegmentId());
-        }
-        return true;
+    private CompletableFuture<Boolean> splitAndRelease(Segment segmentToSplit) {
+        return unitOfWorkFactory.create().executeWithResult(
+                context -> tokenStore.fetchToken(name, segmentToSplit.getSegmentId(), context)
+                                     .thenApply(tokenToSplit -> TrackerStatus.split(segmentToSplit, tokenToSplit))
+                                     .thenCompose(splitStatuses -> splitAndRelease(splitStatuses, segmentToSplit, context))
+        ).thenApply(unused -> true)
+         .whenComplete((result, throwable) ->
+                 // Remove the segment from the releases deadlines to allow the Coordinator to claim the split segments
+                 releasesDeadlines.remove(segmentToSplit.getSegmentId())
+         );
     }
 
     private CompletableFuture<Void> splitAndRelease(TrackerStatus[] splitStatuses,

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTaskTest.java
@@ -154,7 +154,7 @@ class ClaimTaskTest {
                 throws ExecutionException, InterruptedException {
             // the given-token is already claimed by another processor
             when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
-                    .thenThrow(new UnableToClaimTokenException("already claimed by another processor"));
+                    .thenReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("already claimed by another processor")));
 
             // when
             testSubject.run();

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/ClaimTaskTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
+
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToClaimTokenException;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class validating the {@link ClaimTask}.
+ *
+ * @author Laura Devriendt
+ */
+class ClaimTaskTest {
+
+    private static final String PROCESSOR_NAME = "test";
+    private static final int SEGMENT_ID = 0;
+    private static final Segment SEGMENT = Segment.splitBalanced(Segment.ROOT_SEGMENT, 1).getFirst();
+    private static final Segment OTHER_SEGMENT = Segment.splitBalanced(Segment.ROOT_SEGMENT, 1).getLast();
+
+    private final TokenStore tokenStore = mock(TokenStore.class);
+    private final Map<Integer, WorkPackage> workPackages = new HashMap<>();
+    private final Map<Integer, Instant> releasesDeadlines = new HashMap<>();
+
+    private CompletableFuture<Boolean> result;
+    private ClaimTask testSubject;
+
+    @BeforeEach
+    void setUp() {
+        result = new CompletableFuture<>();
+        testSubject = new ClaimTask(
+                result,
+                PROCESSOR_NAME,
+                SEGMENT_ID,
+                workPackages,
+                releasesDeadlines,
+                tokenStore,
+                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE)
+        );
+    }
+
+    @Nested
+    class WhenSegmentAlreadyActivelyProcessed {
+
+        @Test
+        void runReturnsTrueImmediatelyWithoutQueryingTokenStore() throws ExecutionException, InterruptedException {
+            // given - segment is already being processed by this coordinator
+            workPackages.put(SEGMENT_ID, mock(WorkPackage.class));
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isDone();
+            assertThat(result.get()).isTrue();
+            verifyNoInteractions(tokenStore);
+        }
+    }
+
+    @Nested
+    class WhenSegmentNotAvailableForClaiming {
+
+        @Test
+        void runReturnsFalseWhenNoSegmentsAreAvailable() throws ExecutionException, InterruptedException {
+            // given - token store has no available segments
+            when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
+                    .thenReturn(completedFuture(List.of()));
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isDone();
+            assertThat(result.get()).isFalse();
+        }
+
+        @Test
+        void runReturnsFalseWhenTargetSegmentIsNotAmongAvailableSegments() throws ExecutionException, InterruptedException {
+            // given - token store has available segments, but not the one we want to claim
+            when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
+                    .thenReturn(completedFuture(List.of(OTHER_SEGMENT)));
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isDone();
+            assertThat(result.get()).isFalse();
+        }
+    }
+
+    @Nested
+    class WhenSegmentAvailableForClaiming {
+
+        @BeforeEach
+        void stubAvailableSegments() {
+            when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
+                    .thenReturn(completedFuture(List.of(SEGMENT)));
+        }
+
+        @Test
+        void runReturnsTrueWhenTokenIsSuccessfullyClaimed() throws ExecutionException, InterruptedException {
+            // given - token store allows fetching the token (i.e., claiming the segment)
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+
+            // when
+            testSubject.run();
+
+            // then
+            verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any());
+            assertThat(result).isDone();
+            assertThat(result.get()).isTrue();
+        }
+
+        @Test
+        void runReturnsFalseWithoutExceptionalCompletionWhenFetchTokenThrows()
+                throws ExecutionException, InterruptedException {
+            // the given-token is already claimed by another processor
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenThrow(new UnableToClaimTokenException("already claimed by another processor"));
+
+            // when
+            testSubject.run();
+
+            // then - claim failure is a normal false result, not an exceptional completion
+            assertThat(result).isDone();
+            assertThat(result.isCompletedExceptionally()).isFalse();
+            assertThat(result.get()).isFalse();
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -45,7 +46,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -224,7 +224,7 @@ class MergeTaskTest {
     @Test
     void runCompletesExceptionallyThroughUnableToClaimTokenExceptionOnFetch() {
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
-                .thenThrow(new UnableToClaimTokenException("some exception"));
+                .thenReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("some exception")));
 
         testSubject.run();
 
@@ -252,9 +252,8 @@ class MergeTaskTest {
 
         workPackages.put(SEGMENT_TO_BE_MERGED, workPackageTwo);
 
-        doThrow(new UnableToClaimTokenException("some exception"))
-                .when(tokenStore)
-                .deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any());
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                .thenReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("some exception")));
 
         testSubject.run();
 
@@ -281,9 +280,8 @@ class MergeTaskTest {
                 .thenReturn(FutureUtils.emptyCompletedFuture());
         workPackages.put(SEGMENT_TO_BE_MERGED, workPackageTwo);
 
-        doThrow(new IllegalStateException("some exception"))
-                .when(tokenStore)
-                .deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any());
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("some exception")));
 
         testSubject.run();
 
@@ -326,6 +324,30 @@ class MergeTaskTest {
         assertThat(resultToken).isInstanceOf(MergedTrackingToken.class);
         assertThat(((MergedTrackingToken) resultToken).lowerSegmentToken()).isEqualTo(tokenForSegment0);
         assertThat(((MergedTrackingToken) resultToken).upperSegmentToken()).isEqualTo(tokenForSegment1);
+    }
+
+    @Nested
+    class WhenMergeSegmentsFails {
+
+        @Test
+        void runClearsReleasesDeadlinesEvenWhenMergedWithThrows() {
+            // given - fetchSegment returns an incompatible thatSegment (different mask), causing mergedWith to throw
+            Segment incompatibleSegment = new Segment(1, 3);
+            when(tokenStore.fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ONE.getSegmentId()), any()))
+                    .thenReturn(completedFuture(incompatibleSegment));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+
+            // when
+            testSubject.run();
+
+            // then - the result is exceptionally completed, and both release deadlines are removed
+            assertThat(result).isDone();
+            assertThat(result.isCompletedExceptionally()).isTrue();
+            assertThat(releasesDeadlines).isEmpty();
+        }
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -292,6 +293,39 @@ class MergeTaskTest {
             .isInstanceOf(ExecutionException.class)
             .cause()
             .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void runMergeSegmentsPlacesLowerSegmentTokenFirstRegardlessOfInitiatingSegment() {
+        // given - merge is initiated from segment 1 (higher ID), so thatSegment (0) < thisSegment (1) is true
+        // this exercises the swapped branch: MergedTrackingToken.merged(thatToken, thisToken)
+        TrackingToken tokenForSegment0 = new GlobalSequenceTrackingToken(0);
+        TrackingToken tokenForSegment1 = new GlobalSequenceTrackingToken(1);
+
+        MergeTask mergeFromSegmentOne = new MergeTask(
+                new CompletableFuture<>(), PROCESSOR_NAME, SEGMENT_TO_BE_MERGED, workPackages,
+                releasesDeadlines, tokenStore, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE), clock
+        );
+        when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                .thenReturn(completedFuture(tokenForSegment0));
+        when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                .thenReturn(completedFuture(tokenForSegment1));
+        when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
+        when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                .thenReturn(FutureUtils.emptyCompletedFuture());
+
+        ArgumentCaptor<TrackingToken> mergedTokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+
+        // when
+        mergeFromSegmentOne.run();
+
+        // then - lower-ID segment token is always placed first, regardless of which segment initiated the merge
+        verify(tokenStore).initializeSegment(mergedTokenCaptor.capture(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any());
+        TrackingToken resultToken = mergedTokenCaptor.getValue();
+        assertThat(resultToken).isInstanceOf(MergedTrackingToken.class);
+        assertThat(((MergedTrackingToken) resultToken).lowerSegmentToken()).isEqualTo(tokenForSegment0);
+        assertThat(((MergedTrackingToken) resultToken).upperSegmentToken()).isEqualTo(tokenForSegment1);
     }
 
     @Test


### PR DESCRIPTION
Removes all joinAndUnwrap calls from ClaimTask, SplitTask and MergeTask. Each task's internal logic is now a proper async chain — no coordinator threads are blocked waiting on token store operations.

Key changes:
- ClaimTask: two sequential UoW calls chained with thenCompose; fetchToken failure caught via exceptionally returning false (preserving original try/catch behavior)
- SplitTask: splitAndRelease(Segment) changed from boolean to CompletableFuture<Boolean>; callers updated from thenApply to thenCompose to avoid unwaited nested futures; try/finally replaced with whenComplete to guarantee deadline cleanup on both success and failure
- MergeTask: two sequential segment fetches chained with thenCompose; thenCombine(...).thenCompose(f -> f) keeps parallel token fetching while flattening the nested future; mergeSegments now returns CompletableFuture<Boolean> with whenComplete for deadline cleanup

Adds ClaimTaskTest covering all four scenarios: segment already active, segment not in available list, successful claim, and failed claim (returns false as normal completion, not exceptional).

Extends MergeTaskTest with a missing branch: merge initiated from the higher-ID segment, verifying the lower-ID segment token is always placed first in MergedTrackingToken regardless of which segment triggered the merge.
