### PR TITLE
[#4583] fix(messaging): SplitTask leaves token store inconsistent after segment split

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/PooledStreamingEventProcessorSpringTestSuite.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/PooledStreamingEventProcessorSpringTestSuite.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.streaming.pooled;
+
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorTestSuite;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Spring Boot variant of {@link PooledStreamingEventProcessorTestSuite}.
+ * <p>
+ * Obtains the {@link AxonConfiguration} from the Spring {@link ApplicationContext}.
+ *
+ * @since 5.1.1
+ */
+public abstract class PooledStreamingEventProcessorSpringTestSuite extends PooledStreamingEventProcessorTestSuite {
+
+    @Autowired
+    private AxonConfiguration axonConfiguration;
+
+    @Override
+    protected AxonConfiguration axonConfiguration() {
+        return axonConfiguration;
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/PooledStreamingEventProcessorSpringTestSuite.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/PooledStreamingEventProcessorSpringTestSuite.java
@@ -17,14 +17,27 @@
 package org.axonframework.extension.springboot.streaming.pooled;
 
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorTestSuite;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Spring Boot variant of {@link PooledStreamingEventProcessorTestSuite}.
  * <p>
- * Obtains the {@link AxonConfiguration} from the Spring {@link ApplicationContext}.
+ * Creates a fresh {@link PooledStreamingEventProcessor} per test using components obtained from the Spring
+ * {@link AxonConfiguration}. Each processor gets a unique UUID-based name, providing natural token store isolation
+ * between tests without requiring context teardown or schema cleanup.
  *
  * @since 5.1.1
  */
@@ -33,8 +46,42 @@ public abstract class PooledStreamingEventProcessorSpringTestSuite extends Poole
     @Autowired
     private AxonConfiguration axonConfiguration;
 
+    private ScheduledExecutorService coordinatorExecutor;
+    private ScheduledExecutorService workerExecutor;
+
     @Override
-    protected AxonConfiguration axonConfiguration() {
-        return axonConfiguration;
+    protected PooledStreamingEventProcessor buildProcessor() {
+        String processorName = "PSEPTest-" + UUID.randomUUID();
+        coordinatorExecutor = Executors.newSingleThreadScheduledExecutor();
+        workerExecutor = Executors.newScheduledThreadPool(4);
+
+        var eventSource = axonConfiguration.getComponent(StreamableEventSource.class);
+        var tokenStore = axonConfiguration.getComponent(TokenStore.class);
+        var unitOfWorkFactory = axonConfiguration.getComponent(UnitOfWorkFactory.class);
+
+        var config = new PooledStreamingEventProcessorConfiguration(
+                new EventProcessorConfiguration(processorName, null))
+                .unitOfWorkFactory(unitOfWorkFactory)
+                .eventSource(eventSource)
+                .tokenStore(tokenStore)
+                .initialSegmentCount(1)
+                .coordinatorExecutor(coordinatorExecutor)
+                .workerExecutor(workerExecutor);
+
+        return new PooledStreamingEventProcessor(
+                processorName,
+                List.of(SimpleEventHandlingComponent.create(processorName)),
+                config
+        );
+    }
+
+    @Override
+    protected void afterProcessorShutdown() {
+        if (coordinatorExecutor != null) {
+            coordinatorExecutor.shutdownNow();
+        }
+        if (workerExecutor != null) {
+            workerExecutor.shutdownNow();
+        }
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jdbc/PooledStreamingJdbcTokenStoreIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jdbc/PooledStreamingJdbcTokenStoreIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.streaming.pooled.jdbc;
+
+import org.axonframework.conversion.GeneralConverter;
+import org.axonframework.messaging.core.annotation.Namespace;
+import org.axonframework.messaging.core.unitofwork.transaction.jdbc.JdbcTransactionalExecutorProvider;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.GenericTokenTableFactory;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.JdbcTokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.JdbcTokenStoreConfiguration;
+import org.axonframework.extension.springboot.streaming.pooled.PooledStreamingEventProcessorSpringTestSuite;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+
+import javax.sql.DataSource;
+
+/**
+ * Spring Boot integration test for
+ * {@link org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor} backed by
+ * a {@link JdbcTokenStore}.
+ * <p>
+ * JPA autoconfiguration is included to provide the JPA-backed event store (HSQLDB in-memory). The token store is
+ * overridden to use JDBC (not JPA) by providing a custom {@code TokenStore} bean, preventing
+ * {@link org.axonframework.extension.springboot.autoconfig.JpaAutoConfiguration}'s {@code @ConditionalOnMissingBean}
+ * from registering a JPA token store.
+ *
+ * @since 5.1.1
+ */
+@SpringBootTest(
+        properties = {
+                "axon.axonserver.enabled=false",
+                "spring.main.banner-mode=off",
+                "spring.datasource.generate-unique-name=true",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "axon.eventstorage.jpa.polling-interval=0",
+                "axon.eventhandling.processors.PooledStreamingIT.initial-segment-count=1"
+        },
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+public class PooledStreamingJdbcTokenStoreIT extends PooledStreamingEventProcessorSpringTestSuite {
+
+    @Override
+    protected void cleanTokenStore() {
+        // No-op: @DirtiesContext + spring.datasource.generate-unique-name=true gives a fresh in-memory DB per test
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        /**
+         * Overrides the JPA token store autoconfigured by
+         * {@link org.axonframework.extension.springboot.autoconfig.JpaAutoConfiguration}. Creates the JDBC schema
+         * before returning the store, so the table exists when the processor starts.
+         */
+        @Bean
+        public TokenStore tokenStore(DataSource dataSource, GeneralConverter converter) {
+            var store = new JdbcTokenStore(
+                    new JdbcTransactionalExecutorProvider(dataSource),
+                    converter,
+                    JdbcTokenStoreConfiguration.DEFAULT
+            );
+            store.createSchema(GenericTokenTableFactory.INSTANCE);
+            return store;
+        }
+    }
+
+    @Component
+    @Namespace("PooledStreamingIT")
+    static class TestEventHandler {
+
+        @EventHandler
+        void on(Object event) {
+            // no-op — processor needs a handler to be assigned to the "PooledStreamingIT" namespace
+        }
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jdbc/PooledStreamingJdbcTokenStoreIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jdbc/PooledStreamingJdbcTokenStoreIT.java
@@ -17,9 +17,7 @@
 package org.axonframework.extension.springboot.streaming.pooled.jdbc;
 
 import org.axonframework.conversion.GeneralConverter;
-import org.axonframework.messaging.core.annotation.Namespace;
 import org.axonframework.messaging.core.unitofwork.transaction.jdbc.JdbcTransactionalExecutorProvider;
-import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.GenericTokenTableFactory;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.JdbcTokenStore;
@@ -32,8 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
-import org.springframework.stereotype.Component;
-import org.springframework.test.annotation.DirtiesContext;
 
 import javax.sql.DataSource;
 
@@ -46,6 +42,9 @@ import javax.sql.DataSource;
  * overridden to use JDBC (not JPA) by providing a custom {@code TokenStore} bean, preventing
  * {@link org.axonframework.extension.springboot.autoconfig.JpaAutoConfiguration}'s {@code @ConditionalOnMissingBean}
  * from registering a JPA token store.
+ * <p>
+ * Each test creates its own processor with a UUID-based name, giving natural token store row isolation without any
+ * schema teardown between tests.
  *
  * @since 5.1.1
  */
@@ -55,21 +54,14 @@ import javax.sql.DataSource;
                 "spring.main.banner-mode=off",
                 "spring.datasource.generate-unique-name=true",
                 "spring.jpa.hibernate.ddl-auto=create-drop",
-                "axon.eventstorage.jpa.polling-interval=0",
-                "axon.eventhandling.processors.PooledStreamingIT.initial-segment-count=1"
+                "axon.eventstorage.jpa.polling-interval=0"
         },
         webEnvironment = SpringBootTest.WebEnvironment.NONE
 )
 @SpringBootConfiguration
 @EnableAutoConfiguration
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class PooledStreamingJdbcTokenStoreIT extends PooledStreamingEventProcessorSpringTestSuite {
-
-    @Override
-    protected void cleanTokenStore() {
-        // No-op: @DirtiesContext + spring.datasource.generate-unique-name=true gives a fresh in-memory DB per test
-    }
 
     @Configuration
     static class TestConfig {
@@ -88,16 +80,6 @@ public class PooledStreamingJdbcTokenStoreIT extends PooledStreamingEventProcess
             );
             store.createSchema(GenericTokenTableFactory.INSTANCE);
             return store;
-        }
-    }
-
-    @Component
-    @Namespace("PooledStreamingIT")
-    static class TestEventHandler {
-
-        @EventHandler
-        void on(Object event) {
-            // no-op — processor needs a handler to be assigned to the "PooledStreamingIT" namespace
         }
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jpa/PooledStreamingJpaTokenStoreIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jpa/PooledStreamingJpaTokenStoreIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.streaming.pooled.jpa;
+
+import org.axonframework.messaging.core.annotation.Namespace;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.extension.springboot.streaming.pooled.PooledStreamingEventProcessorSpringTestSuite;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.EnableMBeanExport;
+import org.springframework.jmx.support.RegistrationPolicy;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+
+/**
+ * Spring Boot integration test for {@link org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor}
+ * backed by a {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStore}.
+ * <p>
+ * Full JPA autoconfiguration is used: HSQLDB in-memory provides both the JPA event store and the JPA token store.
+ * The token table is created by Hibernate via {@code ddl-auto=create-drop}.
+ *
+ * @since 5.1.1
+ */
+@SpringBootTest(
+        properties = {
+                "axon.axonserver.enabled=false",
+                "spring.main.banner-mode=off",
+                "spring.datasource.generate-unique-name=true",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "axon.eventstorage.jpa.polling-interval=0",
+                "axon.eventhandling.processors.PooledStreamingIT.initial-segment-count=1"
+        },
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+public class PooledStreamingJpaTokenStoreIT extends PooledStreamingEventProcessorSpringTestSuite {
+
+    @Override
+    protected void cleanTokenStore() {
+        // No-op: @DirtiesContext + create-drop recreates the JPA schema fresh per test
+    }
+
+    @Component
+    @Namespace("PooledStreamingIT")
+    static class TestEventHandler {
+
+        @EventHandler
+        void on(Object event) {
+            // no-op — processor needs a handler to be assigned to the "PooledStreamingIT" namespace
+        }
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jpa/PooledStreamingJpaTokenStoreIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/streaming/pooled/jpa/PooledStreamingJpaTokenStoreIT.java
@@ -16,16 +16,12 @@
 
 package org.axonframework.extension.springboot.streaming.pooled.jpa;
 
-import org.axonframework.messaging.core.annotation.Namespace;
-import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.extension.springboot.streaming.pooled.PooledStreamingEventProcessorSpringTestSuite;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
-import org.springframework.stereotype.Component;
-import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * Spring Boot integration test for {@link org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor}
@@ -33,6 +29,9 @@ import org.springframework.test.annotation.DirtiesContext;
  * <p>
  * Full JPA autoconfiguration is used: HSQLDB in-memory provides both the JPA event store and the JPA token store.
  * The token table is created by Hibernate via {@code ddl-auto=create-drop}.
+ * <p>
+ * Each test creates its own processor with a UUID-based name, giving natural token store row isolation without any
+ * schema teardown between tests.
  *
  * @since 5.1.1
  */
@@ -42,29 +41,13 @@ import org.springframework.test.annotation.DirtiesContext;
                 "spring.main.banner-mode=off",
                 "spring.datasource.generate-unique-name=true",
                 "spring.jpa.hibernate.ddl-auto=create-drop",
-                "axon.eventstorage.jpa.polling-interval=0",
-                "axon.eventhandling.processors.PooledStreamingIT.initial-segment-count=1"
+                "axon.eventstorage.jpa.polling-interval=0"
         },
         webEnvironment = SpringBootTest.WebEnvironment.NONE
 )
 @SpringBootConfiguration
 @EnableAutoConfiguration
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
 public class PooledStreamingJpaTokenStoreIT extends PooledStreamingEventProcessorSpringTestSuite {
 
-    @Override
-    protected void cleanTokenStore() {
-        // No-op: @DirtiesContext + create-drop recreates the JPA schema fresh per test
-    }
-
-    @Component
-    @Namespace("PooledStreamingIT")
-    static class TestEventHandler {
-
-        @EventHandler
-        void on(Object event) {
-            // no-op — processor needs a handler to be assigned to the "PooledStreamingIT" namespace
-        }
-    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -166,11 +166,6 @@ class MergeTask extends CoordinatorTask {
                                              mergedSegment,
                                              context
                                          ))
-                                         .thenCompose(result -> tokenStore.releaseClaim(
-                                             name,
-                                             mergedSegment.getSegmentId(),
-                                             context
-                                         ))
             ));
 
             logger.info("Processor [{}] successfully merged {} with {} into {}.",

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
@@ -151,11 +151,6 @@ class SplitTask extends CoordinatorTask {
                                  splitStatuses[1].getSegment(),
                                  context
                          )
-                         .thenCompose(result -> tokenStore.releaseClaim(
-                                 name,
-                                 splitStatuses[0].getSegment().getSegmentId(),
-                                 context
-                         ))
                          .thenCompose(result -> tokenStore.deleteToken(
                                  name,
                                  splitStatuses[0].getSegment().getSegmentId(),

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStore.java
@@ -223,6 +223,11 @@ public class JpaTokenStore implements TokenStore {
             if (updates == 0) {
                 throw new UnableToClaimTokenException("Unable to remove token. It is not owned by " + nodeId);
             }
+            // Bulk JPQL DELETE bypasses the persistence context — evict stale state so subsequent
+            // em.persist() of a new entity with the same PK (e.g., re-initializing after split) doesn't
+            // throw NonUniqueObjectException.
+            em.flush();
+            em.clear();
         });
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -113,8 +114,6 @@ class MergeTaskTest {
         when(workPackageTwo.segment()).thenReturn(SEGMENT_ONE);
         when(workPackageTwo.abort(null)).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.storeToken(any(), anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(testTokenToBeMerged));
         when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
@@ -138,7 +137,7 @@ class MergeTaskTest {
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
         assertEquals(testTokenToBeMerged, ((MergedTrackingToken) resultToken).upperSegmentToken());
-        verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
 
         assertTrue(result.isDone());
         assertTrue(result.get());
@@ -149,8 +148,6 @@ class MergeTaskTest {
         TrackingToken testTokenToMerge = new GlobalSequenceTrackingToken(0);
         TrackingToken testTokenToBeMerged = new GlobalSequenceTrackingToken(1);
         when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.storeToken(any(), anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
                 .thenReturn(completedFuture(testTokenToMerge));
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
@@ -174,7 +171,7 @@ class MergeTaskTest {
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
         assertEquals(testTokenToBeMerged, ((MergedTrackingToken) resultToken).upperSegmentToken());
-        verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
 
         assertTrue(result.isDone());
         assertTrue(result.get());
@@ -191,8 +188,6 @@ class MergeTaskTest {
                 .thenReturn(completedFuture(testTokenToMerge));
         workPackages.put(SEGMENT_TO_MERGE, workPackageOne);
         when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.storeToken(any(), anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
-        when(tokenStore.releaseClaim(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
                 .thenReturn(completedFuture(testTokenToBeMerged));
         when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
@@ -214,7 +209,7 @@ class MergeTaskTest {
         assertTrue(resultToken.getClass().isAssignableFrom(MergedTrackingToken.class));
         assertEquals(testTokenToMerge, ((MergedTrackingToken) resultToken).lowerSegmentToken());
         assertEquals(testTokenToBeMerged, ((MergedTrackingToken) resultToken).upperSegmentToken());
-        verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any());
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
 
         assertTrue(result.isDone());
         assertTrue(result.get());

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTestSuite.java
@@ -17,9 +17,6 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.awaitility.Awaitility;
-import org.axonframework.common.configuration.AxonConfiguration;
-import org.axonframework.common.configuration.Configuration;
-import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.junit.jupiter.api.*;
 
 import java.util.concurrent.TimeUnit;
@@ -28,39 +25,51 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract integration test suite for {@link PooledStreamingEventProcessor}.
+ * <p>
+ * Each test method creates its own processor instance via {@link #buildProcessor()}, started in {@link #initProcessor()}
+ * and stopped in {@link #tearDownProcessor()}. Using a unique processor name per test (e.g., UUID-based) naturally
+ * isolates token store state without requiring context or schema resets between tests.
  *
  * @since 5.1.1
  */
 public abstract class PooledStreamingEventProcessorTestSuite {
 
-    protected String processorName() {
-        return "PooledStreamingIT";
-    }
+    private PooledStreamingEventProcessor processor;
 
-    protected abstract AxonConfiguration axonConfiguration();
+    /**
+     * Builds a fresh, not-yet-started {@link PooledStreamingEventProcessor} for the current test.
+     * <p>
+     * Implementations should use a unique processor name per call (e.g., via {@code UUID.randomUUID()}) to ensure token
+     * store isolation between tests without requiring any cleanup.
+     *
+     * @return a configured but not started processor
+     */
+    protected abstract PooledStreamingEventProcessor buildProcessor();
 
-    protected PooledStreamingEventProcessor processor() {
-        AxonConfiguration config = axonConfiguration();
-        Configuration moduleConfig = config
-                .getModuleConfiguration("EventProcessor[" + processorName() + "]")
-                .orElseThrow(() -> new IllegalStateException(
-                        "Module 'EventProcessor[" + processorName() + "]' not found. "));
-        return moduleConfig
-                .getOptionalComponent(StreamingEventProcessor.class, processorName())
-                .map(p -> (PooledStreamingEventProcessor) p)
-                .orElseThrow(() -> new IllegalStateException(
-                        "PooledStreamingEventProcessor '" + processorName() + "' not found in module config"));
+    /**
+     * Hook invoked after the processor is stopped in {@link #tearDownProcessor()}.
+     * <p>
+     * Override to release resources created alongside the processor (e.g., executor services).
+     */
+    protected void afterProcessorShutdown() {}
+
+    @BeforeEach
+    void initProcessor() throws Exception {
+        processor = buildProcessor();
+        processor.start().get(10, TimeUnit.SECONDS);
     }
 
     @AfterEach
-    void tearDown() {
-        cleanTokenStore();
+    void tearDownProcessor() throws Exception {
+        if (processor != null) {
+            processor.shutdown().get(10, TimeUnit.SECONDS);
+        }
+        afterProcessorShutdown();
     }
 
-    /**
-     * Subclass resets the token store state for test isolation.
-     */
-    protected abstract void cleanTokenStore();
+    protected PooledStreamingEventProcessor processor() {
+        return processor;
+    }
 
     @Nested
     class WhenSplittingSegments {
@@ -75,7 +84,7 @@ public abstract class PooledStreamingEventProcessorTestSuite {
             // when
             boolean splitResult = processor().splitSegment(0).get(15, TimeUnit.SECONDS);
             assertTrue(splitResult,
-                       "splitSegment(0) should return true — if it throws UnableToClaimTokenException, the bug is present");
+                       "splitSegment(0) should return true and do not throw UnableToClaimTokenException");
 
             // then
             Awaitility.await()
@@ -85,6 +94,37 @@ public abstract class PooledStreamingEventProcessorTestSuite {
                        "Segment 0 (re-initialized with new mask) must be active after split");
             assertTrue(processor().processingStatus().containsKey(1),
                        "Segment 1 (sibling) must be active after split");
+        }
+    }
+
+    @Nested
+    class WhenMergingSegments {
+
+        @Test
+        void mergeSegment_afterSplit_returnsTrue_andMergedSegmentBecomesActive() throws Exception {
+            // given — start with segment 0 active, then split to get two segments
+            Awaitility.await()
+                      .atMost(10, TimeUnit.SECONDS)
+                      .until(() -> processor().processingStatus().containsKey(0));
+
+            boolean splitResult = processor().splitSegment(0).get(15, TimeUnit.SECONDS);
+            assertTrue(splitResult, "splitSegment(0) should return true before merging");
+
+            Awaitility.await()
+                      .atMost(15, TimeUnit.SECONDS)
+                      .until(() -> processor().processingStatus().size() == 2);
+
+            // when
+            boolean mergeResult = processor().mergeSegment(0).get(15, TimeUnit.SECONDS);
+            assertTrue(mergeResult,
+                       "mergeSegment(0) should return true and do not throw UnableToClaimTokenException");
+
+            // then
+            Awaitility.await()
+                      .atMost(30, TimeUnit.SECONDS)
+                      .until(() -> processor().processingStatus().size() == 1);
+            assertTrue(processor().processingStatus().containsKey(0),
+                       "Segment 0 (merged) must be active after merge");
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTestSuite.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
+
+import org.awaitility.Awaitility;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract integration test suite for {@link PooledStreamingEventProcessor}.
+ *
+ * @since 5.1.1
+ */
+public abstract class PooledStreamingEventProcessorTestSuite {
+
+    protected String processorName() {
+        return "PooledStreamingIT";
+    }
+
+    protected abstract AxonConfiguration axonConfiguration();
+
+    protected PooledStreamingEventProcessor processor() {
+        AxonConfiguration config = axonConfiguration();
+        Configuration moduleConfig = config
+                .getModuleConfiguration("EventProcessor[" + processorName() + "]")
+                .orElseThrow(() -> new IllegalStateException(
+                        "Module 'EventProcessor[" + processorName() + "]' not found. "));
+        return moduleConfig
+                .getOptionalComponent(StreamingEventProcessor.class, processorName())
+                .map(p -> (PooledStreamingEventProcessor) p)
+                .orElseThrow(() -> new IllegalStateException(
+                        "PooledStreamingEventProcessor '" + processorName() + "' not found in module config"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanTokenStore();
+    }
+
+    /**
+     * Subclass resets the token store state for test isolation.
+     */
+    protected abstract void cleanTokenStore();
+
+    @Nested
+    class WhenSplittingSegments {
+
+        @Test
+        void splitSegment_returnsTrue_andBothNewSegmentsBecomeClaimed() throws Exception {
+            // given
+            Awaitility.await()
+                      .atMost(10, TimeUnit.SECONDS)
+                      .until(() -> processor().processingStatus().containsKey(0));
+
+            // when
+            boolean splitResult = processor().splitSegment(0).get(15, TimeUnit.SECONDS);
+            assertTrue(splitResult,
+                       "splitSegment(0) should return true — if it throws UnableToClaimTokenException, the bug is present");
+
+            // then
+            Awaitility.await()
+                      .atMost(10, TimeUnit.SECONDS)
+                      .until(() -> processor().processingStatus().size() == 2);
+            assertTrue(processor().processingStatus().containsKey(0),
+                       "Segment 0 (re-initialized with new mask) must be active after split");
+            assertTrue(processor().processingStatus().containsKey(1),
+                       "Segment 1 (sibling) must be active after split");
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.UnableToClaimTokenException;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
 import org.junit.jupiter.api.*;
+import org.mockito.InOrder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -86,8 +87,6 @@ class SplitTaskTest {
                 .thenReturn(emptyCompletedFuture());
         when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(1, 1)), any()))
                 .thenReturn(emptyCompletedFuture());
-        when(tokenStore.releaseClaim(eq(PROCESSOR_NAME), anyInt(), any()))
-                .thenReturn(emptyCompletedFuture());
         when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
                 .thenReturn(emptyCompletedFuture());
 
@@ -104,9 +103,10 @@ class SplitTaskTest {
                                              eq(PROCESSOR_NAME),
                                              eq(expectedSplit.getSegment()),
                                              any());
-        verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME),
-                                        eq(expectedOriginal.getSegment().getSegmentId()),
-                                        any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME),
+                                       eq(expectedOriginal.getSegment().getSegmentId()),
+                                       any());
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
         assertTrue(result.isDone());
         assertTrue(result.get());
     }
@@ -128,8 +128,6 @@ class SplitTaskTest {
                 .thenReturn(emptyCompletedFuture());
         when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(1, 1)), any()))
                 .thenReturn(emptyCompletedFuture());
-        when(tokenStore.releaseClaim(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
-                .thenReturn(emptyCompletedFuture());
         when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
                 .thenReturn(emptyCompletedFuture());
 
@@ -144,9 +142,10 @@ class SplitTaskTest {
                                              eq(PROCESSOR_NAME),
                                              eq(expectedSplit.getSegment()),
                                              any());
-        verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME),
-                                        eq(expectedOriginal.getSegment().getSegmentId()),
-                                        any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME),
+                                       eq(expectedOriginal.getSegment().getSegmentId()),
+                                       any());
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
         assertTrue(result.isDone());
         assertTrue(result.get());
     }
@@ -188,5 +187,47 @@ class SplitTaskTest {
         String result = testSubject.getDescription();
         assertNotNull(result);
         assertTrue(result.contains("Split"));
+    }
+
+    @Test
+    void runSplitsSegment_deleteTokenCalledBeforeReInitialization_andNoSeparateReleaseClaim()
+            throws ExecutionException, InterruptedException {
+        Segment testSegmentToSplit = Segment.ROOT_SEGMENT;
+        TrackingToken testTokenToSplit = new GlobalSequenceTrackingToken(0);
+
+        TrackerStatus[] expectedTokens = TrackerStatus.split(testSegmentToSplit, testTokenToSplit);
+        TrackerStatus expectedOriginal = expectedTokens[0]; // Segment(0, mask=1)
+        TrackerStatus expectedSplit   = expectedTokens[1]; // Segment(1, mask=1)
+
+        when(workPackage.segment()).thenReturn(testSegmentToSplit);
+        when(workPackage.abort(null)).thenReturn(emptyCompletedFuture());
+        when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                .thenReturn(completedFuture(testTokenToSplit));
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(1, 1)), any()))
+                .thenReturn(emptyCompletedFuture());
+        when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(Segment.ROOT_SEGMENT.getSegmentId()), any()))
+                .thenReturn(emptyCompletedFuture());
+
+        workPackages.put(SEGMENT_ID, workPackage);
+
+        testSubject.run();
+
+        verify(tokenStore, never()).releaseClaim(any(), anyInt(), any());
+        verify(tokenStore).deleteToken(eq(PROCESSOR_NAME),
+                                       eq(Segment.ROOT_SEGMENT.getSegmentId()),
+                                       any());
+
+        InOrder inOrder = inOrder(tokenStore);
+        inOrder.verify(tokenStore).initializeSegment(
+                eq(expectedSplit.getTrackingToken()), eq(PROCESSOR_NAME), eq(expectedSplit.getSegment()), any());
+        inOrder.verify(tokenStore).deleteToken(
+                eq(PROCESSOR_NAME), eq(expectedOriginal.getSegment().getSegmentId()), any());
+        inOrder.verify(tokenStore).initializeSegment(
+                eq(expectedOriginal.getTrackingToken()), eq(PROCESSOR_NAME), eq(expectedOriginal.getSegment()), any());
+
+        assertTrue(result.isDone());
+        assertTrue(result.get());
     }
 }


### PR DESCRIPTION
closes #4583 

## Bug description

**Introduced in:** commit [185c4332](https://github.com/AxonIQ/AxonFramework/commit/185c4332) — *"When splitting and merging tokens, update both tokens involved"*

Before persistent segment masks were introduced, `SplitTask` only needed to insert the sibling segment and call `releaseClaim(original)` to release ownership. When that commit added support for updating the original segment's mask, it appended `deleteToken(original)` + `initializeSegment(original with new mask)` **after** the existing `releaseClaim` rather than replacing it:

```
releaseClaim(original)   ← sets owner = NULL
deleteToken(original)    ← DELETE WHERE owner = nodeId → 0 rows → UnableToClaimTokenException
initializeSegment(...)   ← never reached
```

`MergeTask` has the same problem in its `mergeSegments()` method: after `initializeSegment(mergedSegment)` creates the merged token with `owner = NULL`, the code called `releaseClaim(merged)`, which again matches zero rows and throws `UnableToClaimTokenException`, preventing the coordinator from reclaiming the merged segment.

The `InMemoryTokenStore` (used in all existing unit tests) has a no-op `releaseClaim` and ignores ownership in `deleteToken`, so both bugs were invisible to the test suite and only surfaced against a real JDBC or JPA token store.

---

## What was fixed

**`SplitTask.splitAndRelease()`** — `releaseClaim()` was removed entirely and the operation order corrected:

1. `initializeSegment(sibling)` — insert sibling with `owner = NULL`
2. `deleteToken(original)` — DELETE while `owner = nodeId` still holds
3. `initializeSegment(original with new mask)` — re-insert with `owner = NULL`, ready for reclaiming

**`MergeTask.mergeSegments()`** — `releaseClaim()` was removed. After the two source tokens are deleted and the merged token is initialized with `owner = NULL`, no claim release is needed — the coordinator picks it up on the next cycle.

**`JpaTokenStore.deleteToken()`** (found thanks to the new integration tests) — A secondary issue specific to JPA: after a JPQL bulk DELETE the Hibernate identity map still holds the deleted `TokenEntry`, causing `NonUniqueObjectException` when `initializeSegment` calls `em.persist()` with the same PK in the same persistence context. Fixed by calling `em.flush()` + `em.clear()` after `executeUpdate()` to evict the stale entry.

---

## Tests introduced

**Unit — `SplitTaskTest`** (existing class updated):
- Removed `releaseClaim` mock setup and verification from existing tests; added `verify(never()).releaseClaim()`
- Added a new test asserting the exact operation order: `initializeSegment(sibling)` → `deleteToken` → `initializeSegment(original)`

**Unit — `MergeTaskTest`** (existing class updated):
- Removed `releaseClaim` mock setup and verification from existing tests; added `verify(never()).releaseClaim()`

**Integration — new Spring Boot IT suite against real token stores:**

It's a cornerstone for better test coverage, providing more valuable end-to-end tests of `PooledStreamingEventProcessor`.

`PooledStreamingEventProcessorTestSuite` (added to `messaging` test-jar, no Spring dependency) holds all test logic. It requires subclasses to implement only a `buildProcessor()` factory method, making it reusable outside Spring contexts. Each test creates its own processor with a UUID-based name for natural token store row isolation — no schema teardown or context reset needed.

`PooledStreamingEventProcessorSpringTestSuite` (in `spring-boot-autoconfigure`) is a thin Spring subclass that builds the processor from components obtained via `@Autowired AxonConfiguration`.

Two concrete IT classes run the full suite against HSQLDB in-memory:
- `PooledStreamingJdbcTokenStoreIT` — overrides the JPA token store with a `JdbcTokenStore` bean
- `PooledStreamingJpaTokenStoreIT` — uses full JPA autoconfiguration with `ddl-auto=create-drop`

The suite covers two scenarios against both token stores:
- **`WhenSplittingSegments`** — calls `processor().splitSegment(0)` end-to-end and asserts both resulting segments become active, directly reproducing the original bug
- **`WhenMergingSegments`** — splits first, then calls `processor().mergeSegment(0)` and asserts the merged segment becomes active, reproducing the symmetric `MergeTask` bug
