### PR TITLE
Backport (5.1.x): Add reference to migration guide for 5.0 to 5.1

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/index.adoc
@@ -23,12 +23,19 @@ Whether you are performing a straightforward version bump or a deep architectura
 * xref:migration:paths/configuration.adoc[Configuration migration]
 * xref:migration:paths/sequencing-policies.adoc[Sequencing Policy migration]
 * xref:migration:paths/dlq.adoc[Dead-Letter Queue migration]
+ifdef::advanced-framework[]
+* xref:advanced-migration:paths/5.0-to-5.1.adoc[Axon Framework 5.0 to Axoniq Framework migration]
+endif::[]
 3. **What is not yet there**
 4. **Missing a Migration Path?**
 
 == Base migration changes
 
 Every user migrating from Axon Framework 4.x to 5.x will encounter a set of base changes. These primarily involve package renames and module restructurings.
+
+ifdef::advanced-framework[]
+NOTE: Axon Framework 5.1 extracts several production components into a dedicated commercial library: *Axoniq Framework*. If you are migrating to 5.1, be sure to consider the steps explained in the xref:advanced-migration:paths/5.0-to-5.1.adoc[Axon Framework 5.0 to *Axoniq* Framework 5.1] migration path.
+endif::[]
 
 [#import-and-package-changes]
 === Import and package changes

--- a/docs/reference-guide/modules/migration/partials/nav.adoc
+++ b/docs/reference-guide/modules/migration/partials/nav.adoc
@@ -19,3 +19,6 @@
 *** xref:migration:paths/interceptors.adoc[]
 *** xref:migration:paths/configuration.adoc[]
 *** xref:migration:paths/sequencing-policies.adoc[]
+ifdef::advanced-framework[]
+include::advanced-migration:partial$nav.adoc[]
+endif::[]


### PR DESCRIPTION
Add references in the navigation and migration paths index file to the migration path for Axon Framework 5.0 to Axoniq Framework 5.1

Backport for #4528 to 5.1.x