### PR TITLE
[#3310] Fix axon auto configuration with graceful shutdown test

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -191,6 +191,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Serializer dependencies -->
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -40,6 +41,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -85,6 +87,7 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
 
         // then
         assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).isNotNull();
         assertThat((String) entity.getBody().get("message")).contains("Shutting down");
     }
 
@@ -124,7 +127,9 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
 
         @Bean
         public TestRestTemplate testRestTemplate() {
-            return new TestRestTemplate();
+            return new TestRestTemplate(new RestTemplateBuilder()
+                                                .connectTimeout(Duration.ofSeconds(5))
+                                                .readTimeout(Duration.ofSeconds(5)));
         }
 
         @Component
@@ -155,7 +160,8 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
                 logger.info("GRACEFUL SHUTDOWN TEST | Before sleep...");
                 Thread.sleep(1000);
                 logger.info("GRACEFUL SHUTDOWN TEST | After sleep...");
-                var queryMessage = new GenericQueryMessage(new MessageType(new QualifiedName("dummy")), new DummyQuery());
+                var queryMessage = new GenericQueryMessage(new MessageType(new QualifiedName("dummy")),
+                                                           new DummyQuery());
                 try {
                     var resultOpt = queryGateway.query(queryMessage, DummyQueryResponse.class, null);
                     var result = resultOpt.get(1, TimeUnit.SECONDS);

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
@@ -17,6 +17,9 @@
 package org.axonframework.extension.springboot;
 
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.queryhandling.GenericQueryMessage;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
 import org.junit.jupiter.api.*;
@@ -127,7 +130,7 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
         @Component
         static class DummyQueryHandler {
 
-            @QueryHandler
+            @QueryHandler(queryName = "dummy")
             DummyQueryResponse handle(DummyQuery query) {
                 return new DummyQueryResponse("Successful response!");
             }
@@ -152,9 +155,9 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
                 logger.info("GRACEFUL SHUTDOWN TEST | Before sleep...");
                 Thread.sleep(1000);
                 logger.info("GRACEFUL SHUTDOWN TEST | After sleep...");
-                var dummyQuery = new DummyQuery();
+                var queryMessage = new GenericQueryMessage(new MessageType(new QualifiedName("dummy")), new DummyQuery());
                 try {
-                    var resultOpt = queryGateway.query(dummyQuery, DummyQueryResponse.class, null);
+                    var resultOpt = queryGateway.query(queryMessage, DummyQueryResponse.class, null);
                     var result = resultOpt.get(1, TimeUnit.SECONDS);
                     logger.info("GRACEFUL SHUTDOWN TEST | Query executed!");
                     return ResponseEntity.ok(result);

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
@@ -62,8 +62,11 @@ import static org.assertj.core.api.Assertions.assertThat;
                 "management.endpoints.migrate-legacy-ids=true"
         }
 )
-@Disabled("TODO as part of issue #3310")
 class AxonAutoConfigurationWithGracefulShutdownTest {
+
+    // Counted down by DummyController when a request is actively being handled,
+    // so tests can reliably trigger shutdown only after the request is in-flight.
+    static volatile CountDownLatch requestHandlerStarted;
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -71,7 +74,6 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
     @LocalServerPort
     private int port;
 
-    @Disabled("TODO as part of issue #3310")
     @Test
     @DirtiesContext
     void whenPostForActuatorShutdownThenShuttingDownIsStarted() {
@@ -84,18 +86,14 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
         assertThat((String) entity.getBody().get("message")).contains("Shutting down");
     }
 
-    @Disabled("TODO as part of issue #3310")
     @Test
     @DirtiesContext
     void givenActiveRequestWhenTriggerShutdownThenWaitingForRequestsToComplete() throws Exception {
         // given
-        CountDownLatch requestStarted = new CountDownLatch(1);
+        requestHandlerStarted = new CountDownLatch(1);
         CompletableFuture<ResponseEntity<DummyQueryResponse>> requestActiveDuringShutdown = CompletableFuture.supplyAsync(
-                () -> {
-                    requestStarted.countDown();
-                    return restTemplate.getForEntity("http://localhost:" + port + "/dummy", DummyQueryResponse.class);
-                });
-        assertThat(requestStarted.await(1, TimeUnit.SECONDS)).isTrue();
+                () -> restTemplate.getForEntity("http://localhost:" + port + "/dummy", DummyQueryResponse.class));
+        assertThat(requestHandlerStarted.await(2, TimeUnit.SECONDS)).isTrue();
 
         // when
         ResponseEntity<Void> shutdownResponse = this.restTemplate.postForEntity(
@@ -126,7 +124,7 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
         @Component
         static class DummyQueryHandler {
 
-            @QueryHandler(queryName = "dummy")
+            @QueryHandler
             DummyQueryResponse handle(DummyQuery query) {
                 return new DummyQueryResponse("Successful response!");
             }
@@ -146,6 +144,9 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
 
             @GetMapping("/dummy")
             ResponseEntity<?> dummyQuery() throws InterruptedException {
+                if (requestHandlerStarted != null) {
+                    requestHandlerStarted.countDown();
+                }
                 logger.info("GRACEFUL SHUTDOWN TEST | Before sleep...");
                 Thread.sleep(1000);
                 logger.info("GRACEFUL SHUTDOWN TEST | After sleep...");

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/AxonAutoConfigurationWithGracefulShutdownTest.java
@@ -64,12 +64,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 class AxonAutoConfigurationWithGracefulShutdownTest {
 
-    // Counted down by DummyController when a request is actively being handled,
-    // so tests can reliably trigger shutdown only after the request is in-flight.
-    static volatile CountDownLatch requestHandlerStarted;
-
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private CountDownLatch requestHandlerStarted;
 
     @LocalServerPort
     private int port;
@@ -90,7 +89,6 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
     @DirtiesContext
     void givenActiveRequestWhenTriggerShutdownThenWaitingForRequestsToComplete() throws Exception {
         // given
-        requestHandlerStarted = new CountDownLatch(1);
         CompletableFuture<ResponseEntity<DummyQueryResponse>> requestActiveDuringShutdown = CompletableFuture.supplyAsync(
                 () -> restTemplate.getForEntity("http://localhost:" + port + "/dummy", DummyQueryResponse.class));
         assertThat(requestHandlerStarted.await(2, TimeUnit.SECONDS)).isTrue();
@@ -117,6 +115,11 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
     static class TestConfig {
 
         @Bean
+        public CountDownLatch requestHandlerStarted() {
+            return new CountDownLatch(1);
+        }
+
+        @Bean
         public TestRestTemplate testRestTemplate() {
             return new TestRestTemplate();
         }
@@ -130,23 +133,22 @@ class AxonAutoConfigurationWithGracefulShutdownTest {
             }
         }
 
-
         @RestController
         static class DummyController {
 
             private static final Logger logger = LoggerFactory.getLogger(DummyController.class);
 
             private final QueryGateway queryGateway;
+            private final CountDownLatch requestHandlerStarted;
 
-            public DummyController(QueryGateway queryGateway) {
+            public DummyController(QueryGateway queryGateway, CountDownLatch requestHandlerStarted) {
                 this.queryGateway = queryGateway;
+                this.requestHandlerStarted = requestHandlerStarted;
             }
 
             @GetMapping("/dummy")
             ResponseEntity<?> dummyQuery() throws InterruptedException {
-                if (requestHandlerStarted != null) {
-                    requestHandlerStarted.countDown();
-                }
+                requestHandlerStarted.countDown();
                 logger.info("GRACEFUL SHUTDOWN TEST | Before sleep...");
                 Thread.sleep(1000);
                 logger.info("GRACEFUL SHUTDOWN TEST | After sleep...");


### PR DESCRIPTION
[3310](https://github.com/AxonIQ/AxonFramework/issues/3310)
**1. 404 on `/actuator/shutdown` — missing autoconfigure dependency**

The test was calling the Spring Boot actuator shutdown endpoint, but `spring-boot-actuator-autoconfigure` was not on the test classpath. Without it, Spring Boot never registers the actuator endpoints, causing every request to return 404. Fixed by adding `spring-boot-starter-actuator` as a test-scoped dependency in `pom.xml`, which transitively brings in `spring-boot-actuator-autoconfigure`.

---

**2. `NoHandlerForQueryException` — query name mismatch**

The query handler was registered under an explicit name (`@QueryHandler(queryName = "dummy")`), which maps to `QualifiedName("dummy")`. But the controller was dispatching using `queryGateway.query(new DummyQuery(), ...)`, which derives the query name from the payload class name (`DummyQuery#0.0.1`). The names didn't match so no handler was found. Fixed by dispatching via `new GenericQueryMessage(new MessageType(new QualifiedName("dummy")), new DummyQuery())` so the dispatch name explicitly matches the handler's registered name.

---

**3. Race condition — `CountDownLatch` counted down before the HTTP request reached the server**

The original code counted down the latch in the test thread before firing the HTTP request, so the main thread could trigger the actuator shutdown before the controller had even started processing the request. Fixed by moving the `countDown()` call into `DummyController.dummyQuery()` — the latch is now counted down only once the request is actively being handled by the server, guaranteeing the shutdown is triggered while a real in-flight request exists.

As a cleanup, the `CountDownLatch` was also moved from a `static volatile` field (referenced by both test class and inner controller) to a proper Spring `@Bean` in `TestConfig`, injected into the controller via constructor DI and into the test via `@Autowired`. This makes the per-context lifecycle explicit and removes the static coupling.