### PR TITLE
[#3083] Configure application wide Clock

### DIFF
--- a/common/src/main/java/org/axonframework/common/ClockUtils.java
+++ b/common/src/main/java/org/axonframework/common/ClockUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Global access point for the framework's current {@link Clock}.
+ * <p>
+ * This utility provides a shared clock abstraction that can be read from anywhere in the framework and overridden in
+ * tests or integration scenarios. It also implements {@link InstantSource} so callers can use it wherever an instant
+ * source is required.
+ */
+public final class ClockUtils  {
+
+    /**
+     * A supplier that returns the current instant of the global clock.
+     */
+    public static final Supplier<Instant> SUPPLIER = ClockUtils::instant;
+
+    /**
+     * The default global clock used by the framework.
+     * <p>
+     * This clock is UTC-based and is restored by {@link #reset()}.
+     */
+    private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
+
+    private static final AtomicReference<Clock> CLOCK = new AtomicReference<>(DEFAULT_CLOCK);
+
+    /**
+     * Returns the currently configured global clock.
+     *
+     * @return the shared clock instance, or the default UTC clock if none has been configured explicitly
+     */
+    public static Clock get() {
+        return CLOCK.get();
+    }
+
+    /**
+     * Replaces the currently configured global clock.
+     *
+     * @param clock the new global clock to use
+     * @return the clock that was installed
+     */
+    public static Clock set(Clock clock) {
+        CLOCK.set(clock);
+        return clock;
+    }
+
+    /**
+     * Restores the global clock to the default UTC clock.
+     *
+     * @return the default UTC clock
+     */
+    public static Clock reset() {
+        return set(DEFAULT_CLOCK);
+    }
+
+    /**
+     * Adapts the current clock to the {@link InstantSource} interface.
+     *
+     * @return the {@link InstantSource#instant()} of the current clock
+     */
+    public static Instant instant() {
+        return get().instant();
+    }
+
+    private ClockUtils() {
+        // do not instantiate
+    }
+}

--- a/common/src/test/java/org/axonframework/common/ClockUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/ClockUtilsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Constructor;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClockUtilsTest {
+
+    @AfterEach
+    void resetClock() {
+        ClockUtils.reset();
+    }
+
+    @Nested
+    class GetSetReset {
+
+        @Test
+        void getReturnsDefaultClockByDefault() {
+            // when
+            Clock clock = ClockUtils.get();
+
+            // then
+            assertThat(clock).isEqualTo(Clock.systemUTC());
+        }
+
+        @Test
+        void setStoresAndReturnsProvidedClock() {
+            // given
+            Clock clock = Clock.fixed(Instant.parse("2024-01-01T12:30:45Z"), ZoneOffset.UTC);
+
+            // when
+            Clock returnedClock = ClockUtils.set(clock);
+
+            // then
+            assertThat(returnedClock).isSameAs(clock);
+            assertThat(ClockUtils.get()).isSameAs(clock);
+        }
+
+        @Test
+        void resetRestoresDefaultClock() {
+            // given
+            Clock clock = Clock.fixed(Instant.parse("2024-01-01T12:30:45Z"), ZoneOffset.UTC);
+            ClockUtils.set(clock);
+
+            // when
+            Clock resetClock = ClockUtils.reset();
+
+            // then
+            assertThat(resetClock).isEqualTo(Clock.systemUTC());
+            assertThat(ClockUtils.get()).isEqualTo(Clock.systemUTC());
+        }
+    }
+
+    @Nested
+    class InstantSourceBehavior {
+
+        @Test
+        void instantDelegatesToConfiguredClock() throws Exception {
+            // given
+            Instant instant = Instant.parse("2024-01-01T12:30:45Z");
+            Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
+            ClockUtils.set(clock);
+
+            // when
+            Instant result = ClockUtils.instant();
+
+            // then
+            assertThat(result).isEqualTo(instant);
+        }
+    }
+
+    @Nested
+    class UtilityClass {
+
+        @Test
+        void constructorIsNotAccessible() throws Exception {
+            // when
+            Constructor<ClockUtils> constructor = ClockUtils.class.getDeclaredConstructor();
+
+            // then
+            assertThatThrownBy(constructor::newInstance)
+                    .isInstanceOf(IllegalAccessException.class);
+        }
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -16,12 +16,13 @@
 
 package org.axonframework.eventsourcing.eventstore.jpa;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.slf4j.Logger;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -36,8 +37,13 @@ import java.util.List;
  */
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
-        Logger logger
+        Logger logger,
+        Clock clock
 ) {
+
+    GapAwareTrackingTokenOperations(int gapTimeout, Logger logger) {
+        this(gapTimeout, logger, ClockUtils.get());
+    }
 
     GapAwareTrackingToken withGapsCleaned(GapAwareTrackingToken token, List<Object[]> indexAndTimestampBetweenGaps) {
         Instant gapTimeoutThreshold = gapTimeoutThreshold();
@@ -79,8 +85,7 @@ record GapAwareTrackingTokenOperations(
         }
     }
 
-
     Instant gapTimeoutThreshold() {
-        return GenericEventMessage.clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
+        return clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.handler;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.conversion.Converter;
@@ -187,7 +188,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
     }
 
     private void storeSnapshot(I identifier, E entity, Position position) {
-        Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, GenericEventMessage.clock.instant(), Map.of());
+        Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, ClockUtils.instant(), Map.of());
 
         snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot)
             .whenComplete((voidResult, ex) -> {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -42,8 +42,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.repository.ManagedEntity;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Type;
 import java.time.Instant;

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -19,6 +19,7 @@ package org.axonframework.extension.springboot.eventsourcing.eventstore.jpa;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerExecutor;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -41,7 +42,6 @@ import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -249,21 +249,18 @@ class AggregateBasedJpaEventStorageEngineIT
         entityManager.clear();
         transaction.commit();
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-1", Set.of()), taggedEventMessage("0", Set.of()));
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-2", Set.of()), taggedEventMessage("1", Set.of()));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-3", Set.of()), taggedEventMessage("2", Set.of()));
 
-        GenericEventMessage.clock = Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-4", Set.of()), taggedEventMessage("3", Set.of()));
 
@@ -317,26 +314,26 @@ class AggregateBasedJpaEventStorageEngineIT
         Tag aggregateToKeep = Tag.of("MyAggregate", "keep");
         AppendCondition keepAggregateCondition =
                 AppendCondition.withCriteria(EventCriteria.havingTags(aggregateToKeep));
-        GenericEventMessage.clock = Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject, removeAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-1", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject, keepAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("1", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-2", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("2", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-3", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("3", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now, Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 5)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-4", Set.of(aggregateToRemove)));
@@ -510,5 +507,10 @@ class AggregateBasedJpaEventStorageEngineIT
         public static PersistenceAnnotationBeanPostProcessor persistenceAnnotationBeanPostProcessor() {
             return new PersistenceAnnotationBeanPostProcessor();
         }
