### PR TITLE
Document EntityScan for custom event storage engines

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -443,6 +443,32 @@ With Spring Boot, the `AggregateBasedJpaEventStorageEngine` is automatically con
 axon.axonserver.enabled=false
 ----
 
+If you declare your own `@Bean EventStorageEngine` while using JPA event storage, Spring Boot may skip the
+auto-configuration that registers Axon Framework's JPA entities.
+In that case, explicitly include your application package and the Axon Framework packages in `@EntityScan`:
+
+[source,java]
+----
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+
+@SpringBootApplication
+@EntityScan(basePackages = {
+        "com.example.myapplication",
+        "org.axonframework",
+        "io.axoniq.framework"
+})
+public class MyApplication {
+}
+----
+
+[IMPORTANT]
+====
+If your application already uses `@EntityScan`, make sure it includes all application and Axon Framework entity packages.
+A partial `@EntityScan` replaces Spring Boot's default package discovery and can hide framework entities such as event
+store, token store, or dead-letter queue entries.
+====
+
 If you had customized the `JpaEventStorageEngine` in Axon Framework 4 to, for example, have a different gap cleaning threshold, you can now move that customization to the properties file:
 
 [source,properties]


### PR DESCRIPTION
Documents the @EntityScan requirement when using a custom @Bean EventStorageEngine with JPA event storage during AF4 → AF5 migration.

The update explains that a user-defined EventStorageEngine can prevent the auto-configuration that registers Axon Framework JPA entities from running, and shows how to include both the application package and Axon Framework packages in @EntityScan.

Fixes #4574

Documentation
Updates the event-store migration path with Spring Boot guidance for custom JPA event storage configuration and warns that partial @EntityScan declarations can hide framework entities such as event store, token store, and dead-letter queue entries.