### PR TITLE
[#3083] Configure application wide Clock

### DIFF
--- a/common/src/main/java/org/axonframework/common/ClockUtils.java
+++ b/common/src/main/java/org/axonframework/common/ClockUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Global access point for the framework's current {@link Clock}.
+ * <p>
+ * This utility provides a shared clock abstraction that can be read from anywhere in the framework and overridden in
+ * tests or integration scenarios. It also implements {@link InstantSource} so callers can use it wherever an instant
+ * source is required.
+ *
+ * @author Jan Galinski
+ * @since 5.2.0
+ */
+public final class ClockUtils  {
+
+    /**
+     * A supplier that returns the current instant of the global clock.
+     */
+    public static final Supplier<Instant> SUPPLIER = ClockUtils::instant;
+
+    /**
+     * The default global clock used by the framework.
+     * <p>
+     * This clock is UTC-based and is restored by {@link #reset()}.
+     */
+    private static final Clock DEFAULT_CLOCK = Clock.systemUTC();
+
+    private static final AtomicReference<Clock> CLOCK = new AtomicReference<>(DEFAULT_CLOCK);
+
+    /**
+     * Returns the currently configured global clock.
+     *
+     * @return the shared clock instance, or the default UTC clock if none has been configured explicitly
+     */
+    public static Clock get() {
+        return CLOCK.get();
+    }
+
+    /**
+     * Replaces the currently configured global clock.
+     *
+     * @param clock the new global clock to use
+     * @return the clock that was installed
+     */
+    public static Clock set(Clock clock) {
+        CLOCK.set(clock);
+        return clock;
+    }
+
+    /**
+     * Restores the global clock to the default UTC clock.
+     *
+     * @return the default UTC clock
+     */
+    public static Clock reset() {
+        return set(DEFAULT_CLOCK);
+    }
+
+    /**
+     * Adapts the current clock to the {@link InstantSource} interface.
+     *
+     * @return the {@link InstantSource#instant()} of the current clock
+     */
+    public static Instant instant() {
+        return get().instant();
+    }
+
+    private ClockUtils() {
+        // do not instantiate
+    }
+}

--- a/common/src/test/java/org/axonframework/common/ClockUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/ClockUtilsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Constructor;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClockUtilsTest {
+
+    @AfterEach
+    void resetClock() {
+        ClockUtils.reset();
+    }
+
+    @Nested
+    class GetSetReset {
+
+        @Test
+        void getReturnsDefaultClockByDefault() {
+            // when
+            Clock clock = ClockUtils.get();
+
+            // then
+            assertThat(clock).isEqualTo(Clock.systemUTC());
+        }
+
+        @Test
+        void setStoresAndReturnsProvidedClock() {
+            // given
+            Clock clock = Clock.fixed(Instant.parse("2024-01-01T12:30:45Z"), ZoneOffset.UTC);
+
+            // when
+            Clock returnedClock = ClockUtils.set(clock);
+
+            // then
+            assertThat(returnedClock).isSameAs(clock);
+            assertThat(ClockUtils.get()).isSameAs(clock);
+        }
+
+        @Test
+        void resetRestoresDefaultClock() {
+            // given
+            Clock clock = Clock.fixed(Instant.parse("2024-01-01T12:30:45Z"), ZoneOffset.UTC);
+            ClockUtils.set(clock);
+
+            // when
+            Clock resetClock = ClockUtils.reset();
+
+            // then
+            assertThat(resetClock).isEqualTo(Clock.systemUTC());
+            assertThat(ClockUtils.get()).isEqualTo(Clock.systemUTC());
+        }
+    }
+
+    @Nested
+    class InstantSourceBehavior {
+
+        @Test
+        void instantDelegatesToConfiguredClock() throws Exception {
+            // given
+            Instant instant = Instant.parse("2024-01-01T12:30:45Z");
+            Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
+            ClockUtils.set(clock);
+
+            // when
+            Instant result = ClockUtils.instant();
+
+            // then
+            assertThat(result).isEqualTo(instant);
+        }
+    }
+
+    @Nested
+    class UtilityClass {
+
+        @Test
+        void constructorIsNotAccessible() throws Exception {
+            // when
+            Constructor<ClockUtils> constructor = ClockUtils.class.getDeclaredConstructor();
+
+            // then
+            assertThatThrownBy(constructor::newInstance)
+                    .isInstanceOf(IllegalAccessException.class);
+        }
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -37,14 +37,8 @@ import java.util.List;
  */
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
-        Logger logger,
-        @Deprecated(forRemoval = true, since = "5.2.0")
-        Clock clock
+        Logger logger
 ) {
-
-    GapAwareTrackingTokenOperations(int gapTimeout, Logger logger) {
-        this(gapTimeout, logger, ClockUtils.get());
-    }
 
     GapAwareTrackingToken withGapsCleaned(GapAwareTrackingToken token, List<Object[]> indexAndTimestampBetweenGaps) {
         Instant gapTimeoutThreshold = gapTimeoutThreshold();
@@ -87,6 +81,6 @@ record GapAwareTrackingTokenOperations(
     }
 
     Instant gapTimeoutThreshold() {
-        return clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
+        return ClockUtils.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -16,12 +16,13 @@
 
 package org.axonframework.eventsourcing.eventstore.jpa;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.slf4j.Logger;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -36,8 +37,13 @@ import java.util.List;
  */
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
-        Logger logger
+        Logger logger,
+        Clock clock
 ) {
+
+    GapAwareTrackingTokenOperations(int gapTimeout, Logger logger) {
+        this(gapTimeout, logger, ClockUtils.get());
+    }
 
     GapAwareTrackingToken withGapsCleaned(GapAwareTrackingToken token, List<Object[]> indexAndTimestampBetweenGaps) {
         Instant gapTimeoutThreshold = gapTimeoutThreshold();
@@ -79,8 +85,7 @@ record GapAwareTrackingTokenOperations(
         }
     }
 
-
     Instant gapTimeoutThreshold() {
-        return GenericEventMessage.clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
+        return clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -38,6 +38,7 @@ import java.util.List;
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
         Logger logger,
+        @Deprecated(forRemoval = true, since = "5.2.0")
         Clock clock
 ) {
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.handler;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.conversion.Converter;
@@ -165,11 +166,11 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
             };
 
         return source
-            .reduce((E) null, accumulator)
+            .reduce(null, accumulator)
             .exceptionallyCompose(e -> switch (e) {
                 case SnapshotIncompatibleException sce ->
                     transaction.source(SourcingCondition.conditionFor(Position.START, criteria), positionRef::set)
-                        .reduce((E) null, accumulator);
+                        .reduce(null, accumulator);
                 default -> CompletableFuture.failedFuture(e);
             })
             .thenApply(entity -> {
@@ -187,7 +188,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
     }
 
     private void storeSnapshot(I identifier, E entity, Position position) {
-        Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, GenericEventMessage.clock.instant(), Map.of());
+        Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, ClockUtils.instant(), Map.of());
 
         snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot)
             .whenComplete((voidResult, ex) -> {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -42,8 +42,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.repository.ManagedEntity;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Type;
 import java.time.Instant;

--- a/examples/university-java/pom.xml
+++ b/examples/university-java/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
         <dependency>
             <groupId>org.axonframework</groupId>
+            <artifactId>axon-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
             <artifactId>axon-eventsourcing</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitor.java
+++ b/extensions/metrics/metrics-dropwizard/src/main/java/org/axonframework/extension/metrics/dropwizard/EventProcessorLatencyMonitor.java
@@ -20,6 +20,7 @@ import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.Metric;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricSet;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
@@ -48,21 +49,24 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class EventProcessorLatencyMonitor implements MessageMonitor<EventMessage>, MetricSet {
 
+    @Deprecated(forRemoval = true, since = "5.2.0")
     private final Clock clock;
     private final AtomicLong processTime = new AtomicLong();
 
     /**
-     * Construct an {@link EventProcessorLatencyMonitor} using a {@link Clock#systemUTC()}.
+     * Construct an EventProcessorLatencyMonitor using {@link ClockUtils#get()}.
      */
     public EventProcessorLatencyMonitor() {
-        this(Clock.systemUTC());
+        this(ClockUtils.get());
     }
 
     /**
-     * Construct an {@link EventProcessorLatencyMonitor} using the given {@code clock}.
+     * Construct an EventProcessorLatencyMonitor using the given {@code clock}.
      *
      * @param clock defines the {@link Clock} used by this {@link MessageMonitor} implementation
+     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
      */
+    @Deprecated(forRemoval = true, since = "5.2.0")
     public EventProcessorLatencyMonitor(Clock clock) {
         this.clock = clock;
     }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -19,6 +19,7 @@ package org.axonframework.extension.springboot.eventsourcing.eventstore.jpa;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.jpa.EntityManagerExecutor;
 import org.axonframework.common.jpa.EntityManagerProvider;
@@ -41,7 +42,6 @@ import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -249,21 +249,18 @@ class AggregateBasedJpaEventStorageEngineIT
         entityManager.clear();
         transaction.commit();
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-1", Set.of()), taggedEventMessage("0", Set.of()));
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-2", Set.of()), taggedEventMessage("1", Set.of()));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-3", Set.of()), taggedEventMessage("2", Set.of()));
 
-        GenericEventMessage.clock = Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-4", Set.of()), taggedEventMessage("3", Set.of()));
 
@@ -317,26 +314,26 @@ class AggregateBasedJpaEventStorageEngineIT
         Tag aggregateToKeep = Tag.of("MyAggregate", "keep");
         AppendCondition keepAggregateCondition =
                 AppendCondition.withCriteria(EventCriteria.havingTags(aggregateToKeep));
-        GenericEventMessage.clock = Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject, removeAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-1", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject, keepAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("1", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-2", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("2", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-3", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("3", Set.of(aggregateToKeep)));
-        GenericEventMessage.clock = Clock.fixed(now, Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 5)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-4", Set.of(aggregateToRemove)));
@@ -510,5 +507,10 @@ class AggregateBasedJpaEventStorageEngineIT
         public static PersistenceAnnotationBeanPostProcessor persistenceAnnotationBeanPostProcessor() {
             return new PersistenceAnnotationBeanPostProcessor();
         }
+    }
+
+    @AfterEach
+    void afterAll() {
+        ClockUtils.reset();
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -307,7 +307,7 @@ class AggregateBasedJpaEventStorageEngineIT
         entityManager.clear();
         transaction.commit();
 
-        Instant now = Clock.systemUTC().instant();
+        Instant now = ClockUtils.instant();
         Tag aggregateToRemove = Tag.of("MyAggregate", "remove");
         AppendCondition removeAggregateCondition =
                 AppendCondition.withCriteria(EventCriteria.havingTags(aggregateToRemove));

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -68,6 +68,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -115,6 +117,7 @@ class AggregateBasedJpaEventStorageEngineIT
         if (testSubject != null) {
             testSubject.close();
         }
+        ClockUtils.reset();
     }
 
     @Override
@@ -249,18 +252,21 @@ class AggregateBasedJpaEventStorageEngineIT
         entityManager.clear();
         transaction.commit();
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
+        Instant now = ClockUtils.instant();
+
+        ClockUtils.set(fixed(now.minus(1, ChronoUnit.HOURS)));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-1", Set.of()), taggedEventMessage("0", Set.of()));
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
+
+        ClockUtils.set(fixed(now.minus(2, ChronoUnit.MINUTES)));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-2", Set.of()), taggedEventMessage("1", Set.of()));
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
+        ClockUtils.set(fixed(now.minus(50, ChronoUnit.SECONDS)));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-3", Set.of()), taggedEventMessage("2", Set.of()));
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
+        ClockUtils.set(fixed(now));
         appendCommitAndWait(testSubject, AppendCondition.none(),
                             taggedEventMessage("-4", Set.of()), taggedEventMessage("3", Set.of()));
 
@@ -308,32 +314,37 @@ class AggregateBasedJpaEventStorageEngineIT
         transaction.commit();
 
         Instant now = ClockUtils.instant();
+
         Tag aggregateToRemove = Tag.of("MyAggregate", "remove");
         AppendCondition removeAggregateCondition =
                 AppendCondition.withCriteria(EventCriteria.havingTags(aggregateToRemove));
         Tag aggregateToKeep = Tag.of("MyAggregate", "keep");
         AppendCondition keepAggregateCondition =
                 AppendCondition.withCriteria(EventCriteria.havingTags(aggregateToKeep));
-        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
+
+        ClockUtils.set(fixed(now.minus(1, ChronoUnit.HOURS)));
         appendCommitAndWait(gapConfigTestSubject, removeAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-1", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject, keepAggregateCondition,
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("1", Set.of(aggregateToKeep)));
-        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
+
+        ClockUtils.set(fixed(now.minus(2, ChronoUnit.MINUTES)));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-2", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 1)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("2", Set.of(aggregateToKeep)));
-        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
+
+        ClockUtils.set(fixed(now.minus(50, ChronoUnit.SECONDS)));
         appendCommitAndWait(gapConfigTestSubject,
                             removeAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-3", Set.of(aggregateToRemove)));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("keep", 3)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("3", Set.of(aggregateToKeep)));
-        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
+
+        ClockUtils.set(fixed(now));
         appendCommitAndWait(gapConfigTestSubject,
                             keepAggregateCondition.withMarker(new AggregateBasedConsistencyMarker("remove", 5)),
                             AggregateBasedStorageEngineTestSuite.taggedEventMessage("-4", Set.of(aggregateToRemove)));
@@ -509,8 +520,11 @@ class AggregateBasedJpaEventStorageEngineIT
         }
     }
 
-    @AfterEach
-    void afterAll() {
-        ClockUtils.reset();
+    static Clock fixed(Instant instant) {
+        return fixed(instant, ZoneOffset.UTC);
+    }
+
+    static Clock fixed(Instant instant, ZoneId zoneId) {
+        return Clock.fixed(instant, zoneId);
     }
 }

--- a/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/MetadataContextGetterTest.java
+++ b/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/MetadataContextGetterTest.java
@@ -16,10 +16,11 @@
 
 package org.axonframework.extension.tracing.opentelemetry;
 
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.junit.jupiter.api.*;
 
 import java.util.Collections;
@@ -57,7 +58,7 @@ class MetadataContextGetterTest {
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                ClockUtils::instant
         );
     }
 }

--- a/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
+++ b/extensions/tracing/tracing-opentelemetry/src/test/java/org/axonframework/extension/tracing/opentelemetry/OpenTelemetrySpanFactoryTest.java
@@ -27,11 +27,12 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.tracing.SpanAttributesProvider;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -95,7 +96,7 @@ class OpenTelemetrySpanFactoryTest {
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                ClockUtils::instant
         );
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventMessage.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public interface EventMessage extends Message {
 
     /**
-     * Returns the identifier of this {@link EventMessage event}.
+     * Returns the identifier of this .
      * <p>
      * The identifier is used to define the uniqueness of an event. Two events may contain similar (or equal)
      * {@link #payload() payloads} and {@link #timestamp() timestamp}, if the event identifiers are different, they both
@@ -52,17 +52,17 @@ public interface EventMessage extends Message {
      * previous address. In that case, the event payload is equal for both {@code EventMessage} instances, but the event
      * identifier is different for both.
      *
-     * @return The identifier of this {@link EventMessage event}.
+     * @return The identifier of this .
      */
     @Override
     String identifier();
 
     /**
-     * Returns the timestamp of this {@link EventMessage event}.
+     * Returns the timestamp of this .
      * <p>
      * The timestamp is set to the date and time the event was reported.
      *
-     * @return The timestamp of this {@link EventMessage event}.
+     * @return The timestamp of this .
      */
     Instant timestamp();
 
@@ -73,12 +73,12 @@ public interface EventMessage extends Message {
     EventMessage andMetadata(Map<String,@Nullable String> metadata);
 
     @Override
-        default EventMessage withConvertedPayload(Class<?> type, Converter converter) {
+    default EventMessage withConvertedPayload(Class<?> type, Converter converter) {
         return withConvertedPayload((Type) type, converter);
     }
 
     @Override
-        default EventMessage withConvertedPayload(TypeReference<?> type, Converter converter) {
+    default EventMessage withConvertedPayload(TypeReference<?> type, Converter converter) {
         return withConvertedPayload(type.getType(), converter);
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/GenericEventMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/GenericEventMessage.java
@@ -16,8 +16,8 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.ObjectUtils;
-import org.axonframework.common.annotation.Internal;
 import org.axonframework.conversion.CachingSupplier;
 import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.GenericMessage;
@@ -28,7 +28,6 @@ import org.axonframework.messaging.core.Metadata;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -44,16 +43,6 @@ import java.util.function.Supplier;
 public class GenericEventMessage extends MessageDecorator implements EventMessage {
 
     private final Supplier<Instant> timestampSupplier;
-
-    /**
-     * {@link Clock} instance used to set the time on new events. To fix the time while testing set this value to a
-     * constant value.
-     *
-     * @deprecated #3083 - Configure application wide Clock
-     */
-    @Internal
-    @Deprecated // TODO #3083 - Configure application wide Clock
-    public static Clock clock = Clock.systemUTC();
 
     /**
      * Constructs a {@code GenericEventMessage} for the given {@code type} and {@code payload}.
@@ -78,7 +67,7 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     public GenericEventMessage(MessageType type,
                                @Nullable Object payload,
                                Map<String, @Nullable String> metadata) {
-        this(new GenericMessage(type, payload, metadata), clock.instant());
+        this(new GenericMessage(type, payload, metadata), ClockUtils.instant());
     }
 
     /**
@@ -97,6 +86,23 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
                                Map<String, String> metadata,
                                Instant timestamp) {
         this(new GenericMessage(identifier, type, payload, metadata), timestamp);
+    }
+
+    /**
+     * Constructs a {@code GenericEventMessage} for the given {@code delegate}, intended
+     * to reconstruct another {@link EventMessage}.
+     * <p>
+     * The timestamp of the event is supplied lazily through the global {@link ClockUtils#SUPPLIER}.
+     * <p>
+     * Unlike the other constructors, this constructor will not attempt to retrieve any correlation data from the Unit
+     * of Work.
+     *
+     * @param delegate          The {@link Message} containing {@link Message#payload() payload},
+     *                          {@link Message#type() type}, {@link Message#identifier() identifier} and
+     *                          {@link Message#metadata() metadata} for the {@link EventMessage} to reconstruct.
+     */
+    public GenericEventMessage(Message delegate) {
+        this(delegate, ClockUtils.SUPPLIER);
     }
 
     /**
@@ -142,12 +148,12 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     }
 
     @Override
-        public Instant timestamp() {
+    public Instant timestamp() {
         return timestampSupplier.get();
     }
 
     @Override
-        public EventMessage withMetadata(Map<String, String> metadata) {
+    public EventMessage withMetadata(Map<String, String> metadata) {
         if (metadata().equals(metadata)) {
             return this;
         }
@@ -155,7 +161,7 @@ public class GenericEventMessage extends MessageDecorator implements EventMessag
     }
 
     @Override
-        public EventMessage andMetadata(Map<String, String> metadata) {
+    public EventMessage andMetadata(Map<String, String> metadata) {
         //noinspection ConstantConditions
         if (metadata == null || metadata.isEmpty() || metadata().equals(metadata)) {
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventPublishingUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventPublishingUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.gateway;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
@@ -49,7 +50,7 @@ class EventPublishingUtils {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message, ClockUtils::instant);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -77,7 +78,7 @@ class EventPublishingUtils {
             return e.andMetadata(metadata);
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message.andMetadata(metadata), () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message.andMetadata(metadata), ClockUtils::instant);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -100,6 +100,7 @@ class Coordinator {
     private final long claimExtensionThreshold;
     private final long tokenStoreInitRetryInterval;
     private final long tokenStoreInitMaxRetries;
+    @Deprecated(forRemoval = true, since = "5.2.0")
     private final Clock clock;
     private final MaxSegmentProvider maxSegmentProvider;
     private final int initialSegmentCount;
@@ -411,6 +412,7 @@ class Coordinator {
         private long claimExtensionThreshold = 5000;
         private long tokenStoreInitRetryInterval = 100;
         private long tokenStoreInitMaxRetries = 30;
+        @Deprecated(forRemoval = true, since = "5.2.0")
         private Clock clock = ClockUtils.get();
         private MaxSegmentProvider maxSegmentProvider;
         private int initialSegmentCount = 16;
@@ -565,9 +567,11 @@ class Coordinator {
          * The {@link Clock} used for any time dependent operations in this {@link Coordinator}. For example used to
          * define when to attempt claiming new tokens. Defaults to {@link ClockUtils#get()}.
          *
+         * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
          * @param clock a {@link Clock} used for any time dependent operations in this {@link Coordinator}
          * @return the current Builder instance, for fluent interfacing
          */
+        @Deprecated(forRemoval = true, since = "5.2.0")
         Builder clock(Clock clock) {
             this.clock = clock;
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -358,40 +358,40 @@ class Coordinator {
     }
 
     /**
-         * Status holder for this service. Defines whether it is running, has been started (to ensure double
-         * {@link #start()} invocations do not restart this coordinator) and maintains a shutdown handler to complete
-         * asynchronously through {@link #stop()}.
-         */
-        private record RunState(boolean isRunning, boolean wasStarted, CompletableFuture<Void> shutdownHandle,
-                                Runnable shutdownAction) {
+     * Status holder for this service. Defines whether it is running, has been started (to ensure double
+     * {@link #start()} invocations do not restart this coordinator) and maintains a shutdown handler to complete
+     * asynchronously through {@link #stop()}.
+     */
+    private record RunState(boolean isRunning, boolean wasStarted, @Nullable CompletableFuture<Void> shutdownHandle,
+                            Runnable shutdownAction) {
 
         public static RunState initial(Runnable shutdownAction) {
-                return new RunState(false, false, emptyCompletedFuture(), shutdownAction);
-            }
+            return new RunState(false, false, emptyCompletedFuture(), shutdownAction);
+        }
 
-            public RunState attemptStart() {
-                if (isRunning) {
-                    // It was already started
-                    return new RunState(true, false, null, shutdownAction);
-                } else if (shutdownHandle.isDone()) {
-                    // Shutdown has previously been completed. It's allowed to start
-                    return new RunState(true, true, null, shutdownAction);
-                } else {
-                    // Shutdown is in progress
-                    return this;
-                }
-            }
-
-            public RunState attemptStop() {
-                // It's already stopped
-                if (!isRunning || shutdownHandle != null) {
-                    return this;
-                }
-                CompletableFuture<Void> newShutdownHandle = new CompletableFuture<>();
-                newShutdownHandle.whenComplete((r, e) -> shutdownAction.run());
-                return new RunState(false, false, newShutdownHandle, shutdownAction);
+        public RunState attemptStart() {
+            if (isRunning) {
+                // It was already started
+                return new RunState(true, false, null, shutdownAction);
+            } else if (shutdownHandle.isDone()) {
+                // Shutdown has previously been completed. It's allowed to start
+                return new RunState(true, true, null, shutdownAction);
+            } else {
+                // Shutdown is in progress
+                return this;
             }
         }
+
+        public RunState attemptStop() {
+            // It's already stopped
+            if (!isRunning || shutdownHandle != null) {
+                return this;
+            }
+            CompletableFuture<Void> newShutdownHandle = new CompletableFuture<>();
+            newShutdownHandle.whenComplete((r, e) -> shutdownAction.run());
+            return new RunState(false, false, newShutdownHandle, shutdownAction);
+        }
+    }
 
     /**
      * Package private builder class to construct a {@link Coordinator}. Not used for validation of the fields as is the

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.ProcessUtils;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -356,66 +357,40 @@ class Coordinator {
     }
 
     /**
-     * Status holder for this service. Defines whether it is running, has been started (to ensure double
-     * {@link #start()} invocations do not restart this coordinator) and maintains a shutdown handler to complete
-     * asynchronously through {@link #stop()}.
-     */
-    private static class RunState {
-
-        private final boolean isRunning;
-        private final boolean wasStarted;
-        private final CompletableFuture<Void> shutdownHandle;
-        private final Runnable shutdownAction;
-
-        private RunState(boolean isRunning,
-                         boolean wasStarted,
-                         CompletableFuture<Void> shutdownHandle,
-                         Runnable shutdownAction) {
-            this.isRunning = isRunning;
-            this.wasStarted = wasStarted;
-            this.shutdownHandle = shutdownHandle;
-            this.shutdownAction = shutdownAction;
-        }
+         * Status holder for this service. Defines whether it is running, has been started (to ensure double
+         * {@link #start()} invocations do not restart this coordinator) and maintains a shutdown handler to complete
+         * asynchronously through {@link #stop()}.
+         */
+        private record RunState(boolean isRunning, boolean wasStarted, CompletableFuture<Void> shutdownHandle,
+                                Runnable shutdownAction) {
 
         public static RunState initial(Runnable shutdownAction) {
-            return new RunState(false, false, emptyCompletedFuture(), shutdownAction);
-        }
+                return new RunState(false, false, emptyCompletedFuture(), shutdownAction);
+            }
 
-        public RunState attemptStart() {
-            if (isRunning) {
-                // It was already started
-                return new RunState(true, false, null, shutdownAction);
-            } else if (shutdownHandle.isDone()) {
-                // Shutdown has previously been completed. It's allowed to start
-                return new RunState(true, true, null, shutdownAction);
-            } else {
-                // Shutdown is in progress
-                return this;
+            public RunState attemptStart() {
+                if (isRunning) {
+                    // It was already started
+                    return new RunState(true, false, null, shutdownAction);
+                } else if (shutdownHandle.isDone()) {
+                    // Shutdown has previously been completed. It's allowed to start
+                    return new RunState(true, true, null, shutdownAction);
+                } else {
+                    // Shutdown is in progress
+                    return this;
+                }
+            }
+
+            public RunState attemptStop() {
+                // It's already stopped
+                if (!isRunning || shutdownHandle != null) {
+                    return this;
+                }
+                CompletableFuture<Void> newShutdownHandle = new CompletableFuture<>();
+                newShutdownHandle.whenComplete((r, e) -> shutdownAction.run());
+                return new RunState(false, false, newShutdownHandle, shutdownAction);
             }
         }
-
-        public RunState attemptStop() {
-            // It's already stopped
-            if (!isRunning || shutdownHandle != null) {
-                return this;
-            }
-            CompletableFuture<Void> newShutdownHandle = new CompletableFuture<>();
-            newShutdownHandle.whenComplete((r, e) -> shutdownAction.run());
-            return new RunState(false, false, newShutdownHandle, shutdownAction);
-        }
-
-        public boolean isRunning() {
-            return isRunning;
-        }
-
-        public boolean wasStarted() {
-            return wasStarted;
-        }
-
-        public CompletableFuture<Void> shutdownHandle() {
-            return shutdownHandle;
-        }
-    }
 
     /**
      * Package private builder class to construct a {@link Coordinator}. Not used for validation of the fields as is the
@@ -436,7 +411,7 @@ class Coordinator {
         private long claimExtensionThreshold = 5000;
         private long tokenStoreInitRetryInterval = 100;
         private long tokenStoreInitMaxRetries = 30;
-        private Clock clock = GenericEventMessage.clock;
+        private Clock clock = ClockUtils.get();
         private MaxSegmentProvider maxSegmentProvider;
         private int initialSegmentCount = 16;
         private Function<TrackingTokenSource, CompletableFuture<TrackingToken>> initialToken;
@@ -588,7 +563,7 @@ class Coordinator {
 
         /**
          * The {@link Clock} used for any time dependent operations in this {@link Coordinator}. For example used to
-         * define when to attempt claiming new tokens. Defaults to {@link GenericEventMessage#clock}.
+         * define when to attempt claiming new tokens. Defaults to {@link ClockUtils#get()}.
          *
          * @param clock a {@link Clock} used for any time dependent operations in this {@link Coordinator}
          * @return the current Builder instance, for fluent interfacing
@@ -1092,7 +1067,7 @@ class Coordinator {
                             .limit(workPackages.size() - maxSegmentsPerNode)
                             .forEach(workPackage -> releaseUntil(
                                     workPackage.segment().getSegmentId(),
-                                    GenericEventMessage.clock.instant().plusMillis(tokenClaimInterval)
+                                    clock.instant().plusMillis(tokenClaimInterval)
                             ));
             }
             return tooManySegmentsClaimed;
@@ -1149,7 +1124,7 @@ class Coordinator {
                 Segment segment, Map<Segment, TrackingToken> claims
         ) {
             int segmentId = segment.getSegmentId();
-            return unitOfWorkFactory.create().<TrackingToken>executeWithResult(
+            return unitOfWorkFactory.create().executeWithResult(
                     context -> tokenStore.fetchToken(name, segment, context)
             ).thenApply(token -> {
                 claims.put(segment, token);

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.MergedTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -26,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -55,8 +58,9 @@ class MergeTask extends CoordinatorTask {
     private final Map<Integer, WorkPackage> workPackages;
     private final TokenStore tokenStore;
     private final UnitOfWorkFactory unitOfWorkFactory;
-    private final Map<Integer, java.time.Instant> releasesDeadlines;
-    private final java.time.Clock clock;
+    private final Map<Integer, Instant> releasesDeadlines;
+    @Deprecated(forRemoval = true, since = "5.2.0")
+    private final Clock clock;
 
     /**
      * Constructs a {@code MergeTask}.
@@ -75,16 +79,17 @@ class MergeTask extends CoordinatorTask {
      *                          the merged token.
      * @param unitOfWorkFactory The {@link UnitOfWorkFactory} that spawns {@link UnitOfWork UnitOfWorks} used to invoke
      *                          all {@link TokenStore} operations inside a unit of work.
-     * @param clock              the clock used for time-based operations
+     * @param clock             the clock used for time-based operations, deprecated in favor of {@link ClockUtils#get()}
      */
     MergeTask(CompletableFuture<Boolean> result,
               String name,
               int segmentId,
               Map<Integer, WorkPackage> workPackages,
-              Map<Integer, java.time.Instant> releasesDeadlines,
+              Map<Integer, Instant> releasesDeadlines,
               TokenStore tokenStore,
               UnitOfWorkFactory unitOfWorkFactory,
-              java.time.Clock clock) {
+              @Deprecated(forRemoval = true, since = "5.2.0")
+              Clock clock) {
         super(result, name);
         this.name = name;
         this.segmentId = segmentId;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -230,7 +230,7 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
     @Override
     public CompletableFuture<Void> releaseSegment(int segmentId, long releaseDuration, TimeUnit unit) {
         coordinator.releaseUntil(
-                segmentId, GenericEventMessage.clock.instant().plusMillis(unit.toMillis(releaseDuration))
+                segmentId, configuration.clock().instant().plusMillis(unit.toMillis(releaseDuration))
         );
         return FutureUtils.emptyCompletedFuture();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.ObjectUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.configuration.Configuration;
@@ -102,7 +103,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
     private MaxSegmentProvider maxSegmentProvider = MaxSegmentProvider.maxShort();
     private long claimExtensionThreshold = 5000;
     private int batchSize = 1;
-    private Clock clock = GenericEventMessage.clock;
+    private Clock clock = ClockUtils.get();
     private boolean coordinatorExtendsClaims = false;
     private Function<Set<QualifiedName>, EventCriteria> eventCriteriaProvider =
             (supportedEvents) -> EventCriteria.havingAnyTag().andBeingOneOfTypes(supportedEvents);
@@ -383,7 +384,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * Defines the {@link Clock} used for time dependent operation by this {@link EventProcessor}. Used by the
      * {@link Coordinator} and {@link WorkPackage} threads to decide when to perform certain tasks, like updating
      * {@link TrackingToken} claims or when to unmark a {@link Segment} as "unclaimable". Defaults to
-     * {@link GenericEventMessage#clock}.
+     * {@link ClockUtils#get()}.
      *
      * @param clock The {@link Clock} used for time dependent operation by this {@link EventProcessor}.
      * @return The current instance, for fluent interfacing.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -75,7 +75,7 @@ import static org.axonframework.common.BuilderUtils.assertStrictPositive;
  *     <li>The {@link MaxSegmentProvider} (used by {@link PooledStreamingEventProcessor#maxCapacity()}) defaults to {@link MaxSegmentProvider#maxShort()}.</li>
  *     <li>The {@code claimExtensionThreshold} defaults to {@code 5000} milliseconds.</li>
  *     <li>The {@code batchSize} defaults to {@code 1}.</li>
- *     <li>The {@link Clock} defaults to {@link GenericEventMessage#clock}.</li>
+ *     <li>The {@link Clock} defaults to {@link ClockUtils#get()}.</li>
  *     <li>The {@code coordinatorExtendsClaims} defaults to a {@code false}.</li>
  * </ul>
  * The following fields of this configuration are <b>hard requirements</b> and as such should be provided:
@@ -103,6 +103,7 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
     private MaxSegmentProvider maxSegmentProvider = MaxSegmentProvider.maxShort();
     private long claimExtensionThreshold = 5000;
     private int batchSize = 1;
+    @Deprecated(forRemoval = true, since = "5.2.0")
     private Clock clock = ClockUtils.get();
     private boolean coordinatorExtendsClaims = false;
     private Function<Set<QualifiedName>, EventCriteria> eventCriteriaProvider =
@@ -388,7 +389,9 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      *
      * @param clock The {@link Clock} used for time dependent operation by this {@link EventProcessor}.
      * @return The current instance, for fluent interfacing.
+     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
      */
+    @Deprecated(forRemoval = true, since = "5.2.0")
     public PooledStreamingEventProcessorConfiguration clock(Clock clock) {
         assertNonNull(clock, "Clock may not be null");
         this.clock = clock;
@@ -609,7 +612,9 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * Returns the {@link Clock} used for time-dependent operations.
      *
      * @return The {@link Clock} for this processor.
+     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
      */
+    @Deprecated(forRemoval = true, since = "5.2.0")
     public Clock clock() {
         return clock;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -27,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -52,10 +55,11 @@ class SplitTask extends CoordinatorTask {
     private final String name;
     private final int segmentId;
     private final Map<Integer, WorkPackage> workPackages;
-    private final Map<Integer, java.time.Instant> releasesDeadlines;
+    private final Map<Integer, Instant> releasesDeadlines;
     private final TokenStore tokenStore;
     private final UnitOfWorkFactory unitOfWorkFactory;
-    private final java.time.Clock clock;
+    @Deprecated(forRemoval = true, since = "5.2.0")
+    private final Clock clock;
 
     /**
      * Constructs a {@code SplitTask}.
@@ -72,16 +76,17 @@ class SplitTask extends CoordinatorTask {
      *                          it is not present in the {@code workPackages} and to store the split segment.
      * @param unitOfWorkFactory The {@link UnitOfWorkFactory} that spawns {@link UnitOfWork UnitOfWorks} used to invoke
      *                          all {@link TokenStore} operations inside a unit of work.
-     * @param clock             the clock used for time-based operations
+     * @param clock             the clock used for time-based operations, deprecated in favor of {@link ClockUtils#get()}.
      */
     SplitTask(CompletableFuture<Boolean> result,
               String name,
               int segmentId,
               Map<Integer, WorkPackage> workPackages,
-              Map<Integer, java.time.Instant> releasesDeadlines,
+              Map<Integer, Instant> releasesDeadlines,
               TokenStore tokenStore,
               UnitOfWorkFactory unitOfWorkFactory,
-              java.time.Clock clock) {
+              @Deprecated(forRemoval = true, since = "5.2.0")
+              Clock clock) {
 
         super(result, name);
         this.name = name;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -98,6 +98,7 @@ class WorkPackage {
     private final Consumer<UnaryOperator<TrackerStatus>> segmentStatusUpdater;
     private final Supplier<ProcessingContext> schedulingProcessingContextProvider;
     private Runnable batchProcessedCallback;
+    @Deprecated(forRemoval = true, since = "5.2.0")
     private final Clock clock;
 
     private TrackingToken lastDeliveredToken; // For use only by event delivery threads, like Coordinator
@@ -607,6 +608,7 @@ class WorkPackage {
         private int batchSize = 1;
         private long claimExtensionThreshold = 5000;
         private @Nullable Consumer<UnaryOperator<TrackerStatus>> segmentStatusUpdater;
+        @Deprecated(forRemoval = true, since = "5.2.0")
         private Clock clock = ClockUtils.get();
         private Supplier<ProcessingContext> schedulingProcessingContextProvider = () ->
                 new EventSchedulingProcessingContext(EmptyApplicationContext.INSTANCE);
@@ -745,7 +747,9 @@ class WorkPackage {
          *
          * @param clock the {@link Clock} used for time dependent operations
          * @return the current Builder instance, for fluent interfacing
+         * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
          */
+        @Deprecated(forRemoval = true, since = "5.2.0")
         Builder clock(Clock clock) {
             this.clock = clock;
             return this;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -17,6 +17,8 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.ClockUtils;
+import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.LegacyResources;
@@ -605,7 +607,7 @@ class WorkPackage {
         private int batchSize = 1;
         private long claimExtensionThreshold = 5000;
         private @Nullable Consumer<UnaryOperator<TrackerStatus>> segmentStatusUpdater;
-        private Clock clock = GenericEventMessage.clock;
+        private Clock clock = ClockUtils.get();
         private Supplier<ProcessingContext> schedulingProcessingContextProvider = () ->
                 new EventSchedulingProcessingContext(EmptyApplicationContext.INSTANCE);
 
@@ -739,8 +741,7 @@ class WorkPackage {
 
         /**
          * Defines the {@link Clock} used for time dependent operations. For example used to update whenever this
-         * {@code WorkPackage} updated the {@link TrackingToken} claim last. Defaults to
-         * {@link GenericEventMessage#clock}.
+         * {@code WorkPackage} updated the {@link TrackingToken} claim last.
          *
          * @param clock the {@link Clock} used for time dependent operations
          * @return the current Builder instance, for fluent interfacing
@@ -818,35 +819,28 @@ class WorkPackage {
     }
 
     /**
-     * Container of a {@link MessageStream.Entry} and {@code boolean} whether the given {@code eventMessage} can be
-     * handled in this package. The combination constitutes to a processing entry the {@code WorkPackage} should
-     * ingest.
-     */
-    private static class DefaultProcessingEntry implements ProcessingEntry {
-
-        private final MessageStream.Entry<? extends EventMessage> eventEntry;
-        private final boolean canHandle;
-
-        public DefaultProcessingEntry(MessageStream.Entry<? extends EventMessage> eventEntry, boolean canHandle) {
-            this.eventEntry = eventEntry;
-            this.canHandle = canHandle;
-        }
+         * Container of a {@link MessageStream.Entry} and {@code boolean} whether the given {@code eventMessage} can be
+         * handled in this package. The combination constitutes to a processing entry the {@code WorkPackage} should
+         * ingest.
+         */
+        private record DefaultProcessingEntry(MessageStream.Entry<? extends EventMessage> eventEntry, boolean canHandle)
+            implements ProcessingEntry {
 
         @Override
-        public TrackingToken trackingToken() {
-            return TrackingToken.fromContext(eventEntry).orElse(null);
-        }
+            public TrackingToken trackingToken() {
+                return TrackingToken.fromContext(eventEntry).orElse(null);
+            }
 
-        @Override
-        public void addToBatch(
-                List<MessageStream.Entry<? extends EventMessage>> eventBatch,
-                TrackingToken wrappedToken
-        ) {
-            if (canHandle) {
-                eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
+            @Override
+            public void addToBatch(
+                    List<MessageStream.Entry<? extends EventMessage>> eventBatch,
+                    TrackingToken wrappedToken
+            ) {
+                if (canHandle) {
+                    eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
+                }
             }
         }
-    }
 
     /**
      * Container of a batch of {@link ProcessingEntry ProcessingEntries}. These entries are grouped together since they

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -823,28 +823,28 @@ class WorkPackage {
     }
 
     /**
-         * Container of a {@link MessageStream.Entry} and {@code boolean} whether the given {@code eventMessage} can be
-         * handled in this package. The combination constitutes to a processing entry the {@code WorkPackage} should
-         * ingest.
-         */
-        private record DefaultProcessingEntry(MessageStream.Entry<? extends EventMessage> eventEntry, boolean canHandle)
+     * Container of a {@link MessageStream.Entry} and {@code boolean} whether the given {@code eventMessage} can be
+     * handled in this package. The combination constitutes to a processing entry the {@code WorkPackage} should
+     * ingest.
+     */
+    private record DefaultProcessingEntry(MessageStream.Entry<? extends EventMessage> eventEntry, boolean canHandle)
             implements ProcessingEntry {
 
         @Override
-            public TrackingToken trackingToken() {
+        public TrackingToken trackingToken() {
                 return TrackingToken.fromContext(eventEntry).orElse(null);
             }
 
-            @Override
-            public void addToBatch(
-                    List<MessageStream.Entry<? extends EventMessage>> eventBatch,
-                    TrackingToken wrappedToken
-            ) {
-                if (canHandle) {
-                    eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
-                }
+        @Override
+        public void addToBatch(
+                List<MessageStream.Entry<? extends EventMessage>> eventBatch,
+                TrackingToken wrappedToken
+        ) {
+            if (canHandle) {
+                eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
             }
         }
+    }
 
     /**
      * Container of a batch of {@link ProcessingEntry ProcessingEntries}. These entries are grouped together since they

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -832,8 +832,8 @@ class WorkPackage {
 
         @Override
         public TrackingToken trackingToken() {
-                return TrackingToken.fromContext(eventEntry).orElse(null);
-            }
+            return TrackingToken.fromContext(eventEntry).orElse(null);
+        }
 
         @Override
         public void addToBatch(

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenEntry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenEntry.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc;
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.Nullable;
 import org.axonframework.common.ClassUtils;
 import org.axonframework.common.DateTimeUtils;
@@ -44,8 +45,11 @@ public class JdbcTokenEntry {
 
     /**
      * The clock used to persist timestamps in this entry. Defaults to UTC system time.
+     *
+     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
      */
-    public static Clock clock = Clock.systemUTC();
+    @Deprecated(forRemoval = true, since = "5.2.0")
+    public static Clock clock = ClockUtils.get();
 
     private byte[] token;
     private String tokenType;

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenEntry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenEntry.java
@@ -43,14 +43,6 @@ import static org.axonframework.common.DateTimeUtils.formatInstant;
  */
 public class JdbcTokenEntry {
 
-    /**
-     * The clock used to persist timestamps in this entry. Defaults to UTC system time.
-     *
-     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
-     */
-    @Deprecated(forRemoval = true, since = "5.2.0")
-    public static Clock clock = ClockUtils.get();
-
     private byte[] token;
     private String tokenType;
     private String timestamp;
@@ -196,7 +188,7 @@ public class JdbcTokenEntry {
         if (!mayClaim(owner, claimTimeout)) {
             return false;
         }
-        this.timestamp = formatInstant(clock.instant());
+        this.timestamp = formatInstant(ClockUtils.instant());
         this.owner = owner;
         return true;
     }
@@ -214,7 +206,7 @@ public class JdbcTokenEntry {
     }
 
     private boolean expired(TemporalAmount claimTimeout) {
-        return timestamp().plus(claimTimeout).isBefore(clock.instant());
+        return timestamp().plus(claimTimeout).isBefore(ClockUtils.instant());
     }
 
     /**
@@ -227,7 +219,7 @@ public class JdbcTokenEntry {
     public boolean releaseClaim(String owner) {
         if (Objects.equals(this.owner, owner)) {
             this.owner = null;
-            this.timestamp = formatInstant(clock.instant());
+            this.timestamp = formatInstant(ClockUtils.instant());
         }
         return this.owner == null;
     }
@@ -240,7 +232,7 @@ public class JdbcTokenEntry {
      * @param converter The converter to update token to.
      */
     public final void updateToken(@Nullable TrackingToken token, Converter converter) {
-        this.timestamp = formatInstant(clock.instant());
+        this.timestamp = formatInstant(ClockUtils.instant());
         if (token != null) {
             this.token = converter.convert(token, byte[].class);
             this.tokenType = token.getClass().getName();

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStore.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.jdbc.JdbcException;
 import org.axonframework.common.tx.TransactionalExecutor;
@@ -812,7 +813,7 @@ public class JdbcTokenStore implements TokenStore {
                         " = ? AND " + schema.ownerColumn() + " = ?";
         PreparedStatement preparedStatement = connection.prepareStatement(sql);
         preparedStatement.setString(1, null);
-        preparedStatement.setString(2, formatInstant(JdbcTokenEntry.clock.instant()));
+        preparedStatement.setString(2, formatInstant(ClockUtils.instant()));
         preparedStatement.setString(3, processorName);
         preparedStatement.setInt(4, segment);
         preparedStatement.setString(5, nodeId);

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStore.java
@@ -19,6 +19,7 @@ package org.axonframework.messaging.eventhandling.processing.streaming.token.sto
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.tx.TransactionalExecutor;
 import org.axonframework.conversion.Converter;
@@ -46,7 +47,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.DateTimeUtils.formatInstant;
-import static org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.TokenEntry.clock;
 
 /**
  * Implementation of a token store that uses JPA to save and load tokens. This implementation uses {@link TokenEntry}
@@ -262,7 +262,7 @@ public class JpaTokenStore implements TokenStore {
                             .setParameter(PROCESSOR_NAME_PARAM, processorName)
                             .setParameter(SEGMENT_PARAM, segment)
                             .setParameter(OWNER_PARAM, nodeId)
-                            .setParameter("timestamp", formatInstant(clock.instant()))
+                            .setParameter("timestamp", formatInstant(ClockUtils.instant()))
                             .executeUpdate();
 
             if (updates == 0) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/TokenEntry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/TokenEntry.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa;
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.Nullable;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
@@ -51,7 +52,10 @@ public class TokenEntry {
 
     /**
      * The clock used to persist timestamps in this entry. Defaults to UTC system time.
+     *
+     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
      */
+    @Deprecated(forRemoval = true, since = "5.2.0")
     public static Clock clock = Clock.systemUTC();
 
     /**
@@ -66,6 +70,7 @@ public class TokenEntry {
     @Lob
     @Column(length = 10000)
     private byte[] token;
+
     @Basic
     private String tokenType;
 
@@ -77,8 +82,10 @@ public class TokenEntry {
 
     @Id
     private String processorName;
+
     @Id
     private int segment;
+
     @Basic(optional = false)
     private int mask;
 
@@ -158,7 +165,7 @@ public class TokenEntry {
     }
 
     private boolean expired(TemporalAmount claimTimeout) {
-        return timestamp().plus(claimTimeout).isBefore(clock.instant());
+        return timestamp().plus(claimTimeout).isBefore(ClockUtils.instant());
     }
 
     /**
@@ -171,7 +178,7 @@ public class TokenEntry {
     public boolean releaseClaim(String owner) {
         if (Objects.equals(this.owner, owner)) {
             this.owner = null;
-            this.timestamp = formatInstant(clock.instant());
+            this.timestamp = formatInstant(ClockUtils.instant());
         }
         return this.owner == null;
     }
@@ -202,7 +209,7 @@ public class TokenEntry {
      * @param converter The converter that will be used to serialize the token.
      */
     public void updateToken(@Nullable TrackingToken token, Converter converter) {
-        this.timestamp = formatInstant(clock.instant());
+        this.timestamp = formatInstant(ClockUtils.instant());
         if (token != null) {
             this.token = converter.convert(token, byte[].class);
             this.tokenType = token.getClass().getName();

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/TokenEntry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/TokenEntry.java
@@ -51,20 +51,12 @@ import static org.axonframework.common.DateTimeUtils.formatInstant;
 public class TokenEntry {
 
     /**
-     * The clock used to persist timestamps in this entry. Defaults to UTC system time.
-     *
-     * @deprecated Use {@link ClockUtils#set(Clock)} if you have to provide a non-default {@link Clock} instance.
-     */
-    @Deprecated(forRemoval = true, since = "5.2.0")
-    public static Clock clock = Clock.systemUTC();
-
-    /**
      * Computes a token timestamp.
      *
      * @return A token timestamp.
      */
     public static String computeTokenTimestamp() {
-        return formatInstant(clock.instant());
+        return formatInstant(ClockUtils.instant());
     }
 
     @Lob
@@ -102,7 +94,7 @@ public class TokenEntry {
                       Segment segment,
                       @Nullable TrackingToken token,
                       Converter converter) {
-        this.timestamp = formatInstant(clock.instant());
+        this.timestamp = formatInstant(ClockUtils.instant());
         if (token != null) {
             this.token = converter.convert(token, byte[].class);
             this.tokenType = token.getClass().getName();
@@ -147,7 +139,7 @@ public class TokenEntry {
         if (!mayClaim(owner, claimTimeout)) {
             return false;
         }
-        this.timestamp = formatInstant(clock.instant());
+        this.timestamp = formatInstant(ClockUtils.instant());
         this.owner = owner;
         return true;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/EventTestUtils.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/EventTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.NonNull;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
@@ -84,11 +85,11 @@ public abstract class EventTestUtils {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message, ClockUtils.instant());
         }
         return new GenericEventMessage(
                 new GenericMessage(new MessageType(event.getClass()), event),
-                GenericEventMessage.clock.instant()
+                ClockUtils.instant()
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.annotation;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.conversion.Converter;
 import org.axonframework.conversion.PassThroughConverter;
 import org.axonframework.messaging.core.LegacyResources;
@@ -237,7 +238,7 @@ class AnnotatedEventHandlingComponentTest {
         @Test
         void resolvesTimestamps() {
             var timestamp = Instant.now();
-            GenericEventMessage.clock = Clock.fixed(timestamp, ZoneId.systemDefault());
+            ClockUtils.set(Clock.fixed(timestamp, ZoneId.systemDefault()));
 
             // given
             var event = eventMessage(0);
@@ -252,7 +253,7 @@ class AnnotatedEventHandlingComponentTest {
 
         @AfterEach
         void afterEach() {
-            GenericEventMessage.clock = Clock.systemUTC();
+            ClockUtils.reset();
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -297,7 +297,8 @@ class MergeTaskTest {
 
         MergeTask mergeFromSegmentOne = new MergeTask(
                 new CompletableFuture<>(), PROCESSOR_NAME, SEGMENT_TO_BE_MERGED, workPackages,
-                releasesDeadlines, tokenStore, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE), clock
+                releasesDeadlines, tokenStore, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE),
+                ClockUtils.get()
         );
         when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
                 .thenReturn(completedFuture(tokenForSegment0));

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
@@ -71,7 +72,6 @@ class MergeTaskTest {
     private MergeTask testSubject;
 
     private final Map<Integer, java.time.Instant> releasesDeadlines = new HashMap<>();
-    private final java.time.Clock clock = java.time.Clock.systemUTC();
 
     @BeforeEach
     void setUp() {
@@ -86,7 +86,7 @@ class MergeTaskTest {
 
         testSubject = new MergeTask(
                 result, PROCESSOR_NAME, SEGMENT_TO_MERGE, workPackages, releasesDeadlines, tokenStore,
-                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE), clock
+                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE), ClockUtils.get()
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
@@ -51,7 +52,6 @@ class SplitTaskTest {
     private final WorkPackage workPackage = mock(WorkPackage.class);
     private final Map<Integer, java.time.Instant> releasesDeadlines = new HashMap<>();
     private CompletableFuture<Boolean> result;
-    private final java.time.Clock clock = java.time.Clock.systemUTC();
     private SplitTask testSubject;
 
     @BeforeEach
@@ -66,7 +66,7 @@ class SplitTaskTest {
                 releasesDeadlines,
                 tokenStore,
                 UnitOfWorkTestUtils.SIMPLE_FACTORY,
-                clock
+                ClockUtils.get()
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
@@ -423,7 +423,7 @@ class JdbcTokenStoreTest {
 
         transactionManager.executeInTransaction(
                 () -> joinAndUnwrap(tokenStore.fetchToken("concurrent", 0, null)));
-        ClockUtils.set(Clock.offset(Clock.systemUTC(), Duration.ofHours(1)));
+        ClockUtils.set(Clock.offset(ClockUtils.get(), Duration.ofHours(1)));
         TrackingToken token = transactionManager.fetchInTransaction(
                 () -> joinAndUnwrap(concurrentTokenStore.fetchToken("concurrent", 0, null)));
         assertNull(token);

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jdbc.ConnectionExecutor;
 import org.axonframework.conversion.TestConverter;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -100,7 +101,7 @@ class JdbcTokenStoreTest {
 
     @AfterEach
     void tearDown() {
-        JdbcTokenEntry.clock = Clock.systemUTC();
+        ClockUtils.reset();
     }
 
     @Test
@@ -422,7 +423,7 @@ class JdbcTokenStoreTest {
 
         transactionManager.executeInTransaction(
                 () -> joinAndUnwrap(tokenStore.fetchToken("concurrent", 0, null)));
-        JdbcTokenEntry.clock = Clock.offset(Clock.systemUTC(), Duration.ofHours(1));
+        ClockUtils.set(Clock.offset(Clock.systemUTC(), Duration.ofHours(1)));
         TrackingToken token = transactionManager.fetchInTransaction(
                 () -> joinAndUnwrap(concurrentTokenStore.fetchToken("concurrent", 0, null)));
         assertNull(token);
@@ -542,7 +543,7 @@ class JdbcTokenStoreTest {
                 () -> {
                     try (PreparedStatement ps = dataSource.getConnection()
                                                           .prepareStatement(
-                                                                  "INSERT INTO TokenEntry(processorName, segment, mask, tokenType, token) VALUES(?, ?, ?, ?, ?)");) {
+                                                                  "INSERT INTO TokenEntry(processorName, segment, mask, tokenType, token) VALUES(?, ?, ?, ?, ?)")) {
                         ps.setString(1, "__config");
                         ps.setInt(2, 0);
                         ps.setInt(3, 0);

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageType;
@@ -165,7 +166,7 @@ class AnnotationBasedEntityEvolvingComponentTest {
         @Test
         void resolvesTimestamps() {
             var timestamp = Instant.now();
-            GenericEventMessage.clock = Clock.fixed(timestamp, ZoneId.systemDefault());
+            ClockUtils.set(Clock.fixed(timestamp, ZoneId.systemDefault()));
 
             // given
             var state = new TestState();
@@ -181,7 +182,7 @@ class AnnotationBasedEntityEvolvingComponentTest {
 
         @AfterEach
         void afterEach() {
-            GenericEventMessage.clock = Clock.systemUTC();
+            ClockUtils.reset();
         }
     }
 

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
@@ -81,7 +82,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
              aggregateIdentifier,
              sequenceNumber,
              new GenericMessage(type, payload, metadata),
-             clock.instant());
+             ClockUtils.instant());
     }
 
     /**
@@ -195,7 +196,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
     }
 
     @Override
-        public GenericDomainEventMessage withMetadata(Map<String, String> metadata) {
+    public GenericDomainEventMessage withMetadata(Map<String, String> metadata) {
         if (metadata().equals(metadata)) {
             return this;
         }

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 
+import org.axonframework.common.ClockUtils;
 import org.jspecify.annotations.Nullable;
 import org.axonframework.common.Assert;
 import org.axonframework.common.FutureUtils;
@@ -462,12 +463,12 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     }
 
     private void executeAtSimulatedTime(Runnable runnable) {
-        Clock previousClock = GenericEventMessage.clock;
+        Clock previousClock = ClockUtils.get();
         try {
-            GenericEventMessage.clock = Clock.fixed(currentTime(), ZoneOffset.UTC);
+            ClockUtils.set(Clock.fixed(currentTime(), ZoneOffset.UTC));
             runnable.run();
         } finally {
-            GenericEventMessage.clock = previousClock;
+            ClockUtils.set(previousClock);
         }
     }
 
@@ -801,33 +802,8 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
         return repository;
     }
 
-    private static class ComparationEntry {
+    private record ComparationEntry(Object workingObject, Object eventSourceObject) {
 
-        private final Object workingObject;
-        private final Object eventSourceObject;
-
-        public ComparationEntry(Object workingObject, Object eventSourceObject) {
-            this.workingObject = workingObject;
-            this.eventSourceObject = eventSourceObject;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            ComparationEntry that = (ComparationEntry) o;
-            return Objects.equals(workingObject, that.workingObject) &&
-                    Objects.equals(eventSourceObject, that.eventSourceObject);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(workingObject, eventSourceObject);
-        }
     }
 
     private static class IdentifierValidatingRepository<T> implements Repository<T> {

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/StubAggregateLifecycle.java
@@ -101,13 +101,11 @@ public class StubAggregateLifecycle extends AggregateLifecycle {
     private static <P> EventMessage asEventMessage(Object event) {
         if (event instanceof EventMessage) {
             return (EventMessage) event;
-        } else if (event instanceof Message) {
-            Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+        } else if (event instanceof Message message) {
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
+++ b/stash/legacy-saga/src/main/java/org/axonframework/test/saga/SagaTestFixture.java
@@ -321,13 +321,11 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     private static <P> EventMessage asEventMessage(Object event) {
         if (event instanceof EventMessage) {
             return (EventMessage) event;
-        } else if (event instanceof Message) {
-            Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+        } else if (event instanceof Message message) {
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 
@@ -608,30 +606,23 @@ public class SagaTestFixture<T> implements FixtureConfiguration, ContinuedGivenS
     }
 
     /**
-     * Wrapping {@link ResourceInjector} instance. Will first call the {@link TransienceValidatingResourceInjector}, to
-     * ensure the fixture's approach of injecting the default classes (like the {@link EventBus} and {@link CommandBus}
-     * for example) is maintained. Afterward, the custom {@code ResourceInjector} provided through the
-     * {@link #registerResourceInjector(ResourceInjector)} is called. This will (depending on the implementation) inject
-     * more resources, as well as potentially override resources already injected by the
-     * {@code TransienceValidatingResourceInjector}.
-     */
-    private static class WrappingResourceInjector implements ResourceInjector {
-
-        private final ResourceInjector customResourceInjector;
-        private final TransienceValidatingResourceInjector defaultResourceInjector;
-
-        public WrappingResourceInjector(ResourceInjector customResourceInjector,
-                                        TransienceValidatingResourceInjector defaultResourceInjector) {
-            this.customResourceInjector = customResourceInjector;
-            this.defaultResourceInjector = defaultResourceInjector;
-        }
+         * Wrapping {@link ResourceInjector} instance. Will first call the {@link TransienceValidatingResourceInjector}, to
+         * ensure the fixture's approach of injecting the default classes (like the {@link EventBus} and {@link CommandBus}
+         * for example) is maintained. Afterward, the custom {@code ResourceInjector} provided through the
+         * {@link #registerResourceInjector(ResourceInjector)} is called. This will (depending on the implementation) inject
+         * more resources, as well as potentially override resources already injected by the
+         * {@code TransienceValidatingResourceInjector}.
+         */
+        private record WrappingResourceInjector(ResourceInjector customResourceInjector,
+                                                TransienceValidatingResourceInjector defaultResourceInjector)
+            implements ResourceInjector {
 
         @Override
-        public void injectResources(Object saga) {
-            // First call the default, transience checking injector to ensure correct fixture workings
-            defaultResourceInjector.injectResources(saga);
-            // Then, call the custom injector, to add other resource or override injection by the default injector
-            customResourceInjector.injectResources(saga);
+            public void injectResources(Object saga) {
+                // First call the default, transience checking injector to ensure correct fixture workings
+                defaultResourceInjector.injectResources(saga);
+                // Then, call the custom injector, to add other resource or override injection by the default injector
+                customResourceInjector.injectResources(saga);
+            }
         }
-    }
 }

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/AnnotatedSagaTest.java
@@ -37,8 +37,7 @@ class AnnotatedSagaTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/EventValidatorTest.java
@@ -45,8 +45,7 @@ class EventValidatorTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), (P) event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
+++ b/stash/legacy-saga/src/test/java/org/axonframework/test/saga/FixtureRegisteringMethodEnhancementsTest.java
@@ -71,7 +71,7 @@ public class FixtureRegisteringMethodEnhancementsTest {
                    .whenPublishingA(new ParameterResolvedEvent(TEST_AGGREGATE_IDENTIFIER))
                    .expectDispatchedCommandsMatching(listWithAnyOf(predicate(commandMessage -> {
                        Object payload = commandMessage.payload();
-                       assertTrue(payload instanceof ResolveParameterCommand);
+                       assertInstanceOf(ResolveParameterCommand.class, payload);
                        AtomicBoolean assertion = ((ResolveParameterCommand) payload).getAssertion();
                        return assertion.get();
                    })));
@@ -79,8 +79,7 @@ public class FixtureRegisteringMethodEnhancementsTest {
 
     private static <P> EventMessage asEventMessage(P event) {
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 
@@ -120,73 +119,55 @@ public class FixtureRegisteringMethodEnhancementsTest {
                    .expectAssociationWith("extraIdentifier", "myExtraIdentifier");
     }
 
-    private static class TestParameterResolverFactory
-            implements ParameterResolverFactory, ParameterResolver<AtomicBoolean> {
-
-        private final AtomicBoolean assertion;
-
-        private TestParameterResolverFactory(AtomicBoolean assertion) {
-            this.assertion = assertion;
-        }
+    private record TestParameterResolverFactory(AtomicBoolean assertion)
+                implements ParameterResolverFactory, ParameterResolver<AtomicBoolean> {
 
         @Nullable
-        @Override
-        public ParameterResolver<AtomicBoolean> createInstance(@NonNull Executable executable,
-                                                               @NonNull Parameter[] parameters,
-                                                               int parameterIndex) {
-            return AtomicBoolean.class.equals(parameters[parameterIndex].getType()) ? this : null;
+            @Override
+            public ParameterResolver<AtomicBoolean> createInstance(@NonNull Executable executable,
+                                                                   @NonNull Parameter[] parameters,
+                                                                   int parameterIndex) {
+                return AtomicBoolean.class.equals(parameters[parameterIndex].getType()) ? this : null;
+            }
+
+            @NonNull
+            @Override
+            public CompletableFuture<AtomicBoolean> resolveParameterValue(@NonNull ProcessingContext context) {
+                return CompletableFuture.completedFuture(assertion);
+            }
+
+            @Override
+            public boolean matches(@NonNull ProcessingContext context) {
+                Message message = Message.fromContext(context);
+                return message.payloadType().isAssignableFrom(ParameterResolvedEvent.class);
+            }
         }
 
-        @NonNull
-        @Override
-        public CompletableFuture<AtomicBoolean> resolveParameterValue(@NonNull ProcessingContext context) {
-            return CompletableFuture.completedFuture(assertion);
-        }
-
-        @Override
-        public boolean matches(@NonNull ProcessingContext context) {
-            Message message = Message.fromContext(context);
-            return message.payloadType().isAssignableFrom(ParameterResolvedEvent.class);
-        }
-    }
-
-    private static class TestHandlerDefinition implements HandlerDefinition {
-
-        private final AtomicBoolean assertion;
-
-        public TestHandlerDefinition(AtomicBoolean assertion) {
-            this.assertion = assertion;
-        }
+    private record TestHandlerDefinition(AtomicBoolean assertion) implements HandlerDefinition {
 
         @Override
-        public <T> Optional<MessageHandlingMember<T>> createHandler(
-                @NonNull Class<T> declaringType,
-                @NonNull Method method,
-                @NonNull ParameterResolverFactory parameterResolverFactory,
-                @NonNull Function<Object, MessageStream<?>> messageStreamResolver
-        ) {
-            assertion.set(true);
-            // We do not care about a specific MessageHandlingMember,
-            //  only that this method is called to ensure its part of the FixtureConfiguration.
-            return Optional.empty();
+            public <T> Optional<MessageHandlingMember<T>> createHandler(
+                    @NonNull Class<T> declaringType,
+                    @NonNull Method method,
+                    @NonNull ParameterResolverFactory parameterResolverFactory,
+                    @NonNull Function<Object, MessageStream<?>> messageStreamResolver
+            ) {
+                assertion.set(true);
+                // We do not care about a specific MessageHandlingMember,
+                //  only that this method is called to ensure its part of the FixtureConfiguration.
+                return Optional.empty();
+            }
         }
-    }
 
-    private static class TestHandlerEnhancerDefinition implements HandlerEnhancerDefinition {
-
-        private final AtomicBoolean assertion;
-
-        private TestHandlerEnhancerDefinition(AtomicBoolean assertion) {
-            this.assertion = assertion;
-        }
+    private record TestHandlerEnhancerDefinition(AtomicBoolean assertion) implements HandlerEnhancerDefinition {
 
         @Override
-        public @NonNull
-        <T> MessageHandlingMember<T> wrapHandler(@NonNull MessageHandlingMember<T> original) {
-            assertion.set(true);
-            // We do not care about a specific MessageHandlingMember,
-            //  only that this method is called to ensure its part of the FixtureConfiguration.
-            return original;
+            public @NonNull
+            <T> MessageHandlingMember<T> wrapHandler(@NonNull MessageHandlingMember<T> original) {
+                assertion.set(true);
+                // We do not care about a specific MessageHandlingMember,
+                //  only that this method is called to ensure its part of the FixtureConfiguration.
+                return original;
+            }
         }
-    }
 }

--- a/stash/todo/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
+++ b/stash/todo/src/main/java/org/axonframework/deadline/SimpleDeadlineManager.java
@@ -18,10 +18,10 @@ package org.axonframework.deadline;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.*;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.tracing.NoOpSpanFactory;
 import org.axonframework.messaging.tracing.Span;
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -131,8 +130,8 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
         Span span = spanFactory.createCancelScheduleSpan(deadlineName, scheduleId);
         runOnPrepareCommitOrNow(span.wrapRunnable(
                 () -> scheduledTasks.keySet().stream()
-                                    .filter(scheduledTaskId -> scheduledTaskId.getDeadlineName().equals(deadlineName)
-                                            && scheduledTaskId.getDeadlineId().equals(scheduleId))
+                                    .filter(scheduledTaskId -> scheduledTaskId.deadlineName().equals(deadlineName)
+                                            && scheduledTaskId.deadlineId().equals(scheduleId))
                                     .forEach(this::cancelSchedule)
         ));
     }
@@ -142,7 +141,7 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
         Span span = spanFactory.createCancelAllSpan(deadlineName);
         runOnPrepareCommitOrNow(span.wrapRunnable(
                 () -> scheduledTasks.keySet().stream()
-                                    .filter(scheduledTaskId -> scheduledTaskId.getDeadlineName().equals(deadlineName))
+                                    .filter(scheduledTaskId -> scheduledTaskId.deadlineName().equals(deadlineName))
                                     .forEach(this::cancelSchedule)
         ));
     }
@@ -152,8 +151,8 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
         Span span = spanFactory.createCancelAllWithinScopeSpan(deadlineName, scope);
         runOnPrepareCommitOrNow(span.wrapRunnable(
                 () -> scheduledTasks.keySet().stream()
-                                    .filter(scheduledTaskId -> scheduledTaskId.getDeadlineName().equals(deadlineName)
-                                            && scheduledTaskId.getDeadlineScope().equals(scope))
+                                    .filter(scheduledTaskId -> scheduledTaskId.deadlineName().equals(deadlineName)
+                                            && scheduledTaskId.deadlineScope().equals(scope))
                                     .forEach(this::cancelSchedule)
         ));
     }
@@ -170,59 +169,17 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
         scheduledExecutorService.shutdown();
     }
 
-    private static class DeadlineId {
-
-        private final String deadlineName;
-        private final ScopeDescriptor deadlineScope;
-        private final String deadlineId;
-
-        private DeadlineId(String deadlineName, ScopeDescriptor deadlineScope,
-                           String deadlineId) {
-            this.deadlineScope = deadlineScope;
-            this.deadlineId = deadlineId;
-            this.deadlineName = deadlineName;
-        }
-
-        public String getDeadlineName() {
-            return deadlineName;
-        }
-
-        public ScopeDescriptor getDeadlineScope() {
-            return deadlineScope;
-        }
-
-        public String getDeadlineId() {
-            return deadlineId;
-        }
+    private record DeadlineId(String deadlineName, ScopeDescriptor deadlineScope, String deadlineId) {
 
         @Override
-        public int hashCode() {
-            return Objects.hash(deadlineName, deadlineScope, deadlineId);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
+            public String toString() {
+                return "DeadlineId{" +
+                        "deadlineName='" + deadlineName + '\'' +
+                        "deadlineScope=" + deadlineScope + '\'' +
+                        ", deadlineId='" + deadlineId + '\'' +
+                        '}';
             }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            final DeadlineId other = (DeadlineId) obj;
-            return Objects.equals(this.deadlineName, other.deadlineName)
-                    && Objects.equals(this.deadlineScope, other.deadlineScope)
-                    && Objects.equals(this.deadlineId, other.deadlineId);
         }
-
-        @Override
-        public String toString() {
-            return "DeadlineId{" +
-                    "deadlineName='" + deadlineName + '\'' +
-                    "deadlineScope=" + deadlineScope + '\'' +
-                    ", deadlineId='" + deadlineId + '\'' +
-                    '}';
-        }
-    }
 
     /**
      * Builder class to instantiate a {@link SimpleDeadlineManager}.
@@ -355,7 +312,7 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
             Span span = spanFactory.createExecuteSpan(deadlineId.deadlineName, deadlineId.deadlineId, deadlineMessage)
                                    .start();
             try (SpanScope unused = span.makeCurrent()) {
-                Instant triggerInstant = GenericEventMessage.clock.instant();
+                Instant triggerInstant = ClockUtils.instant();
                 /*
                 // TODO: reintegrate as part of #3065
                 LegacyUnitOfWork<DeadlineMessage> unitOfWork = new LegacyDefaultUnitOfWork<>(new GenericDeadlineMessage(
@@ -383,7 +340,7 @@ public class SimpleDeadlineManager extends AbstractDeadlineManager {
             } catch (Exception e) {
                 span.recordException(e);
                 logger.error("An error occurred while triggering the deadline [{}] with identifier [{}]",
-                             deadlineId.getDeadlineName(), deadlineId.getDeadlineId(), e);
+                             deadlineId.deadlineName(), deadlineId.deadlineId(), e);
             } finally {
                 span.end();
                 scheduledTasks.remove(deadlineId);

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/GenericDomainEventMessage.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
@@ -81,7 +82,7 @@ public class GenericDomainEventMessage extends GenericEventMessage implements Do
              aggregateIdentifier,
              sequenceNumber,
              new GenericMessage(type, payload, metadata),
-             clock.instant());
+             ClockUtils.instant());
     }
 
     /**

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/dbscheduler/DbSchedulerEventScheduler.java
@@ -23,6 +23,7 @@ import com.github.kagkarlsson.scheduler.task.TaskDescriptor;
 import com.github.kagkarlsson.scheduler.task.TaskInstance;
 import com.github.kagkarlsson.scheduler.task.helper.Tasks;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
@@ -51,7 +52,6 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 import static org.axonframework.messaging.eventhandling.scheduling.dbscheduler.DbSchedulerScheduleToken.TASK_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -80,13 +80,13 @@ public class DbSchedulerEventScheduler implements EventScheduler {
     private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
     /**
-     * Instantiate a {@link DbSchedulerEventScheduler} based on the fields contained in the
+     * Instantiate a  based on the fields contained in the
      * {@link DbSchedulerEventScheduler.Builder}.
      * <p>
      * Will assert that the {@link Scheduler}, {@link Serializer} and {@link EventBus} are not {@code null}, and will
      * throw an {@link AxonConfigurationException} if any of them is {@code null}.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link DbSchedulerEventScheduler} instance
+     * @param builder the {@link Builder} used to instantiate a  instance
      */
     protected DbSchedulerEventScheduler(Builder builder) {
         builder.validate();
@@ -101,7 +101,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
     }
 
     /**
-     * Instantiate a Builder to be able to create a {@link DbSchedulerEventScheduler}.
+     * Instantiate a Builder to be able to create a .
      * <p>
      * The {@link TransactionManager} is defaulted to a {@link NoTransactionManager}. The {@code useBinaryPojo} is
      * defaulted to {@code true}.
@@ -109,7 +109,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
      * The {@link Scheduler}, {@link Serializer} and {@link EventBus} are <b>hard requirements</b> and as such should be
      * provided.
      *
-     * @return a Builder to be able to create a {@link DbSchedulerEventScheduler}
+     * @return a Builder to be able to create a
      */
     public static Builder builder() {
         return new Builder();
@@ -137,7 +137,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
      * Gives the {@link Task} using {@link DbSchedulerBinaryEventData} to publish an event via a {@link Scheduler}. To
      * be able to execute the task, this should be added to the task list, used to create the scheduler.
      *
-     * @param eventSchedulerSupplier a {@link Supplier} of a {@link DbSchedulerEventScheduler}. Preferably a method
+     * @param eventSchedulerSupplier a {@link Supplier} of a . Preferably a method
      *                               involving dependency injection is used. When those are not available the
      *                               {@link DbSchedulerEventSchedulerSupplier} can be used instead.
      * @return a {@link Task} to publish an event
@@ -161,7 +161,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
      * {@link Scheduler}. To be able to execute the task, this should be added to the task list, used to create the
      * scheduler.
      *
-     * @param eventSchedulerSupplier a {@link Supplier} of a {@link DbSchedulerEventScheduler}. Preferably a method
+     * @param eventSchedulerSupplier a {@link Supplier} of a . Preferably a method
      *                               involving dependency injection is used. When those are not available the
      *                               {@link DbSchedulerEventSchedulerSupplier} can be used instead.
      * @return a {@link Task} to publish an event
@@ -253,7 +253,7 @@ public class DbSchedulerEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -279,15 +279,14 @@ public class DbSchedulerEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override
     public void cancelSchedule(ScheduleToken scheduleToken) {
-        if (!(scheduleToken instanceof DbSchedulerScheduleToken)) {
+        if (!(scheduleToken instanceof DbSchedulerScheduleToken reference)) {
             throw new IllegalArgumentException("The given ScheduleToken was not provided by this scheduler.");
         }
-        DbSchedulerScheduleToken reference = (DbSchedulerScheduleToken) scheduleToken;
         scheduler.cancel(reference);
     }
 

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/jobrunr/JobRunrEventScheduler.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.scheduling.jobrunr;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventBus;
@@ -48,7 +49,6 @@ import java.util.UUID;
 import static java.util.Objects.isNull;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.deadline.jobrunr.LabelUtils.getLabel;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 
 /**
  * EventScheduler implementation that delegates scheduling and triggering to a JobRunr JobScheduler.
@@ -151,15 +151,14 @@ public class JobRunrEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override
     public void cancelSchedule(ScheduleToken scheduleToken) {
-        if (!(scheduleToken instanceof JobRunrScheduleToken)) {
+        if (!(scheduleToken instanceof JobRunrScheduleToken reference)) {
             throw new IllegalArgumentException("The given ScheduleToken was not provided by this scheduler.");
         }
-        JobRunrScheduleToken reference = (JobRunrScheduleToken) scheduleToken;
         jobScheduler.delete(reference.getJobIdentifier(), "Deleted via Axon EventScheduler API");
     }
 
@@ -241,7 +240,7 @@ public class JobRunrEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/quartz/QuartzEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventhandling/scheduling/quartz/QuartzEventScheduler.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.scheduling.quartz;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventBus;
@@ -52,7 +53,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
-import static org.axonframework.messaging.eventhandling.GenericEventMessage.clock;
 import static org.axonframework.messaging.eventhandling.scheduling.quartz.FireEventJob.*;
 import static org.quartz.JobKey.jobKey;
 
@@ -81,14 +81,14 @@ public class QuartzEventScheduler implements EventScheduler {
     private volatile boolean initialized;
 
     /**
-     * Instantiate a {@link QuartzEventScheduler} based on the fields contained in the {@link Builder}.
+     * Instantiate a  based on the fields contained in the {@link Builder}.
      * <p>
      * Will assert that the {@link Scheduler} and {@link EventBus} are not {@code null}, and will throw an
      * {@link AxonConfigurationException} if any of them is {@code null}. The EventBus, TransactionManager and
      * EventJobDataBinder will be tied to the Scheduler's context. If this initialization step fails, this will too
      * result in an AxonConfigurationException.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link QuartzEventScheduler} instance
+     * @param builder the {@link Builder} used to instantiate a  instance
      */
     protected QuartzEventScheduler(Builder builder) {
         builder.validate();
@@ -114,7 +114,7 @@ public class QuartzEventScheduler implements EventScheduler {
     }
 
     /**
-     * Instantiate a Builder to be able to create a {@link QuartzEventScheduler}.
+     * Instantiate a Builder to be able to create a .
      * <p>
      * The {@link EventJobDataBinder} is defaulted to a {@link DirectEventJobDataBinder} using the configured
      * {@link Serializer}, and the {@link TransactionManager} defaults to a {@link NoTransactionManager}. Note that if
@@ -122,7 +122,7 @@ public class QuartzEventScheduler implements EventScheduler {
      * <p>
      * The {@link Scheduler} and {@link EventBus} are <b>hard requirements</b> and as such should be provided.
      *
-     * @return a Builder to be able to create a {@link QuartzEventScheduler}
+     * @return a Builder to be able to create a
      */
     public static Builder builder() {
         return new Builder();
@@ -148,7 +148,7 @@ public class QuartzEventScheduler implements EventScheduler {
             return e;
         }
         if (event instanceof Message message) {
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
                 messageTypeResolver.resolveOrThrow(event),
@@ -197,17 +197,16 @@ public class QuartzEventScheduler implements EventScheduler {
 
     @Override
     public ScheduleToken schedule(Duration triggerDuration, Object event) {
-        return schedule(clock.instant().plus(triggerDuration), event);
+        return schedule(ClockUtils.instant().plus(triggerDuration), event);
     }
 
     @Override
     public void cancelSchedule(ScheduleToken scheduleToken) {
-        if (!(scheduleToken instanceof QuartzScheduleToken)) {
+        if (!(scheduleToken instanceof QuartzScheduleToken reference)) {
             throw new IllegalArgumentException("The given ScheduleToken was not provided by this scheduler.");
         }
         Assert.state(initialized, () -> "Scheduler is not yet initialized");
 
-        QuartzScheduleToken reference = (QuartzScheduleToken) scheduleToken;
         try {
             if (!scheduler.deleteJob(jobKey(reference.getJobIdentifier(), reference.getGroupIdentifier()))) {
                 logger.warn("The job belonging to this token could not be deleted.");

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/LegacyJdbcEventStorageEngine.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventsourcing.eventstore.jdbc;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.common.jdbc.ConnectionProvider;
 import org.axonframework.common.jdbc.JdbcSQLErrorCodesResolver;
@@ -130,17 +131,17 @@ public class LegacyJdbcEventStorageEngine extends BatchingEventStorageEngine {
     private final ReadSnapshotDataStatementBuilder readSnapshotData;
     private final ReadEventDataWithoutGapsStatementBuilder readEventDataWithoutGaps;
     private final ReadEventDataWithGapsStatementBuilder readEventDataWithGaps;
-    private int gapTimeout;
-    private int gapCleaningThreshold;
+    private final int gapTimeout;
+    private final int gapCleaningThreshold;
 
     /**
-     * Instantiate a {@link LegacyJdbcEventStorageEngine} based on the fields contained in the {@link Builder}.
+     * Instantiate a  based on the fields contained in the {@link Builder}.
      * <p>
      * Will assert that the event and snapshot {@link Serializer}, the {@link ConnectionProvider} and
      * {@link TransactionManager} are not {@code null}, and will throw an {@link AxonConfigurationException} if any of
      * them is {@code null}.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link LegacyJdbcEventStorageEngine} instance
+     * @param builder the {@link Builder} used to instantiate a  instance
      */
     protected LegacyJdbcEventStorageEngine(Builder builder) {
         super(builder);
@@ -169,7 +170,7 @@ public class LegacyJdbcEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     /**
-     * Instantiate a Builder to be able to create a {@link LegacyJdbcEventStorageEngine}.
+     * Instantiate a Builder to be able to create a .
      * <p>
      * The following configurable fields have defaults:
      * <ul>
@@ -202,7 +203,7 @@ public class LegacyJdbcEventStorageEngine extends BatchingEventStorageEngine {
      * The event and snapshot {@link Serializer}, {@link ConnectionProvider} and {@link TransactionManager} are <b>hard
      * requirements</b> and as such should be provided.
      *
-     * @return a Builder to be able to create a {@link LegacyJdbcEventStorageEngine}
+     * @return a Builder to be able to create a
      */
     public static Builder builder() {
         return new Builder();
@@ -679,7 +680,7 @@ public class LegacyJdbcEventStorageEngine extends BatchingEventStorageEngine {
     }
 
     private Instant gapTimeoutFrame() {
-        return GenericEventMessage.clock.instant().minus(gapTimeout, ChronoUnit.MILLIS);
+        return ClockUtils.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 
     /**

--- a/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/snapshotting/AggregateLoadTimeSnapshotTriggerDefinition.java
+++ b/stash/todo/src/main/java/org/axonframework/messaging/eventsourcing/snapshotting/AggregateLoadTimeSnapshotTriggerDefinition.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.messaging.eventsourcing.snapshotting;
 
+import org.axonframework.common.ClockUtils;
+
 import java.time.Clock;
 
 /**
@@ -41,8 +43,6 @@ public class AggregateLoadTimeSnapshotTriggerDefinition implements SnapshotTrigg
 
     private final Snapshotter snapshotter;
     private final long loadTimeMillisThreshold;
-    public static Clock clock = Clock.systemUTC();
-
 
     /**
      * Initialize a {@link SnapshotTriggerDefinition} to trigger snapshot creation using the given {@code snapshotter}
@@ -73,7 +73,7 @@ public class AggregateLoadTimeSnapshotTriggerDefinition implements SnapshotTrigg
     private static class AggregateLoadTimeSnapshotTrigger extends AbstractSnapshotTrigger {
 
         private final long loadTimeMillisThreshold;
-        private long startTime = clock.instant().toEpochMilli();
+        private long startTime = ClockUtils.instant().toEpochMilli();
 
         public AggregateLoadTimeSnapshotTrigger(Snapshotter snapshotter,
                                                 Class<?> aggregateType,
@@ -84,12 +84,12 @@ public class AggregateLoadTimeSnapshotTriggerDefinition implements SnapshotTrigg
 
         @Override
         public boolean exceedsThreshold() {
-            return (clock.instant().toEpochMilli() - startTime) > loadTimeMillisThreshold;
+            return (ClockUtils.instant().toEpochMilli() - startTime) > loadTimeMillisThreshold;
         }
 
         @Override
         public void reset() {
-            startTime = clock.instant().toEpochMilli();
+            startTime = ClockUtils.instant().toEpochMilli();
         }
     }
 }

--- a/stash/todo/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
+++ b/stash/todo/src/main/java/org/axonframework/test/eventscheduler/StubEventScheduler.java
@@ -91,13 +91,11 @@ public class StubEventScheduler implements EventScheduler {
     private static <P> EventMessage asEventMessage(Object event) {
         if (event instanceof EventMessage) {
             return (EventMessage) event;
-        } else if (event instanceof Message) {
-            Message message = (Message) event;
-            return new GenericEventMessage(message, () -> GenericEventMessage.clock.instant());
+        } else if (event instanceof Message message) {
+            return new GenericEventMessage(message);
         }
         return new GenericEventMessage(
-                new GenericMessage(new MessageType(event.getClass()), (P) event),
-                () -> GenericEventMessage.clock.instant()
+                new GenericMessage(new MessageType(event.getClass()), event)
         );
     }
 

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/DomainEventTestUtils.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventhandling/DomainEventTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.IdentifierFactory;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.Metadata;
@@ -104,12 +105,12 @@ public abstract class DomainEventTestUtils {
                                                        String payload,
                                                        Metadata metadata) {
         return new org.axonframework.messaging.eventhandling.GenericDomainEventMessage(type,
-                                               aggregateId,
-                                               sequenceNumber,
-                                               eventId,
-                                               TYPE,
-                                               payload,
-                                               metadata,
-                                               GenericDomainEventMessage.clock.instant());
+                                                                                       aggregateId,
+                                                                                       sequenceNumber,
+                                                                                       eventId,
+                                                                                       TYPE,
+                                                                                       payload,
+                                                                                       metadata,
+                                                                                       ClockUtils.instant());
     }
 }

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/AggregateLoadSnapshotTriggerDefinitionTest.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/AggregateLoadSnapshotTriggerDefinitionTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventsourcing;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.DomainEventMessage;
 import org.axonframework.messaging.eventhandling.GenericDomainEventMessage;
 import org.axonframework.messaging.eventsourcing.snapshotting.AggregateLoadTimeSnapshotTriggerDefinition;
@@ -65,7 +66,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
                 null
         );
         now = Instant.now();
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now, ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now, ZoneId.of("UTC")));
     }
 
     @AfterEach
@@ -73,6 +74,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
         while (CurrentUnitOfWork.isStarted()) {
             CurrentUnitOfWork.get().rollback();
         }
+        ClockUtils.reset();
     }
 
     @Test
@@ -81,7 +83,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"
         );
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC")));
 
         trigger.eventHandled(testEvent);
 
@@ -96,7 +98,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     @Test
     void snapshotterTriggeredOnUnitOfWorkCommit() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC")));
 
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"
@@ -112,7 +114,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     @Test
     void snapshotterIsNotTriggeredOnUnitOfWorkRollbackIfEventsHandledAfterInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC")));
 
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"
@@ -128,7 +130,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     @Test
     void snapshotterTriggeredOnUnitOfWorkRollbackWhenEventsHandledBeforeInitialization() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC")));
 
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"
@@ -144,7 +146,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     @Test
     void snapshotterNotTriggered() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1000), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1000), ZoneId.of("UTC")));
 
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"
@@ -159,7 +161,7 @@ class AggregateLoadSnapshotTriggerDefinitionTest {
     @Test
     void scheduleANewSnapshotAfterCommitTrigger() {
         SnapshotTrigger trigger = testSubject.prepareTrigger(aggregate.rootType());
-        AggregateLoadTimeSnapshotTriggerDefinition.clock = Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC"));
+        ClockUtils.set(Clock.fixed(now.plusMillis(1001), ZoneId.of("UTC")));
 
         DomainEventMessage testEvent = new GenericDomainEventMessage(
                 "type", aggregateIdentifier, 0, new MessageType("event"), "Mock contents"

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/EventStorageEngineTest.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/EventStorageEngineTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventsourcing.eventstore;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.messaging.eventhandling.DomainEventMessage;
 import org.axonframework.messaging.eventhandling.DomainEventTestUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -53,7 +54,7 @@ public abstract class EventStorageEngineTest {
 
     @AfterEach
     public void tearDown() {
-        GenericEventMessage.clock = Clock.systemUTC();
+        ClockUtils.reset();
     }
 
     @Test

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
@@ -44,6 +44,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -170,16 +171,17 @@ class JdbcEventStorageEngineIT
 
     @Test
     void gapsForVeryOldEventsAreNotIncluded() throws SQLException {
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
+        Instant now = ClockUtils.instant();
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0));
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1));
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2));
 
-        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
+        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3));
 
         try (Connection conn = dataSource.getConnection()) {
@@ -196,14 +198,15 @@ class JdbcEventStorageEngineIT
     void oldGapsAreRemovedFromProvidedTrackingToken() throws SQLException {
         testSubject = createEngine(engineBuilder -> engineBuilder.gapTimeout(50001).gapCleaningThreshold(50));
 
-        Instant now = Clock.systemUTC().instant();
-        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
+        Instant now = ClockUtils.instant();
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), ZoneOffset.UTC));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0)); // index 0 and 1
-        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
+
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), ZoneOffset.UTC));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1)); // index 2 and 3
-        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), ZoneOffset.UTC));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2)); // index 4 and 5
-        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
+        ClockUtils.set(Clock.fixed(now, ZoneOffset.UTC));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3)); // index 6 and 7
 
         try (Connection conn = dataSource.getConnection()) {

--- a/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
+++ b/stash/todo/src/test/java/org/axonframework/messaging/eventsourcing/eventstore/jdbc/JdbcEventStorageEngineIT.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.eventsourcing.eventstore.jdbc;
 
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.messaging.core.unitofwork.transaction.NoTransactionManager;
 import org.axonframework.messaging.eventhandling.DomainEventMessage;
@@ -169,19 +170,16 @@ class JdbcEventStorageEngineIT
 
     @Test
     void gapsForVeryOldEventsAreNotIncluded() throws SQLException {
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1));
 
-        GenericEventMessage.clock =
-                Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant().minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2));
 
-        GenericEventMessage.clock = Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(Clock.systemUTC().instant(), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3));
 
         try (Connection conn = dataSource.getConnection()) {
@@ -199,13 +197,13 @@ class JdbcEventStorageEngineIT
         testSubject = createEngine(engineBuilder -> engineBuilder.gapTimeout(50001).gapCleaningThreshold(50));
 
         Instant now = Clock.systemUTC().instant();
-        GenericEventMessage.clock = Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(1, ChronoUnit.HOURS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-1), createDomainEvent(0)); // index 0 and 1
-        GenericEventMessage.clock = Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(2, ChronoUnit.MINUTES), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-2), createDomainEvent(1)); // index 2 and 3
-        GenericEventMessage.clock = Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now.minus(50, ChronoUnit.SECONDS), Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-3), createDomainEvent(2)); // index 4 and 5
-        GenericEventMessage.clock = Clock.fixed(now, Clock.systemUTC().getZone());
+        ClockUtils.set(Clock.fixed(now, Clock.systemUTC().getZone()));
         testSubject.appendEvents(createDomainEvent(-4), createDomainEvent(3)); // index 6 and 7
 
         try (Connection conn = dataSource.getConnection()) {
@@ -219,7 +217,7 @@ class JdbcEventStorageEngineIT
         List<? extends TrackedEventData<?>> events =
                 testSubject.fetchTrackedEvents(GapAwareTrackingToken.newInstance(6, gaps), 100);
         assertEquals(1, events.size());
-        assertEquals(4L, (long) ((GapAwareTrackingToken) events.get(0).trackingToken()).getGaps().first());
+        assertEquals(4L, (long) ((GapAwareTrackingToken) events.getFirst().trackingToken()).getGaps().first());
     }
 
     @Test
@@ -489,4 +487,5 @@ class JdbcEventStorageEngineIT
             throw new IllegalStateException(e);
         }
     }
+
 }


### PR DESCRIPTION
- allows to get/set clock on a central util class without directly working with a static field
- adjusted all tests
- introduced timestamp-less constructor so only GenericEventMessage needs to know about the clock
- todo: also register in component registry

This Pr resolves #3083.