### PR TITLE
[#4425] Align test naming with Maven surefire/failsafe defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,8 @@ Maven wrapper is used (`./mvnw`). Key commands:
     - Do not add @DisplayName for test methods, try to make method names self-explanatory and add meaningful comments in given-when-then sections if needed
 
 Test naming conventions:
-- **Unit tests** (Surefire): `*Test.java`, `*Tests.java`, `*Test_*.java`, `*Tests_*.java`
-- **Integration tests** (Failsafe): `*IntegrationTest.java`, `*IntegrationTests.java`, `IT*.java`, `*IT.java`, `*ITCase.java`
+- **Unit tests** (Surefire): `*Test.java`, `*Tests.java`, `*TestCase.java`, `Test*.java`
+- **Integration tests** (Failsafe): `*IT.java`, `IT*.java`, `*ITCase.java`
 
 ## Module Dependency Hierarchy
 

--- a/build/parent/pom.xml
+++ b/build/parent/pom.xml
@@ -573,18 +573,7 @@
                         <log4j.version>${log4j.version}</log4j.version>
                         <test.forkNumber>$${surefire.forkNumber}</test.forkNumber>
                     </systemPropertyVariables>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test_*.java</include>
-                        <include>**/*Tests_*.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*IntegrationTest.java</exclude>
-                        <exclude>**/*IntegrationTests.java</exclude>
-                        <exclude>**/*IntegrationTest_*.java</exclude>
-                        <exclude>**/*IntegrationTests_*.java</exclude>
-                    </excludes>
+
                 </configuration>
             </plugin>
             <!-- package -->
@@ -705,22 +694,7 @@
                                     <systemPropertyVariables>
                                         <test.forkNumber>${surefire.forkNumber}</test.forkNumber>
                                     </systemPropertyVariables>
-                                    <includes>
-                                        <include>**/*IntegrationTest.java</include>
-                                        <include>**/*IntegrationTests.java</include>
-                                        <include>**/*IntegrationTest_*.java</include>
-                                        <include>**/*IntegrationTests_*.java</include>
-                                        <!-- these are the defaults -->
-                                        <include>**/IT*.java</include>
-                                        <include>**/*IT.java</include>
-                                        <include>**/*ITCase.java</include>
-                                    </includes>
-                                    <excludes>
-                                        <exclude>**/*Test.java</exclude>
-                                        <exclude>**/*Tests.java</exclude>
-                                        <exclude>**/*Test_*.java</exclude>
-                                        <exclude>**/*Tests_*.java</exclude>
-                                    </excludes>
+
                                 </configuration>
                             </execution>
 

--- a/examples/university-java-springboot-3/src/test/java/org/axonframework/examples/university/UniversityTestApplicationIT.java
+++ b/examples/university-java-springboot-3/src/test/java/org/axonframework/examples/university/UniversityTestApplicationIT.java
@@ -27,7 +27,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class UniversityTestApplicationITest {
+class UniversityTestApplicationIT {
 
     @Container
     private static final AxonServerContainer axonServer = new AxonServerContainer()
@@ -39,24 +39,23 @@ class UniversityTestApplicationITest {
     @SpringBootTest(classes = UniversityExampleApplication.class)
     @ActiveProfiles("itest")
     class DefaultTests {
-
-        @DynamicPropertySource
-        static void datasourceProperties(DynamicPropertyRegistry registry) {
-            registry.add("axon.axonserver.servers", axonServer::getAxonServerAddress);
-        }
-
-        @BeforeAll
-        static void setContextUp() throws Exception {
-            // Mainly needed to create DBC context now:
-            AxonServerContainerUtils.purgeEventsFromAxonServer(axonServer.getHost(),
-                                                               axonServer.getHttpPort(),
-                                                               "default",
-                                                               AxonServerContainerUtils.DCB_CONTEXT);
-        }
-
-        @Test
-        void applicationStarts() {
-            // just run
-        }
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+      registry.add("axon.axonserver.servers", axonServer::getAxonServerAddress);
     }
+
+    @BeforeAll
+    static void setContextUp() throws Exception {
+      // Mainly needed to create DBC context now:
+      AxonServerContainerUtils.purgeEventsFromAxonServer(axonServer.getHost(),
+                                                         axonServer.getHttpPort(),
+                                                         "default",
+                                                         AxonServerContainerUtils.DCB_CONTEXT);
+    }
+
+    @Test
+    void applicationStarts() {
+      // just run
+    }
+  }
 }

--- a/examples/university-java-springboot-4/src/test/java/org/axonframework/examples/university/UniversityTestApplicationIT.java
+++ b/examples/university-java-springboot-4/src/test/java/org/axonframework/examples/university/UniversityTestApplicationIT.java
@@ -27,7 +27,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-class UniversityTestApplicationITest {
+class UniversityTestApplicationIT {
 
     @Container
     private static final AxonServerContainer axonServer = new AxonServerContainer()
@@ -39,23 +39,24 @@ class UniversityTestApplicationITest {
     @SpringBootTest(classes = UniversityExampleApplication.class)
     @ActiveProfiles("itest")
     class DefaultTests {
-    @DynamicPropertySource
-    static void datasourceProperties(DynamicPropertyRegistry registry) {
-      registry.add("axon.axonserver.servers", axonServer::getAxonServerAddress);
-    }
 
-    @BeforeAll
-    static void setContextUp() throws Exception {
-      // Mainly needed to create DBC context now:
-      AxonServerContainerUtils.purgeEventsFromAxonServer(axonServer.getHost(),
-                                                         axonServer.getHttpPort(),
-                                                         "default",
-                                                         AxonServerContainerUtils.DCB_CONTEXT);
-    }
+        @DynamicPropertySource
+        static void datasourceProperties(DynamicPropertyRegistry registry) {
+            registry.add("axon.axonserver.servers", axonServer::getAxonServerAddress);
+        }
 
-    @Test
-    void applicationStarts() {
-      // just run
+        @BeforeAll
+        static void setContextUp() throws Exception {
+            // Mainly needed to create DBC context now:
+            AxonServerContainerUtils.purgeEventsFromAxonServer(axonServer.getHost(),
+                                                               axonServer.getHttpPort(),
+                                                               "default",
+                                                               AxonServerContainerUtils.DCB_CONTEXT);
+        }
+
+        @Test
+        void applicationStarts() {
+            // just run
+        }
     }
-  }
 }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/AbstractIT.java
@@ -42,7 +42,7 @@ import java.util.UUID;
  * @since 5.1.0
  */
 @Internal
-public abstract class AbstractIntegrationTest {
+public abstract class AbstractIT {
 
     protected CommandGateway commandGateway;
     protected AxonConfiguration startedConfiguration;

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
@@ -18,7 +18,7 @@ package org.axonframework.integrationtests.testsuite.administration;
 
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
-import org.axonframework.integrationtests.testsuite.AbstractIntegrationTest;
+import org.axonframework.integrationtests.testsuite.AbstractIT;
 import org.axonframework.integrationtests.testsuite.administration.commands.AssignTaskCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.ChangeEmailAddress;
 import org.axonframework.integrationtests.testsuite.administration.commands.CompleteTaskCommand;
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  * Test suite for verifying polymorphic behavior of entities. Can be implemented by different test classes that verify
  * different ways of building the {@link org.axonframework.modelling.entity.EntityCommandHandlingComponent}.
  */
-public abstract class AbstractAdministrationIT extends AbstractIntegrationTest {
+public abstract class AbstractAdministrationIT extends AbstractIT {
 
     private final CreateEmployee CREATE_EMPLOYEE_1_COMMAND = new CreateEmployee(
             new PersonIdentifier(PersonType.EMPLOYEE, createId("employee")),

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/course/SealedClassCourseIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/course/SealedClassCourseIT.java
@@ -19,7 +19,7 @@ package org.axonframework.integrationtests.testsuite.course;
 import org.axonframework.common.configuration.ApplicationConfigurer;
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
-import org.axonframework.integrationtests.testsuite.AbstractIntegrationTest;
+import org.axonframework.integrationtests.testsuite.AbstractIT;
 import org.axonframework.integrationtests.testsuite.course.commands.CreateCourse;
 import org.axonframework.integrationtests.testsuite.course.commands.PublishCourse;
 import org.axonframework.integrationtests.testsuite.course.module.SealedClassCourseCommandHandlers;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public abstract class SealedClassCourseIT extends AbstractIntegrationTest {
+public abstract class SealedClassCourseIT extends AbstractIT {
 
     protected UnitOfWorkFactory unitOfWorkFactory;
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
@@ -27,7 +27,7 @@ import org.axonframework.common.configuration.ComponentRegistry;
  * <p>
  * Data "purging" is a no-op: each test shuts down and recreates the
  * {@link org.axonframework.common.configuration.AxonConfiguration} via
- * {@link org.axonframework.integrationtests.testsuite.AbstractIntegrationTest#startApp()}, so the in-memory stores
+ * {@link org.axonframework.integrationtests.testsuite.AbstractIT#startApp()}, so the in-memory stores
  * are always fresh at the start of every test.
  * <p>
  * Leaf test classes should hold a {@code private static final} instance of this class:

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/TestInfrastructure.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/TestInfrastructure.java
@@ -24,7 +24,7 @@ import org.axonframework.common.configuration.ComponentRegistry;
  * AxonServer via Testcontainers, pure in-memory, JDBC, etc.).
  * <p>
  * An implementation is provided by each concrete leaf test class via
- * {@link org.axonframework.integrationtests.testsuite.AbstractIntegrationTest#testInfrastructure()}. Leaf classes
+ * {@link org.axonframework.integrationtests.testsuite.AbstractIT#testInfrastructure()}. Leaf classes
  * typically return a {@code private static final} singleton, so {@link #start()} and {@link #stop()} are guaranteed to
  * receive the same object across test methods.
  *
@@ -50,7 +50,7 @@ public interface TestInfrastructure {
 
     /**
      * Purge persisted data so the next test starts with a clean slate. Opt-in — only tests that require a clean
-     * initial state need to call {@link org.axonframework.integrationtests.testsuite.AbstractIntegrationTest#purgeData()}.
+     * initial state need to call {@link org.axonframework.integrationtests.testsuite.AbstractIT#purgeData()}.
      * <p>
      * For in-memory backends this is typically a no-op because the configuration is recreated per test anyway.
      */

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/AbstractStudentIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/AbstractStudentIT.java
@@ -22,7 +22,7 @@ import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
-import org.axonframework.integrationtests.testsuite.AbstractIntegrationTest;
+import org.axonframework.integrationtests.testsuite.AbstractIT;
 import org.axonframework.integrationtests.testsuite.student.events.StudentEnrolledEvent;
 import org.axonframework.integrationtests.testsuite.student.state.Course;
 import org.axonframework.integrationtests.testsuite.student.state.Student;
@@ -55,7 +55,7 @@ import java.util.Objects;
  * @author Mitchell Herrijgers
  * @author Steven van Beelen
  */
-public abstract class AbstractStudentIT extends AbstractIntegrationTest {
+public abstract class AbstractStudentIT extends AbstractIT {
 
     protected static final GenericCommandResultMessage SUCCESSFUL_COMMAND_RESULT =
             new GenericCommandResultMessage(new MessageType("empty"), "successful");

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureAnnotatedTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureAnnotatedTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Allard Buijze
  */
-class FixtureTest_Annotated {
+class FixtureAnnotatedTest {
 
     private static final String AGGREGATE_ID = "aggregateId";
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureCreationPolicyTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureCreationPolicyTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Marc Gathier
  * @author Steven van Beelen
  */
-class FixtureTest_CreationPolicy {
+class FixtureCreationPolicyTest {
 
     private static final ComplexAggregateId AGGREGATE_ID = new ComplexAggregateId(UUID.randomUUID(), 42);
     private static final boolean PUBLISH_EVENTS = true;

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureDeadlinesTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureDeadlinesTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.*;
  *
  * @author Milan Savic
  */
-class FixtureTest_Deadlines {
+class FixtureDeadlinesTest {
 
     private static final String AGGREGATE_ID = "id";
     private static final CreateMyAggregateCommand CREATE_COMMAND = new CreateMyAggregateCommand(AGGREGATE_ID);

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureExceptionHandlingTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureExceptionHandlingTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Patrick Haas
  */
-class FixtureTest_ExceptionHandling {
+class FixtureExceptionHandlingTest {
 
     private static final String AGGREGATE_ID = "1";
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureGenericTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureGenericTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.*;
 /**
  * @author Allard Buijze
  */
-class FixtureTest_Generic {
+class FixtureGenericTest {
 
     private FixtureConfiguration<StandardAggregate> fixture;
     private AggregateFactory<StandardAggregate> mockAggregateFactory;

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureHierarchyTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureHierarchyTest.java
@@ -33,7 +33,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
  *
  * @author Allard Buijze
  */
-class FixtureTest_Hierarchy {
+class FixtureHierarchyTest {
 
     private static final String AGGREGATE_IDENTIFIER = "123";
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureMarkDeletedTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureMarkDeletedTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * @author Jan-Hendrik Kuperus
  */
-class FixtureTest_MarkDeleted {
+class FixtureMarkDeletedTest {
 
     private FixtureConfiguration<AnnotatedAggregate> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureMatcherParamsTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureMatcherParamsTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.*;
  * @author Allard Buijze
  * @since 0.7
  */
-class FixtureTest_MatcherParams {
+class FixtureMatcherParamsTest {
 
     private FixtureConfiguration<StandardAggregate> fixture;
 
@@ -196,7 +196,7 @@ class FixtureTest_MatcherParams {
                         .expectEvents(new DoesMatch<List<? extends EventMessage>>())
         );
         assertTrue(e.getMessage().contains("The published events do not match the expected events"));
-        assertTrue(e.getMessage().contains("FixtureTest_MatcherParams$DoesMatch <|> "));
+        assertTrue(e.getMessage().contains("FixtureMatcherParamsTest$DoesMatch <|> "));
         assertTrue(e.getMessage().contains("probable cause"));
     }
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixturePolymorphismTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixturePolymorphismTest.java
@@ -42,7 +42,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.createNew;
  *
  * @author Milan Savic
  */
-class FixtureTest_Polymorphism {
+class FixturePolymorphismTest {
 
     private FixtureConfiguration<AggregateA> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureRegisteringMethodEnhancementsTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureRegisteringMethodEnhancementsTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author Steven van Beelen
  */
-public class FixtureTest_RegisteringMethodEnhancements {
+public class FixtureRegisteringMethodEnhancementsTest {
 
     private static final String TEST_AGGREGATE_IDENTIFIER = "aggregate-identifier";
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureRegularParamsTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureRegularParamsTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Allard Buijze
  * @since 0.7
  */
-class FixtureTest_RegularParams {
+class FixtureRegularParamsTest {
 
     private FixtureConfiguration<StandardAggregate> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureResourcesTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureResourcesTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.*;
 /**
  * @author Allard Buijze
  */
-class FixtureTest_Resources {
+class FixtureResourcesTest {
 
     private FixtureConfiguration<AggregateWithResources> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureScopeDescriptorTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureScopeDescriptorTest.java
@@ -33,7 +33,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
  *
  * @author Steven van Beelen
  */
-class FixtureTest_ScopeDescriptor {
+class FixtureScopeDescriptorTest {
 
     private FixtureConfiguration<TestAggregate> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureSpawningNewAggregateTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureSpawningNewAggregateTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
  * @author Milan Savic
  */
 @ExtendWith(MockitoExtension.class)
-class FixtureTest_SpawningNewAggregate {
+class FixtureSpawningNewAggregateTest {
 
     private FixtureConfiguration<Aggregate1> fixture;
 

--- a/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureStateStorageTest.java
+++ b/stash/legacy-aggregate/src/test/java/org/axonframework/test/aggregate/FixtureStateStorageTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Allard Buijze
  */
-class FixtureTest_StateStorage {
+class FixtureStateStorageTest {
 
     private static final String AGGREGATE_ID = "id";
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/springboot/SagaCustomizeIT.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/springboot/SagaCustomizeIT.java
@@ -59,7 +59,7 @@ import static org.awaitility.Awaitility.await;
 })
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 @Disabled("TODO #3097")
-class SagaCustomizeIntegrationTest {
+class SagaCustomizeIT {
 
     @Autowired
     private EventBus eventBus;

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureDeadlinesTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureDeadlinesTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.*;
  * @author Milan Savic
  * @author Steven van Beelen
  */
-class FixtureTest_Deadlines {
+class FixtureDeadlinesTest {
 
     private static final String AGGREGATE_ID = "id";
     private static final TriggerSagaStartEvent START_SAGA_EVENT = new TriggerSagaStartEvent(AGGREGATE_ID);

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Steven van Beelen
  */
 @Disabled("#3710 Reenable after ParameterResolver fix")
-public class FixtureTest_RegisteringMethodEnhancements {
+public class FixtureRegisteringMethodEnhancementsTest {
 
     private static final String TEST_AGGREGATE_IDENTIFIER = "aggregate-identifier";
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringSagaEnhancementsTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringSagaEnhancementsTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Steven van Beelen
  */
-class FixtureTest_RegisteringSagaEnhancements {
+class FixtureRegisteringSagaEnhancementsTest {
 
     private SagaTestFixture<SomeTestSaga> testSubject;
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureScheduledEventsTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureScheduledEventsTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
  *
  * @author Steven van Beelen
  */
-class FixtureTest_ScheduledEvents {
+class FixtureScheduledEventsTest {
 
     private static final String IDENTIFIER = UUID.randomUUID().toString();
     private static final Duration TRIGGER_DURATION_MINUTES = Duration.ofMinutes(10);

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureScopeDescriptorTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureScopeDescriptorTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.*;
  *
  * @author Steven van Beelen
  */
-class FixtureTest_ScopeDescriptor {
+class FixtureScopeDescriptorTest {
 
     private FixtureConfiguration fixture;
 

--- a/stash/todo/src/test/java/org/axonframework/integrationtests/cache/EhCacheIT.java
+++ b/stash/todo/src/test/java/org/axonframework/integrationtests/cache/EhCacheIT.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * @author Steven van Beelen
  */
 @Disabled("TODO #3727")
-class EhCacheIntegrationTest extends CachingIntegrationTestSuite {
+class EhCacheIT extends CachingIntegrationTestSuite {
 
     private CacheManager cacheManager;
 

--- a/stash/todo/src/test/java/org/axonframework/integrationtests/cache/JCacheIT.java
+++ b/stash/todo/src/test/java/org/axonframework/integrationtests/cache/JCacheIT.java
@@ -35,7 +35,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @author Gerard Klijs
  */
 @Disabled("TODO #3727")
-class JCacheIntegrationTest extends CachingIntegrationTestSuite {
+class JCacheIT extends CachingIntegrationTestSuite {
 
     private CacheManager cacheManager;
 

--- a/stash/todo/src/test/java/org/axonframework/integrationtests/cache/WeakReferenceCacheIT.java
+++ b/stash/todo/src/test/java/org/axonframework/integrationtests/cache/WeakReferenceCacheIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.*;
  * @author Steven van Beelen
  */
 @Disabled("TODO #3727")
-class WeakReferenceCacheIntegrationTest extends CachingIntegrationTestSuite {
+class WeakReferenceCacheIT extends CachingIntegrationTestSuite {
 
     @Override
     public Cache buildCache(String name) {

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/EventSourcingRepositoryIT.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/EventSourcingRepositoryIT.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.*;
 /**
  * @author Allard Buijze
  */
-public class EventSourcingRepositoryIntegrationTest implements Thread.UncaughtExceptionHandler {
+public class EventSourcingRepositoryIT implements Thread.UncaughtExceptionHandler {
 
     private static final int CONCURRENT_MODIFIERS = 10;
     private LegacyEventSourcingRepository<SimpleAggregateRoot> repository;

--- a/stash/todo/src/test/java/org/axonframework/spring/modeling/command/GenericJpaRepositoryIT.java
+++ b/stash/todo/src/test/java/org/axonframework/spring/modeling/command/GenericJpaRepositoryIT.java
@@ -69,10 +69,10 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
-@ContextConfiguration(classes = GenericJpaRepositoryIntegrationTest.TestContext.class)
+@ContextConfiguration(classes = GenericJpaRepositoryIT.TestContext.class)
 @Transactional
 @Disabled("State based aggregates are not supported") // FIXME #3499
-class GenericJpaRepositoryIntegrationTest implements EventMessageHandler {
+class GenericJpaRepositoryIT implements EventMessageHandler {
 
     private final List<EventMessage> capturedEvents = new ArrayList<>();
     @Autowired

--- a/stash/todo/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIT.java
+++ b/stash/todo/src/test/java/org/axonframework/springboot/PooledStreamingEventProcessorIT.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
  * @author Steven van Beelen
  */
 @Disabled("TODO #3495")
-class PooledStreamingEventProcessorIntegrationTest {
+class PooledStreamingEventProcessorIT {
 
     private ApplicationContextRunner testApplicationContext;
 


### PR DESCRIPTION
Remove custom <includes>/<excludes> from surefire and failsafe in build/parent/pom.xml, relying on Maven defaults instead:
- Surefire: *Test.java, *Tests.java, *TestCase.java, Test*.java
- Failsafe: *IT.java, IT*.java, *ITCase.java

Rename test files to match Maven defaults:
- 20x FixtureTest_*.java → Fixture*Test.java (stash/legacy-aggregate, stash/legacy-saga)
- 8x *IntegrationTest.java → *IT.java (integrationtests/, stash/)
- 2x *ITest.java → *IT.java (examples/)

Update cross-references: imports, extends clauses, Javadoc @link tags, and one string assertion that checked an inner class name.

Before and after: 612 tests run, 0 failures, confirming no tests were lost.

Resolves #4425