### PR TITLE
[#3934] Fix duplicate command handler registration when subtype overrides handler

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.modelling.entity.annotation;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
@@ -45,6 +44,7 @@ import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.entity.PolymorphicEntityMetamodel;
 import org.axonframework.modelling.entity.child.EntityChildMetamodel;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 import static org.axonframework.common.ReflectionUtils.collectMethodsAndFields;
@@ -302,11 +303,10 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
             EntityMetamodelBuilder<E> builder, AnnotatedHandlerInspector<E> inspected
     ) {
         LinkedList<QualifiedName> registeredCommands = new LinkedList<>();
-        inspected.getHandlers(entityType).stream()
-                 .filter(h -> h.canHandleMessageType(CommandMessage.class)
-                         || h.canHandleMessageType(EventMessage.class))
-                 .filter(h -> h.unwrap(Method.class).map(m -> !Modifier.isAbstract(m.getModifiers())).orElse(false))
-                 .forEach(handler -> {
+        Stream.concat(inspected.getUniqueHandlers(entityType, CommandMessage.class).stream(),
+                      inspected.getUniqueHandlers(entityType, EventMessage.class).stream())
+              .filter(h -> h.unwrap(Method.class).map(m -> !Modifier.isAbstract(m.getModifiers())).orElse(false))
+              .forEach(handler -> {
                      QualifiedName qualifiedName = messageTypeResolver.resolveOrThrow(handler.payloadType())
                                                                       .qualifiedName();
                      if (commandsToSkip.contains(qualifiedName)) {

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandHandlerInheritanceTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandHandlerInheritanceTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.conversion.jackson.JacksonConverter;
+import org.axonframework.messaging.commandhandling.DuplicateCommandHandlerSubscriptionException;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.MultiParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.SimpleResourceParameterResolverFactory;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePackagePrivateBasePackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePackagePrivateOtherPackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePackagePrivateOtherPrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePrivateBasePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePrivateOtherPackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypeProtectedBasePackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypeProtectedBasePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypeProtectedBaseProtected;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypeProtectedOtherPackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePublicBasePackagePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePublicBasePrivate;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePublicBaseProtected;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePublicBasePublic;
+import org.axonframework.modelling.entity.annotation.inheritance.SubtypePublicOtherPackagePrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests the {@link AnnotatedEntityMetamodel} command handler inheritance behavior: when a subtype overrides a
+ * {@link org.axonframework.messaging.commandhandling.annotation.CommandHandler}-annotated method from a parent class,
+ * the subtype's handler must take priority and the parent handler must not be registered as a duplicate. The tests
+ * cover all combinations of method visibility (public, protected, package-private, private) in both the base class and
+ * the overriding subtype.
+ *
+ * @author Jakob Hatzl
+ */
+class AnnotatedEntityMetamodelCommandHandlerInheritanceTest {
+
+    /**
+     * Test that for all acceptable cases (supertype handler method visible to subtype) building the metamodel does not
+     * throw any error.
+     *
+     * @param entityType the entity type fixture to test
+     */
+    @ParameterizedTest
+    @ValueSource(classes = {
+            SubtypePublicBasePublic.class,
+            SubtypePublicBaseProtected.class,
+            SubtypeProtectedBaseProtected.class,
+            SubtypePublicBasePackagePrivate.class,
+            SubtypeProtectedBasePackagePrivate.class,
+            SubtypePackagePrivateBasePackagePrivate.class,
+    })
+    void buildingMetamodelDoesNotThrow(Class<?> entityType) {
+        MultiParameterResolverFactory parameterResolverFactory = new MultiParameterResolverFactory(
+                ClasspathParameterResolverFactory.forClass(
+                        getClass()),
+                new SimpleResourceParameterResolverFactory(Set.of())
+        );
+
+        assertThatCode(() -> AnnotatedEntityMetamodel.forConcreteType(
+                entityType,
+                parameterResolverFactory,
+                new ClassBasedMessageTypeResolver(),
+                new DelegatingMessageConverter(new JacksonConverter()),
+                new DelegatingEventConverter(new JacksonConverter())
+        )).doesNotThrowAnyException();
+    }
+
+    /**
+     * Test that for all invalid cases (supertype handler method not visible to subtype) building the metamodel does
+     * throw an error.
+     * <p>
+     * TODO enable when implementing <a href="https://github.com/AxonIQ/AxonFramework/issues/4561">#4561</a>
+     * @param entityType the entity type fixture to test
+     */
+    @ParameterizedTest
+    @ValueSource(classes = {
+            SubtypePublicOtherPackagePrivate.class,
+            SubtypePackagePrivateOtherPackagePrivate.class,
+            SubtypeProtectedOtherPackagePrivate.class,
+            SubtypePrivateOtherPackagePrivate.class,
+            SubtypePublicBasePrivate.class,
+            SubtypePackagePrivateBasePackagePrivate.class,
+            SubtypePackagePrivateOtherPrivate.class,
+            SubtypeProtectedBasePrivate.class,
+            SubtypePrivateBasePrivate.class
+    })
+    @Disabled("TODO enable with #4561 - currently not covered by AnnotatedEntityMetamodel#initializeDetectedHandlers")
+    void buildingMetamodelThrows(Class<?> entityType) {
+        MultiParameterResolverFactory parameterResolverFactory = new MultiParameterResolverFactory(
+                ClasspathParameterResolverFactory.forClass(
+                        getClass()),
+                new SimpleResourceParameterResolverFactory(Set.of())
+        );
+
+        assertThatThrownBy(() -> AnnotatedEntityMetamodel.forConcreteType(
+                entityType,
+                parameterResolverFactory,
+                new ClassBasedMessageTypeResolver(),
+                new DelegatingMessageConverter(new JacksonConverter()),
+                new DelegatingEventConverter(new JacksonConverter())
+        )).isInstanceOf(DuplicateCommandHandlerSubscriptionException.class);
+    }
+
+    /**
+     * Verifies override semantics when the subtype handler is {@code public} and the base handler it overrides is also
+     * {@code public}.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypePublicBasePublic
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypePublicBasePublic> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypePublicBasePublic> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypePublicBasePublic.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypePublicBasePublic();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypePublicBasePublic();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+
+
+    /**
+     * Verifies override semantics when the subtype handler is {@code public} and the base handler it overrides is
+     * {@code protected}.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypePublicBaseProtected
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypePublicBaseProtected> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypePublicBaseProtected> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypePublicBaseProtected.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypePublicBaseProtected();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypePublicBaseProtected();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+
+    /**
+     * Verifies override semantics when the subtype handler is {@code protected} and the base handler it overrides is
+     * also {@code protected}.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypeProtectedBaseProtected
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypeProtectedBaseProtected> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypeProtectedBaseProtected> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypeProtectedBaseProtected.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypeProtectedBaseProtected();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypeProtectedBaseProtected();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+
+    /**
+     * Verifies override semantics when the subtype handler is {@code public} and the base handler it overrides is
+     * package-private.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypePublicBasePackagePrivate
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypePublicBasePackagePrivate> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypePublicBasePackagePrivate> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypePublicBasePackagePrivate.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypePublicBasePackagePrivate();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypePublicBasePackagePrivate();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+
+    /**
+     * Verifies override semantics when the subtype handler is {@code protected} and the base handler it overrides is
+     * package-private.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypeProtectedBasePackagePrivate
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypeProtectedBasePackagePrivate> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypeProtectedBasePackagePrivate> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypeProtectedBasePackagePrivate.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypeProtectedBasePackagePrivate();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypeProtectedBasePackagePrivate();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+
+    /**
+     * Verifies override semantics when both the subtype handler and the base handler it overrides are package-private.
+     */
+    @Nested
+    class SubtypeOverridesForSubtypePackagePrivateBasePackagePrivate
+            extends AbstractAnnotatedEntityMetamodelTest<SubtypePackagePrivateBasePackagePrivate> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<SubtypePackagePrivateBasePackagePrivate> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(
+                    SubtypePackagePrivateBasePackagePrivate.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void subtypeHandlerIsInvoked() {
+            // given
+            entityState = new SubtypePackagePrivateBasePackagePrivate();
+
+            // when
+            dispatchInstanceCommand(new CreateTodoItem("id-1", "desc"));
+
+            // then — subtype sets description to a prefixed value, parent would set it plain
+            assertThat(entityState.getHandledBy()).isEqualTo("subtype");
+        }
+
+        @Test
+        void parentHandlerIsUsedForCommandsNotOverridden() {
+            // given
+            entityState = new SubtypePackagePrivateBasePackagePrivate();
+            dispatchInstanceCommand(new CreateTodoItem("af-5", "desc"));
+
+            // when
+            dispatchInstanceCommand(new FinishTodoItem("af-5"));
+
+            // then — FinishTodoItem is only handled by the parent; completed flag proves it ran
+            assertThat(entityState.isFinished()).isTrue();
+            assertThat(entityState.getHandledBy()).isEqualTo("parent");
+        }
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/Base.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/Base.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+/**
+ * Root entity fixture that holds common state fields ({@code id}, {@code handledBy},
+ * {@code finished}) used by all inheritance test fixtures. The {@code handledBy} field
+ * records which handler method was last invoked, allowing tests to assert whether the
+ * subtype or the parent handler ran.
+ */
+public class Base {
+
+    protected String id;
+    protected String handledBy = "none";
+    protected boolean finished;
+
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getHandledBy() {
+        return handledBy;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePackagePrivate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+/**
+ * Entity fixture that declares a {@link CommandHandler} method with package-private visibility. Used as a base class
+ * for subtype-override inheritance tests.
+ */
+public class BasePackagePrivate extends Base {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePrivate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+/**
+ * Entity fixture that declares a {@link CommandHandler} method with {@code private} visibility. Used as a base class
+ * for subtype-override inheritance tests.
+ */
+public class BasePrivate extends Base {
+
+    @CommandHandler
+    private void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BaseProtected.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BaseProtected.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+/**
+ * Entity fixture that declares a {@link CommandHandler} method with {@code protected} visibility. Used as a base class
+ * for subtype-override inheritance tests.
+ */
+public class BaseProtected extends Base {
+
+    @CommandHandler
+    protected void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePublic.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/BasePublic.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+/**
+ * Entity fixture that declares {@link CommandHandler} methods with {@code public} visibility. Used as a base class for
+ * subtype-override inheritance tests.
+ */
+public class BasePublic extends Base {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateBasePackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateBasePackagePrivate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code package-private} override of the package-private handler declared in
+ * {@link BasePackagePrivate}. Used by inheritance tests to verify that the subtype handler
+ * takes priority over the base class handler when both are annotated.
+ */
+public class SubtypePackagePrivateBasePackagePrivate extends BasePackagePrivate {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateBasePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateBasePrivate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code package-private} override of the private handler declared in {@link BasePrivate}. Used
+ * by inheritance tests to verify that the supertype handler is recognized as duplicate.
+ */
+public class SubtypePackagePrivateBasePrivate extends BasePrivate {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateOtherPackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateOtherPackagePrivate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.other.OtherPackagePrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code package-private} override of the private handler declared in
+ * {@link OtherPackagePrivate}. Used by inheritance tests to verify that the supertype handler is recognized as
+ * duplicate.
+ */
+public class SubtypePackagePrivateOtherPackagePrivate extends OtherPackagePrivate {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateOtherPrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePackagePrivateOtherPrivate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.other.OtherPrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code package-private} override of the private handler declared in {@link OtherPrivate}. Used
+ * by inheritance tests to verify that the supertype handler is recognized as duplicate.
+ */
+public class SubtypePackagePrivateOtherPrivate extends OtherPrivate {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePrivateBasePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePrivateBasePrivate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code private} override of the private handler declared in {@link BasePrivate}. Used by
+ * inheritance tests to verify that the supertype handler is recognized as duplicate.
+ */
+public class SubtypePrivateBasePrivate extends BasePrivate {
+
+    @CommandHandler
+    private void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePrivateOtherPackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePrivateOtherPackagePrivate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.other.OtherPackagePrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code private} override of the package-private handler declared in
+ * {@link OtherPackagePrivate}. Used by inheritance tests to verify that the supertype handler is recognized as
+ * duplicate.
+ */
+public class SubtypePrivateOtherPackagePrivate extends OtherPackagePrivate {
+
+    @CommandHandler
+    private void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBasePackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBasePackagePrivate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code protected} override of the package-private handler declared in
+ * {@link BasePackagePrivate}. Used by inheritance tests to verify that the subtype handler takes priority over the base
+ * class handler when both are annotated.
+ */
+public class SubtypeProtectedBasePackagePrivate extends BasePackagePrivate {
+
+    @CommandHandler
+    protected void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBasePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBasePrivate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code protected} override of the private handler declared in {@link BasePrivate}. Used by
+ * inheritance tests to verify that the supertype handler is recognized as duplicate.
+ */
+public class SubtypeProtectedBasePrivate extends BasePrivate {
+
+    @CommandHandler
+    protected void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBaseProtected.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedBaseProtected.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code protected} override of the protected handler declared in {@link BaseProtected}. Used by
+ * inheritance tests to verify that the subtype handler takes priority over the base class handler when both are
+ * annotated.
+ */
+public class SubtypeProtectedBaseProtected extends BaseProtected {
+
+    @CommandHandler
+    protected void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedOtherPackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypeProtectedOtherPackagePrivate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.other.OtherPackagePrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code protected} override of the package-private handler declared in
+ * {@link OtherPackagePrivate}. Used by inheritance tests to verify that the supertype handler is recognized as
+ * duplicate.
+ */
+public class SubtypeProtectedOtherPackagePrivate extends OtherPackagePrivate {
+
+    @CommandHandler
+    protected void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePackagePrivate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code public} override of the package-private handler declared in
+ * {@link BasePackagePrivate}. Used by inheritance tests to verify that the subtype handler
+ * takes priority over the base class handler when both are annotated.
+ */
+public class SubtypePublicBasePackagePrivate extends BasePackagePrivate {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePrivate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code public} handler alongside the {@code private} handler declared in {@link BasePrivate}.
+ * Used by inheritance tests to verify that the supertype handler is recognized as duplicate.
+ */
+public class SubtypePublicBasePrivate extends BasePrivate {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBaseProtected.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBaseProtected.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code public} override of the {@code protected} handler declared in {@link BaseProtected}.
+ * Used by inheritance tests to verify that the subtype handler takes priority over the base class handler when both are
+ * annotated.
+ */
+public class SubtypePublicBaseProtected extends BaseProtected {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePublic.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicBasePublic.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code public} override of the {@code public} handler declared in {@link BasePublic}. Used by
+ * inheritance tests to verify that the subtype handler takes priority over the base class handler when both are
+ * annotated.
+ */
+public class SubtypePublicBasePublic extends BasePublic {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicOtherPackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/SubtypePublicOtherPackagePrivate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.other.OtherPackagePrivate;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+
+/**
+ * Subtype fixture with a {@code public} handler alongside the {@code package-private} handler declared in
+ * {@link OtherPackagePrivate}. Used by inheritance tests to verify that the supertype handler is recognized as
+ * duplicate.
+ */
+public class SubtypePublicOtherPackagePrivate extends OtherPackagePrivate {
+
+    @CommandHandler
+    public void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "subtype";
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/other/OtherPackagePrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/other/OtherPackagePrivate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance.other;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.Base;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+public class OtherPackagePrivate extends Base {
+
+    @CommandHandler
+    void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/other/OtherPrivate.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/inheritance/other/OtherPrivate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation.inheritance.other;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.modelling.entity.annotation.inheritance.Base;
+import org.axonframework.modelling.entity.domain.todo.commands.CreateTodoItem;
+import org.axonframework.modelling.entity.domain.todo.commands.FinishTodoItem;
+
+public class OtherPrivate extends Base {
+
+    @CommandHandler
+    private void handle(CreateTodoItem command) {
+        this.id = command.id();
+        this.handledBy = "parent";
+    }
+
+    @CommandHandler
+    public void handle(FinishTodoItem command) {
+        this.finished = true;
+        this.handledBy = "parent";
+    }
+
+}


### PR DESCRIPTION
This PR fixes the condition discovered in #3934 (a subtype overriding and annotated command handler in a supertype) for the `AnnotatedEntityMetamodel` in the same way as it was already fixed for the `AnnotatedCommandHandlingComponent` 

When a concrete Entity type overrides a `@CommandHandler` annotated method from a superclass, the framework throws a `DuplicateCommandHandlerSubscriptionException` during handler detection, because the fix implemented in the previous PR #3933 only covered the condition for `AnnotatedCommandHandlingComponent` but not for the `AnnotatedEntityMetamodel`. The `AnnotatedEntityMetamodel` however is an entirely separate registration pipeline and needed to be covered explicitly. 

This PR adjusts handler detection in the `AnnotatedEntityMetamodel` so that it works analogous to how the `AnnotatedCommandHandlingComponent` works - using `org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector#getUniqueHandlers` during detection which deduplicates detected handler methods by method signature.

The new `AnnotatedEntityMetamodelCommandHandlerInheritanceTest` adds regression test cases for all valid inheritance scenarios:

Base Class Method access modifier | Subtype Class Method access modifier | Result
-- | -- | --
public | public | subtype method overrides – no error
public | protected | invalid (weaker access privileges)
public | package private* | invalid (weaker access privileges)
public | package private** | invalid (weaker access privileges)
public | private | invalid (weaker access privileges)
protected | public | subtype method overrides – no error (same as public – public)
protected | protected | subtype method overrides – no error (same as public – public)
protected | package private* | invalid (weaker access privileges)
protected | package private** | invalid (weaker access privileges)
protected | private | invalid (weaker access privileges)
package private* | public | subtype method overrides – no error (same as public – public)
package private* | protected | subtype method overrides – no error (same as public – public)
package private* | package private | subtype method overrides – no error (same as public – public)
package private* | private | invalid (weaker access privileges)
package private** | public | reject as duplicate handler
package private** | package private | reject as duplicate handler
package private** | protected | reject as duplicate handler
package private** | private | reject as duplicate handler
private | public | reject as duplicate handler
private | package private* | reject as duplicate handler
private | package private** | reject as duplicate handler
private | protected | reject as duplicate handler
private | private | reject as duplicate handler

`* = within same package`
`** = in different package`

The PR does not yet cover rejecting those cases as duplicate handlers, where the access modifier in the supertype makes the method invisible for the subtype (test exists but is disable for now). In those cases the supertype handler might get called, but that most probably also affects the `AnnotatedCommandHandlingModule` / `AnnotatedEventHandlingModule` and `AnnotatedQueryHandlingModule` as well and should be solved in a follow-up PR. 
                                                                                                                                                                                                                                                                                                                   
fixes #3934