### PR TITLE
[#3773]: phase 3 Remove joinAndUnwrap from PooledStreamingEventProcessor 

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/StreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/StreamingEventProcessor.java
@@ -52,9 +52,16 @@ public interface StreamingEventProcessor extends EventProcessor {
 
     /**
      * Returns the unique identifier of the {@link TokenStore} used by this {@link StreamingEventProcessor}.
+     * <p>
+     * Implementations may resolve the identifier lazily on the first call to this method, or eagerly during
+     * {@link #start()}. When resolved eagerly, calling this method before {@code start()} has completed
+     * successfully will throw an {@link IllegalStateException}.
      *
      * @return the unique identifier of the {@link TokenStore} used by this {@link StreamingEventProcessor}
-     * @throws UnableToRetrieveIdentifierException if the {@link TokenStore} was unable to retrieve it
+     * @throws IllegalStateException               if the identifier has not yet been resolved (e.g., before
+     *                                             {@link #start()} completes in eager implementations)
+     * @throws UnableToRetrieveIdentifierException if the {@link TokenStore} was unable to retrieve the identifier
+     *                                             (in lazy implementations, thrown directly from this call)
      */
     String getTokenStoreIdentifier();
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -203,12 +203,23 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
         return coordinator.isError();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation resolves the identifier eagerly during {@link #start()}. If called before {@code start()}
+     * has completed, the identifier is resolved lazily with a blocking call to the {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore}.
+     *
+     * @throws org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToRetrieveIdentifierException
+     * if lazy resolution is triggered and the {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore}
+     * fails to retrieve the identifier
+     */
     @Override
     public String getTokenStoreIdentifier() {
         if (tokenStoreIdentifier == null) {
-            throw new IllegalStateException(
-                    "Token store identifier is not yet resolved. Ensure start() has completed before calling this method."
-            );
+            var unitOfWork = unitOfWorkFactory.create();
+            tokenStoreIdentifier = FutureUtils
+                    .joinAndUnwrap(unitOfWork
+                                           .executeWithResult(tokenStore::retrieveStorageIdentifier));
         }
         return tokenStoreIdentifier;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -59,14 +59,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.axonframework.common.BuilderUtils.assertThat;
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 /**
  * A {@link StreamingEventProcessor} implementation which pools its resources to enhance processing speed. It utilizes a
@@ -103,7 +101,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     private final Coordinator coordinator;
     private final WorkPackage.EventFilter workPackageEventFilter;
 
-    private final AtomicReference<@Nullable String> tokenStoreIdentifier = new AtomicReference<>();
+    private volatile @Nullable String tokenStoreIdentifier;
     private final Map<Integer, TrackerStatus> processingStatus = new ConcurrentHashMap<>();
 
     /**
@@ -183,7 +181,10 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     @Override
     public CompletableFuture<Void> start() {
         logger.info("Starting PooledStreamingEventProcessor [{}].", name);
-        return coordinator.start();
+        var unitOfWork = unitOfWorkFactory.create();
+        return unitOfWork.executeWithResult(tokenStore::retrieveStorageIdentifier)
+                         .thenAccept(id -> this.tokenStoreIdentifier = id)
+                         .thenCompose(unused -> coordinator.start());
     }
 
     @Override
@@ -204,12 +205,12 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
 
     @Override
     public String getTokenStoreIdentifier() {
-        return tokenStoreIdentifier.updateAndGet(i -> i != null ? i : calculateIdentifier());
-    }
-
-    private String calculateIdentifier() {
-        var unitOfWork = unitOfWorkFactory.create();
-        return joinAndUnwrap(unitOfWork.executeWithResult(tokenStore::retrieveStorageIdentifier));
+        if (tokenStoreIdentifier == null) {
+            throw new IllegalStateException(
+                    "Token store identifier is not yet resolved. Ensure start() has completed before calling this method."
+            );
+        }
+        return tokenStoreIdentifier;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -563,14 +563,28 @@ class PooledStreamingEventProcessorTest {
             assertWithin(1, TimeUnit.SECONDS, () -> assertEquals(2, testSubject.processingStatus().size()));
         }
 
-        @Test
-        void getTokenStoreIdentifier() {
-            String expectedIdentifier = "some-identifier";
+        @Nested
+        class GetTokenStoreIdentifier {
 
-            when(tokenStore.retrieveStorageIdentifier(any()))
-                    .thenReturn(completedFuture(expectedIdentifier));
+            @Test
+            void returnsIdentifierResolvedDuringStart() {
+                // given
+                String expectedIdentifier = "some-identifier";
+                when(tokenStore.retrieveStorageIdentifier(any()))
+                        .thenReturn(completedFuture(expectedIdentifier));
 
-            assertEquals(expectedIdentifier, testSubject.getTokenStoreIdentifier());
+                // when
+                startEventProcessor();
+
+                // then
+                assertEquals(expectedIdentifier, testSubject.getTokenStoreIdentifier());
+            }
+
+            @Test
+            void throwsIllegalStateExceptionWhenCalledBeforeStart() {
+                // when / then
+                assertThrows(IllegalStateException.class, () -> testSubject.getTokenStoreIdentifier());
+            }
         }
 
         @Test

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -46,6 +46,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.segmenting
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToRetrieveIdentifierException;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.eventhandling.replay.ReplayBlockingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.replay.ReplayStatus;
@@ -581,9 +582,42 @@ class PooledStreamingEventProcessorTest {
             }
 
             @Test
-            void throwsIllegalStateExceptionWhenCalledBeforeStart() {
+            void resolvesIdentifierLazilyWhenCalledBeforeStart() {
+                // when
+                String identifier = testSubject.getTokenStoreIdentifier();
+
+                // then
+                assertThat(identifier).isNotNull();
+            }
+
+            @Test
+            void propagatesExceptionWhenLazyResolutionFails() {
+                // given
+                var failure = new UnableToRetrieveIdentifierException("Storage unavailable", new RuntimeException());
+                when(tokenStore.retrieveStorageIdentifier(any()))
+                        .thenReturn(CompletableFuture.failedFuture(failure));
+
                 // when / then
-                assertThrows(IllegalStateException.class, () -> testSubject.getTokenStoreIdentifier());
+                assertThrows(UnableToRetrieveIdentifierException.class, () -> testSubject.getTokenStoreIdentifier());
+            }
+
+            @Test
+            void startCompletesExceptionallyAndSkipsCoordinatorWhenRetrievalFails() {
+                // given
+                var failure = new UnableToRetrieveIdentifierException("Storage unavailable", new RuntimeException());
+                when(tokenStore.retrieveStorageIdentifier(any()))
+                        .thenReturn(CompletableFuture.failedFuture(failure));
+
+                // when
+                var startFuture = testSubject.start();
+
+                // then
+                assertThat(startFuture).isCompletedExceptionally()
+                                       .failsWithin(1, TimeUnit.SECONDS)
+                                       .withThrowableOfType(ExecutionException.class)
+                                       .havingCause()
+                                       .isInstanceOf(UnableToRetrieveIdentifierException.class);
+                assertFalse(testSubject.isRunning());
             }
         }
 


### PR DESCRIPTION
CHECK FIRST PHASE 0-1-2 (started from 2)


This is Phase 3 of [[#3773](https://github.com/AxonIQ/AxonFramework/issues/3773)](https://github.com/AxonIQ/AxonFramework/issues/3773) — removing all `FutureUtils.joinAndUnwrap` calls from the pooled streaming event processor stack. This PR targets the integration branch `enhancement/3773/replace-joinunwrap-pooled-processor`.

Phase 3 removes the last remaining `joinAndUnwrap` call site in `PooledStreamingEventProcessor

### What changed

**`PooledStreamingEventProcessor.java`**

Previously, the token store identifier was resolved lazily — on the first call to `getTokenStoreIdentifier()`, the method would block the caller's thread via `joinAndUnwrap` to fetch the identifier from the token store, then cache it in an `AtomicReference`.

This PR moves the resolution to `start()`, making it part of the async startup chain:

```java
var unitOfWork = unitOfWorkFactory.create();
return unitOfWork.executeWithResult(tokenStore::retrieveStorageIdentifier)
                 .thenAccept(id -> this.tokenStoreIdentifier = id)
                 .thenCompose(unused -> coordinator.start());
```

- `calculateIdentifier()` is removed along with its `joinAndUnwrap` call
- `AtomicReference<String>` is replaced with a `volatile String` field — a single write during `start()` and read-only access afterwards makes `AtomicReference` unnecessary
- `getTokenStoreIdentifier()` becomes a direct field lookup; it throws `IllegalStateException` when called before `start()` has completed, making the lifecycle contract explicit

**`PooledStreamingEventProcessorTest.java`**

- The existing `getTokenStoreIdentifier` test is updated to call `startEventProcessor()` before asserting the identifier
- A new test is added verifying that calling `getTokenStoreIdentifier()` before `start()` throws `IllegalStateException`