### PR TITLE
docs: fix Antora build warnings and Vale style suggestions

### DIFF
--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -7,6 +7,7 @@ Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download
 [*.{adoc,html}]
 BasedOnStyles = AxonIQ
 
+Google.Acronyms = NO # Replaced by AxonIQ.Acronyms which adds domain-specific exceptions
 Google.Headings = NO # Diasable in favor od AxonIQ one
 Google.Parens = NO # Disable warning about using parens
 Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
@@ -17,3 +18,4 @@ Google.Will = NO # Allow use will
 Google.Contractions = NO
 Google.We = NO
 Google.Exclamation = NO # Allow the use of exclamation marks.
+proselint.Needless = NO # "extensible" and "extendable" are legitimately different words in software contexts

--- a/docs/getting-started/modules/ROOT/pages/implement-command-create-course.adoc
+++ b/docs/getting-started/modules/ROOT/pages/implement-command-create-course.adoc
@@ -172,20 +172,20 @@ class CreateCourseTest {
         var courseName = "Event Sourcing in Practice";
         var capacity = 3;
 
-        fixture.given()
+        fixture.given() // <1>
                 .when()
-                .command(new CreateCourse(courseId, courseName, capacity))
+                .command(new CreateCourse(courseId, courseName, capacity)) // <2>
                 .then()
                 .success()
-                .events(new CourseCreated(courseId, courseName, capacity));
+                .events(new CourseCreated(courseId, courseName, capacity)); // <3>
     }
 
 }
 ----
-<.> In our case, when we receive the `CreateCourse` command, we expect that no previous events were received in the system.
+<1> In our case, when we receive the `CreateCourse` command, we expect that no previous events were received in the system.
 We may even skip the whole `given` section if there is nothing to execute.
-<.> We provide the `CreateCourse` command we want to dispatch against the system (scoped to the given configuration).
-<.> After successfully processing the `CreateCourse`, we expect the publication of a new `CourseCreated` event with the details of the new course.
+<2> We provide the `CreateCourse` command we want to dispatch against the system (scoped to the given configuration).
+<3> After successfully processing the `CreateCourse`, we expect the publication of a new `CourseCreated` event with the details of the new course.
 
 If we run this test now, it will fail with the following error:
 

--- a/docs/getting-started/modules/ROOT/pages/implement-command-subscribe-student.adoc
+++ b/docs/getting-started/modules/ROOT/pages/implement-command-subscribe-student.adoc
@@ -5,7 +5,7 @@ One of the major benefits of Axon Framework 5's Vertical Slice Architecture is t
 Now we'll implement the `SubscribeStudentToCourse` feature without needing to implement every feature in between.
 As long as we keep the `State` needed for command validation private to each slice, the only shared code between slices are the events, which serve as the backbone contract of our system.
 
-You don't even need to stick to certain order. How many times have you heard in the development team: "I'm waiting till the feature X is implemented, to be able to start implementing feature Y"?
+You don't even need to stick to certain order. How many times have you heard in the development team: "We're waiting for feature X to be implemented before we can start on feature Y"?
 
 
 == Define messages

--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -41,7 +41,7 @@ Using xref:axon-server-reference::index.adoc[Axon Server] will, obviously, resol
 However, even when using Axon Server, the predicament remains for tokens and sagas.
 
 For those cases, it would be wise to adjust the Hibernate mapping.
-The most straightforward way, is to enforce the use of the `BYTEA` column type; with some additional steps, of course.
+The most straightforward way is to enforce the use of the `BYTEA` column type, with some additional steps.
 For a full explanation and walkthrough, please check the xref:tuning:rdbms-tuning.adoc#_postgresql_lob_annotated_columns_and_default_hibernate_mapping[PostegreSQL, LOB annotated columns, and default Hibernate mapping] tuning page.
 
 == Sequence generation issues with JPA Entities

