### PR TITLE
[#4546] Return failed futures from InMemoryTokenStore

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStore.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
@@ -99,21 +100,26 @@ public class InMemoryTokenStore implements TokenStore {
                                               int segmentId,
                                               @Nullable ProcessingContext context) {
         Objects.requireNonNull(context, "processingContext may not be null for an InMemoryTokenStore");
+        ProcessAndSegmentId key = new ProcessAndSegmentId(processorName, segmentId);
+        if (!tokens.containsKey(key)) {
+            return noSuchToken(processorName, segmentId);
+        }
         if (context.isStarted()) {
-            context.runOnAfterCommit(c -> updateToken(token, processorName, segmentId));
-        } else {
-            updateToken(token, processorName, segmentId);
+            context.runOnAfterCommit(c -> {
+                if (!updateToken(token, key)) {
+                    throw noSuchTokenException(processorName, segmentId);
+                }
+            });
+        } else if (!updateToken(token, key)) {
+            return noSuchToken(processorName, segmentId);
         }
         return FutureUtils.emptyCompletedFuture();
     }
 
-    private void updateToken(@Nullable TrackingToken token, String processorName, int segmentId) {
-        ProcessAndSegmentId key = new ProcessAndSegmentId(processorName, segmentId);
+    private boolean updateToken(@Nullable TrackingToken token, ProcessAndSegmentId key) {
         SegmentAndToken old = tokens.computeIfPresent(key, (ps, st) -> new SegmentAndToken(st.segment, token));
 
-        if (old == null) {
-            throw new UnableToClaimTokenException("No such token for processor '%s' and segment %d".formatted(processorName, segmentId));
-        }
+        return old != null;
     }
 
     @Override
@@ -122,8 +128,8 @@ public class InMemoryTokenStore implements TokenStore {
                                                        @Nullable ProcessingContext context) {
         SegmentAndToken st = tokens.get(new ProcessAndSegmentId(processorName, segmentId));
         if (st == null) {
-            throw new UnableToClaimTokenException(
-                    "No token was initialized for segment " + segmentId + " for processor " + processorName);
+            return failedFuture(new UnableToClaimTokenException(
+                    "No token was initialized for segment " + segmentId + " for processor " + processorName));
         } else if (NULL_TOKEN == st.trackingToken) {
             return FutureUtils.emptyCompletedFuture();
         }
@@ -158,7 +164,7 @@ public class InMemoryTokenStore implements TokenStore {
         SegmentAndToken previous = tokens.putIfAbsent(new ProcessAndSegmentId(processorName, segment.getSegmentId()),
                                                       new SegmentAndToken(segment, token == null ? NULL_TOKEN : token));
         if (previous != null) {
-            throw new UnableToInitializeTokenException("Token was already present");
+            return failedFuture(new UnableToInitializeTokenException("Token was already present"));
         }
         return completedFuture(null);
     }
@@ -189,6 +195,15 @@ public class InMemoryTokenStore implements TokenStore {
     @Override
     public CompletableFuture<String> retrieveStorageIdentifier(@Nullable ProcessingContext context) {
         return completedFuture(identifier);
+    }
+
+    private CompletableFuture<Void> noSuchToken(String processorName, int segmentId) {
+        return failedFuture(noSuchTokenException(processorName, segmentId));
+    }
+
+    private UnableToClaimTokenException noSuchTokenException(String processorName, int segmentId) {
+        return new UnableToClaimTokenException(
+                "No such token for processor '%s' and segment %d".formatted(processorName, segmentId));
     }
 
     private record SegmentAndToken(Segment segment, TrackingToken trackingToken) {}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStoreTest.java
@@ -18,12 +18,15 @@ package org.axonframework.messaging.eventhandling.processing.streaming.token.sto
 
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToClaimTokenException;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToInitializeTokenException;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.common.FutureUtils.joinAndUnwrap;
@@ -168,6 +171,64 @@ class InMemoryTokenStoreTest {
             final List<Segment> segments =
                     joinAndUnwrap(testSubject.fetchAvailableSegments("proc3", null));
             assertThat(segments.size(), is(0));
+        }
+    }
+
+    @Nested
+    class CompletableFutureFailures {
+
+        @Test
+        void fetchTokenForMissingSegmentReturnsFailedFuture() {
+            // when
+            CompletableFuture<TrackingToken> result = assertDoesNotThrow(
+                    () -> testSubject.fetchToken("test1", 1, null)
+            );
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThat(result.exceptionNow())
+                    .isInstanceOf(UnableToClaimTokenException.class)
+                    .hasMessageContaining("No token was initialized for segment 1 for processor test1");
+        }
+
+        @Test
+        void storeTokenForMissingSegmentReturnsFailedFuture() {
+            // when
+            CompletableFuture<Void> result = assertDoesNotThrow(
+                    () -> testSubject.storeToken(new GlobalSequenceTrackingToken(1),
+                                                 "test1",
+                                                 1,
+                                                 createProcessingContext())
+            );
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThat(result.exceptionNow())
+                    .isInstanceOf(UnableToClaimTokenException.class)
+                    .hasMessageContaining("No such token for processor 'test1' and segment 1");
+        }
+
+        @Test
+        void initializeSegmentForExistingSegmentReturnsFailedFuture() {
+            // given
+            joinAndUnwrap(testSubject.initializeSegment(null,
+                                                        "test1",
+                                                        Segment.ROOT_SEGMENT,
+                                                        createProcessingContext()));
+
+            // when
+            CompletableFuture<Void> result = assertDoesNotThrow(
+                    () -> testSubject.initializeSegment(null,
+                                                        "test1",
+                                                        Segment.ROOT_SEGMENT,
+                                                        createProcessingContext())
+            );
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThat(result.exceptionNow())
+                    .isInstanceOf(UnableToInitializeTokenException.class)
+                    .hasMessageContaining("Token was already present");
         }
     }
 


### PR DESCRIPTION

Fixes InMemoryTokenStore to follow the CompletableFuture contract by returning failed futures instead of throwing synchronously when token operations fail.

This updates:

fetchToken for missing initialized tokens.
storeToken for missing segments.
initializeSegment for already initialized segments.
Fixes #4546