### PR TITLE
chore(migration): document `@EventTag` migration for Axon 5 compatibiity

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/event-tagging.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/event-tagging.adoc
@@ -1,0 +1,79 @@
+= Event tagging with `@EventTag`
+:navtitle: Event tagging
+
+In Axon Framework 4, the `@AggregateIdentifier` field on the aggregate was the single source of truth that linked events to their aggregate instance. Axon Framework 5 inverts this: the entity declares a `tagKey`, and every event the entity emits carries an explicit `@EventTag` whose key matches that `tagKey` and whose value is the entity identifier. The event store uses these tags to source the right events when reconstructing an entity.
+
+[NOTE]
+.Key shift
+====
+* `@AggregateIdentifier` is **no longer required** on the entity (also see xref:migration:paths/aggregates/configuration-migration.adoc[entity configuration migration]).
+* Each event must declare an `@EventTag` whose key matches the entity's `tagKey` and whose value is the entity identifier.
+* Without migrating to xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], **exactly one `@EventTag` per event is supported and required**—the one matching the entity it belongs to.
+====
+
+[source,java]
+----
+// Entity
+@EventSourcedEntity(tagKey = "Bike") // <1>
+public class Bike {
+
+    private String bikeId;
+
+    // command and event sourcing handlers omitted
+}
+
+// Event
+public record BikeRegisteredEvent(
+        @EventTag(key = "Bike") String bikeId, // <2>
+        String bikeType,
+        String location
+) { }
+----
+<1> The entity declares a `tagKey` that the event store uses to locate its events. In Spring environments, use `@EventSourced(tagKey = "Bike")` instead.
+<2> Each event carries an `@EventTag` with the **same key** as the entity's `tagKey`. The tag value is derived by calling `toString()` on the annotated field.
+
+== `@EventTag` without an explicit key
+
+When `@EventTag` is used without specifying a `key`, the framework derives the key from the annotated member's name (the field name, or the getter name with `get` stripped). This is convenient when the field name already matches the entity's `tagKey`.
+
+[source,java]
+----
+@EventSourcedEntity(tagKey = "bikeId")
+public class Bike {
+    private String bikeId;
+    // ...
+}
+
+public record BikeRegisteredEvent(
+        @EventTag String bikeId, // tag key derived from field name → "bikeId"
+        String bikeType,
+        String location
+) { }
+----
+
+[TIP]
+====
+Pick a `tagKey` that conveys the *entity type* rather than the field name (for example, `"Bike"` instead of `"bikeId"`). It tends to read more naturally and stays stable even if the identifier field is later renamed. In that case, use `@EventTag(key = "Bike")` explicitly on the events.
+====
+
+== One tag per event (without DCB)
+
+For an architecture-neutral migration that keeps the existing aggregate model, every event must declare **exactly one** `@EventTag`, and it must match the entity it belongs to. Multiple tags on a single event become meaningful once you start adopting xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], where an event may be relevant to multiple entities and is therefore tagged with several keys.
+
+[source,java]
+----
+// Architecture-neutral migration: ONE tag, matching the entity's tagKey.
+public record BikeReturnedEvent(
+        @EventTag(key = "Bike") String bikeId,
+        String location
+) { }
+
+// DCB-style: an event tagged for multiple entities (only after migrating to DCB).
+public record BikeRequestedEvent(
+        @EventTag(key = "Bike") String bikeId,
+        String renter,
+        @EventTag(key = "Rental") String rentalReference
+) { }
+----
+
+For deeper reference material on tags, custom `TagResolver` implementations, and consistency boundary mechanics, see xref:events:event-publishing.adoc#event_tagging[Event tagging] in the events reference guide.

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/event-tagging.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/event-tagging.adoc
@@ -1,4 +1,4 @@
-= Event tagging with `@EventTag`
+= Event Tagging with `@EventTag`
 :navtitle: Event tagging
 
 In Axon Framework 4, the `@AggregateIdentifier` field on the aggregate was the single source of truth that linked events to their aggregate instance. Axon Framework 5 inverts this: the entity declares a `tagKey`, and every event the entity emits carries an explicit `@EventTag` whose key matches that `tagKey` and whose value is the entity identifier. The event store uses these tags to source the right events when reconstructing an entity.

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
@@ -19,7 +19,7 @@ No more command handling constructors.
 xref:migration:paths/aggregates/index.adoc#eventappender-instead-of-aggregatelifecycle[EventAppender vs. AggregateLifecycle]::
 Do not use static/thread local references any more.
 
-xref:migration:paths/aggregates/index.adoc#event-tagging[Event tagging with @EventTag]::
+xref:migration:paths/aggregates/event-tagging.adoc[Event tagging with @EventTag]::
 How events are now linked to their entity through `@EventTag` instead of `@AggregateIdentifier`.
 
 xref:migration:paths/aggregates/index.adoc#entitycreator-annotation[The @EntityCreator annotation]::