--- a/docs/reference-guide/modules/ROOT/pages/modules.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/modules.adoc
@@ -178,7 +178,6 @@ In addition to the Axon Framework modules and extensions and Axoniq Framework mo
 The BOM is provided to ensure the use of compatible framework and extension dependencies inside an Axon application.
 As such, it is the recommended approach towards defining the overall Axon version used inside of an application.
 
-// TODO anchor
 [#axon-framework-bom]
 === Axon Framework Bill of Materials
 
@@ -188,7 +187,7 @@ For the Axon Framework and extensions, we provide a BOM under the `org.axonframe
 |===
 |Module |Artifact Id |Group Id |Maven Central
 
-|<<Base Axon Framework Bill of Materials>> |`axon-framework-bom` |`org.axonframework` |https://central.sonatype.com/search?q=a:axon-framework-bom[available]
+|<<axon-framework-bom,Axon Framework Bill of Materials>> |`axon-framework-bom` |`org.axonframework` |https://central.sonatype.com/search?q=a:axon-framework-bom[available]
 |===
 
 For using the BOM, you would add the `axon-bom` dependency to your dependency management system:

--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -296,7 +296,7 @@ Whenever the xref:event-processors/index.adoc#error-handling[error handler] reth
 
 The processor will retry processing using an incremental back-off period, starting at 1 second and doubling after each attempt until it reaches the maximum wait time of 60 seconds per attempt.
 
-Due to the <<Pooled streaming processor threading,two-pool threading architecture>>, the failed segment is likely to be picked up quickly by another thread within the same JVM.
+Due to the <<thread_configuration,two-pool threading architecture>>, the failed segment is likely to be picked up quickly by another thread within the same JVM.
 The back-off mechanism applies within the local JVM instance only.
 
 In a distributed environment with multiple PSEP instances, other instances will ignore the back-off and may immediately claim and process the failed segment, providing faster recovery from transient errors.

--- a/docs/reference-guide/modules/events/pages/event-publishing.adoc
+++ b/docs/reference-guide/modules/events/pages/event-publishing.adoc
@@ -28,7 +28,7 @@ Event publication only results in event storage if an xref:infrastructure.adoc#e
 == Event Appender: Publishing events from an entity
 
 The xref:commands:modeling/aggregate.adoc[Entity] or its xref:commands:modeling/multi-entity-aggregates.adoc[child entities] are typically the starting point of all event messages.
-The event simply is the notification that a decision has been made; a successful resolution of handling a command.
+The event simply is the notification that a decision has been made: a successful resolution of handling a command.
 Note that <<event_tagging,tagging>> is a hard requirement to ensure the published event as associated with your entity or entities.
 
 To publish an event from an entity, it is required to do this from the lifecycle of the entity instance.

--- a/docs/reference-guide/modules/events/pages/event-versioning.adoc
+++ b/docs/reference-guide/modules/events/pages/event-versioning.adoc
@@ -196,7 +196,7 @@ To validate if the intermediate representation supports a given type, you can in
 [#provided_abstract_upcaster_implementations]
 === Provided abstract Upcaster implementations
 
-As described earlier, the `Upcaster` interface does not upcast a single event; it requires a `Stream<IntermediateEventRepresentation>` and returns one.
+As described earlier, the `Upcaster` interface does not upcast a single event. It requires a `Stream<IntermediateEventRepresentation>` and returns one.
 However, an upcaster is usually written to adjust a single event out of this stream.
 More elaborate upcasting setups are also imaginable.
 For example from one event to multiple, or an upcaster which pulls state from an earlier event and pushes it in a later one.

--- a/docs/reference-guide/modules/events/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/events/pages/infrastructure.adoc
@@ -16,7 +16,9 @@ This page covers the key infrastructure components you'll work with:
 Next to the infrastructure components, this chapter contains a section for:
 
 * **<<configuring_event_conversion,Event conversion>>**
+ifdef::advanced-framework[]
 * **<<distributing_events,Distributing events>>**
+endif::[]
 
 For more details on event stores specifically, see the xref:events:event-store-internals.adoc[event store internals] page.
 

--- a/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
@@ -6,7 +6,7 @@ Declarative and annotated interceptor support for Message Handling Components wi
 ====
 
 [[command-handler-interceptor-annotation]]
-==== `@CommandHandlerInterceptor` annotation
+== `@CommandHandlerInterceptor` annotation
 
 You can add a handler interceptor as a `@CommandHandlerInterceptor` annotated method on the aggregate or entity.
 This allows you to make decisions based on the current state of the aggregate:

--- a/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/dlq.adoc
@@ -12,7 +12,7 @@ endif::[]
 ====
 The most significant changes are:
 
-* **Database schema**: Column names in the embedded event entry changed; the schema is not backward compatible with Axon Framework 4 data.
+* **Database schema**: Column names in the embedded event entry changed. The schema is not backward compatible with Axon Framework 4 data.
 * **Queue scoping**: DLQs are now scoped per event handling component, not per processing group.
 Each component within a processor gets its own queue.
 * **MongoDB support removed**: The `MongoSequencedDeadLetterQueue` (previously available via the MongoDB Extension) is not available in Axon Framework 5.
@@ -337,7 +337,7 @@ public class AxonConfig {
 
 Axon Framework 5::
 +
-Configuration API (using `InMemorySequencedDeadLetterQueue` for brevity; replace with `JpaSequencedDeadLetterQueue` or `JdbcSequencedDeadLetterQueue` for production):
+Configuration API (using `InMemorySequencedDeadLetterQueue` for brevity, but replace with `JpaSequencedDeadLetterQueue` or `JdbcSequencedDeadLetterQueue` for production):
 +
 [source,java]
 ----

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -183,7 +183,7 @@ public class AxonConfig {
 [#jpa-migration]
 == JPA event storage migration
 
-Axon Framework's JPA event store functionality solely supports the aggregate-based approach; so not DCB.
+Axon Framework's JPA event store functionality solely supports the aggregate-based approach, so it does not support DCB.
 To clarify this distinction, the `JpaEventStorageEngine` is renamed to the `AggregateBasedJpaEventStorageEngine`.
 
 Before we take a look at the <<configuring_jpa_storage_engine,configuration>>, we should cover the <<jpa_schema_changes,schema changes>> imposed on the JPA-based event storage solution:
@@ -248,7 +248,7 @@ Some field constraints have changed:
 
 | `version` (was `payloadRevision`)
 | No longer optional! Axon Framework 5 defaults to 0.0.1 when nothing's given
-| Enforced to ensure non-null versioning inside Axon Framework; foreseen to be used to support version-range registration of event handlers
+| Enforced to ensure non-null versioning inside Axon Framework. Foreseen to be used to support version-range registration of event handlers
 
 | `aggregateSequenceNumber` (was `sequenceNumber`)
 | Now optional

--- a/docs/reference-guide/modules/monitoring/pages/health.adoc
+++ b/docs/reference-guide/modules/monitoring/pages/health.adoc
@@ -15,4 +15,4 @@ When one of the connections is inactive, the custom WARN status is shown.
 This approach is in line with what Axon Server's local health indicator shows.
 
 Next to the status, details are provided about the separate connection's activity.
-These can be found under `"{context-name}.connection.active"`.
+These can be found under `"<context-name>.connection.active"`, where `<context-name>` is the name of the Axon Server context.

--- a/docs/reference-guide/modules/monitoring/pages/index.adoc
+++ b/docs/reference-guide/modules/monitoring/pages/index.adoc
@@ -2,7 +2,7 @@
 :page-aliases: README.adoc
 
 The ability to monitor and measure what is going on is really important.
-This section contains all information regarding metrics, tracing and monitoring of your Axon Framework application.
+This section contains all information regarding metrics, tracing, and monitoring of your Axon Framework application.
 
 == Axoniq Platform: Easy monitoring and management
 

--- a/docs/reference-guide/modules/testing/pages/advanced-testing.adoc
+++ b/docs/reference-guide/modules/testing/pages/advanced-testing.adoc
@@ -2,7 +2,7 @@
 :navtitle: Advanced Testing
 
 After having taken note of the xref:basic-testing.adoc[basic test] flow and the use of xref:matchers-and-field-filters.adoc[matchers and field filters], it's worth to investigate more advanced testing scenarios.
-This page covers those advanced tests, discussing <<integration_testing,integration tests>>, <<testing-with-spring-boot,testing with spring boot>>, and <<testing-with-axon-server-testcontainer,testing with Testcontainers>> to name a few.
+This page covers those advanced tests, discussing <<integration_testing,integration tests>> and <<testing-with-spring-boot,testing with Spring Boot>> to name a few.
 
 [#integration_testing]
 == Integration testing
@@ -125,8 +125,10 @@ class AccountSpringTest {
 }
 ----
 
+ifdef::advanced-framework[]
 From here, it is rather straightforward to add Testcontainers into the mix, when your (integration) test requires it.
 Be sure to check out the <<testing-with-axon-server-testcontainer,tests with Testcontainers>> section for that.
+endif::[]
 
 === Using @AxonSpringBootTest
 
@@ -177,7 +179,7 @@ class AccountSpringBootTest {
 ----
 
 The fixture's `Customization` is derived automatically from the Spring environment.
-When `axon.axonserver.enabled` is `false`, the fixture disables Axon Server; when `true` or absent, it remains enabled.
+When `axon.axonserver.enabled` is `false`, the fixture disables Axon Server. When `true` or absent, it remains enabled.
 
 To override the default customization, declare a `Customization` bean in the test:
 

--- a/docs/reference-guide/modules/tuning/pages/rdbms-tuning.adoc
+++ b/docs/reference-guide/modules/tuning/pages/rdbms-tuning.adoc
@@ -116,6 +116,7 @@ This indicates this file should be used to override existing annotations, instea
 For the best results, ensure that the `DomainEventEntry`  table uses its own sequence.
 This can be ensured by specifying a different sequence generator for that entity only.
 
+pass:[<!-- vale AxonIQ.Acronyms = NO -->]
 == PostgreSQL, `@LOB`-annotated columns, and default Hibernate mapping
 
 Specific to link:https://www.postgresql.org/[PostgreSQL] is its link:https://www.postgresql.org/docs/current/storage-toast.html[TOAST] and link:https://www.postgresql.org/docs/current/largeobjects.html[Large Object Storage] functionality.
@@ -467,3 +468,4 @@ databaseChangeLog:
             constraintName: dead_letter_sequence_index_index
             tableName: dead_letter_entry
 ----
+pass:[<!-- vale AxonIQ.Acronyms = YES -->]

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -97,7 +97,7 @@ Current implementations include:
 * *`AxonServerSnapshotStore`* - Stores snapshots in Axon Server with thread-safe, concurrent access.
 
 Each snapshot contains the entity identifier, payload, position, version, timestamp, and optional metadata.
-By default, only a single snapshot per entity is retained; new snapshots overwrite the previous one.
+By default, only a single snapshot per entity is retained. New snapshots overwrite the previous one.
 Future versions of the framework may allow storing multiple snapshots per entity, enabling scenarios such as rollbacks or retaining older snapshot versions.
 
 A suitable `SnapshotStore` is typically registered automatically by Axon Framework, but may be overridden when required.


### PR DESCRIPTION
Resolve asciidoctor-level warnings: missing callout markers in implement-command-create-course.adoc, section heading level out of sequence in component-message-intercepting.adoc, undefined attribute in health.adoc, and broken cross-references (wrapped in ifdef::advanced-framework[] where targets are absent in the standard build).

Fix Google.Semicolons suggestions by splitting prose sentences or replacing semicolons with appropriate punctuation. Fix Oxford comma and first-person pronoun in getting-started pages.

Update .vale.ini to disable Google.Acronyms (replaced by AxonIQ.Acronyms in the vale package with domain-specific exceptions) and proselint.Needless (flags legitimately distinct words such as "extensible"). Add per-page Vale suppression in rdbms-tuning.adoc for PostgreSQL-specific acronyms.