### PR TITLE
[#3773]: phase 2 remove joinAndUnwrap from workPackage and coordinator

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1363,10 +1363,10 @@ class Coordinator {
                                             name, generation, work.segment());
                            }
                        })
-                       .thenRun(() -> joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+                       .thenCompose(unused -> unitOfWorkFactory.create().executeWithResult(
                                context -> tokenStore.releaseClaim(name, segmentId, context)
-                                                    .thenCompose(unused -> segmentChangeListener.onSegmentReleased(work.segment()))
-                       )))
+                                                    .thenCompose(ignored -> segmentChangeListener.onSegmentReleased(work.segment()))
+                       ))
                        .exceptionally(throwable -> {
                            logger.warn(
                                    "Processor [{}] (Coordination Task [{}]). An exception occurred during the abort of work package [{}].",

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -181,7 +181,7 @@ class Coordinator {
         }
         return initializeTokenStore()
                 .thenCompose(initialized -> {
-                    if (initialized) {
+                    if (Boolean.TRUE.equals(initialized)) {
                         return emptyCompletedFuture();
                     }
                     return CompletableFuture
@@ -1107,10 +1107,10 @@ class Coordinator {
         private List<Segment> selectClaimCandidates(List<Segment> segments, int maxSegmentsToClaim) {
             List<Segment> candidates = new ArrayList<>();
             for (Segment segment : segments) {
-                if (workPackages.containsKey(segment.getSegmentId())) {
+                int segmentId = segment.getSegmentId();
+                if (workPackages.containsKey(segmentId)) {
                     continue;
                 }
-                int segmentId = segment.getSegmentId();
                 if (isSegmentBlockedFromClaim(segmentId)) {
                     logger.debug(
                             "Processor [{}] (Coordination Task [{}]). Segment {} is still marked to not be claimed till [{}].",
@@ -1119,9 +1119,7 @@ class Coordinator {
                             segmentId,
                             releasesDeadlines.get(segmentId));
                     processingStatusUpdater.accept(segmentId, ignored -> null);
-                    continue;
-                }
-                if (candidates.size() < maxSegmentsToClaim) {
+                } else if (candidates.size() < maxSegmentsToClaim) {
                     candidates.add(segment);
                 }
             }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1092,19 +1092,24 @@ class Coordinator {
                     context -> tokenStore.fetchAvailableSegments(name, context)
             ).thenCompose(segments -> {
                 int maxSegmentsToClaim = maxSegmentProvider.apply(name) - workPackages.size();
-                List<Segment> candidates = selectClaimCandidates(segments, maxSegmentsToClaim);
-
-                Map<Segment, TrackingToken> newClaims = new HashMap<>();
-                CompletableFuture<Map<Segment, TrackingToken>> result = CompletableFuture.completedFuture(newClaims);
-                for (Segment segment : candidates) {
-                    result = result.thenCompose(claims -> claimSegmentToken(segment, claims));
-                }
-                return result;
+                List<Segment> candidates = selectClaimCandidates(segments);
+                return claimUpTo(candidates, maxSegmentsToClaim, new HashMap<>());
             });
         }
 
-        // As segments are used for Segment#computeSegment, we cannot filter out the WorkPackages upfront.
-        private List<Segment> selectClaimCandidates(List<Segment> segments, int maxSegmentsToClaim) {
+        private CompletableFuture<Map<Segment, TrackingToken>> claimUpTo(
+                List<Segment> remainingCandidates, int maxSegmentsToClaim, Map<Segment, TrackingToken> successfulClaims
+        ) {
+            if (remainingCandidates.isEmpty() || successfulClaims.size() >= maxSegmentsToClaim) {
+                return CompletableFuture.completedFuture(successfulClaims);
+            }
+            Segment firstCandidateToClaim = remainingCandidates.getFirst();
+            List<Segment> subsequentCandidates = remainingCandidates.subList(1, remainingCandidates.size());
+            return claimSegmentToken(firstCandidateToClaim, successfulClaims)
+                    .thenCompose(claimsAfterAttempt -> claimUpTo(subsequentCandidates, maxSegmentsToClaim, claimsAfterAttempt));
+        }
+
+        private List<Segment> selectClaimCandidates(List<Segment> segments) {
             List<Segment> candidates = new ArrayList<>();
             for (Segment segment : segments) {
                 int segmentId = segment.getSegmentId();
@@ -1119,7 +1124,7 @@ class Coordinator {
                             segmentId,
                             releasesDeadlines.get(segmentId));
                     processingStatusUpdater.accept(segmentId, ignored -> null);
-                } else if (candidates.size() < maxSegmentsToClaim) {
+                } else {
                     candidates.add(segment);
                 }
             }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -64,8 +65,6 @@ import java.util.function.UnaryOperator;
 
 import static org.axonframework.common.BuilderUtils.assertStrictPositive;
 import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
-import static org.axonframework.common.ProcessUtils.executeUntilTrue;
 
 /**
  * Coordinator for the {@link PooledStreamingEventProcessor}. Uses coordination tasks (separate threads) to start a work
@@ -150,26 +149,45 @@ class Coordinator {
      * Start the event coordination task of this coordinator. Will shut down this service immediately if the
      * coordination task cannot be started.
      */
-    public void start() {
+    public CompletableFuture<Void> start() {
         RunState newState = this.runState.updateAndGet(RunState::attemptStart);
         if (newState.wasStarted()) {
             logger.debug("Processor [{}]. Starting Coordinator...", name);
-            try {
-                executeUntilTrue(Coordinator.this::initializeTokenStore, 100L, 30L);
-                CoordinationTask task = new CoordinationTask();
-                executorService.submit(task);
-                this.coordinationTask.set(task);
-            } catch (Exception e) {
-                // A failure starting the processor. We need to stop immediately.
-                runState.updateAndGet(RunState::attemptStop)
-                        .shutdownHandle()
-                        .complete(null);
-                throw e;
-            }
+            return initializeTokenStoreWithRetry(30)
+                    .thenRun(() -> {
+                        CoordinationTask task = new CoordinationTask();
+                        executorService.submit(task);
+                        this.coordinationTask.set(task);
+                    })
+                    .exceptionally(e -> {
+                        runState.updateAndGet(RunState::attemptStop)
+                                .shutdownHandle()
+                                .complete(null);
+                        if (e instanceof CompletionException ce) throw ce;
+                        throw new CompletionException(e);
+                    });
         } else if (!newState.isRunning) {
             throw new IllegalStateException(String.format(
                     "Cannot start a processor [%s] while it's in process of shutting down.", name));
         }
+        return emptyCompletedFuture();
+    }
+
+    private CompletableFuture<Void> initializeTokenStoreWithRetry(int attemptsLeft) {
+        if (attemptsLeft <= 0) {
+            return CompletableFuture.failedFuture(new IllegalStateException(
+                    String.format("Processor [%s]. Unable to initialize the token store after multiple attempts.", name)
+            ));
+        }
+        return initializeTokenStore()
+                .thenCompose(initialized -> {
+                    if (initialized) {
+                        return emptyCompletedFuture();
+                    }
+                    return CompletableFuture
+                            .runAsync(() -> {}, CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS, executorService))
+                            .thenCompose(ignored -> initializeTokenStoreWithRetry(attemptsLeft - 1));
+                });
     }
 
     /**
@@ -319,32 +337,28 @@ class Coordinator {
         return result;
     }
 
-    private boolean initializeTokenStore() {
-        AtomicBoolean tokenStoreInitialized = new AtomicBoolean(false);
-        try {
-            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-                    context -> {
-                        List<Segment> segments = joinAndUnwrap(tokenStore.fetchSegments(name, context));
-                        if (segments.isEmpty()) {
-                            logger.info("Processor [{}]. Initializing ({}) segments", name, initialSegmentCount);
-                            joinAndUnwrap(tokenStore.initializeTokenSegments(
-                                    name,
-                                    initialSegmentCount,
-                                    joinAndUnwrap(initialToken.apply(eventSource)),
-                                    context
-                            ));
-                        }
-                        tokenStoreInitialized.set(true);
-                        return emptyCompletedFuture();
-                    }
-            ));
-        } catch (Exception e) {
+    private CompletableFuture<Boolean> initializeTokenStore() {
+        return unitOfWorkFactory.create().executeWithResult(
+                context -> tokenStore.fetchSegments(name, context)
+                                     .thenCompose(segments -> {
+                                         if (!segments.isEmpty()) {
+                                             return CompletableFuture.completedFuture(true);
+                                         }
+                                         logger.info("Processor [{}]. Initializing ({}) segments",
+                                                     name, initialSegmentCount);
+                                         return initialToken.apply(eventSource)
+                                                            .thenCompose(token -> tokenStore.initializeTokenSegments(
+                                                                    name, initialSegmentCount, token, context
+                                                            ))
+                                                            .thenApply(ignored -> true);
+                                     })
+        ).exceptionally(e -> {
             logger.warn(
                     "Error while initializing the Token Store. This may simply indicate concurrent attempts to initialize.",
                     e
             );
-        }
-        return tokenStoreInitialized.get();
+            return false;
+        });
     }
 
     /**
@@ -783,20 +797,24 @@ class Coordinator {
                             .stream()
                             .filter(workPackage -> !workPackage.isAbortTriggered())
                             .filter(WorkPackage::isProcessingEvents)
-                            .forEach(workPackage -> {
-                                try {
-                                    workPackage.extendClaimIfThresholdIsMet();
-                                } catch (Exception e) {
-                                    logger.warn(
-                                            "Processor [{}] (Coordination Task [{}]). Error while extending claim for Work Package [{}]. "
-                                                    + "Aborting Work Package...",
-                                            name,
-                                            generation,
-                                            workPackage.segment().getSegmentId(),
-                                            e);
-                                    workPackage.abort(e);
-                                }
-                            });
+                            .forEach(workPackage -> workPackage.extendClaimIfThresholdIsMet()
+                                                               .whenComplete((ignored, e) -> {
+                                                                   if (e == null) {
+                                                                       return;
+                                                                   }
+                                                                   Throwable cause = e instanceof CompletionException ce
+                                                                           ? ce.getCause() : e;
+                                                                   logger.warn(
+                                                                           "Processor [{}] (Coordination Task [{}]). Error while extending claim for Work Package [{}]. "
+                                                                                   + "Aborting Work Package...",
+                                                                           name,
+                                                                           generation,
+                                                                           workPackage.segment().getSegmentId(),
+                                                                           cause);
+                                                                   workPackage.abort(cause instanceof Exception ex
+                                                                                             ? ex
+                                                                                             : new RuntimeException(String.valueOf(cause)));
+                                                               }));
             }
 
             if (!coordinatorTasks.isEmpty()) {
@@ -834,46 +852,63 @@ class Coordinator {
             if (eventStream == null || unclaimedSegmentValidationThreshold <= clock.instant().toEpochMilli()) {
                 // Claim new segments, construct work packages per new segment, and open stream based on lowest segment
                 unclaimedSegmentValidationThreshold = clock.instant().toEpochMilli() + tokenClaimInterval;
-                try {
-                    TrackingToken streamStartPosition = lastScheduledToken;
-                    if (!releaseSegmentsIfTooManyClaimed()) {
-                        logger.debug("Processor [{}] (Coordination Task [{}]) will try to claim new segments.",
-                                     name,
-                                     generation);
-                        Map<Segment, TrackingToken> newSegments = claimNewSegments();
-
-                        for (Map.Entry<Segment, TrackingToken> entry : newSegments.entrySet()) {
-                            Segment segment = entry.getKey();
-                            TrackingToken token = entry.getValue();
-                            TrackingToken otherUnwrapped = WrappedToken.unwrapLowerBound(token);
-
-                            streamStartPosition = streamStartPosition == null || otherUnwrapped == null
-                                    ? null : streamStartPosition.lowerBound(otherUnwrapped);
-                            workPackages.computeIfAbsent(segment.getSegmentId(),
-                                                         wp -> createWorkPackage(segment, token));
-                        }
-
-                        if (logger.isInfoEnabled() && !newSegments.isEmpty()) {
-                            logger.info(
-                                    "Processor [{}] (Coordination Task [{}]) claimed {} new segments for processing.",
-                                    name,
-                                    generation,
-                                    newSegments.size());
-                        }
-                    }
-                    ensureOpenStream(streamStartPosition);
-                } catch (Exception e) {
-                    logger.warn(
-                            "Processor [{}] (Coordination Task [{}]). Exception occurred while starting work packages"
-                                    + " and opening the event stream.",
-                            name,
-                            generation,
-                            e);
-                    abortAndScheduleRetry(e);
-                    return;
+                TrackingToken streamStartPosition = lastScheduledToken;
+                CompletableFuture<Void> claimAndStreamFuture;
+                if (releaseSegmentsIfTooManyClaimed()) {
+                    claimAndStreamFuture = ensureOpenStream(streamStartPosition);
+                } else {
+                    logger.debug("Processor [{}] (Coordination Task [{}]) will try to claim new segments.",
+                                 name,
+                                 generation);
+                    claimAndStreamFuture = claimNewSegments()
+                            .thenCompose(newSegments -> {
+                                TrackingToken[] position = {streamStartPosition};
+                                CompletableFuture<Void> chain = emptyCompletedFuture();
+                                for (Map.Entry<Segment, TrackingToken> entry : newSegments.entrySet()) {
+                                    Segment segment = entry.getKey();
+                                    TrackingToken token = entry.getValue();
+                                    TrackingToken otherUnwrapped = WrappedToken.unwrapLowerBound(token);
+                                    position[0] = position[0] == null || otherUnwrapped == null
+                                            ? null : position[0].lowerBound(otherUnwrapped);
+                                    int segmentId = segment.getSegmentId();
+                                    if (!workPackages.containsKey(segmentId)) {
+                                        chain = chain.thenCompose(ignored ->
+                                                createWorkPackage(segment, token)
+                                                        .thenAccept(wp -> workPackages.putIfAbsent(segmentId, wp))
+                                        );
+                                    }
+                                }
+                                if (logger.isInfoEnabled() && !newSegments.isEmpty()) {
+                                    logger.info(
+                                            "Processor [{}] (Coordination Task [{}]) claimed {} new segments for processing.",
+                                            name,
+                                            generation,
+                                            newSegments.size());
+                                }
+                                return chain.thenCompose(ignored -> ensureOpenStream(position[0]));
+                            });
                 }
+                claimAndStreamFuture.whenComplete((ignored, e) -> {
+                    if (e != null) {
+                        Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
+                        logger.warn(
+                                "Processor [{}] (Coordination Task [{}]). Exception occurred while starting work packages"
+                                        + " and opening the event stream.",
+                                name,
+                                generation,
+                                cause);
+                        abortAndScheduleRetry(cause instanceof Exception ex ? ex : new RuntimeException(String.valueOf(cause)));
+                    } else {
+                        coordinateEvents();
+                    }
+                });
+                return;
             }
 
+            coordinateEvents();
+        }
+
+        private void coordinateEvents() {
             if (workPackages.isEmpty()) {
                 // We didn't start any work packages. Retry later.
                 logger.debug(
@@ -985,21 +1020,22 @@ class Coordinator {
             }
         }
 
-        private WorkPackage createWorkPackage(Segment segment, TrackingToken token) {
+        private CompletableFuture<WorkPackage> createWorkPackage(Segment segment, TrackingToken token) {
             WorkPackage workPackage = workPackageFactory.apply(segment, token);
             workPackage.onBatchProcessed(() -> resetRetryExponentialBackoff(segment.getSegmentId()));
-            try {
-                joinAndUnwrap(segmentChangeListener.onSegmentClaimed(segment));
-            } catch (Exception e) {
-                logger.info(
-                        "Processor [{}] (Coordination Task [{}]). An exception occurred while invoking claim listeners for [{}].",
-                        name,
-                        generation,
-                        segment,
-                        e
-                );
-            }
-            return workPackage;
+            return segmentChangeListener.onSegmentClaimed(segment)
+                                        .handle((ignored, e) -> {
+                                            if (e != null) {
+                                                logger.info(
+                                                        "Processor [{}] (Coordination Task [{}]). An exception occurred while invoking claim listeners for [{}].",
+                                                        name,
+                                                        generation,
+                                                        segment,
+                                                        e
+                                                );
+                                            }
+                                            return workPackage;
+                                        });
         }
 
         private void resetRetryExponentialBackoff(int segmentId) {
@@ -1049,22 +1085,31 @@ class Coordinator {
         /**
          * Attempts to claim new segments.
          *
-         * @return a Map with each {@link TrackingToken} for newly claimed {@link Segment}
+         * @return a {@link CompletableFuture} with each {@link TrackingToken} for newly claimed {@link Segment}
          */
-        private Map<Segment, TrackingToken> claimNewSegments() {
-            Map<Segment, TrackingToken> newClaims = new HashMap<>();
-            List<Segment> segments = joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+        private CompletableFuture<Map<Segment, TrackingToken>> claimNewSegments() {
+            return unitOfWorkFactory.create().executeWithResult(
                     context -> tokenStore.fetchAvailableSegments(name, context)
-            ));
-            if (segments == null) {
-                return newClaims;
-            }
-            // As segments are used for Segment#computeSegment, we cannot filter out the WorkPackages upfront.
-            List<Segment> unClaimedSegments = segments.stream()
-                                                      .filter(segment -> !workPackages.containsKey(segment.getSegmentId()))
-                                                      .toList();
-            int maxSegmentsToClaim = maxSegmentProvider.apply(name) - workPackages.size();
-            for (Segment segment : unClaimedSegments) {
+            ).thenCompose(segments -> {
+                int maxSegmentsToClaim = maxSegmentProvider.apply(name) - workPackages.size();
+                List<Segment> candidates = selectClaimCandidates(segments, maxSegmentsToClaim);
+
+                Map<Segment, TrackingToken> newClaims = new HashMap<>();
+                CompletableFuture<Map<Segment, TrackingToken>> result = CompletableFuture.completedFuture(newClaims);
+                for (Segment segment : candidates) {
+                    result = result.thenCompose(claims -> claimSegmentToken(segment, claims));
+                }
+                return result;
+            });
+        }
+
+        // As segments are used for Segment#computeSegment, we cannot filter out the WorkPackages upfront.
+        private List<Segment> selectClaimCandidates(List<Segment> segments, int maxSegmentsToClaim) {
+            List<Segment> candidates = new ArrayList<>();
+            for (Segment segment : segments) {
+                if (workPackages.containsKey(segment.getSegmentId())) {
+                    continue;
+                }
                 int segmentId = segment.getSegmentId();
                 if (isSegmentBlockedFromClaim(segmentId)) {
                     logger.debug(
@@ -1073,32 +1118,45 @@ class Coordinator {
                             generation,
                             segmentId,
                             releasesDeadlines.get(segmentId));
-                    processingStatusUpdater.accept(segmentId, u -> null);
+                    processingStatusUpdater.accept(segmentId, ignored -> null);
                     continue;
                 }
-                if (newClaims.size() < maxSegmentsToClaim) {
-                    try {
-                        TrackingToken token = joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
-                                context -> tokenStore.fetchToken(name, segment, context)
-                        ));
-                        newClaims.put(segment, token);
-                        logger.debug("Processor [{}] (Coordination Task [{}]) claimed the token for segment {}.",
-                                     name,
-                                     generation,
-                                     segmentId);
-                    } catch (UnableToClaimTokenException e) {
-                        processingStatusUpdater.accept(segmentId, u -> null);
-                        logger.debug(
-                                "Processor [{}] (Coordination Task [{}]) is unable to claim the token for segment {}. "
-                                        + "It is owned by another process or has been split/merged concurrently.",
-                                name,
-                                generation,
-                                segmentId);
-                    }
+                if (candidates.size() < maxSegmentsToClaim) {
+                    candidates.add(segment);
                 }
             }
+            return candidates;
+        }
 
-            return newClaims;
+        private CompletableFuture<Map<Segment, TrackingToken>> claimSegmentToken(
+                Segment segment, Map<Segment, TrackingToken> claims
+        ) {
+            int segmentId = segment.getSegmentId();
+            return unitOfWorkFactory.create().<TrackingToken>executeWithResult(
+                    context -> tokenStore.fetchToken(name, segment, context)
+            ).thenApply(token -> {
+                claims.put(segment, token);
+                logger.debug(
+                        "Processor [{}] (Coordination Task [{}]) claimed the token for segment {}.",
+                        name,
+                        generation,
+                        segmentId);
+                return claims;
+            }).exceptionally(e -> {
+                Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
+                if (cause instanceof UnableToClaimTokenException) {
+                    processingStatusUpdater.accept(segmentId, ignored -> null);
+                    logger.debug(
+                            "Processor [{}] (Coordination Task [{}]) is unable to claim the token for segment {}. "
+                                    + "It is owned by another process or has been split/merged concurrently.",
+                            name,
+                            generation,
+                            segmentId);
+                    return claims;
+                }
+                if (e instanceof CompletionException ce) throw ce;
+                throw new CompletionException(e);
+            });
         }
 
         private boolean isSegmentBlockedFromClaim(int segmentId) {
@@ -1109,7 +1167,7 @@ class Coordinator {
             return releaseDeadline != null;
         }
 
-        private void ensureOpenStream(TrackingToken trackingToken) {
+        private CompletableFuture<Void> ensureOpenStream(@Nullable TrackingToken trackingToken) {
             // We already had a stream and the token differs the last scheduled token, thus we started new WorkPackages.
             // Close old stream to start at the new position, if we have Work Packages left.
             if (eventStream != null && !Objects.equals(trackingToken, lastScheduledToken)) {
@@ -1121,27 +1179,30 @@ class Coordinator {
             }
 
             if (eventStream == null && !workPackages.isEmpty() && !(trackingToken instanceof NoToken)) {
-                var startStreamingFrom = Objects.requireNonNullElse(
-                        trackingToken, joinAndUnwrap(eventSource.firstToken(null))
-                );
-                eventStream = eventSource.open(
-                        StreamingCondition.conditionFor(startStreamingFrom, eventCriteria), null
-                );
-                logger.debug(
-                        "Processor [{}] (Coordination Task [{}]) opened stream with tracking token [{}] and criteria [{}].",
-                        name, generation, trackingToken, eventCriteria
-                );
-                availabilityCallbackSupported = true;
-                eventStream.setCallback(() -> {
-                    logger.trace(
-                            "Processor [{}] (Coordination Task [{}]). Events became available (callback triggered). "
-                                    + "Scheduling immediate coordination task (itself).",
-                            name, generation
+                CompletableFuture<TrackingToken> tokenFuture = trackingToken != null
+                        ? CompletableFuture.completedFuture(trackingToken)
+                        : eventSource.firstToken(null);
+                return tokenFuture.thenAccept(startStreamingFrom -> {
+                    eventStream = eventSource.open(
+                            StreamingCondition.conditionFor(startStreamingFrom, eventCriteria), null
                     );
-                    scheduleImmediateCoordinationTask();
+                    logger.debug(
+                            "Processor [{}] (Coordination Task [{}]) opened stream with tracking token [{}] and criteria [{}].",
+                            name, generation, startStreamingFrom, eventCriteria
+                    );
+                    availabilityCallbackSupported = true;
+                    eventStream.setCallback(() -> {
+                        logger.trace(
+                                "Processor [{}] (Coordination Task [{}]). Events became available (callback triggered). "
+                                        + "Scheduling immediate coordination task (itself).",
+                                name, generation
+                        );
+                        scheduleImmediateCoordinationTask();
+                    });
+                    lastScheduledToken = startStreamingFrom;
                 });
-                lastScheduledToken = trackingToken;
             }
+            return emptyCompletedFuture();
         }
 
         private boolean isSpaceAvailable() {
@@ -1365,7 +1426,7 @@ class Coordinator {
                        })
                        .thenCompose(unused -> unitOfWorkFactory.create().executeWithResult(
                                context -> tokenStore.releaseClaim(name, segmentId, context)
-                                                    .thenCompose(ignored -> segmentChangeListener.onSegmentReleased(work.segment()))
+                                                    .thenCompose(r -> segmentChangeListener.onSegmentReleased(work.segment()))
                        ))
                        .exceptionally(throwable -> {
                            logger.warn(

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1093,20 +1093,18 @@ class Coordinator {
             ).thenCompose(segments -> {
                 int maxSegmentsToClaim = maxSegmentProvider.apply(name) - workPackages.size();
                 List<Segment> candidates = selectClaimCandidates(segments);
-                return claimUpTo(candidates, maxSegmentsToClaim, new HashMap<>());
-            });
-        }
 
-        private CompletableFuture<Map<Segment, TrackingToken>> claimUpTo(
-                List<Segment> remainingCandidates, int maxSegmentsToClaim, Map<Segment, TrackingToken> successfulClaims
-        ) {
-            if (remainingCandidates.isEmpty() || successfulClaims.size() >= maxSegmentsToClaim) {
-                return CompletableFuture.completedFuture(successfulClaims);
-            }
-            Segment firstCandidateToClaim = remainingCandidates.getFirst();
-            List<Segment> subsequentCandidates = remainingCandidates.subList(1, remainingCandidates.size());
-            return claimSegmentToken(firstCandidateToClaim, successfulClaims)
-                    .thenCompose(claimsAfterAttempt -> claimUpTo(subsequentCandidates, maxSegmentsToClaim, claimsAfterAttempt));
+                CompletableFuture<Map<Segment, TrackingToken>> successfullyClaimedSegments = CompletableFuture.completedFuture(new HashMap<>());
+                for (Segment candidate : candidates) {
+                    successfullyClaimedSegments = successfullyClaimedSegments.thenCompose(successfulClaims -> {
+                        if (successfulClaims.size() >= maxSegmentsToClaim) {
+                            return CompletableFuture.completedFuture(successfulClaims);
+                        }
+                        return claimSegmentToken(candidate, successfulClaims);
+                    });
+                }
+                return successfullyClaimedSegments;
+            });
         }
 
         private List<Segment> selectClaimCandidates(List<Segment> segments) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -183,8 +183,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     @Override
     public CompletableFuture<Void> start() {
         logger.info("Starting PooledStreamingEventProcessor [{}].", name);
-        coordinator.start();
-        return FutureUtils.emptyCompletedFuture();
+        return coordinator.start();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -411,7 +411,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     }
 
     private WorkPackage spawnWorker(Segment segment, TrackingToken initialToken) {
-        WorkPackage.BatchProcessor batchProcessor = (events, context) -> processWithErrorHandling(events, context);
+        WorkPackage.BatchProcessor batchProcessor = this::processWithErrorHandling;
         var batchSize = configuration.batchSize();
         var claimExtensionThreshold = configuration.claimExtensionThreshold();
         var clock = configuration.clock();

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -17,7 +17,6 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.Assert;
-import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.LegacyResources;
@@ -42,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
+import java.util.concurrent.CompletionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +57,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 /**
  * Defines the process of handling {@link EventMessage}s for a specific {@link Segment}. This entails validating if the
@@ -341,23 +340,25 @@ class WorkPackage {
                 return;
             }
 
-            try {
-                processEvents();
-            } catch (Exception e) {
-                logger.warn("Error while processing batch in Work Package [{}]-[{}]. Aborting Work Package...",
-                            segment.getSegmentId(), name, e);
-                abort(e);
-            }
-            scheduled.set(false);
-            if (!processingQueue.isEmpty() || abortFlag.get() != null) {
-                logger.debug("Rescheduling Work Package [{}]-[{}] since there are events left.",
-                             segment.getSegmentId(), name);
-                scheduleWorker();
-            }
+            processEvents().whenCompleteAsync((r, e) -> {
+                processingEvents.set(false);
+                if (e != null) {
+                    Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
+                    logger.warn("Error while processing batch in Work Package [{}]-[{}]. Aborting Work Package...",
+                                segment.getSegmentId(), name, cause);
+                    abort(cause instanceof Exception ex ? ex : new RuntimeException(String.valueOf(cause)));
+                }
+                scheduled.set(false);
+                if (!processingQueue.isEmpty() || abortFlag.get() != null) {
+                    logger.debug("Rescheduling Work Package [{}]-[{}] since there are events left.",
+                                 segment.getSegmentId(), name);
+                    scheduleWorker();
+                }
+            }, executorService);
         });
     }
 
-    private void processEvents() {
+    private CompletableFuture<Void> processEvents() {
         List<EventMessage> eventBatch = new ArrayList<>();
         while (!isAbortTriggered() && eventBatch.size() < batchSize && !processingQueue.isEmpty()) {
             ProcessingEntry entry = processingQueue.poll();
@@ -371,42 +372,29 @@ class WorkPackage {
         if (!eventBatch.isEmpty()) {
             logger.debug("Work Package [{}]-[{}] is processing a batch of {} events.",
                          segment.getSegmentId(), name, eventBatch.size());
-            try {
-                processingEvents.set(true);
-                var unitOfWork = unitOfWorkFactory.create();
-                unitOfWork.runOnPreInvocation(ctx -> {
-                    ctx.putResource(Segment.RESOURCE_KEY, segment);
-                    ctx.putResource(TrackingToken.RESOURCE_KEY, lastConsumedToken);
-                });
-
-                unitOfWork.onInvocation(ctx -> batchProcessor.process(eventBatch, ctx).asCompletableFuture());
-
-                unitOfWork.runOnPrepareCommit(ctx -> storeToken(lastConsumedToken, ctx));
-                unitOfWork.runOnAfterCommit(
-                        ctx -> {
-                            segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
-                            if (batchProcessedCallback != null) {
-                                batchProcessedCallback.run();
-                            }
-                        }
-                );
-                FutureUtils.joinAndUnwrap(unitOfWork.execute());
-            } finally {
-                processingEvents.set(false);
-            }
+            processingEvents.set(true);
+            var unitOfWork = unitOfWorkFactory.create();
+            unitOfWork.runOnPreInvocation(ctx -> {
+                ctx.putResource(Segment.RESOURCE_KEY, segment);
+                ctx.putResource(TrackingToken.RESOURCE_KEY, lastConsumedToken);
+            });
+            unitOfWork.onInvocation(ctx -> batchProcessor.process(eventBatch, ctx).asCompletableFuture());
+            unitOfWork.onPrepareCommit(ctx -> storeToken(lastConsumedToken, ctx));
+            unitOfWork.runOnAfterCommit(ctx -> {
+                segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
+                if (batchProcessedCallback != null) {
+                    batchProcessedCallback.run();
+                }
+            });
+            return unitOfWork.execute();
         } else {
             segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
             if (lastStoredToken != lastConsumedToken && now() > nextClaimExtension.get()) {
-                joinAndUnwrap(
-                        unitOfWorkFactory
-                                .create()
-                                .executeWithResult(context -> {
-                                    storeToken(lastConsumedToken, context);
-                                    return emptyCompletedFuture();
-                                })
+                return unitOfWorkFactory.create().executeWithResult(
+                        context -> storeToken(lastConsumedToken, context)
                 );
             } else {
-                extendClaimIfThresholdIsMet();
+                return extendClaimIfThresholdIsMet();
             }
         }
     }
@@ -416,21 +404,23 @@ class WorkPackage {
      * {@link PooledStreamingEventProcessorConfiguration#claimExtensionThreshold(long) claim extension threshold} is
      * met.
      */
-    public void extendClaimIfThresholdIsMet() {
+    public CompletableFuture<Void> extendClaimIfThresholdIsMet() {
         if (now() > nextClaimExtension.get()) {
             logger.debug("Work Package [{}]-[{}] will extend its token claim.", name, segment.getSegmentId());
-            joinAndUnwrap(unitOfWorkFactory.create().executeWithResult(
+            return unitOfWorkFactory.create().executeWithResult(
                     context -> tokenStore.extendClaim(name, segment.getSegmentId(), context)
-            ));
-            nextClaimExtension.set(now() + claimExtensionThreshold);
+            ).thenRun(() -> nextClaimExtension.set(now() + claimExtensionThreshold));
         }
+        return emptyCompletedFuture();
     }
 
-    private void storeToken(TrackingToken token, ProcessingContext processingContext) {
+    private CompletableFuture<Void> storeToken(TrackingToken token, ProcessingContext processingContext) {
         logger.debug("Work Package [{}]-[{}] will store token [{}].", name, segment.getSegmentId(), token);
-        joinAndUnwrap(tokenStore.storeToken(token, name, segment.getSegmentId(), processingContext));
-        lastStoredToken = token;
-        nextClaimExtension.set(now() + claimExtensionThreshold);
+        return tokenStore.storeToken(token, name, segment.getSegmentId(), processingContext)
+                         .thenRun(() -> {
+                             lastStoredToken = token;
+                             nextClaimExtension.set(now() + claimExtensionThreshold);
+                         });
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -388,7 +388,11 @@ class WorkPackage {
                     batchProcessedCallback.run();
                 }
             });
-            return unitOfWork.execute();
+            try {
+                return unitOfWork.execute();
+            } catch (Exception e) {
+                return CompletableFuture.failedFuture(e);
+            }
         } else {
             segmentStatusUpdater.accept(status -> status.advancedTo(lastConsumedToken));
             if (lastStoredToken != lastConsumedToken && now() > nextClaimExtension.get()) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -329,33 +329,35 @@ class WorkPackage {
             return;
         }
         logger.debug("Scheduling Work Package [{}]-[{}] to process events.", segment.getSegmentId(), name);
+        executorService.submit(this::runWorker);
+    }
 
-        executorService.submit(() -> {
-            CompletableFuture<Exception> aborting = abortFlag.get();
-            if (aborting != null) {
-                logger.debug("Work Package [{}]-[{}] should be aborted. Will shutdown this work package.",
-                             segment.getSegmentId(), name);
-                segmentStatusUpdater.accept(previousStatus -> null);
-                aborting.complete(abortException.get());
-                return;
-            }
+    private void runWorker() {
+        CompletableFuture<Exception> aborting = abortFlag.get();
+        if (aborting != null) {
+            logger.debug("Work Package [{}]-[{}] should be aborted. Will shutdown this work package.",
+                         segment.getSegmentId(), name);
+            segmentStatusUpdater.accept(previousStatus -> null);
+            aborting.complete(abortException.get());
+            return;
+        }
+        processEvents().whenCompleteAsync(this::onProcessingComplete, executorService);
+    }
 
-            processEvents().whenCompleteAsync((r, e) -> {
-                processingEvents.set(false);
-                if (e != null) {
-                    Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
-                    logger.warn("Error while processing batch in Work Package [{}]-[{}]. Aborting Work Package...",
-                                segment.getSegmentId(), name, cause);
-                    abort(cause instanceof Exception ex ? ex : new RuntimeException(String.valueOf(cause)));
-                }
-                scheduled.set(false);
-                if (!processingQueue.isEmpty() || abortFlag.get() != null) {
-                    logger.debug("Rescheduling Work Package [{}]-[{}] since there are events left.",
-                                 segment.getSegmentId(), name);
-                    scheduleWorker();
-                }
-            }, executorService);
-        });
+    private void onProcessingComplete(@Nullable Void ignored, @Nullable Throwable e) {
+        processingEvents.set(false);
+        if (e != null) {
+            Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
+            logger.warn("Error while processing batch in Work Package [{}]-[{}]. Aborting Work Package...",
+                        segment.getSegmentId(), name, cause);
+            abort(cause instanceof Exception ex ? ex : new RuntimeException(String.valueOf(cause)));
+        }
+        scheduled.set(false);
+        if (!processingQueue.isEmpty() || abortFlag.get() != null) {
+            logger.debug("Rescheduling Work Package [{}]-[{}] since there are events left.",
+                         segment.getSegmentId(), name);
+            scheduleWorker();
+        }
     }
 
     private CompletableFuture<Void> processEvents() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -99,6 +99,7 @@ class CoordinatorTest {
                                  .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
                                  .executorService(executorService)
                                  .workPackageFactory((segment, trackingToken) -> workPackage)
+                                 .processingStatusUpdater((id, updater) -> {})
                                  .initialToken(es -> es.firstToken(null).thenApply(ReplayToken::createReplayToken))
                                  .maxSegmentProvider(e -> SEGMENTS.size())
                                  .build();
@@ -112,7 +113,7 @@ class CoordinatorTest {
         final GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
 
         doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
-        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt(), any());
+        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
         doThrow(releaseClaimException).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
         doThrow(streamOpenException).when(messageSource).open(any(), isNull());
         doReturn(completedFuture(streamOpenException)).when(workPackage).abort(any());
@@ -143,7 +144,7 @@ class CoordinatorTest {
                 .when(tokenStore)
                 .initializeTokenSegments(eq(PROCESSOR_NAME), anyInt(), any(), any(ProcessingContext.class)
                 );
-        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt(), any());
+        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
         doReturn(SEGMENT_ZERO).when(workPackage).segment();
         doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
 
@@ -215,24 +216,62 @@ class CoordinatorTest {
         verify(workPackage, times(0)).scheduleEvent(any());
     }
 
-    @Test
-    void claimsNewSegmentsSkipsSegmentWhenUnableToClaimToken() {
-        // given - token store has segments but claiming fails with UnableToClaimTokenException
-        doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
-        doReturn(completedFuture(List.of(SEGMENT_ZERO)))
-                .when(tokenStore).fetchAvailableSegments(eq(PROCESSOR_NAME), any());
-        doReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("claim failed")))
-                .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
-        doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+    /**
+     * Tests for the {@code claimNewSegments} path — specifically how the coordinator handles
+     * {@link UnableToClaimTokenException} during token claiming.
+     */
+    @Nested
+    class ClaimNewSegments {
 
-        // when
-        testSubject.start();
+        @BeforeEach
+        void setUp() {
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+        }
 
-        // then - token claim was attempted, no work package created for the segment
-        verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
-        verify(workPackage, never()).onBatchProcessed(any());
-        // coordinator schedules delayed retry since no segments were successfully claimed
-        verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        @Test
+        void skipsSegmentWhenUnableToClaimToken() {
+            // given - token store has segments but claiming fails with UnableToClaimTokenException
+            doReturn(completedFuture(List.of(SEGMENT_ZERO)))
+                    .when(tokenStore).fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("claim failed")))
+                    .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+
+            // when
+            testSubject.start();
+
+            // then - token claim was attempted, no work package created for the segment
+            verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+            verify(workPackage, never()).onBatchProcessed(any());
+            // coordinator schedules delayed retry since no segments were successfully claimed
+            verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        }
+
+        @Test
+        void continuesClaimingRemainingSegmentsAfterOneClaimFails() {
+            // given - SEGMENT_ZERO fails to claim, SEGMENT_ONE succeeds
+            GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
+            doReturn(completedFuture(List.of(SEGMENT_ZERO, SEGMENT_ONE)))
+                    .when(tokenStore).fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("already claimed")))
+                    .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            doReturn(completedFuture(token))
+                    .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ONE), any());
+            doReturn(SEGMENT_ONE).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).hasRemainingCapacity();
+            doReturn(false).when(workPackage).isDone();
+            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+                    .when(messageSource).open(any(StreamingCondition.class), isNull());
+
+            // when
+            testSubject.start();
+
+            // then - SEGMENT_ZERO was attempted but skipped; SEGMENT_ONE was still claimed and scheduled
+            verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ONE), any());
+            verify(workPackage).scheduleWorker();
+        }
     }
 
     @Test
@@ -258,7 +297,7 @@ class CoordinatorTest {
         final GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
 
         doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
-        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt(), any());
+        doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
         doReturn(SEGMENT_ZERO).when(workPackage).segment();
         doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
         //Using reflection to add a work package to keep the test simple
@@ -484,7 +523,7 @@ class CoordinatorTest {
             doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
             doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
-            doReturn(completedFuture(null)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt(), any());
+            doReturn(completedFuture(null)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
             // override setUp default so firstToken resolves to a real token
             doReturn(completedFuture(resolvedFirstToken)).when(messageSource).firstToken(null);
             doReturn(SEGMENT_ZERO).when(workPackage).segment();

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -623,9 +623,8 @@ class CoordinatorTest {
         @Test
         void abortsWorkPackagesAndSchedulesRetryWhenEventStreamIsNullButWorkPackagesPresent()
                 throws NoSuchFieldException {
-            // given - inject a work package so the coordinator has active work but no open stream;
-            //         fetchAvailableSegments returns empty, so no new segments are claimed and
-            //         ensureOpenStream receives NoToken → stream stays null
+            // given - coordinator has an active work package but no open stream and no new available segments to claim
+            // No token received, stream stays null
             doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
             doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
                                                               .fetchAvailableSegments(eq(PROCESSOR_NAME), any());

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
 import static org.axonframework.common.util.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,10 +27,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.ReflectionUtils;
@@ -42,10 +47,12 @@ import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventTestUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentChangeListener;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToClaimTokenException;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
@@ -173,6 +180,13 @@ class CoordinatorTest {
         );
 
         when(executorService.submit(any(Runnable.class))).thenAnswer(runTaskAsync());
+        // Segment claiming is async. The stream's setCallback fires scheduleImmediateCoordinationTask immediately
+        // (events are ready), consuming one schedule call while processingGate is still true — that run exits early.
+        // The whenComplete callback then calls coordinateEvents() directly (no extra round-trip), which processes
+        // events and schedules a delayed reschedule — that second schedule call is ignored.
+        doAnswer(invocation -> { ((Runnable) invocation.getArgument(0)).run(); return null; })
+                .doAnswer(invocation -> null)
+                .when(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
         when(tokenStore.fetchSegments(eq(PROCESSOR_NAME), any())).thenReturn(completedFuture(SEGMENTS));
         when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
                 .thenReturn(completedFuture(Collections.singletonList(SEGMENT_ONE)));
@@ -199,6 +213,43 @@ class CoordinatorTest {
         assertTrue(resultEvents.contains(testEntryTwo));
 
         verify(workPackage, times(0)).scheduleEvent(any());
+    }
+
+    @Test
+    void claimsNewSegmentsSkipsSegmentWhenUnableToClaimToken() {
+        // given - token store has segments but claiming fails with UnableToClaimTokenException
+        doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+        doReturn(completedFuture(List.of(SEGMENT_ZERO)))
+                .when(tokenStore).fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+        doReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("claim failed")))
+                .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+        doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+        // when
+        testSubject.start();
+
+        // then - token claim was attempted, no work package created for the segment
+        verify(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+        verify(workPackage, never()).onBatchProcessed(any());
+        // coordinator schedules delayed retry since no segments were successfully claimed
+        verify(executorService, times(1)).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    void claimTokenUnexpectedExceptionCausesAbortAndRetry() {
+        // given - fetchToken fails with an exception that is not UnableToClaimTokenException
+        doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+        doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                         .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+        doReturn(CompletableFuture.failedFuture(new RuntimeException("unexpected token failure")))
+                .when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+        doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+        // when
+        testSubject.start();
+
+        // then - the unexpected exception propagates through claimSegmentToken and triggers a retry
+        verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
 
     @Test
@@ -234,5 +285,438 @@ class CoordinatorTest {
 
     private Answer<Future<Void>> runTaskAsync() {
         return invocationOnMock -> CompletableFuture.runAsync(invocationOnMock.getArgument(0));
+    }
+
+    /**
+     * Tests for the {@code initializeTokenStoreWithRetry} retry logic:
+     * single-failure-then-success path, and all-attempts-exhausted path.
+     * <p>
+     * Note: each retry incurs a real 100 ms delay imposed by the JDK-internal
+     * {@code CompletableFuture} delayer; the 30-retry exhaustion test therefore
+     * takes ~3 s by design.
+     */
+    @Nested
+    class InitializeTokenStoreWithRetry {
+
+        @BeforeEach
+        void stubExecutorExecuteToRunImmediately() {
+            // The JDK-internal delayer fires executorService.execute(r) after the real 100 ms.
+            // Stub execute so the runnable runs immediately once the delay has elapsed,
+            // allowing the CompletableFuture chain to continue without further blocking.
+            doAnswer(invocation -> {
+                ((Runnable) invocation.getArgument(0)).run();
+                return null;
+            }).when(executorService).execute(any(Runnable.class));
+            // Prevent the coordination task from running after a successful start.
+            doReturn(completedFuture(null)).when(executorService).submit(any(Runnable.class));
+        }
+
+        @Test
+        void retriesOnceAndSucceedsWhenFirstAttemptReturnsFalse() {
+            // given - first fetchSegments call throws (initializeTokenStore returns false), second succeeds
+            AtomicInteger callCount = new AtomicInteger(0);
+            doAnswer(invocation -> {
+                if (callCount.getAndIncrement() == 0) {
+                    return CompletableFuture.failedFuture(new RuntimeException("transient store error"));
+                }
+                return completedFuture(SEGMENTS);
+            }).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+
+            // when
+            CompletableFuture<Void> startFuture = testSubject.start();
+
+            // then - fetchSegments is called twice (initial attempt + 1 retry) and start completes normally
+            assertWithin(1, TimeUnit.SECONDS, () -> {
+                assertTrue(startFuture.isDone());
+                assertFalse(startFuture.isCompletedExceptionally());
+            });
+            verify(tokenStore, times(2)).fetchSegments(eq(PROCESSOR_NAME), any());
+        }
+
+        @Test
+        void completesExceptionallyWithIllegalStateExceptionWhenAllAttemptsExhausted() {
+            // given - fetchSegments always throws so initializeTokenStore always returns false
+            doReturn(CompletableFuture.failedFuture(new RuntimeException("persistent store error")))
+                    .when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+
+            // when
+            CompletableFuture<Void> startFuture = testSubject.start();
+
+            // then - after all 30 retries (each separated by a real 100 ms JDK delay, ~3 s total)
+            //        the future completes exceptionally with an IllegalStateException
+            assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(startFuture.isCompletedExceptionally()));
+            CompletionException thrown = assertThrows(CompletionException.class, startFuture::join);
+            assertInstanceOf(IllegalStateException.class, thrown.getCause());
+            assertThat(thrown.getCause().getMessage()).contains(PROCESSOR_NAME);
+        }
+    }
+
+    /**
+     * Tests for the {@code start()} exceptionally handler that runs when
+     * {@code initializeTokenStoreWithRetry} itself fails permanently.
+     */
+    @Nested
+    class Start {
+
+        @BeforeEach
+        void stubExecutorExecuteToRunImmediately() {
+            doAnswer(invocation -> {
+                ((Runnable) invocation.getArgument(0)).run();
+                return null;
+            }).when(executorService).execute(any(Runnable.class));
+            doReturn(completedFuture(null)).when(executorService).submit(any(Runnable.class));
+        }
+
+        @Test
+        void returnsCompletedFutureWhenAlreadyRunning() {
+            // given - coordinator already running
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            testSubject.start();
+
+            // when - start is called again
+            CompletableFuture<Void> secondStart = testSubject.start();
+
+            // then - returns an already-completed, non-exceptional future immediately
+            assertThat(secondStart).isCompleted();
+            assertThat(secondStart.isCompletedExceptionally()).isFalse();
+        }
+
+        @Test
+        void throwsIllegalStateExceptionWhenStartCalledWhileShuttingDown() {
+            // given - coordinator that has been started and then stopped (shutdown handle not yet done,
+            //         because the coordination task was captured without running)
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            testSubject.start();
+            testSubject.stop();
+
+            // when / then
+            assertThrows(IllegalStateException.class, testSubject::start);
+        }
+
+        @Test
+        void completesShutdownHandleWhenInitializationPermanentlyFails() {
+            // given - a coordinator with a tracked shutdown action
+            AtomicBoolean shutdownInvoked = new AtomicBoolean(false);
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, token) -> workPackage)
+                                                 .initialToken(es -> es.firstToken(null).thenApply(ReplayToken::createReplayToken))
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .onShutdown(() -> shutdownInvoked.set(true))
+                                                 .build();
+
+            // fetchSegments always fails so all retries are exhausted and start() enters its exceptionally block
+            doReturn(CompletableFuture.failedFuture(new RuntimeException("persistent store error")))
+                    .when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+
+            // when
+            CompletableFuture<Void> startFuture = coordinator.start();
+
+            // then - the shutdown action is triggered once the start future completes exceptionally
+            assertWithin(5, TimeUnit.SECONDS, () -> {
+                assertTrue(startFuture.isCompletedExceptionally());
+                assertTrue(shutdownInvoked.get());
+            });
+        }
+    }
+
+    /**
+     * Tests for the {@code createWorkPackage} method, specifically the error-handling path
+     * in which the {@link SegmentChangeListener#onSegmentClaimed} callback throws.
+     */
+    @Nested
+    class CreateWorkPackage {
+
+        @Test
+        void stillRegistersWorkPackageWhenOnSegmentClaimedFails() {
+            // given - coordinator with a claim listener that always fails
+            GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                                 .initialToken(es -> es.firstToken(null).thenApply(ReplayToken::createReplayToken))
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .segmentChangeListener(SegmentChangeListener.onClaim(
+                                                         segment -> CompletableFuture.failedFuture(
+                                                                 new RuntimeException("claim listener failed"))
+                                                 ))
+                                                 .build();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                             .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).hasRemainingCapacity();
+            doReturn(false).when(workPackage).isDone();
+            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+                    .when(messageSource).open(any(StreamingCondition.class), isNull());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            // when
+            coordinator.start();
+
+            // then - the work package is still registered and scheduled despite the failing claim listener
+            verify(workPackage).scheduleWorker();
+        }
+    }
+
+    /**
+     * Tests for the {@code ensureOpenStream} null-token path where
+     * {@link StreamableEventSource#firstToken} is used to determine the stream start position.
+     */
+    @Nested
+    class EnsureOpenStream {
+
+        @Test
+        void callsFirstTokenWhenAllClaimedTokensAreNull() {
+            // given - fetchToken returns null, so the lower-bound position is null after claiming
+            GlobalSequenceTrackingToken resolvedFirstToken = new GlobalSequenceTrackingToken(0);
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                             .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(null)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), anyInt(), any());
+            // override setUp default so firstToken resolves to a real token
+            doReturn(completedFuture(resolvedFirstToken)).when(messageSource).firstToken(null);
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).hasRemainingCapacity();
+            doReturn(false).when(workPackage).isDone();
+            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+                    .when(messageSource).open(any(StreamingCondition.class), isNull());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            // when
+            testSubject.start();
+
+            // then - firstToken is consulted to determine the stream start position,
+            //        and the stream is subsequently opened from that resolved token
+            verify(messageSource).firstToken(null);
+            verify(messageSource).open(streamingFrom(resolvedFirstToken), null);
+        }
+    }
+
+    /**
+     * Tests for the {@link Coordinator.CoordinationTask#run()} method — specifically the
+     * stale-generation guard and the async {@code extendClaimIfThresholdIsMet} failure path.
+     */
+    @Nested
+    class Run {
+
+        @Test
+        void staleTaskExitsWithoutClaimingSegments() throws NoSuchFieldException {
+            // given - capture the first task without running it, then advance the generation counter
+            AtomicReference<Runnable> capturedTask = new AtomicReference<>();
+            doAnswer(inv -> {
+                capturedTask.set(inv.getArgument(0));
+                return completedFuture(null);
+            }).when(executorService).submit(any(Runnable.class));
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+
+            testSubject.start();
+
+            AtomicLong generationCounter = ReflectionUtils.getFieldValue(
+                    Coordinator.class.getDeclaredField("coordinationTaskGeneration"), testSubject);
+            generationCounter.incrementAndGet();
+
+            // when - the now-stale task runs
+            capturedTask.get().run();
+
+            // then - no segment claiming attempted; stale task exited early
+            verify(tokenStore, never()).fetchAvailableSegments(any(), any());
+        }
+
+        @Test
+        void extendClaimCompletionExceptionCauseIsUnwrappedBeforeAbort() throws NoSuchFieldException {
+            // given - work package whose extension fails with a CompletionException wrapping an inner cause
+            RuntimeException innerCause = new RuntimeException("inner cause");
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, token) -> workPackage)
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .coordinatorClaimExtension(true)
+                                                 .build();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).isProcessingEvents();
+            doReturn(CompletableFuture.failedFuture(new CompletionException(innerCause)))
+                    .when(workPackage).extendClaimIfThresholdIsMet();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            coordinator.start();
+
+            // then - abort is called with the unwrapped inner cause, not the CompletionException wrapper
+            ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+            verify(workPackage, atLeastOnce()).abort(captor.capture());
+            assertThat(captor.getAllValues()).anyMatch(e -> e == innerCause);
+        }
+
+        @Test
+        void extendClaimFailureAbortsWorkPackage() throws NoSuchFieldException {
+            // given - coordinator with claim extension enabled and a work package that fails to extend
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, token) -> workPackage)
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .coordinatorClaimExtension(true)
+                                                 .build();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).isProcessingEvents();
+            doReturn(CompletableFuture.failedFuture(new RuntimeException("extend claim failed")))
+                    .when(workPackage).extendClaimIfThresholdIsMet();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            coordinator.start();
+
+            // then - abort was triggered on the work package due to the extend-claim failure
+            verify(workPackage, atLeastOnce()).abort(any());
+        }
+    }
+
+    /**
+     * Tests for the {@code coordinateEvents()} guard that handles the unexpected state
+     * in which work packages exist but the event stream is null.
+     */
+    @Nested
+    class CoordinateEvents {
+
+        @Test
+        void abortsWorkPackagesAndSchedulesRetryWhenEventStreamIsNullButWorkPackagesPresent()
+                throws NoSuchFieldException {
+            // given - inject a work package so the coordinator has active work but no open stream;
+            //         fetchAvailableSegments returns empty, so no new segments are claimed and
+            //         ensureOpenStream receives NoToken → stream stays null
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            // inject the pre-existing work package before the coordination task runs
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), testSubject);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            testSubject.start();
+
+            // then - the null-stream guard triggers abort on the active work package
+            verify(workPackage).abort(any());
+        }
+
+        @Test
+        void callsOnSegmentReleasedAfterAbortingWorkPackage() throws NoSuchFieldException {
+            // given - coordinator with a release listener that records the released segment
+            AtomicBoolean releasedCalled = new AtomicBoolean(false);
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .segmentChangeListener(SegmentChangeListener.onRelease(segment -> {
+                                                     releasedCalled.set(true);
+                                                     return emptyCompletedFuture();
+                                                 }))
+                                                 .build();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            coordinator.start();
+
+            // then - onSegmentReleased was invoked as part of the abort chain
+            assertThat(releasedCalled.get()).isTrue();
+        }
+
+        @Test
+        void onSegmentReleasedFailureIsHandledGracefully() throws NoSuchFieldException {
+            // given - coordinator with a release listener that always fails
+            Coordinator coordinator = Coordinator.builder()
+                                                 .name(PROCESSOR_NAME)
+                                                 .eventSource(messageSource)
+                                                 .tokenStore(tokenStore)
+                                                 .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                                                 .executorService(executorService)
+                                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                                 .maxSegmentProvider(e -> SEGMENTS.size())
+                                                 .segmentChangeListener(SegmentChangeListener.onRelease(
+                                                         segment -> CompletableFuture.failedFuture(
+                                                                 new RuntimeException("release listener failed"))
+                                                 ))
+                                                 .build();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            coordinator.start();
+
+            // then - the failure is swallowed by the exceptionally handler and a retry is still scheduled
+            verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -817,6 +817,39 @@ class PooledStreamingEventProcessorTest {
             assertFalse(coordinatorExecutor.isShutdown());
             assertFalse(workerExecutor.isShutdown());
         }
+
+        @Test
+        void abortFlowWaitsForSegmentChangeListenerBeforeCompleting() {
+            // given - processor with a single segment and a listener that blocks release until a gate is opened
+            CompletableFuture<Void> releaseGate = new CompletableFuture<>();
+            AtomicReference<Segment> releasedSegment = new AtomicReference<>();
+
+            withTestSubject(List.of(), c -> c
+                    .initialSegmentCount(1)
+                    .addSegmentChangeListener(SegmentChangeListener.onRelease(segment -> {
+                        releasedSegment.set(segment);
+                        return releaseGate;
+                    })));
+            startEventProcessor();
+            assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(testSubject.processingStatus().isEmpty()));
+
+            // when - shutdown is triggered while the release listener is still pending
+            CompletableFuture<Void> shutdownFuture = testSubject.shutdown();
+
+            // then - the listener is called with the correct segment before shutdown can proceed
+            await().atMost(1, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(releasedSegment.get())
+                           .isNotNull()
+                           .extracting(Segment::getSegmentId)
+                           .isEqualTo(0));
+
+            // then - shutdown is blocked as long as the listener future is not completed
+            assertThat(shutdownFuture).isNotCompleted();
+
+            // then - completing the gate unblocks the abort flow and shutdown finishes
+            releaseGate.complete(null);
+            assertWithin(1, TimeUnit.SECONDS, () -> assertThat(shutdownFuture).isCompleted());
+        }
     }
 
     @Nested

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -559,6 +559,77 @@ class WorkPackageTest {
         });
     }
 
