### PR TITLE
Revert accidental 4060 docs commits from main

### DIFF
--- a/docs/getting-started/antora.yml
+++ b/docs/getting-started/antora.yml
@@ -10,4 +10,4 @@ asciidoc:
     group: beginner
 
 nav:
-  - modules/nav.adoc
+  - modules/ROOT/nav.adoc

--- a/docs/getting-started/modules/ROOT/nav.adoc
+++ b/docs/getting-started/modules/ROOT/nav.adoc
@@ -2,6 +2,7 @@
 * xref:sample-domain-event-modeling.adoc[]
 * xref:project-structure.adoc[]
 * xref:implement-command-create-course.adoc[]
+* xref:implement-command-entity-approach.adoc[]
 * xref:implement-command-subscribe-student.adoc[]
 * xref:configure-axon-server.adoc[]
 * xref:implement-stateless-event-handler.adoc[]

--- a/docs/reference-guide/modules/commands/pages/command-handlers.adoc
+++ b/docs/reference-guide/modules/commands/pages/command-handlers.adoc
@@ -6,6 +6,20 @@ Command handlers can be either stateless or stateful, depending on whether they 
 
 This page explains how to define command handlers, handle commands, and work with the key concepts like `ProcessingContext`, `EventAppender`, and message types.
 
+In Axon Framework 5, commands are the primary driver of all state changes.
+A command handler decides whether a requested change is valid and applies it by updating the state directly or by appending events to a log.
+
+Some commands need no prior state: they validate the request on its own terms and apply the change.
+Others require checking what happened before.
+A bank account command needs the current balance; a course enrollment command needs the current student count.
+When a command needs prior state, one approach is to load an *entity*: a class that holds the relevant fields and enforces the business rules for that command.
+
+An entity is an implementation choice, not an architectural requirement.
+A command handler that needs no prior state requires no entity.
+This is why entities are documented under commands: they exist to serve commands, not as a concept of their own.
+
+For full documentation on event-sourced entities, state-stored entities, entity hierarchies, and polymorphism, see xref:commands:entities/index.adoc[Entities].
+
 [TIP]
 .Annotating command messages
 ====
