### PR TITLE
[#4544] Fix JDBC dead-letter claimable sequence paging

### DIFF
--- a/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
+++ b/messaging/src/main/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactory.java
@@ -341,7 +341,6 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
         String sql = "SELECT * "
                 + "FROM " + schema.deadLetterTable() + " dl "
                 + "WHERE dl." + schema.processingGroupColumn() + "=? "
-                + "AND dl." + schema.sequenceIndexColumn() + ">=? "
                 + "AND dl." + schema.sequenceIndexColumn() + "="
                 + "("
                 + "SELECT MIN(dl2." + schema.sequenceIndexColumn() + ") "
@@ -355,15 +354,16 @@ public class DefaultDeadLetterStatementFactory<E extends EventMessage<?>> implem
                 + ") "
                 + "ORDER BY dl." + schema.lastTouchedColumn() + " "
                 + "ASC "
-                + "LIMIT ?";
+                + "LIMIT ? "
+                + "OFFSET ?";
 
         PreparedStatement statement =
                 connection.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 
         statement.setString(1, processingGroup);
-        statement.setInt(2, offset);
-        statement.setString(3, DateTimeUtils.formatInstant(processingStartedLimit));
-        statement.setInt(4, maxSize);
+        statement.setString(2, DateTimeUtils.formatInstant(processingStartedLimit));
+        statement.setInt(3, maxSize);
+        statement.setInt(4, offset);
         return statement;
     }
 

--- a/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactoryTest.java
+++ b/messaging/src/test/java/org/axonframework/eventhandling/deadletter/jdbc/DefaultDeadLetterStatementFactoryTest.java
@@ -18,9 +18,20 @@ package org.axonframework.eventhandling.deadletter.jdbc;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.serialization.TestSerializer;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Instant;
+
+import static org.axonframework.common.DateTimeUtils.formatInstant;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class validating the {@link DefaultDeadLetterStatementFactory}.
@@ -66,5 +77,45 @@ class DefaultDeadLetterStatementFactoryTest {
                                                  .genericSerializer(TestSerializer.JACKSON.getSerializer());
 
         assertThrows(AxonConfigurationException.class, testBuilder::build);
+    }
+
+    @Test
+    void claimableSequencesStatementUsesSqlOffsetPagingOnOrderedSequenceHeads() throws Exception {
+        DefaultDeadLetterStatementFactory<?> testSubject = DefaultDeadLetterStatementFactory.builder()
+                .genericSerializer(TestSerializer.JACKSON.getSerializer())
+                .eventSerializer(TestSerializer.JACKSON.getSerializer())
+                .build();
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(anyString(), eq(ResultSet.TYPE_FORWARD_ONLY), eq(ResultSet.CONCUR_READ_ONLY)))
+                .thenReturn(statement);
+
+        Instant processingStartedLimit = Instant.parse("2026-05-08T00:00:00Z");
+        testSubject.claimableSequencesStatement(connection, "processing-group", processingStartedLimit, 20, 10);
+
+        String expectedSql = "SELECT * "
+                + "FROM DeadLetterEntry dl "
+                + "WHERE dl.processingGroup=? "
+                + "AND dl.sequenceIndex="
+                + "("
+                + "SELECT MIN(dl2.sequenceIndex) "
+                + "FROM DeadLetterEntry dl2 "
+                + "WHERE dl2.processingGroup=dl.processingGroup "
+                + "AND dl2.sequenceIdentifier=dl.sequenceIdentifier"
+                + ") "
+                + "AND ("
+                + "dl.processingStarted IS NULL "
+                + "OR dl.processingStarted<?"
+                + ") "
+                + "ORDER BY dl.lastTouched "
+                + "ASC "
+                + "LIMIT ? "
+                + "OFFSET ?";
+
+        verify(connection).prepareStatement(expectedSql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        verify(statement).setString(1, "processing-group");
+        verify(statement).setString(2, formatInstant(processingStartedLimit));
+        verify(statement).setInt(3, 10);
+        verify(statement).setInt(4, 20);
     }
 }


### PR DESCRIPTION
## Summary
- align JDBC claimable sequence paging with the JPA dead-letter queue semantics
- page the ordered sequence-head result set instead of using sequenceIndex as the paging boundary
- add a focused statement-factory test covering SQL shape and parameter order

## Details
The JDBC implementation used the paging offset as `sequenceIndex >= ?` while also ordering by `lastTouched ASC`. Since `sequenceIndex` is sequence-local, that paging boundary can skip eligible sequence heads on later pages.

This change keeps the existing sequence-head and processing-started filters, but pages the ordered result set directly through SQL `LIMIT ? OFFSET ?` semantics.

## Testing
- added `DefaultDeadLetterStatementFactoryTest.claimableSequencesStatementUsesSqlOffsetPagingOnOrderedSequenceHeads`
- local Maven execution was blocked in my environment by repository mirror resolution failures