@@ -299,84 +299,6 @@ public static void handle(IssueGiftCard cmd,
 * *`CreationPolicy.NEVER`*
 +
 New entites are created when a command appends an event that can be routed to an `@EntityCreator`. So any `@CommandHandler` that does not append such an event will implicitly follow the `NEVER` policy.
-
-[#event-tagging]
-== Event tagging with `@EventTag`
-
-In Axon Framework 4, the `@AggregateIdentifier` field on the aggregate was the single source of truth that linked events to their aggregate instance. Axon Framework 5 inverts this: the entity declares a `tagKey`, and every event the entity emits carries an explicit `@EventTag` whose key matches that `tagKey` and whose value is the entity identifier. The event store uses these tags to source the right events when reconstructing an entity.
-
-[NOTE]
-.Key shift
-====
-* `@AggregateIdentifier` is **no longer required** on the entity (also see xref:migration:paths/aggregates/configuration-migration.adoc[entity configuration migration]).
-* Each event must declare a `@EventTag` whose key matches the entity's `tagKey` and whose value is the entity identifier.
-* Without migrating to xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], **exactly one `@EventTag` per event is supported and required** — the one matching the entity it belongs to.
-====
-
-[source,java]
-----
-// Entity
-@EventSourcedEntity(tagKey = "Bike") // <1>
-public class Bike {
-
-    private String bikeId;
-
-    // command and event sourcing handlers omitted
-}
-
-// Event
-public record BikeRegisteredEvent(
-        @EventTag(key = "Bike") String bikeId, // <2>
-        String bikeType,
-        String location
-) { }
-----
-<1> The entity declares a `tagKey` that the event store uses to locate its events. In Spring environments, use `@EventSourced(tagKey = "Bike")` instead.
-<2> Each event carries a `@EventTag` with the **same key** as the entity's `tagKey`. The tag value is derived by calling `toString()` on the annotated field.
-
-=== `@EventTag` without an explicit key
-
-When `@EventTag` is used without specifying a `key`, the framework derives the key from the annotated member's name (the field name, or the getter name with `get` stripped). This is convenient when the field name already matches the entity's `tagKey`.
-
-[source,java]
-----
-@EventSourcedEntity(tagKey = "bikeId")
-public class Bike {
-    private String bikeId;
-    // ...
-}
-
-public record BikeRegisteredEvent(
-        @EventTag String bikeId, // tag key derived from field name → "bikeId"
-        String bikeType,
-        String location
-) { }
-----
-
-[TIP]
-====
-Pick a `tagKey` that conveys the *entity type* rather than the field name (for example, `"Bike"` instead of `"bikeId"`). It tends to read more naturally and stays stable even if the identifier field is later renamed. In that case, use `@EventTag(key = "Bike")` explicitly on the events.
-====
-
-=== One tag per event (without DCB)
-
-For an architecture-neutral migration that keeps the existing aggregate model, every event must declare **exactly one** `@EventTag`, and it must match the entity it belongs to. Multiple tags on a single event become meaningful once you start adopting xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], where an event may be relevant to multiple entities and is therefore tagged with several keys.
-
-[source,java]
-----
-// Architecture-neutral migration: ONE tag, matching the entity's tagKey.
-public record BikeReturnedEvent(
-        @EventTag(key = "Bike") String bikeId,
-        String location
-) { }
-
-// DCB-style: an event tagged for multiple entities (only after migrating to DCB).
-public record BikeRequestedEvent(
-        @EventTag(key = "Bike") String bikeId,
-        String renter,
-        @EventTag(key = "Rental") String rentalReference
-) { }
-----
 
 [#see-also]
 == See also

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
@@ -19,6 +19,9 @@ No more command handling constructors.
 xref:migration:paths/aggregates/index.adoc#eventappender-instead-of-aggregatelifecycle[EventAppender vs. AggregateLifecycle]::
 Do not use static/thread local references any more.
 
+xref:migration:paths/aggregates/index.adoc#event-tagging[Event tagging with @EventTag]::
+How events are now linked to their entity through `@EventTag` instead of `@AggregateIdentifier`.
+
 xref:migration:paths/aggregates/index.adoc#entitycreator-annotation[The @EntityCreator annotation]::
 Required for entity construction.
 
@@ -296,6 +299,84 @@ public static void handle(IssueGiftCard cmd,
 * *`CreationPolicy.NEVER`*
 +
 New entites are created when a command appends an event that can be routed to an `@EntityCreator`. So any `@CommandHandler` that does not append such an event will implicitly follow the `NEVER` policy.
+
+[#event-tagging]
+== Event tagging with `@EventTag`
+
+In Axon Framework 4, the `@AggregateIdentifier` field on the aggregate was the single source of truth that linked events to their aggregate instance. Axon Framework 5 inverts this: the entity declares a `tagKey`, and every event the entity emits carries an explicit `@EventTag` whose key matches that `tagKey` and whose value is the entity identifier. The event store uses these tags to source the right events when reconstructing an entity.
+
+[NOTE]
+.Key shift
+====
+* `@AggregateIdentifier` is **no longer required** on the entity (also see xref:migration:paths/aggregates/configuration-migration.adoc[entity configuration migration]).
+* Each event must declare a `@EventTag` whose key matches the entity's `tagKey` and whose value is the entity identifier.
+* Without migrating to xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], **exactly one `@EventTag` per event is supported and required** — the one matching the entity it belongs to.
+====
+
+[source,java]
+----
+// Entity
+@EventSourcedEntity(tagKey = "Bike") // <1>
+public class Bike {
+
+    private String bikeId;
+
+    // command and event sourcing handlers omitted
+}
+
+// Event
+public record BikeRegisteredEvent(
+        @EventTag(key = "Bike") String bikeId, // <2>
+        String bikeType,
+        String location
+) { }
+----
+<1> The entity declares a `tagKey` that the event store uses to locate its events. In Spring environments, use `@EventSourced(tagKey = "Bike")` instead.
+<2> Each event carries a `@EventTag` with the **same key** as the entity's `tagKey`. The tag value is derived by calling `toString()` on the annotated field.
+
+=== `@EventTag` without an explicit key
+
+When `@EventTag` is used without specifying a `key`, the framework derives the key from the annotated member's name (the field name, or the getter name with `get` stripped). This is convenient when the field name already matches the entity's `tagKey`.
+
+[source,java]
+----
+@EventSourcedEntity(tagKey = "bikeId")
+public class Bike {
+    private String bikeId;
+    // ...
+}
+
+public record BikeRegisteredEvent(
+        @EventTag String bikeId, // tag key derived from field name → "bikeId"
+        String bikeType,
+        String location
+) { }
+----
+
+[TIP]
+====
+Pick a `tagKey` that conveys the *entity type* rather than the field name (for example, `"Bike"` instead of `"bikeId"`). It tends to read more naturally and stays stable even if the identifier field is later renamed. In that case, use `@EventTag(key = "Bike")` explicitly on the events.
+====
+
+=== One tag per event (without DCB)
+
+For an architecture-neutral migration that keeps the existing aggregate model, every event must declare **exactly one** `@EventTag`, and it must match the entity it belongs to. Multiple tags on a single event become meaningful once you start adopting xref:migration:understanding-architecture-principles.adoc#moving-away-from-aggregates[Dynamic Consistency Boundaries (DCB)], where an event may be relevant to multiple entities and is therefore tagged with several keys.
+
+[source,java]
+----
+// Architecture-neutral migration: ONE tag, matching the entity's tagKey.
+public record BikeReturnedEvent(
+        @EventTag(key = "Bike") String bikeId,
+        String location
+) { }
+
+// DCB-style: an event tagged for multiple entities (only after migrating to DCB).
+public record BikeRequestedEvent(
+        @EventTag(key = "Bike") String bikeId,
+        String renter,
+        @EventTag(key = "Rental") String rentalReference
+) { }
+----
 
 [#see-also]
 == See also

--- a/docs/reference-guide/modules/migration/pages/paths/messages.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/messages.adoc
@@ -151,4 +151,4 @@ public class OrderCreatedEvent {
 ----
 
 This tagging is crucial for maintaining the link between the event and its entity, enabling correct event sourcing and consistency boundary protection in AF5.
-For more details on how tagging works, see the xref:events:event-publishing.adoc#event_tagging[Event tagging] section.
+For more details on migrating to event tagging, see xref:migration:paths/aggregates/event-tagging.adoc[Event tagging migration guide].

--- a/docs/reference-guide/modules/migration/partials/nav.adoc
+++ b/docs/reference-guide/modules/migration/partials/nav.adoc
@@ -8,6 +8,7 @@
 *** xref:migration:paths/messages.adoc[]
 *** xref:migration:paths/aggregates/index.adoc[]
 **** xref:migration:paths/aggregates/configuration-migration.adoc[]
+**** xref:migration:paths/aggregates/event-tagging.adoc[]
 **** xref:migration:paths/aggregates/multi-entity-migration.adoc[]
 **** xref:migration:paths/aggregates/polymorphism-migration.adoc[]
 *** xref:migration:paths/projectors-event-processors.adoc[]


### PR DESCRIPTION
Add comprehensive guidelines for migrating from `@AggregateIdentifier` to `@EventTag` in Axon Framework 5. Include examples for explicit and derived tag keys, architecture-neutral constraints, and Dynamic Consistency Boundaries (DCB) preparations.