### PR TITLE
[#4553] backport(5.1.x): Add Snapshotting annotation support

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/configuration-migration.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/configuration-migration.adoc
@@ -55,4 +55,4 @@ Also, `@AggregateMember` is replaced by `@EntityMember` for child entities withi
 
 [IMPORTANT]
 .
-The `@EventSourced` annotation in Axon Framework 5/Spring Boot is the configuration replacement for `@Aggregate`, but not a fully functional/feature replacement, as attributes you may have used in AF4 (like caching, snapshotting, ...) are no longer supported. xref:migration:paths/index.adoc#missing-a-migration-path[Contact us] if you require these use-cases.
+The `@EventSourced` annotation in Axon Framework 5/Spring Boot is the configuration replacement for `@Aggregate`, but not a fully functional/feature replacement, as attributes you may have used in AF4 (like caching) are no longer supported. xref:migration:paths/index.adoc#missing-a-migration-path[Contact us] if you require these use-cases.

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -83,9 +83,20 @@ If you are migrating an Axon Framework 4 application, this is the closest equiva
 [#spring_boot_configuration]
 == Spring Boot configuration
 
-For Spring Boot applications, the annotation-based `@EventSourced` shortcut currently does not expose snapshot policy configuration.
-If you need snapshotting, declare the entity as an explicit `EventSourcedEntityModule` bean and configure the `SnapshotPolicy` there.
-Spring's component registry picks up `Module` beans automatically, so this integrates with the regular Spring Boot setup.
+For Spring Boot applications, snapshotting can be enabled by adding `@Snapshotting` alongside the `@EventSourced` annotation on the entity class:
+
+[source,java]
+----
+@EventSourced
+@Snapshotting
+public class Account { ... }
+----
+
+At least one threshold must be configured, either on the annotation directly or via a higher-level annotation on an enclosing class, package, or module.
+See xref:tuning:snapshotting.adoc#_annotation_based_configuration[annotation-based configuration] for details.
+
+For more complex policies that require payload inspection, declare the entity as an explicit `EventSourcedEntityModule` bean and configure the `SnapshotPolicy` programmatically.
+Spring's component registry picks up `Module` beans automatically, so this integrates with the regular Spring Boot setup:
 
 [source,java]
 ----
@@ -95,7 +106,12 @@ class AccountConfiguration {
     @Bean
     EventSourcedEntityModule<String, Account> accountModule() {
         return EventSourcedEntityModule.declarative(String.class, Account.class)
-                .snapshotPolicy(c -> SnapshotPolicy.afterEvents(250))
+                .snapshotPolicy(c -> SnapshotPolicy.afterEvents(250)
+                        .or(SnapshotPolicy.whenEventMatches(
+                                msg -> msg.type().qualifiedName().equals(
+                                        new QualifiedName(AccountClosed.class)
+                                )
+                        )))
                 .build();
     }
 
@@ -105,9 +121,6 @@ class AccountConfiguration {
     }
 }
 ----
-
-This is the Spring-friendly migration path when you still want to use the AF5 snapshotting model.
-If you are only using `@EventSourced` annotations today, you will need to move this entity to explicit module registration before you can configure snapshotting.
 
 [#snapshot_storage]
 == Snapshot storage

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -88,11 +88,17 @@ For Spring Boot applications, snapshotting can be enabled by adding `@Snapshotti
 [source,java]
 ----
 @EventSourced
-@Snapshotting
+@Snapshotting(afterEvents = 100)
 public class Account { ... }
 ----
 
-At least one threshold must be configured, either on the annotation directly or via a higher-level annotation on an enclosing class, package, or module.
+The annotation supports two threshold attributes:
+
+* `afterEvents`: trigger a snapshot after a fixed number of events have been applied during sourcing.
+* `afterSourcingTime`: trigger a snapshot when the total sourcing time exceeds the given ISO-8601 duration (for example, `"PT5S"` for five seconds).
+
+When both attributes are set, either condition independently triggers a snapshot.
+Use a bare `@Snapshotting` (no attributes) when the threshold is inherited from a higher-level annotation on an enclosing class, package, or module.
 See xref:tuning:snapshotting.adoc#_annotation_based_configuration[annotation-based configuration] for details.
 
 For more complex policies that require payload inspection, declare the entity as an explicit `EventSourcedEntityModule` bean and configure the `SnapshotPolicy` programmatically.

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -47,7 +47,7 @@ As events are applied during sourcing, the configured `SnapshotPolicy` is invoke
 This allows the policy to detect whether a snapshot should be triggered based on the events being processed.
 
 After sourcing has completed, the policy is evaluated based on the full evolution of the entity.
-If the policy indicates that a snapshot should be created—either based on the overall evolution (such as event count or sourcing time) or because a triggering event was observed—a new snapshot is created and stored.
+If the policy indicates that a snapshot should be created, either based on the overall evolution (such as event count or sourcing time) or because a triggering event was observed, a new snapshot is created and stored.
 
 This snapshot can then be used the next time the entity is loaded, reducing the number of events that need to be replayed.
 
@@ -132,8 +132,61 @@ Snapshotting is enabled by providing a `SnapshotPolicy` for an event-sourced ent
 When a policy is configured, the repository automatically handles the creation and application of snapshots during sourcing.
 If no policy is provided, snapshotting is disabled, and the entity is always reconstructed from the event stream.
 
+The repository requires several supporting components to be present when snapshotting is enabled:
+
+* A `Converter` to serialize and deserialize snapshot payloads.
+* A `MessageTypeResolver` capable of resolving a `MessageType` for the entity type, used to identify the snapshot and its version.
+* A `SnapshotStore` to persist snapshots.
+
+If any of these components are missing, configuration will fail when snapshotting is enabled.
+
+==== Annotation-based configuration
+
+For entities registered with `@EventSourcedEntity`, snapshotting can be enabled by adding `@Snapshotting` to the entity class.
+At least one threshold must be configured, either directly on the annotation or via a higher-level annotation on an enclosing class, package, or module:
+
+[source,java]
+----
+@EventSourcedEntity
+@Snapshotting(afterEvents = 100)
+public class Account { ... }
+----
+
+`afterEvents` sets the event-count threshold.
+`afterSourcingTime` accepts an ISO-8601 duration string and triggers a snapshot when sourcing time exceeds that threshold.
+When both are set, either condition independently triggers a snapshot.
+
+[source,java]
+----
+@EventSourcedEntity
+@Snapshotting(afterEvents = 100, afterSourcingTime = "PT5S")
+public class Account { ... }
+----
+
+A shared default can be provided at the package level, so individual entity classes can opt in with a bare `@Snapshotting` annotation:
+
+[source,java]
+----
+// package-info.java
+@Snapshotting(afterEvents = 50)
+package com.example.orders;
+----
+
+[source,java]
+----
+@EventSourcedEntity
+@Snapshotting  // inherits afterEvents = 50 from the package annotation
+public class Account { ... }
+----
+
+If no concrete threshold can be resolved from the annotation hierarchy, configuration fails with an error at startup.
+
+For payload-based triggers, such as forcing a snapshot when a specific event type is encountered, use the programmatic API described below.
+
+==== Programmatic configuration
+
 The `SnapshotPolicy` is configured as part of the entity registration.
-The example below shows how to configure snapshotting for an event-sourced entity:
+The example below shows how to configure snapshotting for an event-sourced entity using the declarative builder:
 
 [source,java]
 ----
@@ -157,13 +210,6 @@ In this configuration:
 In the example, a snapshot is created after more than five events have been applied or when a matching event is encountered during sourcing.
 * Snapshotting is activated automatically when a `SnapshotPolicy` is configured.
 If no policy is provided, snapshotting is not used and the entity is always sourced from events only.
-* The repository requires several supporting components to be present when snapshotting is enabled:
-** A `Converter` to serialize and deserialize snapshot payloads.
-** A `MessageTypeResolver` capable of resolving a `MessageType` for the entity type.
-This type is used to identify the snapshot and its version.
-** A `SnapshotStore` to persist snapshots (this requirement will change in future versions as snapshotting becomes more tightly integrated with the event store).
-
-If any of these components are missing, configuration will fail when snapshotting is enabled.
 
 Custom snapshot behavior can be achieved by using `whenEventMatches` for domain-specific triggers, as shown in the example, or by implementing the `SnapshotPolicy` interface directly.
 

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -210,6 +210,7 @@ In the example, a snapshot is created after more than five events have been appl
 If no policy is provided, snapshotting is not used and the entity is always sourced from events only.
 
 Custom snapshot behavior can be achieved by using `whenEventMatches` for domain-specific triggers, as shown in the example, or by implementing the `SnapshotPolicy` interface directly.
+For a complete use of the declarative `EventSourcedEntityModule` API, please check xref:commands:command-handlers.adoc#stateful-command-handlers[here.]
 
 === Entity conversion for snapshots
 

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -149,7 +149,7 @@ At least one threshold must be configured, either directly on the annotation or 
 ----
 @EventSourcedEntity
 @Snapshotting(afterEvents = 100)
-public class Account { ... }
+public class Course { ... }
 ----
 
 `afterEvents` sets the event-count threshold.
@@ -160,7 +160,7 @@ When both are set, either condition independently triggers a snapshot.
 ----
 @EventSourcedEntity
 @Snapshotting(afterEvents = 100, afterSourcingTime = "PT5S")
-public class Account { ... }
+public class Course { ... }
 ----
 
 A shared default can be provided at the package level, so individual entity classes can opt in with a bare `@Snapshotting` annotation:
@@ -169,14 +169,14 @@ A shared default can be provided at the package level, so individual entity clas
 ----
 // package-info.java
 @Snapshotting(afterEvents = 50)
-package com.example.orders;
+package com.example.faculty;
 ----
 
 [source,java]
 ----
 @EventSourcedEntity
 @Snapshotting  // inherits afterEvents = 50 from the package annotation
-public class Account { ... }
+public class Course { ... }
 ----
 
 If no concrete threshold can be resolved from the annotation hierarchy, configuration fails with an error at startup.
@@ -193,12 +193,12 @@ The example below shows how to configure snapshotting for an event-sourced entit
 SnapshotPolicy snapshotPolicy = SnapshotPolicy.afterEvents(5)
         .or(SnapshotPolicy.whenEventMatches(
                 msg -> msg.type().qualifiedName().equals(
-                        new QualifiedName(AccountClosed.class)
+                        new QualifiedName(CourseRenamed.class)
                 )
         ));
 
-EventSourcedEntityModule<String, Account> accountModule =
-        EventSourcedEntityModule.declarative(String.class, Account.class)
+EventSourcedEntityModule<CourseId, Course> courseModule =
+        EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                 // other entity configuration omitted
                                 .snapshotPolicy(c -> snapshotPolicy)
                                 .build();
@@ -223,17 +223,20 @@ Most JSON-based converters (such as Jackson, when compiled with parameter names 
 
 [source,java]
 ----
-public class Account {
-    private final String accountId;
-    private final int balance;
+public class Course {
+    private final String courseId;
+    private final String name;
+    private final int capacity;
 
-    public Account(String accountId, int balance) {
-        this.accountId = accountId;
-        this.balance = balance;
+    public Course(String courseId, String name, int capacity) {
+        this.courseId = courseId;
+        this.name = name;
+        this.capacity = capacity;
     }
 
-    public String getAccountId() { return accountId; }
-    public int getBalance() { return balance; }
+    public String getCourseId() { return courseId; }
+    public String getName() { return name; }
+    public int getCapacity() { return capacity; }
 }
 ----
 
@@ -241,7 +244,7 @@ Or using a `record`:
 
 [source,java]
 ----
-public record Account(String accountId, int balance) {}
+public record Course(String courseId, String name, int capacity) {}
 ----
 
 While setters and default constructors can still be used if necessary, the constructor-based approach ensures immutability and aligns with modern Java development practices.

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -1,5 +1,3 @@
-// TODO this is currently not referenced, but should be restructured to accompany the snapshotting docs
-// we include in Axoniq Framework. See https://github.com/AxonIQ/AxonFramework/pull/4420#discussion_r3100143396
 = Snapshots
 
 == Snapshotting

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/EventSourcedEntity.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/EventSourcedEntity.java
@@ -96,6 +96,13 @@ import java.lang.annotation.Target;
  * id based on the {@link TargetEntityId} annotation on a field or method
  * of the command payload. You can customize this behavior by providing a custom {@link #entityIdResolverDefinition()}.
  *
+ * <h2>Snapshotting</h2>
+ * Snapshotting can be enabled declaratively by adding {@link Snapshotting @Snapshotting} alongside this annotation.
+ * By default, {@code @Snapshotting} triggers a snapshot after every 50 events sourced. Both the event-count and
+ * sourcing-time thresholds are tunable via its attributes. For more complex policies (e.g. payload-based triggers),
+ * use the programmatic API via
+ * {@link org.axonframework.eventsourcing.configuration.EventSourcedEntityModule.OptionalPhase#snapshotPolicy}.
+ *
  * <h2>Polymorphic entities</h2>
  * Polymorphic entities are entities that can have multiple concrete types, and the type of the entity is determined
  * by the payload of the first event. In this case, the {@link EventSourcedEntity#concreteTypes()} should be

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/Snapshotting.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/Snapshotting.java
@@ -68,7 +68,7 @@ import java.lang.annotation.Target;
  * @author John Hendrikx
  * @see SnapshotPolicy
  * @see org.axonframework.eventsourcing.configuration.EventSourcedEntityModule.OptionalPhase#snapshotPolicy(org.axonframework.common.configuration.ComponentBuilder)
- * @since 5.1.0
+ * @since 5.1.1
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/Snapshotting.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/Snapshotting.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.annotation;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures snapshotting behaviour for an event-sourced entity when using the annotation-based registration path
+ * (see {@link EventSourcedEntityModule#autodetected(Class, Class)}).
+ * <p>
+ * Place this annotation on an {@link EventSourcedEntity @EventSourcedEntity}-annotated class to declare one or both
+ * snapshot trigger conditions:
+ * <ul>
+ *     <li>{@link #afterEvents()} — trigger a snapshot after a fixed number of events have been applied during
+ *     sourcing.</li>
+ *     <li>{@link #afterSourcingTime()} — trigger a snapshot when the total sourcing time for a load operation
+ *     exceeds the given duration.</li>
+ * </ul>
+ * When both attributes are active, either condition independently triggers a snapshot (logical OR), matching the
+ * composition semantics of {@link SnapshotPolicy#or(SnapshotPolicy)}.
+ * <p>
+ * Both attributes default to sentinel values ({@link #USE_DEFAULT} and {@link #USE_DEFAULT_DURATION}) meaning
+ * "not configured here". At least one attribute must resolve to a concrete value, either directly on the annotation
+ * or via a higher-level annotation on an enclosing class, package, or module. If no concrete value can be resolved,
+ * configuration fails with an {@link AxonConfigurationException}.
+ * <p>
+ * This makes it possible to define a shared snapshotting policy at the package or module level and let individual
+ * entities inherit it by simply placing {@code @Snapshotting} without further attributes:
+ * <pre>{@code
+ * // package-info.java
+ * @Snapshotting(afterEvents = 50)
+ * package com.example.orders;
+ * }</pre>
+ * <p>
+ * Example usage:
+ * {@snippet :
+ * @EventSourcedEntity
+ * @Snapshotting(afterEvents = 100)  // snapshot after every 100 events
+ * public class BankAccount { ... }
+ *
+ * @EventSourcedEntity
+ * @Snapshotting(afterEvents = 100, afterSourcingTime = "PT5S")  // combined thresholds
+ * public class OrderAggregate { ... }
+ * }
+ *
+ * @author John Hendrikx
+ * @see SnapshotPolicy
+ * @see org.axonframework.eventsourcing.configuration.EventSourcedEntityModule.OptionalPhase#snapshotPolicy(org.axonframework.common.configuration.ComponentBuilder)
+ * @since 5.1.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Snapshotting {
+
+    /**
+     * Sentinel value for {@link #afterEvents()} indicating that no event-count threshold is configured at this level.
+     * The framework will look for a concrete value in enclosing classes, the package, or the module.
+     */
+    int USE_DEFAULT = Integer.MIN_VALUE;
+
+    /**
+     * Sentinel value for {@link #afterSourcingTime()} indicating that no sourcing-time threshold is configured at
+     * this level. The framework will look for a concrete value in enclosing classes, the package, or the module.
+     */
+    String USE_DEFAULT_DURATION = "\0";
+
+    /**
+     * The number of events after which a snapshot is triggered during sourcing. Set to a positive integer to enable.
+     * Set to {@code 0} to explicitly disable this trigger. Defaults to {@link #USE_DEFAULT}, meaning the value
+     * is resolved from a higher-level annotation.
+     *
+     * @return the event count threshold, {@code 0} to disable, or {@link #USE_DEFAULT} to inherit
+     */
+    int afterEvents() default USE_DEFAULT;
+
+    /**
+     * The maximum sourcing duration after which a snapshot is triggered, expressed as an ISO-8601 duration string
+     * (e.g., {@code "PT5S"} for five seconds). Defaults to {@link #USE_DEFAULT_DURATION}, meaning the value
+     * is resolved from a higher-level annotation.
+     *
+     * @return the sourcing-time threshold as an ISO-8601 duration, or {@link #USE_DEFAULT_DURATION} to inherit
+     */
+    String afterSourcingTime() default USE_DEFAULT_DURATION;
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.configuration;
 
 import org.axonframework.common.Assert;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ConstructorUtils;
 import org.axonframework.common.annotation.AnnotationUtils;
 import org.axonframework.common.configuration.BaseModule;
@@ -27,6 +28,8 @@ import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.annotation.CriteriaResolverDefinition;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntityFactoryDefinition;
+import org.axonframework.eventsourcing.annotation.Snapshotting;
+import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.MessageConverter;
@@ -36,6 +39,7 @@ import org.axonframework.modelling.annotation.EntityIdResolverDefinition;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -56,6 +60,7 @@ import static org.axonframework.common.ReflectionUtils.collectSealedHierarchyIfS
  * @param <E> The type of the event-sourced entity being built.
  * @author Mitchell Herrijgers
  * @author Steven van Beelen
+ * @author John Hendrikx
  * @since 5.0.0
  */
 class AnnotatedEventSourcedEntityModule<I, E>
@@ -77,15 +82,32 @@ class AnnotatedEventSourcedEntityModule<I, E>
                 .orElseThrow(() -> new IllegalArgumentException("The given class is not an @EventSourcedEntity."));
         this.concreteTypes = getConcreteEntityTypes(annotationAttributes);
 
-        componentRegistry(cr -> cr.registerModule(
-                EventSourcedEntityModule
-                        .declarative(idType, entityType)
-                        .messagingModel((c, b) -> this.buildMetaModel(c))
-                        .entityFactory(entityFactory(annotationAttributes, concreteTypes))
-                        .criteriaResolver(criteriaResolver(annotationAttributes))
-                        .entityIdResolver(entityIdResolver(annotationAttributes))
-                        .build()
-        ));
+        OptionalPhase<I, E> phase = EventSourcedEntityModule
+                .declarative(idType, entityType)
+                .messagingModel((c, b) -> this.buildMetaModel(c))
+                .entityFactory(entityFactory(annotationAttributes, concreteTypes))
+                .criteriaResolver(criteriaResolver(annotationAttributes))
+                .entityIdResolver(entityIdResolver(annotationAttributes));
+
+        boolean hasSnapshottingAnnotation = AnnotationUtils
+                .findAnnotationAttributes(entityType, Snapshotting.class)
+                .isPresent();
+
+        if (hasSnapshottingAnnotation) {
+            Map<String, Object> resolved = AnnotationUtils
+                    .findAnnotationAttributesOnType(entityType, Snapshotting.class,
+                                                   AnnotatedEventSourcedEntityModule::hasConcreteSnapshotValue)
+                    .orElseThrow(() -> new AxonConfigurationException(
+                            "@Snapshotting on [" + entityType.getName()
+                                    + "] could not resolve a concrete trigger. "
+                                    + "Configure afterEvents or afterSourcingTime on the annotation or a "
+                                    + "higher-level annotation on an enclosing class, package, or module."
+                    ));
+            SnapshotPolicy policy = buildSnapshotPolicy(entityType, resolved);
+            phase.snapshotPolicy(c -> policy);
+        }
+
+        componentRegistry(cr -> cr.registerModule(phase.build()));
     }
 
     private AnnotatedEntityMetamodel<E> buildMetaModel(Configuration c) {
@@ -133,6 +155,37 @@ class AnnotatedEventSourcedEntityModule<I, E>
             var component = (AnnotatedEntityMetamodel<E>) c.getComponent(EntityMetamodel.class, entityName());
             return definition.createIdResolver(entityType, idType, component, c);
         };
+    }
+
+    private static boolean hasConcreteSnapshotValue(Map<String, Object> attrs) {
+        return (int) attrs.get("afterEvents") != Snapshotting.USE_DEFAULT
+                || !Snapshotting.USE_DEFAULT_DURATION.equals(attrs.get("afterSourcingTime"));
+    }
+
+    private static SnapshotPolicy buildSnapshotPolicy(Class<?> entityType, Map<String, Object> attrs) {
+        int afterEvents = (int) attrs.get("afterEvents");
+        String afterSourcingTime = (String) attrs.get("afterSourcingTime");
+
+        SnapshotPolicy policy = null;
+
+        if (afterEvents > 0) {
+            policy = SnapshotPolicy.afterEvents(afterEvents);
+        }
+
+        if (!Snapshotting.USE_DEFAULT_DURATION.equals(afterSourcingTime)) {
+            SnapshotPolicy timePart = SnapshotPolicy.whenSourcingTimeExceeds(Duration.parse(afterSourcingTime));
+
+            policy = policy == null ? timePart : policy.or(timePart);
+        }
+
+        if (policy == null) {
+            throw new AxonConfigurationException(
+                    "@Snapshotting on [" + entityType.getName() + "] has no active trigger: afterEvents is 0 and "
+                            + "afterSourcingTime is not configured. Remove the annotation or configure at least one trigger."
+            );
+        }
+
+        return policy;
     }
 
     /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
@@ -16,6 +16,8 @@
 
 package org.axonframework.eventsourcing.configuration;
 
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.DefaultComponentRegistry;
 import org.axonframework.common.configuration.StubLifecycleRegistry;
@@ -26,9 +28,12 @@ import org.axonframework.eventsourcing.EventSourcingRepository;
 import org.axonframework.eventsourcing.annotation.CriteriaResolverDefinition;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntityFactoryDefinition;
+import org.axonframework.eventsourcing.annotation.Snapshotting;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.eventsourcing.handler.EntityLifecycleHandler;
 import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
+import org.axonframework.eventsourcing.handler.SnapshottingEntityLifecycleHandler;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
@@ -62,6 +67,7 @@ import static org.mockito.Mockito.verify;
  * @author Mitchell Herrijgers
  * @author Steven van Beelen
  * @author Simon Zambrovski
+ * @author John Hendrikx
  */
 @ExtendWith(MockitoExtension.class)
 class AnnotatedEventSourcedEntityModuleTest {
@@ -296,5 +302,158 @@ class AnnotatedEventSourcedEntityModuleTest {
     @EventSourcedEntity(concreteTypes = {String.class})
     interface PolymorphicEventSourcedEntity {
 
+    }
+
+    @Nested
+    class WhenSnapshottingAnnotationIsPresent {
+        private ComponentDescriptor componentDescriptor = mock(ComponentDescriptor.class);
+
+        @Test
+        void allTriggersDisabledShouldThrowAxonConfigurationException() {
+            assertThatThrownBy(() -> EventSourcedEntityModule.autodetected(CourseId.class, AllTriggersDisabledCourse.class))
+                .isInstanceOf(AxonConfigurationException.class)
+                .hasMessageContaining("has no active trigger");
+        }
+
+        @Test
+        void afterEventsConfigurationShouldUseSnapshottingEntityLifecycleHandler() {
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                .componentRegistry(cr -> cr.registerModule(
+                    EventSourcedEntityModule.autodetected(CourseId.class, AfterEventsCourse.class)))
+                .start();
+
+            Repository<CourseId, AfterEventsCourse> result = configuration.getComponent(StateManager.class)
+                .repository(AfterEventsCourse.class, CourseId.class);
+
+            result.describeTo(componentDescriptor);
+
+            verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+
+        @Test
+        void afterSourcingTimeConfigurationShouldUseSnapshottingEntityLifecycleHandler() {
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                .componentRegistry(cr -> cr.registerModule(
+                    EventSourcedEntityModule.autodetected(CourseId.class, AfterSourcingTimeCourse.class)))
+                .start();
+
+            Repository<CourseId, AfterSourcingTimeCourse> result = configuration.getComponent(StateManager.class)
+                .repository(AfterSourcingTimeCourse.class, CourseId.class);
+
+            result.describeTo(componentDescriptor);
+
+            verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+
+        @Test
+        void combinedConditionsShouldUseSnapshottingEntityLifecycleHandler() {
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                .componentRegistry(cr -> cr.registerModule(
+                    EventSourcedEntityModule.autodetected(CourseId.class, CombinedSnapshotCourse.class)))
+                .start();
+
+            Repository<CourseId, CombinedSnapshotCourse> result = configuration.getComponent(StateManager.class)
+                .repository(CombinedSnapshotCourse.class, CourseId.class);
+
+            result.describeTo(componentDescriptor);
+
+            verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+
+        @Test
+        void bareAnnotationWithoutThresholdsThrowsAxonConfigurationException() {
+            assertThatThrownBy(() -> EventSourcedEntityModule.autodetected(CourseId.class, DefaultSnapshotCourse.class))
+                .isInstanceOf(AxonConfigurationException.class)
+                .hasMessageContaining("could not resolve a concrete trigger");
+        }
+
+        @Test
+        void bareAnnotationResolvesDefaultFromEnclosingClass() {
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                .componentRegistry(cr -> cr.registerModule(
+                    EventSourcedEntityModule.autodetected(CourseId.class,
+                                                          WithDefaultPolicy.EnclosedCourse.class)))
+                .start();
+
+            Repository<CourseId, WithDefaultPolicy.EnclosedCourse> result =
+                    configuration.getComponent(StateManager.class)
+                                 .repository(WithDefaultPolicy.EnclosedCourse.class, CourseId.class);
+
+            result.describeTo(componentDescriptor);
+
+            verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+
+        @Test
+        void metaAnnotatedSnapshottingShouldUseSnapshottingEntityLifecycleHandler() {
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                .componentRegistry(cr -> cr.registerModule(
+                    EventSourcedEntityModule.autodetected(CourseId.class, MetaAnnotatedSnapshottingCourse.class)))
+                .start();
+
+            Repository<CourseId, MetaAnnotatedSnapshottingCourse> result =
+                    configuration.getComponent(StateManager.class)
+                                 .repository(MetaAnnotatedSnapshottingCourse.class, CourseId.class);
+
+            result.describeTo(componentDescriptor);
+
+            verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+    }
+
+    @EventSourcedEntity
+    @Snapshotting(afterEvents = 5)
+    record AfterEventsCourse(CourseId id) {
+        @EntityCreator public AfterEventsCourse {}
+    }
+
+    @EventSourcedEntity
+    @Snapshotting(afterSourcingTime = "PT5S")
+    record AfterSourcingTimeCourse(CourseId id) {
+        @EntityCreator public AfterSourcingTimeCourse {}
+    }
+
+    @EventSourcedEntity
+    @Snapshotting(afterEvents = 5, afterSourcingTime = "PT5S")
+    record CombinedSnapshotCourse(CourseId id) {
+        @EntityCreator public CombinedSnapshotCourse {}
+    }
+
+    @EventSourcedEntity
+    @Snapshotting
+    record DefaultSnapshotCourse(CourseId id) {
+        @EntityCreator public DefaultSnapshotCourse {}
+    }
+
+    @EventSourcedEntity
+    @Snapshotting(afterEvents = 0)
+    record AllTriggersDisabledCourse(CourseId id) {
+        @EntityCreator public AllTriggersDisabledCourse {}
+    }
+
+    @EventSourcedEntity
+    @MetaSnapshotting
+    record MetaAnnotatedSnapshottingCourse(CourseId id) {
+        @EntityCreator public MetaAnnotatedSnapshottingCourse {}
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Snapshotting(afterEvents = 10)
+    public @interface MetaSnapshotting {}
+
+    @Snapshotting(afterEvents = 20)
+    static class WithDefaultPolicy {
+
+        @EventSourcedEntity
+        @Snapshotting
+        record EnclosedCourse(CourseId id) {
+            @EntityCreator public EnclosedCourse {}
+        }
     }
 }


### PR DESCRIPTION
## Summary

Backports PR #4553 (Add Snapshotting annotation support) from `main` to `axon-5.1.x`.

One conflict resolved in `AnnotatedEventSourcedEntityModuleTest`: the tests were
adapted to the 5.1.x handler architecture (`SnapshottingEntityLifecycleHandler` /
`"entityLifecycleHandler"`) introduced by PR #4460, which is present on `axon-5.1.x`
but not yet on `main`.