### PR TITLE
chore(migration): set expected `axoniq.version` to `5.1.1`

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -42,7 +42,7 @@
              root `${revision}`); this property is the single source of truth
              for the *commercial* coordinates the recipes migrate to. Bump
              here when re-targeting the migration to a newer Axoniq release. -->
-        <axoniq.version>5.1.1-SNAPSHOT</axoniq.version>
+        <axoniq.version>5.1.1</axoniq.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Axon4ToAxon5BomTest is disabled on CI, so it won't broke even if the `5.1.1` is not released yet