### PR TITLE
Remove describe method from ComponentDescriptor interface.

### DIFF
--- a/common/src/main/java/org/axonframework/common/infra/ComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/ComponentDescriptor.java
@@ -119,10 +119,4 @@ public interface ComponentDescriptor {
         describeProperty("delegate", delegate);
     }
 
-    /**
-     * Provides the description of {@code this ComponentDescriptor}.
-     *
-     * @return The description result of {@code this ComponentDescriptor}.
-     */
-    String describe();
 }

--- a/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
@@ -213,7 +213,7 @@ public class FilesystemStyleComponentDescriptor implements ComponentDescriptor {
     /**
      * Provides a description of what has been described in this Descriptor as a String.
      *
-     * @return A description of what has been described in this Descriptor.
+     * @return a description of what has been described in this Descriptor.
      */
     public String describe() {
         try {

--- a/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
@@ -19,8 +19,13 @@ package org.axonframework.common.infra;
 import org.axonframework.common.configuration.Component;
 import org.jspecify.annotations.Nullable;
 
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A {@link ComponentDescriptor} implementation inspired by filesystem structures. Components are represented as
@@ -205,7 +210,11 @@ public class FilesystemStyleComponentDescriptor implements ComponentDescriptor {
         processedComponents.put(name, value);
     }
 
-    @Override
+    /**
+     * Provides a description of what has been described in this Descriptor as a String.
+     *
+     * @return A description of what has been described in this Descriptor.
+     */
     public String describe() {
         try {
             return new TreeRenderer().render(processedComponents);

--- a/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptor.java
@@ -213,7 +213,7 @@ public class FilesystemStyleComponentDescriptor implements ComponentDescriptor {
     /**
      * Provides a description of what has been described in this Descriptor as a String.
      *
-     * @return a description of what has been described in this Descriptor.
+     * @return a description of what has been described in this Descriptor
      */
     public String describe() {
         try {

--- a/common/src/main/java/org/axonframework/common/infra/JacksonComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/JacksonComponentDescriptor.java
@@ -98,12 +98,12 @@ public class JacksonComponentDescriptor implements ComponentDescriptor {
     }
 
     @Override
-    public void describeProperty(String name, Object object) {
+    public void describeProperty(String name, @Nullable Object object) {
         var json = describeObject(object);
         rootNode.set(name, json);
     }
 
-    private JsonNode describeObject(Object object) {
+    private JsonNode describeObject(@Nullable Object object) {
         if (object instanceof DescribableComponent component) {
             var id = processedComponents.get(component);
             var componentSeenAlready = id != null;
@@ -179,21 +179,25 @@ public class JacksonComponentDescriptor implements ComponentDescriptor {
     }
 
     @Override
-    public void describeProperty(String name, String value) {
+    public void describeProperty(String name, @Nullable String value) {
         rootNode.put(name, value);
     }
 
     @Override
-    public void describeProperty(String name, Long value) {
+    public void describeProperty(String name, @Nullable Long value) {
         rootNode.put(name, value);
     }
 
     @Override
-    public void describeProperty(String name, Boolean value) {
+    public void describeProperty(String name, @Nullable Boolean value) {
         rootNode.put(name, value);
     }
 
-    @Override
+    /**
+     * Provides a description of what has been described in this Descriptor as a String.
+     *
+     * @return A description of what has been described in this Descriptor.
+     */
     public String describe() {
         try {
             return objectMapper.writeValueAsString(rootNode);

--- a/common/src/main/java/org/axonframework/common/infra/JacksonComponentDescriptor.java
+++ b/common/src/main/java/org/axonframework/common/infra/JacksonComponentDescriptor.java
@@ -196,7 +196,7 @@ public class JacksonComponentDescriptor implements ComponentDescriptor {
     /**
      * Provides a description of what has been described in this Descriptor as a String.
      *
-     * @return A description of what has been described in this Descriptor.
+     * @return a description of what has been described in this Descriptor
      */
     public String describe() {
         try {

--- a/common/src/test/java/org/axonframework/common/infra/ComponentDescriptorTestSuite.java
+++ b/common/src/test/java/org/axonframework/common/infra/ComponentDescriptorTestSuite.java
@@ -36,6 +36,8 @@ public abstract class ComponentDescriptorTestSuite {
 
     abstract ComponentDescriptor testSubject();
 
+    abstract String describeAsString(ComponentDescriptor testSubject);
+
     @BeforeEach
     void setUp() {
         testSubject = testSubject();
@@ -51,7 +53,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullString", nullString);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullString(result);
@@ -64,7 +66,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullLong", nullLong);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullLong(result);
@@ -77,7 +79,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullBoolean", nullBoolean);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullBoolean(result);
@@ -90,7 +92,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullObject", nullObject);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullObject(result);
@@ -103,7 +105,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullList", nullList);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullList(result);
@@ -116,7 +118,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("nullMap", nullMap);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeNullMap(result);
@@ -144,7 +146,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("testName", "testValue");
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeString(result);
@@ -156,7 +158,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("testName", 42L);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeLong(result);
@@ -168,7 +170,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("testName", true);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeBoolean(result);
@@ -191,7 +193,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("collection", collection);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeCollection(result);
@@ -204,7 +206,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("emptyCollection", emptyCollection);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeEmptyCollection(result);
@@ -222,7 +224,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("components", components);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeCollectionOfDescribableComponentsShouldIncludeTypeAndId(result, component1, component2);
@@ -251,7 +253,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("map", map);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeMap(result);
@@ -264,7 +266,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("emptyMap", emptyMap);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeEmptyMap(result);
@@ -280,7 +282,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("componentMap", map);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeMapWithDescribableComponentsShouldIncludeTypeAndId(result, component1);
@@ -304,7 +306,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("component", component);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeDescribableComponentShouldIncludeTypeAndId(result, component);
@@ -327,7 +329,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("circularRef", component1);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeComponentWithCircularReference(result, component1, component2);
@@ -341,7 +343,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("selfRef", component);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeComponentWithSelfReference(result, component);
@@ -359,7 +361,7 @@ public abstract class ComponentDescriptorTestSuite {
             testSubject.describeProperty("circularRefCollection", components);
 
             // when
-            var result = testSubject.describe();
+            var result = describeAsString(testSubject);
 
             // then
             assertDescribeCollectionWithCircularReferences(result, component1, component2);

--- a/common/src/test/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptorTest.java
+++ b/common/src/test/java/org/axonframework/common/infra/FilesystemStyleComponentDescriptorTest.java
@@ -32,6 +32,11 @@ class FilesystemStyleComponentDescriptorTest extends ComponentDescriptorTestSuit
     }
 
     @Override
+    String describeAsString(ComponentDescriptor testSubject) {
+        return ((FilesystemStyleComponentDescriptor) testSubject).describe();
+    }
+
+    @Override
     void assertDescribeNullString(String result) {
         var expected = """
                 /
@@ -100,7 +105,7 @@ class FilesystemStyleComponentDescriptorTest extends ComponentDescriptorTestSuit
         testSubject.describeProperty("container", container);
 
         // when
-        var result = testSubject.describe();
+        var result = describeAsString(testSubject);
 
         // then
         var expected = """
@@ -151,7 +156,7 @@ class FilesystemStyleComponentDescriptorTest extends ComponentDescriptorTestSuit
         testSubject.describeProperty("booleanValue", true);
 
         // when
-        var result = testSubject.describe();
+        var result = describeAsString(testSubject);
 
         // then
         var expected = """

--- a/common/src/test/java/org/axonframework/common/infra/JacksonComponentDescriptorTest.java
+++ b/common/src/test/java/org/axonframework/common/infra/JacksonComponentDescriptorTest.java
@@ -31,6 +31,11 @@ class JacksonComponentDescriptorTest extends ComponentDescriptorTestSuite {
         return new JacksonComponentDescriptor();
     }
 
+    @Override
+    String describeAsString(ComponentDescriptor testSubject) {
+        return ((JacksonComponentDescriptor) testSubject).describe();
+    }
+
     @BeforeEach
     void setUp() {
         testSubject = new JacksonComponentDescriptor();
@@ -131,7 +136,7 @@ class JacksonComponentDescriptorTest extends ComponentDescriptorTestSuite {
         testSubject.describeProperty("complexStructure", structure);
 
         // when
-        var result = testSubject.describe();
+        var result = describeAsString(testSubject);
 
         // then
         assertJsonMatchesPattern(
@@ -391,7 +396,7 @@ class JacksonComponentDescriptorTest extends ComponentDescriptorTestSuite {
                       "name": "Component2",
                       "dependency": {
                         "$ref": "%s",
-                        "_type": "org.axonframework.common.infra.ComponentDescriptorTestSuite$CircularReferencesTests$CircularComponent" 
+                        "_type": "org.axonframework.common.infra.ComponentDescriptorTestSuite$CircularReferencesTests$CircularComponent"
                       }
                     }
                   }

--- a/common/src/test/java/org/axonframework/common/infra/MockComponentDescriptor.java
+++ b/common/src/test/java/org/axonframework/common/infra/MockComponentDescriptor.java
@@ -82,8 +82,4 @@ public class MockComponentDescriptor implements ComponentDescriptor {
         properties.put(name, value);
     }
 
-    @Override
-    public String describe() {
-        throw new UnsupportedOperationException("This mock Component Descriptor cannot describe itself.");
-    }
 }


### PR DESCRIPTION
The way a ComponentDescriptor describes a certain component, and whether it fits in a String or not, is entirely implementation dependent. Therefore, the describe() method should not be placed on the ComponentDescriptor interface.