@@ -80,7 +94,7 @@ public class GiftCardBulkOperationsHandler {
 
 <2> State is accessed through injected services, not maintained in the handler itself.
 
-<3> Each command invocation is independent—no instance state is maintained between calls.
+<3> Each command invocation is independent: no instance state is maintained between calls.
 
 <4> Commands change the conceptual state of the system (reserving stock, issuing cards).
 
@@ -187,8 +201,12 @@ The task of finding the entity identifier is performed by the `EntityIdResolver`
 The `AnnotatedEntityIdResolver` in turn checks for the existence of an `@TargetEntityId` annotated field or getter on the command.
 
 <5> Instance handlers have access to current state for decision-making.
+This state was built up by replaying past events via the `@EventSourcingHandler` methods.
 
-<6> The entity creator of the event-sourced entity, as described in more detail <<Entity creation with `@EntityCreator`,here>>. A no-arg constructor in this example.
+<6> The `@EntityCreator` constructor tells Axon how to create an empty entity instance before replaying events.
+See xref:commands:command-handlers.adoc#entity-creation-with-entitycreator[Entity creation with `@EntityCreator`] for all three creation patterns.
+
+For a full guide to event-sourced and state-stored entities (including configuration, snapshots, and child entities), see xref:commands:entities/index.adoc[Entities].
 
 [#_command_centric_stateful_handlers]
 === Command-centric command handlers
@@ -263,7 +281,7 @@ public class GiftCardCommandHandlers {
 
 <1> Command handlers are defined in a separate component (not on the entity itself).
 
-<2> Creational handlers don't receive an entity parameter—they create the entity through publication of the first event.
+<2> Creational handlers don't receive an entity parameter: they create the entity through publication of the first event.
 
 <3> Instance handler receives entities when the parameter is annotated with `@InjectEntity`.
 Axon automatically loads it based on the command's routing key.
@@ -324,7 +342,7 @@ public class GiftCard {
 <2> Events are appended to create and initialize the entity.
 The entity instance itself doesn't need to be created or returned by the handler.
 
-<3> The method can return whatever value makes sense for the caller—typically the entity identifier, but could be any result type.
+<3> The method can return whatever value makes sense for the caller, typically the entity identifier, but could be any result type.
 
 <4> The entity creator of the event-sourced entity, as described in more detail <<Entity creation with `@EntityCreator`,here>>. A no-arg constructor in this example.
 
@@ -361,6 +379,7 @@ The task of finding the entity identifier is performed by the `EntityIdResolver`
 
 The framework automatically loads the correct instance based on the command's routing key before invoking the handler.
 
+[#entity-creation-with-entitycreator]
 === Entity creation with `@EntityCreator`
 
 In event sourcing, events are used to reconstruct the state of an entity.
@@ -504,29 +523,8 @@ Both annotations work together in the entity lifecycle, but serve distinct purpo
 
 === Polymorphic entities
 
-Axon Framework allows for polymorphism in your entities when desired.
-Please check out the following example that shows how to construct a polymorphic entity:
-
-[source,java]
-----
-@EventSourcedEntity(concreteTypes = {StandardCard.class, PremiumCard.class}) // <1>
-public abstract class GiftCard {
-
-    @EntityCreator // <2>
-    public static GiftCard create(@InjectEntityId CardId id) {
-        if (id.type() == CardType.STANDARD) {
-            return new StandardCard(id);
-        } else {
-            return new PremiumCard(id);
-        }
-    }
-}
-----
-
-<1> The base or parent class is on purpose made abstract, to signal it is not the concrete entity type.
-Furthermore, the `@EventSourcedEntity` (or `@EventSourced` for Spring environments) annotation specifies the concrete types of the entity through the `concreteTypes` field.
-
-<2> Static factory method with `@EntityCreator` can return different subtypes based on the identifier.
+Axon Framework supports polymorphic entity hierarchies where the concrete type is determined at creation time.
+See xref:commands:entities/entity-polymorphism.adoc[Polymorphic Entities] for a full guide including configuration, constraints, and plain Java setup.
 
 == Command message types
 
@@ -590,7 +588,7 @@ public void handle(IssueCardDto dto) {
 ----
 
 The framework uses `Converters` to transform the payload to match the handler's parameter type.
-This eliminates many use cases for upcasters—simple type conversions happen during handling rather than requiring explicit upcasting logic.
+This eliminates many use cases for upcasters: simple type conversions happen during handling rather than requiring explicit upcasting logic.
 
 [NOTE]
 ====
@@ -684,7 +682,7 @@ If yes, they publish events.
 If not, they throw an exception, ignore the command, or publish entirely different events,depending on business requirements.
 
 * **Event sourcing handlers** apply state changes based on events.
-They must *never* contain business logic—only state updates.
+They must *never* contain business logic, only state updates.
 
 State changes should *never* occur in command handling functions.
 Event sourcing handlers should be the only methods where state is updated.
@@ -835,7 +833,7 @@ By specifying the `idProperty` attributes on `@InjectEntity` annotated parameter
 **Alternative: Manual loading with repository**
 
 If you have a different way of loading required state (for example, from a custom data source or with special loading logic), you can manually load entities using the repository.
-However, this is effectively the same as a stateless command handler—you're just using services to access state:
+However, this is effectively the same as a stateless command handler: you're just using services to access state:
 
 [source,java]
 ----
@@ -892,6 +890,39 @@ public class GiftCardCustomLoadingHandler {
 <6> Both load operations extract their entities, so `thenCombine()` receives the actual `GiftCard` instances directly.
 
 <7> Return `null` since the command handler return type is `CompletableFuture<Void>`.
+
+== Dispatching commands from within a command handler
+
+A command handler can dispatch further commands as part of its processing.
+The typical use case is creating a new entity as a side effect of handling a command on an existing one.
+
+Declare `CommandDispatcher` as a handler method parameter and Axon injects a context-scoped instance automatically:
+
+[source,java]
+----
+import org.axonframework.messaging.commandhandling.gateway.CommandDispatcher;
+
+@CommandHandler
+public void handle(CompleteCourseCommand cmd,
+                   CommandDispatcher commandDispatcher, // <1>
+                   EventAppender eventAppender) {
+    eventAppender.append(new CourseCompletedEvent(courseId));
+
+    commandDispatcher.send(new CreateCertificatesCommand(courseId, enrolledStudents)); // <2>
+}
+----
+
+<1> Declaring `CommandDispatcher` as a parameter is sufficient.
+Axon injects a dispatcher bound to the current processing context.
+<2> `send` returns a `CommandResult` you can use to inspect the outcome.
+For fire-and-forget cases, the return value can be ignored.
+
+[NOTE]
+====
+If you are migrating from Axon Framework 4, this pattern covers the use case of `AggregateLifecycle.createNew()`.
+The behavior is different: `createNew()` ran within the same unit of work as the outer command and returned the new aggregate directly.
+Dispatching via `CommandDispatcher` runs in a separate unit of work with its own transaction, and returns a `CommandResult` rather than the created entity.
+====
 
 == Explicit command handler subscription
 
@@ -986,4 +1017,4 @@ Without Spring, you can register command handlers using the Configuration API:
     }
 ----
 
-For more details on configuration, see xref:configuration.adoc[].
+For more details on configuration, see xref:configuration.adoc[] and xref:commands:entities/event-sourced-entity.adoc#configuring-event-sourced-entities[configuring event-sourced entities].

--- a/docs/reference-guide/modules/commands/pages/entities/index.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/index.adoc
@@ -1,0 +1,102 @@
+= Entities
+:navtitle: Entities
+
+Entities are a tool for implementing stateful command handling in Axon Framework.
+They maintain state across command invocations and use that state to enforce business rules.
+
+== When to use entities
+
+Use an entity when a command needs to validate against state that was established by earlier commands.
+
+Examples:
+
+* "A course cannot accept more students than its capacity": the handler needs to know how many students are already enrolled.
+* "A bank account cannot go below zero": the handler needs the current balance.
+* "An order can only be cancelled if it has not yet shipped": the handler needs the order's current status.
+
+In each case, the command cannot make a correct decision without reading state that persists between invocations.
+An entity provides that state.
+
+== When not to use entities
+
+Do not use an entity when the command can be validated and executed without reading any prior state.
+
+Examples:
+
+* Sending a notification: no prior state needed, just execute.
+* Creating a new resource with a client-supplied identifier: no existing state to check.
+* Forwarding a command to an external system: the external system owns the state.
+
+These are *stateless command handlers*.
+They are simpler and cheaper to run.
+When you find yourself adding an entity only to hold a flag that is set once and never changes, that is a signal the command may not need an entity at all.
+
+== What entities are
+
+An entity is a domain object that reconstructs its current state from past events (event-sourced) or from a persistent store (state-stored), then applies the incoming command against that state.
+
+Entities are an _implementation pattern_, not a core framework concept.
+A command handler that needs no persistent state requires no entity.
+A command handler that needs state from multiple independent streams can source several entities simultaneously.
+See xref:commands:command-handlers.adoc[Command Handlers] for the full picture.
+
+== Storage strategies
+
+Axon Framework supports two ways of storing entity state:
+
+* **Event-sourced entities** derive their current state by replaying a sequence of past events stored in an event store.
+State is never stored directly; instead, events act as the source of truth.
+This is the recommended approach in most cases and the natural fit for CQRS with Event Sourcing.
++
+xref:commands:entities/event-sourced-entity.adoc[Read more about event-sourced entities →]
+
+* **State-stored entities** store their current state directly in a database (for example via JPA).
+State is persisted after each command, without relying on an event log for reconstruction.
+This is useful when event history is not required or when integrating with existing databases.
++
+xref:commands:entities/state-stored-entities.adoc[Read more about state-stored entities →]
+
+== Advanced entity patterns
+
+Beyond the two basic storage strategies, Axon supports:
+
+* **Entity hierarchies**: parent entities that contain child entities, each capable of handling commands and events.
+Useful when business logic must be partitioned within a single entity boundary.
++
+xref:commands:entities/entity-hierarchies.adoc[Read more about entity hierarchies →]
+
+* **Polymorphic entities**: entity hierarchies where the concrete type is determined at runtime.
+Useful when multiple specializations of an entity share common behavior.
++
+xref:commands:entities/entity-polymorphism.adoc[Read more about polymorphic entities →]
+
+== Choosing a strategy
+
+[cols="1,2,2",options="header"]
+|===
+| Concern | Event-sourced | State-stored
+
+| Audit trail
+| Built-in: every state change is an event
+| Must be added separately
+
+| Temporal queries
+| Full event history is retained; past state can be reconstructed by replaying events up to a given position
+| No history by default; requires audit tables or snapshots to support temporal queries
+
+| Write performance
+| Append-only: generally fast
+| Update in place: may cause lock contention
+
+| Read current state
+| Requires replaying the event stream to reconstruct current state
+| Current state is stored directly; no replay needed
+
+| Complexity
+| Higher: requires event design
+| Lower: familiar ORM patterns
+
+|===
+
+When in doubt, prefer event sourcing.
+It gives you the full audit trail, temporal query capability, and clean separation between commands and state that Axon Framework is designed around.

--- a/docs/reference-guide/modules/commands/partials/nav.adoc
+++ b/docs/reference-guide/modules/commands/partials/nav.adoc
@@ -2,12 +2,11 @@
 
 ** xref:commands:command-handlers.adoc[]
 ** xref:commands:command-dispatchers.adoc[]
-// TODO - Decide what to do with modeling section
-// ** xref:commands:modeling/aggregate.adoc[]
-// *** xref:commands:modeling/multi-entity-aggregates.adoc[]
-// *** xref:commands:modeling/state-stored-aggregates.adoc[]
-// *** xref:commands:modeling/aggregate-creation-from-another-aggregate.adoc[]
-// *** xref:commands:modeling/aggregate-polymorphism.adoc[]
+** xref:commands:entities/index.adoc[]
+*** xref:commands:entities/event-sourced-entity.adoc[]
+*** xref:commands:entities/state-stored-entities.adoc[]
+*** xref:commands:entities/entity-hierarchies.adoc[]
+*** xref:commands:entities/entity-polymorphism.adoc[]
 
 ** xref:commands:infrastructure.adoc[]
 ** xref:commands:configuration.adoc[]


### PR DESCRIPTION
## Summary

- Reverts commits `4b957dec13` through `4890379c0c` (7 commits tagged `4060`) that were accidentally pushed directly to `main`
- These changes belong on the `documentation/4060/docs` branch, which already contains them

## Test plan

- [ ] Verify `main` matches `98a675bfdf` after merge
- [ ] Verify `documentation/4060/docs` still contains all 4060 work intact