+    @Nested
+    class ScheduleWorkerLifecycleTest {
+
+        @Test
+        void processingEventsIsFalseAfterSuccessfulProcessing() {
+            // given
+            TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
+            var testEvent = new SimpleEntry<>(EventTestUtils.asEventMessage("some-event"), trackingTokenContext(testToken));
+
+            // when
+            testSubject.scheduleEvent(testEvent);
+
+            // then
+            await().atMost(TIMEOUT).untilAsserted(() -> {
+                verify(tokenStore).storeToken(any(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any());
+                assertThat(testSubject.isProcessingEvents()).isFalse();
+            });
+        }
+
+        @Test
+        void processingEventsIsFalseAfterFailedProcessing() {
+            // given
+            TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
+            var testEvent = new SimpleEntry<>(EventTestUtils.asEventMessage("some-event"), trackingTokenContext(testToken));
+            batchProcessorPredicate = (events, token) -> {
+                throw new IllegalStateException("processing failure");
+            };
+
+            // when
+            testSubject.scheduleEvent(testEvent);
+
+            // then - wait for abort to be fully processed (trackerStatus set to null by abort handler)
+            await().atMost(TIMEOUT).untilAsserted(() -> assertThat(trackerStatus).isNull());
+            assertThat(testSubject.isProcessingEvents()).isFalse();
+        }
+
+        @Test
+        void workerReschedulesWhenQueueHasRemainingEventsAfterBatch() {
+            // given - two events with different tokens; batchSize is 1 so each is processed separately
+            TrackingToken tokenOne = new GlobalSequenceTrackingToken(1L);
+            TrackingToken tokenTwo = new GlobalSequenceTrackingToken(2L);
+            var eventOne = new SimpleEntry<>(EventTestUtils.asEventMessage("event-one"), trackingTokenContext(tokenOne));
+            var eventTwo = new SimpleEntry<>(EventTestUtils.asEventMessage("event-two"), trackingTokenContext(tokenTwo));
+
+            // when
+            testSubject.scheduleEvent(eventOne);
+            testSubject.scheduleEvent(eventTwo);
+
+            // then - second event is only reachable if scheduleWorker reschedules after the first batch
+            await().atMost(TIMEOUT).untilAsserted(
+                    () -> assertThat(batchProcessor.getProcessedEvents()).hasSize(2)
+            );
+        }
+
+        @Test
+        void tokenStoreFailureTriggersAbort() {
+            // given
+            TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
+            var testEvent = new SimpleEntry<>(EventTestUtils.asEventMessage("some-event"), trackingTokenContext(testToken));
+            doReturn(CompletableFuture.failedFuture(new RuntimeException("store failure")))
+                    .when(tokenStore).storeToken(any(), anyString(), anyInt(), any());
+
+            // when
+            testSubject.scheduleEvent(testEvent);
+
+            // then
+            await().atMost(TIMEOUT).untilAsserted(() -> assertThat(trackerStatus).isNull());
+            assertThat(testSubject.abort(null)).isDone();
+        }
+    }
+
     private static Context globalTrackingTokenContext(long globalIndex) {
         return trackingTokenContext(new GlobalSequenceTrackingToken(globalIndex));
     }


### PR DESCRIPTION
DO NOT MERGE BEFORE PHASE 0 AND 1


## What

Removes all blocking `joinAndUnwrap` call sites from `WorkPackage` (4 sites) and `Coordinator` (8 sites) as part of [[#3773](https://github.com/AxonIQ/AxonFramework/issues/3773)](https://github.com/AxonIQ/AxonFramework/issues/3773). All blocking is replaced with proper async `CompletableFuture` composition.

## Changes

**`WorkPackage.java`**
- `storeToken`, `extendClaimIfThresholdIsMet`, `processEvents` return `CompletableFuture<Void>` instead of blocking
- `scheduleWorker` uses `whenComplete` for async error handling with `CompletionException` unwrapping

**`Coordinator.java`**
- `start()` returns `CompletableFuture<Void>`; initialization extracted to `initializeTokenStoreWithRetry(int)` with async retry loop (replaces `executeUntilTrue`)
- `initializeTokenStore()` returns `CompletableFuture<Boolean>`
- `claimNewSegments()` returns `CompletableFuture<Map<Segment, TrackingToken>>`
- `createWorkPackage()` returns `CompletableFuture<WorkPackage>`; `onSegmentClaimed` chained via `thenCompose` (design decision: Optie 1)
- `ensureOpenStream()` returns `CompletableFuture<Void>`; `firstToken` only called when token is actually null
- `extendClaimIfThresholdIsMet` error handling converted to async `whenComplete` with `CompletionException` unwrapping
- `run()` restructured: claim/stream opening is fully async via `claimAndStreamFuture`; stale-task generation guard added to prevent race conditions

**Tests**
- `CoordinatorTest`: 14 new tests covering `initializeTokenStoreWithRetry` retry/exhaustion, `start()` state transitions (already running, shutting down, permanent failure), stale-task generation guard, `extendClaimIfThresholdIsMet` failure + `CompletionException` unwrapping, `claimSegmentToken` error propagation, `onSegmentReleased` invocation and graceful failure handling, `ensureOpenStream` null-token path
- `WorkPackageTest`: tests for the new async signatures

## Notes
- `PooledStreamingEventProcessor` has a minor related change; full PSEP async work (identifier resolve) is deferred to Phase 3
- Integration branch: `enhancement/3773/replace-joinunwrap-pooled-processor`