+    }
+
+    @AfterEach
+    void afterAll() {
+        ClockUtils.reset();
     }
 }

--- a/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/MetadataContextGetterTest.java
+++ b/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/MetadataContextGetterTest.java
@@ -16,10 +16,11 @@
 
 package org.axonframework.extension.tracing.opentelemetry;
 
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
@@ -57,7 +58,7 @@ class MetadataContextGetterTest {
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                ClockUtils::instant
         );
     }
 }

--- a/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
+++ b/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
@@ -27,11 +27,12 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.tracing.SpanAttributesProvider;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -95,7 +96,7 @@ class OpenTelemetrySpanFactoryTest {
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                ClockUtils::instant
         );
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventMessage.java
@@ -73,12 +73,12 @@ public interface EventMessage extends Message {
     EventMessage andMetadata(Map<String,@Nullable String> metadata);
 
     @Override
-        default EventMessage withConvertedPayload(Class<?> type, Converter converter) {
+    default EventMessage withConvertedPayload(Class<?> type, Converter converter) {
         return withConvertedPayload((Type) type, converter);
     }
 
     @Override
-        default EventMessage withConvertedPayload(TypeReference<?> type, Converter converter) {
+    default EventMessage withConvertedPayload(TypeReference<?> type, Converter converter) {
         return withConvertedPayload(type.getType(), converter);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/GenericEventMessage.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.ObjectUtils;
-import org.axonframework.common.annotation.Internal;
 import org.axonframework.conversion.CachingSupplier;
 import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.GenericMessage;
@@ -28,7 +28,6 @@ import org.axonframework.messaging.core.Metadata;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -44,16 +43,6 @@ import java.util.function.Supplier;
 public class GenericEventMessage extends MessageDecorator implements EventMessage {
 
     private final Supplier<Instant> timestampSupplier;
-
-    /**
-     * {@link Clock} instance used to set the time on new events. To fix the time while testing set this value to a
-     * constant value.
-     *
-     * @deprecated #3083 - Configure application wide Clock
-     */
-    @Internal
-    @Deprecated // TODO #3083 - Configure application wide Clock
-    public static Clock clock = Clock.systemUTC();
 
     /**
      * Constructs a {@code GenericEventMessage} for the given {@code type} and {@code payload}.
@@ -78,7 +67,7 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     public GenericEventMessage(MessageType type,
                                @Nullable Object payload,
                                Map<String, @Nullable String> metadata) {
-        this(new GenericMessage(type, payload, metadata), clock.instant());
+        this(new GenericMessage(type, payload, metadata), ClockUtils.instant());
     }
 
     /**
@@ -97,6 +86,23 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
                                Map<String, String> metadata,
                                Instant timestamp) {
         this(new GenericMessage(identifier, type, payload, metadata), timestamp);
+    }
+
+    /**
+     * Constructs a {@code GenericEventMessage} for the given {@code delegate} and {@code timestampSupplier}, intended
+     * to reconstruct another {@link EventMessage}.
+     * <p>
+     * The timestamp of the event is supplied lazily through the global {@link ClockUtils#SUPPLIER}.
+     * <p>
+     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
+     * of Work.
+     *
+     * @param delegate          The {@link Message} containing {@link Message#payload() payload},
+     *                          {@link Message#type() type}, {@link Message#identifier() identifier} and
+     *                          {@link Message#metadata() metadata} for the {@link EventMessage} to reconstruct.
+     */
+    public GenericEventMessage(Message delegate) {
+        this(delegate, ClockUtils.SUPPLIER);
     }
 
     /**
@@ -142,12 +148,12 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     }
 
     @Override
-        public Instant timestamp() {
+    public Instant timestamp() {
         return timestampSupplier.get();
     }
 
     @Override
-        public EventMessage withMetadata(Map<String, String> metadata) {
+    public EventMessage withMetadata(Map<String, String> metadata) {
         if (metadata().equals(metadata)) {
             return this;
         }
@@ -155,7 +161,7 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     }
 
     @Override
-        public EventMessage andMetadata(Map<String, String> metadata) {
+    public EventMessage andMetadata(Map<String, String> metadata) {
         //noinspection ConstantConditions
         if (metadata == null || metadata.isEmpty() || metadata().equals(metadata)) {
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventPublishingUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventPublishingUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.gateway;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
@@ -49,7 +50,7 @@ class EventPublishingUtils {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message, ClockUtils::instant);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -77,7 +78,7 @@ class EventPublishingUtils {
             return e.andMetadata(metadata);
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message.andMetadata(metadata), () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message.andMetadata(metadata), ClockUtils::instant);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -426,7 +427,7 @@ class Coordinator {
         private BiConsumer<Integer, UnaryOperator<TrackerStatus>> processingStatusUpdater;
         private long tokenClaimInterval = 5000;
         private long claimExtensionThreshold = 5000;
-        private Clock clock = GenericEventMessage.clock;
+        private Clock clock = ClockUtils.get();
         private MaxSegmentProvider maxSegmentProvider;
         private int initialSegmentCount = 16;
         private Function<TrackingTokenSource, CompletableFuture<TrackingToken>> initialToken;
@@ -556,7 +557,7 @@ class Coordinator {
 
         /**
          * The {@link Clock} used for any time dependent operations in this {@link Coordinator}. For example used to
-         * define when to attempt claiming new tokens. Defaults to {@link GenericEventMessage#clock}.
+         * define when to attempt claiming new tokens. Defaults to {@link ClockUtils#get()}.
          *
          * @param clock a {@link Clock} used for any time dependent operations in this {@link Coordinator}
          * @return the current Builder instance, for fluent interfacing
@@ -1040,7 +1041,7 @@ class Coordinator {
                             .limit(workPackages.size() - maxSegmentsPerNode)
                             .forEach(workPackage -> releaseUntil(
                                     workPackage.segment().getSegmentId(),
-                                    GenericEventMessage.clock.instant().plusMillis(tokenClaimInterval)
+                                    clock.instant().plusMillis(tokenClaimInterval)
                             ));
             }
             return tooManySegmentsClaimed;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -222,7 +222,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     @Override
     public CompletableFuture<Void> releaseSegment(int segmentId, long releaseDuration, TimeUnit unit) {
         coordinator.releaseUntil(
-                segmentId, GenericEventMessage.clock.instant().plusMillis(unit.toMillis(releaseDuration))
+                segmentId, configuration.clock().instant().plusMillis(unit.toMillis(releaseDuration))
         );
         return FutureUtils.emptyCompletedFuture();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.configuration.Configuration;
@@ -102,7 +103,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
     private MaxSegmentProvider maxSegmentProvider = MaxSegmentProvider.maxShort();
     private long claimExtensionThreshold = 5000;
     private int batchSize = 1;
-    private Clock clock = GenericEventMessage.clock;
+    private Clock clock = ClockUtils.get();
     private boolean coordinatorExtendsClaims = false;
     private Function<Set<QualifiedName>, EventCriteria> eventCriteriaProvider =
             (supportedEvents) -> EventCriteria.havingAnyTag().andBeingOneOfTypes(supportedEvents);
@@ -383,7 +384,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * Defines the {@link Clock} used for time dependent operation by this {@link EventProcessor}. Used by the
      * {@link Coordinator} and {@link WorkPackage} threads to decide when to perform certain tasks, like updating
      * {@link TrackingToken} claims or when to unmark a {@link Segment} as "unclaimable". Defaults to
-     * {@link GenericEventMessage#clock}.
+     * {@link ClockUtils#get()}.
      *
      * @param clock The {@link Clock} used for time dependent operation by this {@link EventProcessor}.
      * @return The current instance, for fluent interfacing.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.EmptyApplicationContext;
@@ -609,7 +610,7 @@ class WorkPackage {
         private int batchSize = 1;
         private long claimExtensionThreshold = 5000;
         private @Nullable Consumer<UnaryOperator<TrackerStatus>> segmentStatusUpdater;
-        private Clock clock = GenericEventMessage.clock;
+        private Clock clock = ClockUtils.get();
         private Supplier<ProcessingContext> schedulingProcessingContextProvider = () ->
                 new EventSchedulingProcessingContext(EmptyApplicationContext.INSTANCE);
 
@@ -743,8 +744,7 @@ class WorkPackage {
 
         /**
          * Defines the {@link Clock} used for time dependent operations. For example used to update whenever this
-         * {@code WorkPackage} updated the {@link TrackingToken} claim last. Defaults to
-         * {@link GenericEventMessage#clock}.
+         * {@code WorkPackage} updated the {@link TrackingToken} claim last.
          *
          * @param clock the {@link Clock} used for time dependent operations
          * @return the current Builder instance, for fluent interfacing

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/EventTestUtils.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/EventTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.NonNull;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
@@ -84,11 +85,11 @@ public abstract class EventTestUtils {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message, ClockUtils.instant());
         }
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                GenericEventMessage.clock.instant()
+                ClockUtils.instant()
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.annotation;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.conversion.Converter;
 import org.axonframework.conversion.PassThroughConverter;
 import org.axonframework.messaging.core.LegacyResources;
@@ -231,7 +232,7 @@ class AnnotatedEventHandlingComponentTest {
         @Test
         void resolvesTimestamps() {
             var timestamp = Instant.now();
-            GenericEventMessage.clock = Clock.fixed(timestamp, ZoneId.systemDefault());
+            ClockUtils.set(Clock.fixed(timestamp, ZoneId.systemDefault()));
 
             // given
             var event = eventMessage(0);
@@ -246,7 +247,7 @@ class AnnotatedEventHandlingComponentTest {
 
         @AfterEach
         void afterEach() {
-            GenericEventMessage.clock = Clock.systemUTC();
+            ClockUtils.reset();
         }
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageType;
@@ -165,7 +166,7 @@ class AnnotationBasedEntityEvolvingComponentTest {
         @Test
         void resolvesTimestamps() {
             var timestamp = Instant.now();
-            GenericEventMessage.clock = Clock.fixed(timestamp, ZoneId.systemDefault());
+            ClockUtils.set(Clock.fixed(timestamp, ZoneId.systemDefault()));
 
             // given
             var state = new TestState();
@@ -181,7 +182,7 @@ class AnnotationBasedEntityEvolvingComponentTest {
 
         @AfterEach
         void afterEach() {
-            GenericEventMessage.clock = Clock.systemUTC();
+            ClockUtils.reset();
         }
     }
 

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
@@ -81,7 +82,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
              aggregateIdentifier,
              sequenceNumber,
              new GenericMessage(type, payload, metadata),
-             clock.instant());
+             ClockUtils.instant());
     }
 
     /**
@@ -195,7 +196,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
     }
 
     @Override
-        public GenericDomainEventMessage withMetadata(Map<String, String> metadata) {
+    public GenericDomainEventMessage withMetadata(Map<String, String> metadata) {
         if (metadata().equals(metadata)) {
             return this;
         }

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.Nullable;
 import org.axonframework.common.Assert;
 import org.axonframework.common.FutureUtils;
@@ -462,12 +463,12 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     private void executeAtSimulatedTime(Runnable runnable) {
-        Clock previousClock = GenericEventMessage.clock;
+        Clock previousClock = ClockUtils.get();
         try {
-            GenericEventMessage.clock = Clock.fixed(currentTime(), ZoneOffset.UTC);
+            ClockUtils.set(Clock.fixed(currentTime(), ZoneOffset.UTC));
             runnable.run();
         } finally {
-            GenericEventMessage.clock = previousClock;
+            ClockUtils.set(previousClock);
         }
     }
 

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -103,11 +103,10 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
             return (EventMessage) event;
         } else if (event instanceof Message) {
             Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/stash/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -323,11 +323,10 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
             return (EventMessage) event;
         } else if (event instanceof Message) {
             Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -37,8 +37,7 @@ class AnnotatedSagaTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -45,8 +45,7 @@ class EventValidatorTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), (P) event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), (P) event)
         );
     }
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
@@ -79,8 +79,7 @@ public class FixtureRegisteringMethodEnhancementsTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/todo/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
+++ b/stash/todo/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
@@ -18,10 +18,10 @@ package org.axonframework.deadline;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.*;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.tracing.NoOpSpanFactory;
 import org.axonframework.messaging.tracing.Span;
@@ -355,7 +355,7 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
             Span span = spanFactory.createExecuteSpan(deadlineId.deadlineName, deadlineId.deadlineId, deadlineMessage)
                                    .start();
             try (SpanScope unused = span.makeCurrent()) {
-                Instant triggerInstant = GenericEventMessage.clock.instant();
+                Instant triggerInstant = ClockUtils.instant();
                 /*
                 // TODO: reintegrate as part of #3065
                 LegacyUnitOfWork<DeadlineMessage> unitOfWork = new LegacyDefaultUnitOfWork<>(new GenericDeadlineMessage(

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
@@ -81,7 +82,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
              aggregateIdentifier,
              sequenceNumber,
              new GenericMessage(type, payload, metadata),
-             clock.instant());
+             ClockUtils.instant());
     }
 
     /**

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
@@ -23,6 +23,7 @@ import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
@@ -51,7 +52,6 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 import static org.axonframework.messaging.eventhandling.scheduling.dbscheduler.DbSchedulerScheduleToken.TASK_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -253,7 +253,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -279,7 +279,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.scheduling.jobrunr;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventBus;
@@ -48,7 +49,6 @@ import java.util.UUID;
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.deadline.jobrunr.LabelUtils.getLabel;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 
 /**
  * EventScheduler implementation that delegates scheduling and triggering to a JobRunr JobScheduler.
@@ -151,7 +151,7 @@ public class JobRunrEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override
@@ -241,7 +241,7 @@ public class JobRunrEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.scheduling.quartz;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventBus;
@@ -52,7 +53,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 import static org.axonframework.messaging.eventhandling.scheduling.quartz.FireEventJob.*;
 import static org.quartz.JobKey.jobKey;
 
@@ -148,7 +148,7 @@ public class QuartzEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -197,7 +197,7 @@ public class QuartzEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventsourcing.eventstore.jdbc;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.JdbcSQLErrorCodesResolver;
@@ -679,7 +680,7 @@ public class LegacyJdbcEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     private Instant gapTimeoutFrame() {
-        return GenericEventMessage.clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
+        return ClockUtils.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 
     /**

--- a/stash/todo/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
@@ -93,11 +93,10 @@ public class StubEventScheduler implements EventScheduler {
             return (EventMessage) event;
         } else if (event instanceof Message) {
             Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), (P) event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), (P) event)
         );
     }
 

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/DomainEventTestUtils.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/DomainEventTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.Metadata;
@@ -104,12 +105,12 @@ public abstract class DomainEventTestUtils {
                                                        String payload,
                                                        Metadata metadata) {
         return new org.axonframework.messaging.eventhandling.GenericDomainEventMessage(type,
-                                               aggregateId,
-                                               sequenceNumber,
-                                               eventId,
-                                               TYPE,
-                                               payload,
-                                               metadata,
-                                               GenericDomainEventMessage.clock.instant());
+                                                                                       aggregateId,
+                                                                                       sequenceNumber,
+                                                                                       eventId,
+                                                                                       TYPE,
+                                                                                       payload,
+                                                                                       metadata,
+                                                                                       ClockUtils.instant());
     }
 }

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventsourcing.eventstore;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.DomainEventMessage;
 import org.axonframework.messaging.eventhandling.DomainEventTestUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -53,7 +54,7 @@ public abstract class EventStorageEngineTest {
 
     @AfterEach
     public void tearDown() {
-        GenericEventMessage.clock = Clock.systemUTC();
+        ClockUtils.reset();
     }
 
     @Test

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventsourcing.eventstore.jdbc;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.eventhandling.DomainEventMessage;
@@ -169,19 +170,16 @@ class JdbcEventStorageEngineIT
 
     @Test
     void gapsForVeryOldEventsAreNotIncluded() throws SQLException {
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2));
 
-        GenericEventMessage.clock = Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3));
 
         try (Connection conn = dataSource.getConnection()) {
@@ -199,13 +197,13 @@ class JdbcEventStorageEngineIT
         testSubject = createEngine(engineBuilder -> engineBuilder.gapTimeout(50001).gapCleaningThreshold(50));
 
         Instant now = Clock.systemUTC().instant();
-        GenericEventMessage.clock = Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0)); // index 0 and 1
-        GenericEventMessage.clock = Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1)); // index 2 and 3
-        GenericEventMessage.clock = Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2)); // index 4 and 5
-        GenericEventMessage.clock = Clock.fixed(now, Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3)); // index 6 and 7
 
         try (Connection conn = dataSource.getConnection()) {
@@ -219,7 +217,7 @@ class JdbcEventStorageEngineIT
         List<? extends TrackedEventData<?>> events =
                 testSubject.fetchTrackedEvents(GapAwareTrackingToken.newInstance(6, gaps), 100);
         assertEquals(1, events.size());
-        assertEquals(4L, (long) ((GapAwareTrackingToken) events.get(0).trackingToken()).getGaps().first());
+        assertEquals(4L, (long) ((GapAwareTrackingToken) events.getFirst().trackingToken()).getGaps().first());
     }
 
     @Test
@@ -489,4 +487,5 @@ class JdbcEventStorageEngineIT
             throw new IllegalStateException(e);
         }
     }
+
 }


### PR DESCRIPTION
Introduced ClockUtils to replace `GenericEventMessage.clock` as the central keeper of current clock.

Hint:

- most changes are related to the replacement of the static import
- not yet included in `ComponentRegistry`

will fix #3083