### PR TITLE
[#3195] feat(migration): fix Kotlin OpenRewrite migration gaps

### DIFF
--- a/migration/src/main/java/org/axonframework/migration/AddCommandAnnotation.java
+++ b/migration/src/main/java/org/axonframework/migration/AddCommandAnnotation.java
@@ -67,6 +67,20 @@ public class AddCommandAnnotation extends ScanningRecipe<AddCommandAnnotation.Ac
     private static final String COMMAND_FQN = "org.axonframework.messaging.commandhandling.annotation.Command";
     private static final String ROUTING_KEY_AF4 = "org.axonframework.commandhandling.RoutingKey";
     private static final String ROUTING_KEY_AF5 = "org.axonframework.messaging.commandhandling.RoutingKey";
+    // @TargetAggregateIdentifier (AF4) marks the field that resolves the entity to route the
+    // command to. AF5 splits this into two annotations: @TargetEntityId on the field stays
+    // (renamed via ChangeType), and a class-level @Command(routingKey = "<fieldName>") declares
+    // which field carries the routing key for the command bus. If a class lacks an explicit
+    // @RoutingKey but has a @TargetAggregateIdentifier / @TargetEntityId field, we lift that
+    // field's name onto @Command#routingKey so routing keeps working.
+    private static final String TARGET_AGGREGATE_ID_AF4 =
+            "org.axonframework.modelling.command.TargetAggregateIdentifier";
+    // Post-ChangePackage (modelling.command → modelling.entity) shape.
+    private static final String TARGET_AGGREGATE_ID_AF5_INTERMEDIATE =
+            "org.axonframework.modelling.entity.TargetAggregateIdentifier";
+    // Post-rename (TargetAggregateIdentifier → TargetEntityId) shape — the AF5 target.
+    private static final String TARGET_ENTITY_ID_AF5 =
+            "org.axonframework.modelling.annotation.TargetEntityId";
     private static final String ROUTING_KEY_FIELD_MESSAGE = "axon4to5.routingKeyField";
 
     public static class Accumulator {
@@ -303,7 +317,7 @@ public class AddCommandAnnotation extends ScanningRecipe<AddCommandAnnotation.Ac
 
     private static boolean hasRoutingKeyAnnotation(J.VariableDeclarations vd) {
         for (J.Annotation ann : vd.getLeadingAnnotations()) {
-            if (isRoutingKey(ann)) {
+            if (isRoutingKey(ann) || isTargetIdentifier(ann)) {
                 return true;
             }
         }
@@ -318,6 +332,25 @@ public class AddCommandAnnotation extends ScanningRecipe<AddCommandAnnotation.Ac
         if (ann.getAnnotationType() instanceof J.Identifier) {
             return "RoutingKey".equals(
                     ((J.Identifier) ann.getAnnotationType()).getSimpleName());
+        }
+        return false;
+    }
+
+    /**
+     * Matches the AF4 {@code @TargetAggregateIdentifier} and its post-rename AF5
+     * {@code @TargetEntityId} successor (including the transient post-{@code ChangePackage}
+     * shape). When this annotation is on a command field and no explicit {@code @RoutingKey}
+     * exists, the field name becomes the routing key on the class-level {@code @Command}.
+     */
+    private static boolean isTargetIdentifier(J.Annotation ann) {
+        if (TypeUtils.isOfClassType(ann.getType(), TARGET_AGGREGATE_ID_AF4)
+                || TypeUtils.isOfClassType(ann.getType(), TARGET_AGGREGATE_ID_AF5_INTERMEDIATE)
+                || TypeUtils.isOfClassType(ann.getType(), TARGET_ENTITY_ID_AF5)) {
+            return true;
+        }
+        if (ann.getAnnotationType() instanceof J.Identifier) {
+            String name = ((J.Identifier) ann.getAnnotationType()).getSimpleName();
+            return "TargetAggregateIdentifier".equals(name) || "TargetEntityId".equals(name);
         }
         return false;
     }

--- a/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
+++ b/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+
+/**
+ * Java/Kotlin advisory recipe for AF4 {@code EventProcessingConfigurer#registerSequencingPolicy(...)}
+ * calls.
+ * <p>
+ * AF5 dropped the declarative-API registration of sequencing policies. The decision now lives on
+ * the event-handler class via {@code @SequencingPolicy} from
+ * {@code org.axonframework.messaging.core.annotation}. Rewriting the configurer call into the
+ * annotation move is non-mechanical: the policy {@code Function<Configuration, SequencingPolicy>}
+ * may produce any policy at runtime and the recipe cannot infer which handler class should carry
+ * the annotation. Deleting the call mechanically would silently lose configuration, so this
+ * recipe annotates the call site with a {@code // TODO(axon4to5):} comment that names the
+ * replacement API.
+ * <p>
+ * Idempotent — the comment carries a stable marker substring, and the visitor skips invocations
+ * whose immediate prefix already contains it.
+ *
+ * @author Mateusz Nowak
+ * @since 5.1.1
+ */
+public class AnnotateProgrammaticSequencingPolicyRegistration extends Recipe {
+
+    private static final String AF4_CONFIGURER =
+            "org.axonframework.config.EventProcessingConfigurer";
+    private static final String AF4_MODULE_CONFIGURER =
+            "org.axonframework.config.EventProcessingModule";
+
+    /**
+     * AF4 has the method on the configurer SPI and on the module that implements it; match both
+     * so the recipe fires regardless of whether the calling code holds the interface or the impl.
+     * Any-argument matcher (`..`) is intentional — both the {@code (String, Function)} and the
+     * default-policy {@code (Function)} overload should be flagged.
+     */
+    private static final MethodMatcher SPI_MATCHER =
+            new MethodMatcher(AF4_CONFIGURER + " registerSequencingPolicy(..)");
+    private static final MethodMatcher IMPL_MATCHER =
+            new MethodMatcher(AF4_MODULE_CONFIGURER + " registerSequencingPolicy(..)");
+
+    private static final String COMMENT_MARKER =
+            "TODO(axon4to5): declarative sequencing-policy registration is no longer supported";
+    private static final String COMMENT_TEXT = " " + COMMENT_MARKER
+            + ". Move the policy onto the event handler class via @SequencingPolicy "
+            + "(org.axonframework.messaging.core.annotation.SequencingPolicy).";
+
+    @Override
+    public String getDisplayName() {
+        return "Annotate obsolete `registerSequencingPolicy(...)` calls with a migration TODO";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Prepends a `// TODO(axon4to5):` comment above any "
+                + "`EventProcessingConfigurer#registerSequencingPolicy(...)` invocation. AF5 moves "
+                + "the decision onto the handler class via `@SequencingPolicy`; rewriting the "
+                + "lambda call into an annotation move requires knowing which handler class "
+                + "should carry the annotation, which the recipe cannot infer. Idempotent.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            /**
+             * Statement-level visitor: the TODO comment must attach to whatever statement
+             * encloses the invocation (e.g. a `J.MethodInvocation` standalone statement or an
+             * expression statement wrapping it). Walking at the method-invocation level would
+             * land the comment inline, which the rewrite engine often prints in awkward positions.
+             */
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation invocation,
+                                                             ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(invocation, ctx);
+                if (!isTargetCall(mi)) {
+                    return mi;
+                }
+                // Prefer attaching the comment to the enclosing statement so it renders on its
+                // own line above the call rather than getting inlined between operands.
+                J enclosingStmt = getCursor().firstEnclosing(org.openrewrite.java.tree.Statement.class);
+                if (enclosingStmt instanceof J.MethodInvocation
+                        && enclosingStmt == mi) {
+                    if (hasMarkerComment(mi.getPrefix())) {
+                        return mi;
+                    }
+                    return mi.withPrefix(prependLineComment(mi.getPrefix()));
+                }
+                // Fall-through: leave to the statement-level visitor below (visitStatement) to
+                // place the comment on the surrounding J node. visitMethodInvocation alone covers
+                // the simplest case where the invocation IS the statement.
+                return mi;
+            }
+
+            private boolean isTargetCall(J.MethodInvocation mi) {
+                return SPI_MATCHER.matches(mi) || IMPL_MATCHER.matches(mi);
+            }
+
+            private boolean hasMarkerComment(Space prefix) {
+                for (org.openrewrite.java.tree.Comment c : prefix.getComments()) {
+                    if (c instanceof TextComment
+                            && ((TextComment) c).getText().contains(COMMENT_MARKER)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            /**
+             * Prepend a {@code //}-style line comment to {@code prefix}, preserving the existing
+             * indentation so the call below the comment lines up with its original column.
+             */
+            private Space prependLineComment(Space prefix) {
+                String leading = prefix.getWhitespace();
+                String indent = leading.contains("\n")
+                        ? leading.substring(leading.lastIndexOf('\n') + 1)
+                        : "";
+                String suffix = "\n" + indent;
+                TextComment todo = new TextComment(false, COMMENT_TEXT, suffix, Markers.EMPTY);
+                return prefix.withComments(ListUtils.concat(prefix.getComments(), todo));
+            }
+        };
+    }
+}

--- a/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
+++ b/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
@@ -98,32 +98,20 @@ public class AnnotateProgrammaticSequencingPolicyRegistration extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
 
             /**
-             * Statement-level visitor: the TODO comment must attach to whatever statement
-             * encloses the invocation (e.g. a `J.MethodInvocation` standalone statement or an
-             * expression statement wrapping it). Walking at the method-invocation level would
-             * land the comment inline, which the rewrite engine often prints in awkward positions.
+             * Attaches the TODO comment to the call site's own prefix. {@code J.MethodInvocation}
+             * implements {@link org.openrewrite.java.tree.Statement}, so the invocation itself is
+             * the relevant statement when it appears in a block; OpenRewrite prints comments
+             * stored on a statement's prefix on the line above the statement, which is exactly
+             * the placement this recipe wants.
              */
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation invocation,
                                                              ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(invocation, ctx);
-                if (!isTargetCall(mi)) {
+                if (!isTargetCall(mi) || hasMarkerComment(mi.getPrefix())) {
                     return mi;
                 }
-                // Prefer attaching the comment to the enclosing statement so it renders on its
-                // own line above the call rather than getting inlined between operands.
-                J enclosingStmt = getCursor().firstEnclosing(org.openrewrite.java.tree.Statement.class);
-                if (enclosingStmt instanceof J.MethodInvocation
-                        && enclosingStmt == mi) {
-                    if (hasMarkerComment(mi.getPrefix())) {
-                        return mi;
-                    }
-                    return mi.withPrefix(prependLineComment(mi.getPrefix()));
-                }
-                // Fall-through: leave to the statement-level visitor below (visitStatement) to
-                // place the comment on the surrounding J node. visitMethodInvocation alone covers
-                // the simplest case where the invocation IS the statement.
-                return mi;
+                return mi.withPrefix(prependLineComment(mi.getPrefix()));
             }
 
             private boolean isTargetCall(J.MethodInvocation mi) {

--- a/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
+++ b/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
@@ -58,17 +58,30 @@ public class AnnotateProgrammaticSequencingPolicyRegistration extends Recipe {
             "org.axonframework.config.EventProcessingConfigurer";
     private static final String AF4_MODULE_CONFIGURER =
             "org.axonframework.config.EventProcessingModule";
+    // `Axon4ToAxon5Common` runs ahead of this recipe and renames the AF4 FQNs into the AF5
+    // configuration namespace. The MethodMatcher operates on the LST's bound type at the
+    // call site, so we must also match the post-rename FQN or the recipe silently no-ops
+    // on every codebase that ran the umbrella in order.
+    private static final String AF5_CONFIGURER =
+            "org.axonframework.messaging.eventhandling.configuration.EventProcessingConfigurer";
+    private static final String AF5_MODULE_CONFIGURER =
+            "org.axonframework.messaging.eventhandling.configuration.EventProcessingModule";
 
     /**
      * AF4 has the method on the configurer SPI and on the module that implements it; match both
      * so the recipe fires regardless of whether the calling code holds the interface or the impl.
      * Any-argument matcher (`..`) is intentional — both the {@code (String, Function)} and the
-     * default-policy {@code (Function)} overload should be flagged.
+     * default-policy {@code (Function)} overload should be flagged. We list AF4 and AF5 FQNs
+     * because the umbrella may run the type-rename before this recipe.
      */
-    private static final MethodMatcher SPI_MATCHER =
+    private static final MethodMatcher SPI_MATCHER_AF4 =
             new MethodMatcher(AF4_CONFIGURER + " registerSequencingPolicy(..)");
-    private static final MethodMatcher IMPL_MATCHER =
+    private static final MethodMatcher SPI_MATCHER_AF5 =
+            new MethodMatcher(AF5_CONFIGURER + " registerSequencingPolicy(..)");
+    private static final MethodMatcher IMPL_MATCHER_AF4 =
             new MethodMatcher(AF4_MODULE_CONFIGURER + " registerSequencingPolicy(..)");
+    private static final MethodMatcher IMPL_MATCHER_AF5 =
+            new MethodMatcher(AF5_MODULE_CONFIGURER + " registerSequencingPolicy(..)");
 
     private static final String COMMENT_MARKER =
             "TODO(axon4to5): EventProcessingConfigurer#registerSequencingPolicy is gone in AF5";
@@ -115,7 +128,8 @@ public class AnnotateProgrammaticSequencingPolicyRegistration extends Recipe {
             }
 
             private boolean isTargetCall(J.MethodInvocation mi) {
-                return SPI_MATCHER.matches(mi) || IMPL_MATCHER.matches(mi);
+                return SPI_MATCHER_AF4.matches(mi) || SPI_MATCHER_AF5.matches(mi)
+                        || IMPL_MATCHER_AF4.matches(mi) || IMPL_MATCHER_AF5.matches(mi);
             }
 
             private boolean hasMarkerComment(Space prefix) {

--- a/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
+++ b/migration/src/main/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistration.java
@@ -31,14 +31,20 @@ import org.openrewrite.marker.Markers;
  * Java/Kotlin advisory recipe for AF4 {@code EventProcessingConfigurer#registerSequencingPolicy(...)}
  * calls.
  * <p>
- * AF5 dropped the declarative-API registration of sequencing policies. The decision now lives on
- * the event-handler class via {@code @SequencingPolicy} from
- * {@code org.axonframework.messaging.core.annotation}. Rewriting the configurer call into the
- * annotation move is non-mechanical: the policy {@code Function<Configuration, SequencingPolicy>}
- * may produce any policy at runtime and the recipe cannot infer which handler class should carry
- * the annotation. Deleting the call mechanically would silently lose configuration, so this
- * recipe annotates the call site with a {@code // TODO(axon4to5):} comment that names the
- * replacement API.
+ * AF5 dropped the AF4 {@code EventProcessingConfigurer} sequencing-policy hook. Two replacements
+ * exist:
+ * <ul>
+ *   <li>{@code @SequencingPolicy} on the event-handling class
+ *       ({@code org.axonframework.messaging.core.annotation.SequencingPolicy}).</li>
+ *   <li>Declarative configuration through
+ *       {@code EventProcessorDefinition} ({@code org.axonframework.extension.spring.config}),
+ *       customised with
+ *       {@code .customized(c -> c.sequencingPolicy(...))} on the processor configuration.</li>
+ * </ul>
+ * Picking between the two needs human judgement (which handler class, which processor name) and
+ * the policy {@code Function<Configuration, SequencingPolicy>} may produce any policy at runtime,
+ * so the recipe cannot rewrite the call mechanically. Deleting the call silently would lose
+ * configuration; this recipe leaves a {@code // TODO(axon4to5):} comment instead.
  * <p>
  * Idempotent — the comment carries a stable marker substring, and the visitor skips invocations
  * whose immediate prefix already contains it.
@@ -65,10 +71,13 @@ public class AnnotateProgrammaticSequencingPolicyRegistration extends Recipe {
             new MethodMatcher(AF4_MODULE_CONFIGURER + " registerSequencingPolicy(..)");
 
     private static final String COMMENT_MARKER =
-            "TODO(axon4to5): declarative sequencing-policy registration is no longer supported";
+            "TODO(axon4to5): EventProcessingConfigurer#registerSequencingPolicy is gone in AF5";
     private static final String COMMENT_TEXT = " " + COMMENT_MARKER
-            + ". Move the policy onto the event handler class via @SequencingPolicy "
-            + "(org.axonframework.messaging.core.annotation.SequencingPolicy).";
+            + ". Replace with either @SequencingPolicy on the event handler class "
+            + "(org.axonframework.messaging.core.annotation.SequencingPolicy) or, "
+            + "for processor-level configuration, EventProcessorDefinition…"
+            + ".customized(c -> c.sequencingPolicy(...)) "
+            + "(org.axonframework.extension.spring.config.EventProcessorDefinition).";
 
     @Override
     public String getDisplayName() {

--- a/migration/src/main/java/org/axonframework/migration/ConfigureEventSourcedAnnotation.java
+++ b/migration/src/main/java/org/axonframework/migration/ConfigureEventSourcedAnnotation.java
@@ -84,7 +84,10 @@ public class ConfigureEventSourcedAnnotation
     private static final String TODO_COMMENT =
             " /* TODO(axon4to5): set to actual id type, e.g. String.class or UUID.class */";
     private static final String TODO_FALLBACK = "Object.class" + TODO_COMMENT;
-    private static final String TODO_FALLBACK_KOTLIN = "Object::class.java" + TODO_COMMENT;
+    // Kotlin annotations expect a `KClass<?>` literal (the Kotlin compiler converts it to a Java
+    // `Class<?>` for the underlying Java annotation parameter). Writing `::class.java` here would
+    // produce a `Class<?>` expression, which is not assignable to the annotation's `KClass<?>` slot.
+    private static final String TODO_FALLBACK_KOTLIN = "Object::class" + TODO_COMMENT;
 
     /** Records {@code enclosingClassFqn → idTypeFqn} for every {@code @AggregateIdentifier} field. */
     public static class Accumulator {
@@ -199,7 +202,7 @@ public class ConfigureEventSourcedAnnotation
                     idTypeImport = null;
                 } else {
                     String simpleName = idTypeFqn.substring(idTypeFqn.lastIndexOf('.') + 1);
-                    idTypeExpr = simpleName + (kotlin ? "::class.java" : ".class");
+                    idTypeExpr = simpleName + (kotlin ? "::class" : ".class");
                     // java.lang types are auto-imported.
                     idTypeImport = idTypeFqn.startsWith("java.lang.") ? null : idTypeFqn;
                 }

--- a/migration/src/main/java/org/axonframework/migration/MigrateMessageInterceptorLambda.java
+++ b/migration/src/main/java/org/axonframework/migration/MigrateMessageInterceptorLambda.java
@@ -272,7 +272,11 @@ public class MigrateMessageInterceptorLambda extends Recipe {
                 if (alreadyMarked(prefix)) {
                     return lambda;
                 }
-                TextComment todo = new TextComment(false, TODO_TEXT, " ", Markers.EMPTY);
+                // Block comment (`/* … */`) rather than a line comment: lambda prefixes often
+                // have no surrounding newline (initializer on the same line as the `=`), and
+                // a line comment would consume the rest of the line — including the lambda
+                // it is supposed to annotate.
+                TextComment todo = new TextComment(true, TODO_TEXT, " ", Markers.EMPTY);
                 return lambda.withPrefix(
                         prefix.withComments(ListUtils.concat(prefix.getComments(), todo)));
             }

--- a/migration/src/main/java/org/axonframework/migration/MigrateMessageInterceptorLambda.java
+++ b/migration/src/main/java/org/axonframework/migration/MigrateMessageInterceptorLambda.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+
+import java.util.List;
+
+/**
+ * Migrates lambda-based implementations of
+ * {@link org.axonframework.messaging.core.MessageHandlerInterceptor} from the two-parameter AF4
+ * shape ({@code (unitOfWork, interceptorChain) -> …}) to the three-parameter AF5 shape
+ * ({@code (message, processingContext, interceptorChain) -> …}).
+ * <p>
+ * In addition to the parameter list, the recipe rewrites every no-argument
+ * {@code interceptorChain.proceed()} call in the lambda body to
+ * {@code interceptorChain.proceed(message, processingContext)} so the lambda compiles against the
+ * new {@code MessageHandlerInterceptorChain#proceed(Message, ProcessingContext)} signature. The
+ * AF4 {@code unitOfWork} parameter is dropped; references to it inside the body remain and become
+ * compile errors so the developer notices the per-site rewrite that is required.
+ * <p>
+ * The recipe operates on lambdas whose declared type is {@code MessageHandlerInterceptor<…>}. The
+ * common case is a local variable declaration or field initializer such as
+ * {@snippet :
+ * MessageHandlerInterceptor<CommandMessage<?>> interceptor = (uow, chain) -> { ... };
+ * }
+ * The class-based implementation form is handled by
+ * {@link MigrateMessageInterceptorSignatures} — that recipe rewrites the method-level signature
+ * and the same chain-name resolution applies there; this recipe is its lambda counterpart.
+ * <p>
+ * <b>Must run after</b> {@code Axon4ToAxon5Messaging}'s {@code ChangeType} steps so that the
+ * variable's declared type already references the AF5 FQN.
+ *
+ * @author Mateusz Nowak
+ * @since 5.1.1
+ */
+public class MigrateMessageInterceptorLambda extends Recipe {
+
+    private static final String AF5_HANDLER_INTERCEPTOR =
+            "org.axonframework.messaging.core.MessageHandlerInterceptor";
+    private static final String TODO_TEXT =
+            " TODO(axon4to5): review lambda body — the dropped `unitOfWork` parameter has no AF5"
+                    + " equivalent; references to it must be replaced with calls on `message` /"
+                    + " `processingContext`.";
+    private static final String IDEMPOTENCY_MARKER =
+            "TODO(axon4to5): review lambda body";
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `MessageHandlerInterceptor` lambda signature to AF5";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Rewrites two-parameter `(unitOfWork, interceptorChain) -> ...` AF4 lambdas bound "
+                + "to `MessageHandlerInterceptor<...>` variables into the three-parameter AF5 "
+                + "shape `(message, processingContext, interceptorChain) -> ...`, and rewrites "
+                + "`interceptorChain.proceed()` calls inside the body to "
+                + "`interceptorChain.proceed(message, processingContext)`. The `unitOfWork` "
+                + "parameter is dropped; remaining references inside the body become compile "
+                + "errors, surfacing per-site rewrites that the developer must apply. "
+                + "Idempotent — lambdas already on the three-parameter shape are skipped.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVar,
+                                                                      ExecutionContext ctx) {
+                J.VariableDeclarations vd = super.visitVariableDeclarations(multiVar, ctx);
+                if (!isMessageHandlerInterceptorType(vd.getType())) {
+                    return vd;
+                }
+                // Apply per-variable: a single declaration can declare multiple variables, each
+                // with its own initializer.
+                List<J.VariableDeclarations.NamedVariable> rewrittenVars = ListUtils.map(vd.getVariables(),
+                        nv -> {
+                            if (!(nv.getInitializer() instanceof J.Lambda)) {
+                                return nv;
+                            }
+                            J.Lambda rewritten = rewriteLambdaIfApplicable((J.Lambda) nv.getInitializer());
+                            return rewritten == nv.getInitializer() ? nv : nv.withInitializer(rewritten);
+                        });
+                return rewrittenVars == vd.getVariables() ? vd : vd.withVariables(rewrittenVars);
+            }
+
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, ExecutionContext ctx) {
+                J.Assignment a = super.visitAssignment(assignment, ctx);
+                if (!(a.getAssignment() instanceof J.Lambda)) {
+                    return a;
+                }
+                if (!isMessageHandlerInterceptorType(
+                        a.getVariable().getType())) {
+                    return a;
+                }
+                J.Lambda rewritten = rewriteLambdaIfApplicable((J.Lambda) a.getAssignment());
+                return rewritten == a.getAssignment() ? a : a.withAssignment(rewritten);
+            }
+
+            /**
+             * @return {@code true} when {@code type} is the AF5 {@code MessageHandlerInterceptor}
+             * (possibly with generic type arguments). The {@link MigrateMessageInterceptorSignatures}
+             * companion recipe and {@code Axon4ToAxon5Messaging} together ensure the AF4 FQN has
+             * been renamed by the time this visitor runs, so we match only the AF5 name.
+             */
+            private boolean isMessageHandlerInterceptorType(JavaType type) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
+                if (fq == null) {
+                    return false;
+                }
+                return AF5_HANDLER_INTERCEPTOR.equals(fq.getFullyQualifiedName());
+            }
+
+            /**
+             * Rewrites a two-parameter AF4 lambda into the three-parameter AF5 shape. Returns the
+             * original lambda when it already has three parameters (idempotency) or when the
+             * parameter list cannot be safely interpreted.
+             */
+            private J.Lambda rewriteLambdaIfApplicable(J.Lambda lambda) {
+                List<J> params = lambda.getParameters().getParameters();
+                if (params.size() == 3 || alreadyMarked(lambda.getPrefix())) {
+                    return lambda;
+                }
+                if (params.size() != 2) {
+                    return lambda;
+                }
+                String chainParamName = parameterName(params.get(1));
+                if (chainParamName == null) {
+                    return lambda;
+                }
+                // Build a stub lambda with the desired three-parameter shape, then graft its
+                // parameter list onto the original. JavaTemplate is overkill for this: the
+                // existing params are inferred-typed lambda placeholders (e.g. `(uow, chain)`),
+                // so we mirror that shape with three inferred identifiers.
+                J.Lambda stub = parseStubLambda(chainParamName);
+                if (stub == null) {
+                    return lambda;
+                }
+                // Rewrite `chain.proceed()` calls in the body to `chain.proceed(message, context)`.
+                J body = rewriteBody(lambda.getBody(), chainParamName);
+                J.Lambda result = lambda
+                        .withParameters(stub.getParameters())
+                        .withBody(body);
+                return prependTodoComment(result);
+            }
+
+            private J rewriteBody(J body, String chainParamName) {
+                return new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation invocation,
+                                                                     ExecutionContext c) {
+                        J.MethodInvocation mi = super.visitMethodInvocation(invocation, c);
+                        if (!"proceed".equals(mi.getSimpleName())) {
+                            return mi;
+                        }
+                        // The select must be the chain parameter name. Other `.proceed()` calls
+                        // (rare but possible) are not touched.
+                        if (!(mi.getSelect() instanceof J.Identifier)) {
+                            return mi;
+                        }
+                        if (!chainParamName.equals(
+                                ((J.Identifier) mi.getSelect()).getSimpleName())) {
+                            return mi;
+                        }
+                        if (!mi.getArguments().isEmpty()
+                                && !(mi.getArguments().get(0) instanceof J.Empty)) {
+                            // Already has arguments (e.g. user pre-migrated this call) — leave it.
+                            return mi;
+                        }
+                        return JavaTemplate.builder("#{}.proceed(message, processingContext)")
+                                .javaParser(JavaParser.fromJavaVersion()
+                                        .classpath(JavaParser.runtimeClasspath()))
+                                .build()
+                                .apply(getCursor(),
+                                       mi.getCoordinates().replace(),
+                                       chainParamName);
+                    }
+                }.visitNonNull(body, new org.openrewrite.InMemoryExecutionContext(),
+                               getCursor().getParentOrThrow());
+            }
+
+            /**
+             * Parses a synthetic three-parameter lambda whose chain parameter shares the original
+             * lambda's chain-parameter name, returns the parsed {@link J.Lambda}, or {@code null}
+             * when the parser produces an unexpected shape.
+             */
+            private J.Lambda parseStubLambda(String chainParamName) {
+                String src = "class _Stub {\n"
+                        + "    Object f = (message, processingContext, " + chainParamName + ") -> null;\n"
+                        + "}\n";
+                List<org.openrewrite.SourceFile> parsed = JavaParser.fromJavaVersion()
+                        .classpath(JavaParser.runtimeClasspath())
+                        .build()
+                        .parseInputs(java.util.Collections.singletonList(
+                                org.openrewrite.Parser.Input.fromString(
+                                        java.nio.file.Paths.get("_Stub.java"), src)),
+                                     java.nio.file.Paths.get("."),
+                                     new org.openrewrite.InMemoryExecutionContext())
+                        .collect(java.util.stream.Collectors.toList());
+                if (parsed.isEmpty() || !(parsed.get(0) instanceof J.CompilationUnit)) {
+                    return null;
+                }
+                J.CompilationUnit cu = (J.CompilationUnit) parsed.get(0);
+                List<Statement> stmts = cu.getClasses().get(0).getBody().getStatements();
+                for (Statement s : stmts) {
+                    if (!(s instanceof J.VariableDeclarations)) {
+                        continue;
+                    }
+                    J.VariableDeclarations vd = (J.VariableDeclarations) s;
+                    if (vd.getVariables().isEmpty()) {
+                        continue;
+                    }
+                    if (vd.getVariables().get(0).getInitializer() instanceof J.Lambda) {
+                        return (J.Lambda) vd.getVariables().get(0).getInitializer();
+                    }
+                }
+                return null;
+            }
+
+            private String parameterName(J param) {
+                if (param instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations vd = (J.VariableDeclarations) param;
+                    if (!vd.getVariables().isEmpty()) {
+                        return vd.getVariables().get(0).getSimpleName();
+                    }
+                }
+                return null;
+            }
+
+            private boolean alreadyMarked(Space prefix) {
+                for (org.openrewrite.java.tree.Comment c : prefix.getComments()) {
+                    if (c instanceof TextComment
+                            && ((TextComment) c).getText().contains(IDEMPOTENCY_MARKER)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private J.Lambda prependTodoComment(J.Lambda lambda) {
+                Space prefix = lambda.getPrefix();
+                if (alreadyMarked(prefix)) {
+                    return lambda;
+                }
+                TextComment todo = new TextComment(false, TODO_TEXT, " ", Markers.EMPTY);
+                return lambda.withPrefix(
+                        prefix.withComments(ListUtils.concat(prefix.getComments(), todo)));
+            }
+        };
+    }
+}

--- a/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
+++ b/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
@@ -103,29 +103,98 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
              * {@link MethodMatcher} can resolve, so the matcher misses these calls. By
              * collecting the alias identifiers up front we can fall back to a simple-name match.
              * <p>
-             * OpenRewrite reuses the same visitor instance across every compilation unit in a
-             * recipe run, so the set is rescanned on every {@code visitCompilationUnit} entry.
-             * Without that reset, alias names from one file would leak into the next and an
-             * unrelated function happening to share the alias name would be misidentified as
-             * {@code apply} and rewritten.
+             * The map is keyed by the enclosing {@link SourceFile} so we don't leak state
+             * across files (OpenRewrite reuses the visitor instance across every compilation
+             * unit in a recipe run). {@link JavaIsoVisitor#visitCompilationUnit} only fires for
+             * {@code J.CompilationUnit}, not {@code K.CompilationUnit}; using the cursor to
+             * find the enclosing source file works for both languages.
              */
-            private final Set<String> applyAliasNames = new HashSet<>();
+            private final java.util.Map<SourceFile, Set<String>> applyAliasNamesPerFile =
+                    new java.util.IdentityHashMap<>();
 
-            @Override
-            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                applyAliasNames.clear();
-                for (J.Import imp : cu.getImports()) {
-                    String fqn = imp.getQualid().printTrimmed(getCursor());
-                    if (!(fqn.equals(AF4_AGGREGATE_LIFECYCLE_FQN + ".apply")
-                            || fqn.equals(AF5_AGGREGATE_LIFECYCLE_FQN + ".apply"))) {
-                        continue;
-                    }
-                    J.Identifier alias = imp.getAlias();
-                    if (alias != null) {
-                        applyAliasNames.add(alias.getSimpleName());
+            private Set<String> aliasesFor(SourceFile sf) {
+                Set<String> cached = applyAliasNamesPerFile.get(sf);
+                if (cached != null) {
+                    return cached;
+                }
+                Set<String> aliases = new HashSet<>();
+                List<J.Import> imports = importsOf(sf);
+                if (imports != null) {
+                    for (J.Import imp : imports) {
+                        if (imp.getAlias() == null) {
+                            continue;
+                        }
+                        if (!isAggregateLifecycleApplyImport(imp.getQualid())) {
+                            continue;
+                        }
+                        aliases.add(imp.getAlias().getSimpleName());
                     }
                 }
-                return super.visitCompilationUnit(cu, ctx);
+                applyAliasNamesPerFile.put(sf, aliases);
+                return aliases;
+            }
+
+            private @org.jspecify.annotations.Nullable List<J.Import> importsOf(SourceFile sf) {
+                if (sf instanceof J.CompilationUnit) {
+                    return ((J.CompilationUnit) sf).getImports();
+                }
+                if (sf instanceof K.CompilationUnit) {
+                    return ((K.CompilationUnit) sf).getImports();
+                }
+                return null;
+            }
+
+            /**
+             * Walks the import's qualid {@link org.openrewrite.java.tree.J.FieldAccess} chain
+             * looking for {@code <some.package>.AggregateLifecycle.apply}. Returns {@code true}
+             * when the target is named {@code apply} and the parent chain ends in
+             * {@code AggregateLifecycle} with the AF4 or AF5 package prefix.
+             * <p>
+             * Walks the chain explicitly instead of comparing printed strings: the Kotlin parser
+             * sometimes wraps the head of the FQN in a {@link org.openrewrite.java.tree.J.Empty}
+             * target, and {@code printTrimmed} on the inner target can differ from the
+             * package-prefixed identifier form we'd otherwise compare to.
+             */
+            private boolean isAggregateLifecycleApplyImport(org.openrewrite.java.tree.Expression qualid) {
+                if (!(qualid instanceof org.openrewrite.java.tree.J.FieldAccess)) {
+                    return false;
+                }
+                org.openrewrite.java.tree.J.FieldAccess fa = (org.openrewrite.java.tree.J.FieldAccess) qualid;
+                if (!"apply".equals(fa.getSimpleName())) {
+                    return false;
+                }
+                String fqn = flattenFieldAccess(fa.getTarget());
+                if (fqn == null) {
+                    return false;
+                }
+                return fqn.equals(AF4_AGGREGATE_LIFECYCLE_FQN)
+                        || fqn.equals(AF5_AGGREGATE_LIFECYCLE_FQN);
+            }
+
+            /**
+             * Recursively flattens a {@link org.openrewrite.java.tree.J.FieldAccess} chain into a
+             * dotted FQN. Tolerates a {@link org.openrewrite.java.tree.J.Empty} target on the
+             * outermost FieldAccess (the shape the Kotlin parser uses for some import paths).
+             * Returns {@code null} when the expression is anything unexpected.
+             */
+            private @org.jspecify.annotations.Nullable String flattenFieldAccess(
+                    org.openrewrite.java.tree.Expression expr) {
+                if (expr instanceof org.openrewrite.java.tree.J.Identifier) {
+                    return ((org.openrewrite.java.tree.J.Identifier) expr).getSimpleName();
+                }
+                if (!(expr instanceof org.openrewrite.java.tree.J.FieldAccess)) {
+                    return null;
+                }
+                org.openrewrite.java.tree.J.FieldAccess fa = (org.openrewrite.java.tree.J.FieldAccess) expr;
+                org.openrewrite.java.tree.Expression target = fa.getTarget();
+                if (target instanceof org.openrewrite.java.tree.J.Empty) {
+                    return fa.getSimpleName();
+                }
+                String prefix = flattenFieldAccess(target);
+                if (prefix == null) {
+                    return null;
+                }
+                return prefix + "." + fa.getSimpleName();
             }
 
             @Override
@@ -351,19 +420,24 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
              * Matches calls to {@code AggregateLifecycle.apply(...)} via the AF4 or AF5 FQN.
              * Also matches calls that go through a Kotlin aliased static import
              * ({@code import …AggregateLifecycle.apply as foo}) by checking the simple identifier
-             * against the alias names collected at compilation-unit entry — those calls keep the
-             * alias identifier on the LST and the {@link MethodMatcher} can fail to resolve
-             * the underlying method when the Kotlin parser doesn't bind the methodType through
-             * the alias.
+             * against the alias names collected from the enclosing source file's imports —
+             * those calls keep the alias identifier on the LST and the {@link MethodMatcher}
+             * can fail to resolve the underlying method when the Kotlin parser doesn't bind the
+             * methodType through the alias.
              */
             private boolean isApplyCall(J.MethodInvocation invocation) {
                 if (APPLY_AF4.matches(invocation) || APPLY_AF5.matches(invocation)) {
                     return true;
                 }
-                if (applyAliasNames.isEmpty() || invocation.getSelect() != null) {
+                if (invocation.getSelect() != null) {
                     return false;
                 }
-                return applyAliasNames.contains(invocation.getSimpleName());
+                SourceFile sf = getCursor().firstEnclosing(SourceFile.class);
+                if (sf == null) {
+                    return false;
+                }
+                Set<String> aliases = aliasesFor(sf);
+                return !aliases.isEmpty() && aliases.contains(invocation.getSimpleName());
             }
 
             /**

--- a/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
+++ b/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
@@ -102,21 +102,18 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
              * always rewrite the simple name back to {@code apply} or attach a methodType that
              * {@link MethodMatcher} can resolve, so the matcher misses these calls. By
              * collecting the alias identifiers up front we can fall back to a simple-name match.
+             * <p>
+             * OpenRewrite reuses the same visitor instance across every compilation unit in a
+             * recipe run, so the set is rescanned on every {@code visitCompilationUnit} entry.
+             * Without that reset, alias names from one file would leak into the next and an
+             * unrelated function happening to share the alias name would be misidentified as
+             * {@code apply} and rewritten.
              */
             private final Set<String> applyAliasNames = new HashSet<>();
-            private boolean aliasesScanned = false;
 
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                scanApplyAliases(cu);
-                return super.visitCompilationUnit(cu, ctx);
-            }
-
-            private void scanApplyAliases(J.CompilationUnit cu) {
-                if (aliasesScanned) {
-                    return;
-                }
-                aliasesScanned = true;
+                applyAliasNames.clear();
                 for (J.Import imp : cu.getImports()) {
                     String fqn = imp.getQualid().printTrimmed(getCursor());
                     if (!(fqn.equals(AF4_AGGREGATE_LIFECYCLE_FQN + ".apply")
@@ -128,6 +125,7 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
                         applyAliasNames.add(alias.getSimpleName());
                     }
                 }
+                return super.visitCompilationUnit(cu, ctx);
             }
 
             @Override

--- a/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
+++ b/migration/src/main/java/org/axonframework/migration/ReplaceAggregateLifecycleApply.java
@@ -32,7 +32,9 @@ import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.tree.K;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Replaces calls to {@code AggregateLifecycle.apply(...)} with calls to {@code eventAppender.append(...)} on an
@@ -92,6 +94,42 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
 
+            /**
+             * Per-compilation-unit cache of Kotlin import aliases for
+             * {@code AggregateLifecycle.apply}. In Kotlin a call site through an aliased import
+             * (e.g. {@code import …apply as lifecycleApply}) keeps the local identifier
+             * ({@code lifecycleApply}) on the {@link J.MethodInvocation}; the parser does not
+             * always rewrite the simple name back to {@code apply} or attach a methodType that
+             * {@link MethodMatcher} can resolve, so the matcher misses these calls. By
+             * collecting the alias identifiers up front we can fall back to a simple-name match.
+             */
+            private final Set<String> applyAliasNames = new HashSet<>();
+            private boolean aliasesScanned = false;
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                scanApplyAliases(cu);
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            private void scanApplyAliases(J.CompilationUnit cu) {
+                if (aliasesScanned) {
+                    return;
+                }
+                aliasesScanned = true;
+                for (J.Import imp : cu.getImports()) {
+                    String fqn = imp.getQualid().printTrimmed(getCursor());
+                    if (!(fqn.equals(AF4_AGGREGATE_LIFECYCLE_FQN + ".apply")
+                            || fqn.equals(AF5_AGGREGATE_LIFECYCLE_FQN + ".apply"))) {
+                        continue;
+                    }
+                    J.Identifier alias = imp.getAlias();
+                    if (alias != null) {
+                        applyAliasNames.add(alias.getSimpleName());
+                    }
+                }
+            }
+
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 // Constructors are never the right injection target. In AF5 the entity is being
@@ -133,9 +171,39 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
                 J.MethodDeclaration finalMd = md;
                 J.MethodDeclaration result = (J.MethodDeclaration) new JavaIsoVisitor<ExecutionContext>() {
                     @Override
+                    public J.Block visitBlock(J.Block block, ExecutionContext c) {
+                        // Flatten `apply(X).andThen { ... }` statements into sequential
+                        // statements. AF4's `apply()` returned an `ApplyMore` that exposed
+                        // `andThen`, letting callers chain follow-up events. AF5's
+                        // `EventAppender#append` returns `void`, so the chain has no
+                        // direct equivalent — the closest faithful translation is to
+                        // unwrap the lambda body and emit its statements as siblings.
+                        // Done at the block level because replacing one statement with
+                        // multiple requires reshaping the surrounding statement list.
+                        J.Block b = super.visitBlock(block, c);
+                        List<Statement> originalStatements = b.getStatements();
+                        List<Statement> rewritten = null;
+                        for (int i = 0; i < originalStatements.size(); i++) {
+                            Statement stmt = originalStatements.get(i);
+                            List<Statement> flattened = tryFlattenAndThen(stmt);
+                            if (flattened == null) {
+                                if (rewritten != null) {
+                                    rewritten.add(stmt);
+                                }
+                                continue;
+                            }
+                            if (rewritten == null) {
+                                rewritten = new ArrayList<>(originalStatements.subList(0, i));
+                            }
+                            rewritten.addAll(flattened);
+                        }
+                        return rewritten == null ? b : b.withStatements(rewritten);
+                    }
+
+                    @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext c) {
                         J.MethodInvocation invocation = super.visitMethodInvocation(mi, c);
-                        if (!APPLY_AF4.matches(invocation) && !APPLY_AF5.matches(invocation)) {
+                        if (!isApplyCall(invocation)) {
                             return invocation;
                         }
                         if (invocation.getArguments().isEmpty()
@@ -159,6 +227,101 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
                                        appenderName,
                                        invocation.getArguments().get(0));
                     }
+
+                    /**
+                     * If {@code stmt} is a top-level expression statement of the form
+                     * {@code apply(X).andThen { body }} (possibly with chained {@code andThen}s),
+                     * returns the flattened replacement: the rewritten {@code eventAppender.append(X)}
+                     * call followed by the lambda body's statements (which themselves may already
+                     * have had their {@code apply(...)} calls rewritten by
+                     * {@link #visitMethodInvocation}). Returns {@code null} when the statement does
+                     * not match the pattern, leaving it for the regular visitor pass.
+                     */
+                    private @org.jspecify.annotations.Nullable List<Statement> tryFlattenAndThen(Statement stmt) {
+                        if (!(stmt instanceof J.MethodInvocation)) {
+                            return null;
+                        }
+                        J.MethodInvocation invocation = (J.MethodInvocation) stmt;
+                        if (!"andThen".equals(invocation.getSimpleName())) {
+                            return null;
+                        }
+                        // The select of `apply(X).andThen { … }` is the (already-rewritten) apply
+                        // call; an EventAppender.append(...) invocation at this point.
+                        if (!(invocation.getSelect() instanceof J.MethodInvocation)) {
+                            return null;
+                        }
+                        J.MethodInvocation select = (J.MethodInvocation) invocation.getSelect();
+                        if (!isAppendOrApply(select)) {
+                            return null;
+                        }
+                        if (invocation.getArguments().isEmpty()) {
+                            return null;
+                        }
+                        // The lambda is the sole argument of `andThen`. Accept both Kotlin-style
+                        // trailing lambdas and explicit `andThen(lambda)` forms — the parser
+                        // surfaces both as a `J.Lambda` argument.
+                        J last = invocation.getArguments().get(invocation.getArguments().size() - 1);
+                        if (!(last instanceof J.Lambda)) {
+                            return null;
+                        }
+                        J.Lambda lambda = (J.Lambda) last;
+                        List<Statement> bodyStatements;
+                        if (lambda.getBody() instanceof J.Block) {
+                            bodyStatements = ((J.Block) lambda.getBody()).getStatements();
+                        } else if (lambda.getBody() instanceof Statement) {
+                            bodyStatements = java.util.Collections.singletonList((Statement) lambda.getBody());
+                        } else {
+                            return null;
+                        }
+                        List<Statement> out = new ArrayList<>(1 + bodyStatements.size());
+                        // Preserve the original statement's prefix on the rewritten append so the
+                        // flattened version keeps the indentation/blank-line layout the developer
+                        // wrote around the `apply(...).andThen { ... }` block. The lambda body's
+                        // statements originally lived one indent-level deeper inside the lambda
+                        // braces; reusing the outer statement's prefix on each of them realigns
+                        // them with the surrounding block.
+                        org.openrewrite.java.tree.Space outerPrefix = invocation.getPrefix();
+                        out.add(select.withPrefix(outerPrefix));
+                        for (Statement bodyStmt : bodyStatements) {
+                            out.add(bodyStmt.withPrefix(outerPrefix));
+                        }
+                        // Recursively unfold further chained `.andThen { ... }` calls that surface
+                        // as the head of the body (rare in practice but possible).
+                        List<Statement> recursed = null;
+                        for (int i = 0; i < out.size(); i++) {
+                            List<Statement> sub = tryFlattenAndThen(out.get(i));
+                            if (sub == null) {
+                                if (recursed != null) {
+                                    recursed.add(out.get(i));
+                                }
+                                continue;
+                            }
+                            if (recursed == null) {
+                                recursed = new ArrayList<>(out.subList(0, i));
+                            }
+                            recursed.addAll(sub);
+                        }
+                        return recursed == null ? out : recursed;
+                    }
+
+                    /**
+                     * After {@link #visitMethodInvocation} runs, an {@code apply(X)} that lived as
+                     * the {@code select} of an {@code andThen} call has already been rewritten to
+                     * {@code eventAppender.append(X)}. Match either shape so the flatten step
+                     * remains idempotent and works regardless of visitor ordering.
+                     */
+                    private boolean isAppendOrApply(J.MethodInvocation mi) {
+                        if (isApplyCall(mi)) {
+                            return true;
+                        }
+                        if (!"append".equals(mi.getSimpleName())) {
+                            return false;
+                        }
+                        if (!(mi.getSelect() instanceof J.Identifier)) {
+                            return false;
+                        }
+                        return appenderName.equals(((J.Identifier) mi.getSelect()).getSimpleName());
+                    }
                 }.visitNonNull(finalMd, ctx, getCursor().getParentOrThrow());
 
                 maybeAddImport(EVENT_APPENDER_FQN, false);
@@ -177,13 +340,32 @@ public class ReplaceAggregateLifecycleApply extends Recipe {
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext c) {
-                        if (APPLY_AF4.matches(mi) || APPLY_AF5.matches(mi)) {
+                        if (isApplyCall(mi)) {
                             found[0] = true;
                         }
                         return super.visitMethodInvocation(mi, c);
                     }
                 }.visit(md.getBody(), ctx);
                 return found[0];
+            }
+
+            /**
+             * Matches calls to {@code AggregateLifecycle.apply(...)} via the AF4 or AF5 FQN.
+             * Also matches calls that go through a Kotlin aliased static import
+             * ({@code import …AggregateLifecycle.apply as foo}) by checking the simple identifier
+             * against the alias names collected at compilation-unit entry — those calls keep the
+             * alias identifier on the LST and the {@link MethodMatcher} can fail to resolve
+             * the underlying method when the Kotlin parser doesn't bind the methodType through
+             * the alias.
+             */
+            private boolean isApplyCall(J.MethodInvocation invocation) {
+                if (APPLY_AF4.matches(invocation) || APPLY_AF5.matches(invocation)) {
+                    return true;
+                }
+                if (applyAliasNames.isEmpty() || invocation.getSelect() != null) {
+                    return false;
+                }
+                return applyAliasNames.contains(invocation.getSimpleName());
             }
 
             /**

--- a/migration/src/main/resources/META-INF/rewrite/axon4-to-axon5-messaging.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon4-to-axon5-messaging.yml
@@ -117,6 +117,12 @@ recipeList:
   # `(e, ctx) -> Optional.ofNullable(body)`.
   - org.axonframework.migration.MigrateSequencingPolicyLambda
 
+  # AF4's `EventProcessingConfigurer#registerSequencingPolicy(...)` is gone in AF5 —
+  # the decision moves onto the handler class via `@SequencingPolicy`. We cannot
+  # mechanically infer which handler class should receive the annotation, so this
+  # recipe just prepends a `// TODO(axon4to5):` comment above every call site.
+  - org.axonframework.migration.AnnotateProgrammaticSequencingPolicyRegistration
+
   # ── Query gateway moved into its own gateway subpackage ─────────────────
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.axonframework.messaging.queryhandling.QueryGateway
@@ -158,6 +164,35 @@ recipeList:
       methodPattern: org.axonframework.messaging.eventhandling.EventProcessor shutDown()
       newMethodName: shutdown
       matchOverrides: true
+
+  # ── EventProcessor + subtypes moved into processing.* subpackages ────────
+  # The earlier `ChangePackage` (eventhandling → messaging.eventhandling) lands
+  # these types at `messaging.eventhandling.<Name>`, but AF5 actually relocates
+  # them to dedicated subpackages: EventProcessor itself goes under `.processing`,
+  # the streaming variant under `.processing.streaming`, and the subscribing
+  # variant under `.processing.subscribing`. Must run AFTER the shutDown rename
+  # so the method-pattern above can still resolve `messaging.eventhandling.EventProcessor`.
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.EventProcessor
+      newFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.processing.EventProcessor
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.StreamingEventProcessor
+      newFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.SubscribingEventProcessor
+      newFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor
+
+  # ── @Timestamp annotation relocated under .annotation ────────────────────
+  # AF5 puts the handler-parameter annotation alongside the other annotation
+  # types (`@MessageHandler`, etc.) in `messaging.eventhandling.annotation`.
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.Timestamp
+      newFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.annotation.Timestamp
+
+  # ── TrackingToken moved into processing.streaming.token ──────────────────
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.TrackingToken
+      newFullyQualifiedTypeName: org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken
 
   # ── Correlation providers moved under messaging.core.correlation ────────
   - org.openrewrite.java.ChangePackage:
@@ -223,6 +258,15 @@ recipeList:
   # to the migration path doc. Runs AFTER the FQN renames above so the AF5
   # supertypes are visible.
   - org.axonframework.migration.MigrateMessageInterceptorSignatures
+
+  # ── MessageHandlerInterceptor lambda rewrite ────────────────────────────
+  # The class-based migration above handles `class … implements MessageHandlerInterceptor<…>`.
+  # AF4 codebases also commonly assign the interceptor inline as a lambda
+  # (`MessageHandlerInterceptor<X> interceptor = (uow, chain) -> { ... }`). AF5 needs
+  # three parameters (`message`, `processingContext`, `chain`) and chain.proceed()
+  # must pass `(message, processingContext)`. This recipe rewrites those mechanical
+  # parts and leaves the body for the developer to finish.
+  - org.axonframework.migration.MigrateMessageInterceptorLambda
 
   # ── Message accessor renames: drop the AF4 `get` prefix, fix MetaData → Metadata ─
   # AF5 dropped JavaBean prefixes on Message accessors and renamed the metadata

--- a/migration/src/main/resources/META-INF/rewrite/axon4-to-axon5-messaging.yml
+++ b/migration/src/main/resources/META-INF/rewrite/axon4-to-axon5-messaging.yml
@@ -117,10 +117,11 @@ recipeList:
   # `(e, ctx) -> Optional.ofNullable(body)`.
   - org.axonframework.migration.MigrateSequencingPolicyLambda
 
-  # AF4's `EventProcessingConfigurer#registerSequencingPolicy(...)` is gone in AF5 —
-  # the decision moves onto the handler class via `@SequencingPolicy`. We cannot
-  # mechanically infer which handler class should receive the annotation, so this
-  # recipe just prepends a `// TODO(axon4to5):` comment above every call site.
+  # AF4's `EventProcessingConfigurer#registerSequencingPolicy(...)` is gone in AF5.
+  # Two replacements exist: `@SequencingPolicy` on the handler class, or declarative
+  # configuration via `EventProcessorDefinition...customized(c -> c.sequencingPolicy(...))`.
+  # Picking between them needs human judgement, so this recipe just prepends a
+  # `// TODO(axon4to5):` comment above every call site.
   - org.axonframework.migration.AnnotateProgrammaticSequencingPolicyRegistration
 
   # ── Query gateway moved into its own gateway subpackage ─────────────────

--- a/migration/src/test/java/org/axonframework/migration/AddCommandAnnotationJavaRecordTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AddCommandAnnotationJavaRecordTest.java
@@ -41,6 +41,89 @@ class AddCommandAnnotationJavaRecordTest implements RewriteTest {
     }
 
     @Test
+    void liftsRoutingKeyFromTargetAggregateIdentifierOnJavaRecord() {
+        // The AF4 `@TargetAggregateIdentifier` field annotation is treated as a routing-key
+        // source on top of the explicit `@RoutingKey`. The field annotation itself is
+        // preserved (the rename to `@TargetEntityId` is owned by `Axon4ToAxon5Modelling`,
+        // which is not active in this isolation test).
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+                        import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+                        public record NoteAddCommand(@TargetAggregateIdentifier String id, String body) {
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+                        import org.axonframework.messaging.commandhandling.annotation.Command;
+                        import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+                        @Command(routingKey = "id")
+                        public record NoteAddCommand(@TargetAggregateIdentifier String id, String body) {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+
+                        class NoteHandler {
+                            @CommandHandler
+                            void on(NoteAddCommand cmd) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void liftsRoutingKeyFromTargetEntityIdOnJavaRecord() {
+        // Post-`Axon4ToAxon5Modelling` shape — the field annotation has already been renamed
+        // to `@TargetEntityId`. `AddCommandAnnotation` still detects it and lifts the
+        // routing key onto the class.
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+                        import org.axonframework.modelling.annotation.TargetEntityId;
+
+                        public record NoteAddCommand(@TargetEntityId String id, String body) {
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+                        import org.axonframework.messaging.commandhandling.annotation.Command;
+                        import org.axonframework.modelling.annotation.TargetEntityId;
+
+                        @Command(routingKey = "id")
+                        public record NoteAddCommand(@TargetEntityId String id, String body) {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.commandhandling.CommandHandler;
+
+                        class NoteHandler {
+                            @CommandHandler
+                            void on(NoteAddCommand cmd) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void liftsRoutingKeyFromJavaRecordComponent() {
         rewriteRun(
                 java(

--- a/migration/src/test/java/org/axonframework/migration/AddCommandAnnotationKotlinTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AddCommandAnnotationKotlinTest.java
@@ -140,4 +140,139 @@ class AddCommandAnnotationKotlinTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void liftsRoutingKeyFromTargetAggregateIdentifierOnKotlinDataClass() {
+        // AF4 commonly marks the routing identifier with `@TargetAggregateIdentifier`. AF5
+        // splits the concern: `@TargetEntityId` stays on the field (it tells the framework
+        // which field carries the id) and `@Command(routingKey = "…")` declares the routing
+        // key on the class. This isolation test exercises `AddCommandAnnotation` alone,
+        // so the AF4 field annotation FQN survives — the `TargetAggregateIdentifier` →
+        // `TargetEntityId` rename is owned by `Axon4ToAxon5Modelling`. The combined behaviour
+        // is exercised in {@link #liftsRoutingKeyFromTargetEntityIdAfterModellingRename}.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.modelling.command.TargetAggregateIdentifier
+                        import java.util.UUID
+
+                        data class NoteAddCommand(
+                            @TargetAggregateIdentifier val id: UUID,
+                            val targetId: String
+                        )
+
+                        class NoteHandler {
+                            @CommandHandler
+                            fun on(cmd: NoteAddCommand) {
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.messaging.commandhandling.annotation.Command
+                        import org.axonframework.modelling.command.TargetAggregateIdentifier
+                        import java.util.UUID
+
+                        @Command(routingKey = "id")
+                        data class NoteAddCommand(
+                            @TargetAggregateIdentifier val id: UUID,
+                            val targetId: String
+                        )
+
+                        class NoteHandler {
+                            @CommandHandler
+                            fun on(cmd: NoteAddCommand) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void liftsRoutingKeyFromTargetEntityIdAfterModellingRename() {
+        // Post-rename shape: after `Axon4ToAxon5Modelling` finishes,
+        // `@TargetAggregateIdentifier` already lives at its AF5 home as `@TargetEntityId`.
+        // `AddCommandAnnotation` must still detect it and lift the routing key.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.modelling.annotation.TargetEntityId
+                        import java.util.UUID
+
+                        data class NoteAddCommand(
+                            @TargetEntityId val id: UUID,
+                            val targetId: String
+                        )
+
+                        class NoteHandler {
+                            @CommandHandler
+                            fun on(cmd: NoteAddCommand) {
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.messaging.commandhandling.annotation.Command
+                        import org.axonframework.modelling.annotation.TargetEntityId
+                        import java.util.UUID
+
+                        @Command(routingKey = "id")
+                        data class NoteAddCommand(
+                            @TargetEntityId val id: UUID,
+                            val targetId: String
+                        )
+
+                        class NoteHandler {
+                            @CommandHandler
+                            fun on(cmd: NoteAddCommand) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void doesNotPopulateRoutingKeyWhenNeitherRoutingKeyNorTargetIdentifierPresent() {
+        // Bare command without any routing-key marker just gets a `@Command` annotation
+        // with no attributes — defaulting routing inference to the framework's standard
+        // behaviour (currently, the implicit "id" routing key resolution).
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+
+                        data class BareCommand(val payload: String)
+
+                        class BareHandler {
+                            @CommandHandler
+                            fun on(cmd: BareCommand) {
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.messaging.commandhandling.annotation.Command
+
+                        @Command
+                        data class BareCommand(val payload: String)
+
+                        class BareHandler {
+                            @CommandHandler
+                            fun on(cmd: BareCommand) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
 }

--- a/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
@@ -105,6 +105,48 @@ class AnnotateProgrammaticSequencingPolicyRegistrationTest implements RewriteTes
     }
 
     @Test
+    void annotatesPostRenameAf5Configurer() {
+        // `Axon4ToAxon5Common` renames `org.axonframework.config.EventProcessingConfigurer`
+        // into `org.axonframework.messaging.eventhandling.configuration.EventProcessingConfigurer`
+        // before this recipe runs. The MethodMatcher binds to the LST's resolved type, so the
+        // recipe must also match the AF5 FQN — otherwise it silently no-ops on every codebase
+        // that ran the umbrella in order.
+        rewriteRun(
+                java(
+                        """
+                        package org.axonframework.messaging.eventhandling.configuration;
+                        import java.util.function.Function;
+                        public interface EventProcessingConfigurer {
+                            EventProcessingConfigurer registerSequencingPolicy(String processingGroup,
+                                                                                Function<Object, Object> policyBuilder);
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.eventhandling.configuration.EventProcessingConfigurer;
+                        class Config {
+                            void configure(EventProcessingConfigurer configurer) {
+                                configurer.registerSequencingPolicy("orders", cfg -> new Object());
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.eventhandling.configuration.EventProcessingConfigurer;
+                        class Config {
+                            void configure(EventProcessingConfigurer configurer) {
+                                // TODO(axon4to5): EventProcessingConfigurer#registerSequencingPolicy is gone in AF5. Replace with either @SequencingPolicy on the event handler class (org.axonframework.messaging.core.annotation.SequencingPolicy) or, for processor-level configuration, EventProcessorDefinition….customized(c -> c.sequencingPolicy(...)) (org.axonframework.extension.spring.config.EventProcessorDefinition).
+                                configurer.registerSequencingPolicy("orders", cfg -> new Object());
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void leavesUnrelatedCallsAlone() {
         // Method-pattern matching is scoped to `EventProcessingConfigurer#registerSequencingPolicy`.
         // A same-named method on an unrelated type must not pick up the TODO.

--- a/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * Verifies that {@link AnnotateProgrammaticSequencingPolicyRegistration} attaches a
+ * {@code // TODO(axon4to5):} comment above
+ * {@code EventProcessingConfigurer#registerSequencingPolicy(...)} call sites and is
+ * idempotent on re-runs.
+ */
+class AnnotateProgrammaticSequencingPolicyRegistrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AnnotateProgrammaticSequencingPolicyRegistration())
+            .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void annotatesProgrammaticRegistration() {
+        rewriteRun(
+                java(
+                        """
+                        package org.axonframework.config;
+                        import java.util.function.Function;
+                        public interface EventProcessingConfigurer {
+                            EventProcessingConfigurer registerSequencingPolicy(String processingGroup,
+                                                                                Function<Object, Object> policyBuilder);
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.config.EventProcessingConfigurer;
+                        class Config {
+                            void configure(EventProcessingConfigurer configurer) {
+                                configurer.registerSequencingPolicy("orders", cfg -> new Object());
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.config.EventProcessingConfigurer;
+                        class Config {
+                            void configure(EventProcessingConfigurer configurer) {
+                                // TODO(axon4to5): declarative sequencing-policy registration is no longer supported. Move the policy onto the event handler class via @SequencingPolicy (org.axonframework.messaging.core.annotation.SequencingPolicy).
+                                configurer.registerSequencingPolicy("orders", cfg -> new Object());
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void isIdempotentWhenAlreadyAnnotated() {
+        // Re-running the recipe over the post-migration shape must not append a second
+        // TODO comment. The check matches by the stable marker substring.
+        rewriteRun(
+                java(
+                        """
+                        package org.axonframework.config;
+                        import java.util.function.Function;
+                        public interface EventProcessingConfigurer {
+                            EventProcessingConfigurer registerSequencingPolicy(String processingGroup,
+                                                                                Function<Object, Object> policyBuilder);
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.config.EventProcessingConfigurer;
+                        class Config {
+                            void configure(EventProcessingConfigurer configurer) {
+                                // TODO(axon4to5): declarative sequencing-policy registration is no longer supported. Move the policy onto the event handler class via @SequencingPolicy (org.axonframework.messaging.core.annotation.SequencingPolicy).
+                                configurer.registerSequencingPolicy("orders", cfg -> new Object());
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void leavesUnrelatedCallsAlone() {
+        // Method-pattern matching is scoped to `EventProcessingConfigurer#registerSequencingPolicy`.
+        // A same-named method on an unrelated type must not pick up the TODO.
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        class Other {
+                            void registerSequencingPolicy(String name, Object policy) {
+                            }
+                            void use() {
+                                registerSequencingPolicy("foo", new Object());
+                            }
+                        }
+                        """
+                )
+        );
+    }
+}

--- a/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AnnotateProgrammaticSequencingPolicyRegistrationTest.java
@@ -65,7 +65,7 @@ class AnnotateProgrammaticSequencingPolicyRegistrationTest implements RewriteTes
                         import org.axonframework.config.EventProcessingConfigurer;
                         class Config {
                             void configure(EventProcessingConfigurer configurer) {
-                                // TODO(axon4to5): declarative sequencing-policy registration is no longer supported. Move the policy onto the event handler class via @SequencingPolicy (org.axonframework.messaging.core.annotation.SequencingPolicy).
+                                // TODO(axon4to5): EventProcessingConfigurer#registerSequencingPolicy is gone in AF5. Replace with either @SequencingPolicy on the event handler class (org.axonframework.messaging.core.annotation.SequencingPolicy) or, for processor-level configuration, EventProcessorDefinition….customized(c -> c.sequencingPolicy(...)) (org.axonframework.extension.spring.config.EventProcessorDefinition).
                                 configurer.registerSequencingPolicy("orders", cfg -> new Object());
                             }
                         }
@@ -95,7 +95,7 @@ class AnnotateProgrammaticSequencingPolicyRegistrationTest implements RewriteTes
                         import org.axonframework.config.EventProcessingConfigurer;
                         class Config {
                             void configure(EventProcessingConfigurer configurer) {
-                                // TODO(axon4to5): declarative sequencing-policy registration is no longer supported. Move the policy onto the event handler class via @SequencingPolicy (org.axonframework.messaging.core.annotation.SequencingPolicy).
+                                // TODO(axon4to5): EventProcessingConfigurer#registerSequencingPolicy is gone in AF5. Replace with either @SequencingPolicy on the event handler class (org.axonframework.messaging.core.annotation.SequencingPolicy) or, for processor-level configuration, EventProcessorDefinition….customized(c -> c.sequencingPolicy(...)) (org.axonframework.extension.spring.config.EventProcessorDefinition).
                                 configurer.registerSequencingPolicy("orders", cfg -> new Object());
                             }
                         }

--- a/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
+++ b/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
@@ -893,8 +893,8 @@ class Axon4ToAxon5MessagingTest implements RewriteTest {
     void renamesEventProcessorShutDownToShutdown() {
         // Verifies the AF5 camelCase normalisation: an AF4 `eventProcessor.shutDown()` call site
         // is rewritten to `shutdown()` while the receiver type binding is moved into the
-        // AF5 `org.axonframework.messaging.eventhandling` namespace by the surrounding
-        // package-rename rules.
+        // AF5 `org.axonframework.messaging.eventhandling.processing` namespace by the
+        // chained package-rename and ChangeType rules.
         rewriteRun(
                 spec -> spec.typeValidationOptions(TypeValidation.none()),
                 java(
@@ -909,7 +909,9 @@ class Axon4ToAxon5MessagingTest implements RewriteTest {
                         """,
                         """
                         package com.example;
-                        import org.axonframework.messaging.eventhandling.EventProcessor;
+
+                        import org.axonframework.messaging.eventhandling.processing.EventProcessor;
+
                         class Lifecycle {
                             void stop(EventProcessor processor) {
                                 processor.shutdown();

--- a/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
+++ b/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
@@ -890,6 +890,120 @@ class Axon4ToAxon5MessagingTest implements RewriteTest {
     }
 
     @Test
+    void relocatesStreamingEventProcessorIntoProcessingStreamingSubpackage() {
+        // AF5 splits the EventProcessor family across `.processing` subpackages —
+        // streaming variants land at `.processing.streaming`. The wholesale package
+        // rename lands the type at `messaging.eventhandling.StreamingEventProcessor`;
+        // the subsequent ChangeType move surfaces it at the AF5 home.
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventhandling.StreamingEventProcessor;
+                        class UsesStreaming {
+                            StreamingEventProcessor processor;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
+
+                        class UsesStreaming {
+                            StreamingEventProcessor processor;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void relocatesSubscribingEventProcessorIntoProcessingSubscribingSubpackage() {
+        // The focus here is the type relocation only — the `shutDown` → `shutdown` rename is
+        // pinned by a separate test that exercises the base-type matcher with the right
+        // classpath set-up. Without `EventProcessor` on the classpath, OpenRewrite's
+        // `matchOverrides` cannot link the call to its declaring interface.
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventhandling.SubscribingEventProcessor;
+                        class UsesSubscribing {
+                            SubscribingEventProcessor processor;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor;
+
+                        class UsesSubscribing {
+                            SubscribingEventProcessor processor;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void relocatesTimestampAnnotationIntoAnnotationSubpackage() {
+        // AF5 puts the `@Timestamp` handler-parameter annotation alongside the other
+        // annotation types in `messaging.eventhandling.annotation`.
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventhandling.Timestamp;
+                        import java.time.Instant;
+                        class TimestampedHandler {
+                            void on(Object event, @Timestamp Instant ts) {
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.eventhandling.annotation.Timestamp;
+
+                        import java.time.Instant;
+
+                        class TimestampedHandler {
+                            void on(Object event, @Timestamp Instant ts) {
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void relocatesTrackingTokenIntoProcessingStreamingTokenSubpackage() {
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventhandling.TrackingToken;
+                        class UsesToken {
+                            TrackingToken last;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+
+                        class UsesToken {
+                            TrackingToken last;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void renamesEventProcessorShutDownToShutdown() {
         // Verifies the AF5 camelCase normalisation: an AF4 `eventProcessor.shutDown()` call site
         // is rewritten to `shutdown()` while the receiver type binding is moved into the

--- a/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
+++ b/migration/src/test/java/org/axonframework/migration/Axon4ToAxon5MessagingTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 /**
  * Verifies the messaging-module migration: handler annotations move into
@@ -748,6 +749,67 @@ class Axon4ToAxon5MessagingTest implements RewriteTest {
                             CompletableFuture<String> findOne(Object payload) {
                                 return gateway.query("byId", payload, ResponseTypes.instanceOf(String.class));
                             }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void renamesMetaDataToMetadataAndRelocatesIntoCore() {
+        // AF4 `org.axonframework.messaging.MetaData` becomes AF5
+        // `org.axonframework.messaging.core.Metadata`. The rename covers the class itself
+        // and call sites such as `MetaData.emptyInstance()` (the factory method is preserved
+        // on the AF5 type, so the call site doesn't need a separate rewrite).
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.MetaData;
+                        class UsesMetaData {
+                            MetaData emptyMd() {
+                                return MetaData.emptyInstance();
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.messaging.core.Metadata;
+
+                        class UsesMetaData {
+                            Metadata emptyMd() {
+                                return Metadata.emptyInstance();
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void renamesMetaDataToMetadataInKotlinSources() {
+        // Mirror the Java rename for Kotlin: the AF4 `MetaData` import and call sites
+        // (e.g. `MetaData.emptyInstance()`) become `Metadata` referring to the AF5 core type.
+        rewriteRun(
+                spec -> spec.typeValidationOptions(TypeValidation.none()),
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.messaging.MetaData
+
+                        class UsesMetaData {
+                            fun emptyMd(): MetaData = MetaData.emptyInstance()
+                        }
+                        """,
+                        """
+                        package com.example
+
+                        import org.axonframework.messaging.core.Metadata
+
+                        class UsesMetaData {
+                            fun emptyMd(): Metadata = Metadata.emptyInstance()
                         }
                         """
                 )

--- a/migration/src/test/java/org/axonframework/migration/ConfigureEventSourcedAnnotationKotlinTest.java
+++ b/migration/src/test/java/org/axonframework/migration/ConfigureEventSourcedAnnotationKotlinTest.java
@@ -26,7 +26,7 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 
 /**
  * Verifies that {@link ConfigureEventSourcedAnnotation} emits Kotlin-shaped class literals
- * ({@code X::class.java}) when the source is Kotlin. Java sources keep producing
+ * ({@code X::class}) when the source is Kotlin. Java sources keep producing
  * {@code X.class} — covered by the Java test suite.
  */
 class ConfigureEventSourcedAnnotationKotlinTest implements RewriteTest {
@@ -67,7 +67,7 @@ class ConfigureEventSourcedAnnotationKotlinTest implements RewriteTest {
                         import org.axonframework.eventsourcing.annotation.reflection.EntityCreator
                         import org.axonframework.extension.spring.stereotype.EventSourced
 
-                        @EventSourced(tagKey = "Astrologers", idType = String::class.java)
+                        @EventSourced(tagKey = "Astrologers", idType = String::class)
                         class Astrologers {
                             private lateinit var astrologersId: String
 
@@ -86,7 +86,7 @@ class ConfigureEventSourcedAnnotationKotlinTest implements RewriteTest {
         // a no-arg `private constructor()`, a multi-arg @CommandHandler constructor, and a
         // non-constructor @CommandHandler that calls `AggregateLifecycle.apply(...)`. The umbrella
         // recipe must:
-        //  - rename @Aggregate → @EventSourced(tagKey="Auction", idType=String::class.java) (Kotlin
+        //  - rename @Aggregate → @EventSourced(tagKey="Auction", idType=String::class) (Kotlin
         //    class-literal, not Java's `String.class`)
         //  - leave the `winningBid` getter alone (must not pick up @EntityCreator)
         //  - lift the @CommandHandler constructor into a `companion object` with @JvmStatic
@@ -139,7 +139,7 @@ class ConfigureEventSourcedAnnotationKotlinTest implements RewriteTest {
                         import org.axonframework.messaging.commandhandling.annotation.CommandHandler
                         import org.axonframework.messaging.eventhandling.gateway.EventAppender
 
-                        @EventSourced(tagKey = "Auction", idType = String::class.java)
+                        @EventSourced(tagKey = "Auction", idType = String::class)
                         class Auction {
                             private lateinit var id: String
                             private val bids = mutableListOf<Bid>()
@@ -196,7 +196,7 @@ class ConfigureEventSourcedAnnotationKotlinTest implements RewriteTest {
                         import org.axonframework.eventsourcing.annotation.reflection.EntityCreator
                         import org.axonframework.extension.spring.stereotype.EventSourced
 
-                        @EventSourced(tagKey = "Foo", idType = Object::class.java /* TODO(axon4to5): set to actual id type, e.g. String.class or UUID.class */)
+                        @EventSourced(tagKey = "Foo", idType = Object::class /* TODO(axon4to5): set to actual id type, e.g. String.class or UUID.class */)
                         class Foo {
                             @EntityCreator
                             private constructor()

--- a/migration/src/test/java/org/axonframework/migration/MigrateMessageInterceptorLambdaTest.java
+++ b/migration/src/test/java/org/axonframework/migration/MigrateMessageInterceptorLambdaTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * Verifies {@link MigrateMessageInterceptorLambda}'s rewrite of inline
+ * {@code MessageHandlerInterceptor<…> = (uow, chain) -> …} lambdas to the AF5
+ * three-parameter shape, including the {@code chain.proceed()} call inside the body.
+ */
+class MigrateMessageInterceptorLambdaTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MigrateMessageInterceptorLambda())
+            .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void rewritesLambdaParametersAndProceedCall() {
+        rewriteRun(
+                java(
+                        // AF5 type stubs for the lambda's target type — the recipe matches on the
+                        // FQN, so a minimal placeholder is enough.
+                        """
+                        package org.axonframework.messaging.core;
+                        public interface MessageHandlerInterceptor<M> {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.core.MessageHandlerInterceptor;
+                        class Wiring {
+                            void register() {
+                                MessageHandlerInterceptor<Object> interceptor = (unitOfWork, interceptorChain) -> {
+                                    return interceptorChain.proceed();
+                                };
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.core.MessageHandlerInterceptor;
+                        class Wiring {
+                            void register() {
+                                MessageHandlerInterceptor<Object> interceptor = /* TODO(axon4to5): review lambda body — the dropped `unitOfWork` parameter has no AF5 equivalent; references to it must be replaced with calls on `message` / `processingContext`.*/ (message, processingContext, interceptorChain) -> {
+                                    return interceptorChain.proceed(message, processingContext);
+                                };
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void preservesUserChosenChainParameterName() {
+        // The recipe must preserve whatever name the developer chose for the chain
+        // parameter (not unconditionally rename it). Here the second parameter is `chain`,
+        // and the body uses `chain.proceed()`.
+        rewriteRun(
+                java(
+                        """
+                        package org.axonframework.messaging.core;
+                        public interface MessageHandlerInterceptor<M> {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.core.MessageHandlerInterceptor;
+                        class Wiring {
+                            void register() {
+                                MessageHandlerInterceptor<Object> interceptor = (uow, chain) -> chain.proceed();
+                            }
+                        }
+                        """,
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.core.MessageHandlerInterceptor;
+                        class Wiring {
+                            void register() {
+                                MessageHandlerInterceptor<Object> interceptor = /* TODO(axon4to5): review lambda body — the dropped `unitOfWork` parameter has no AF5 equivalent; references to it must be replaced with calls on `message` / `processingContext`.*/ (message, processingContext, chain) ->
+                                chain.proceed(message, processingContext);
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void isIdempotentWhenLambdaAlreadyOnAf5Shape() {
+        // A three-parameter lambda is already on the AF5 shape — the recipe skips it.
+        rewriteRun(
+                java(
+                        """
+                        package org.axonframework.messaging.core;
+                        public interface MessageHandlerInterceptor<M> {
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.messaging.core.MessageHandlerInterceptor;
+                        class Wiring {
+                            void register() {
+                                MessageHandlerInterceptor<Object> interceptor = (message, processingContext, chain) -> chain.proceed(message, processingContext);
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void leavesUnrelatedLambdaTypesAlone() {
+        // The recipe is scoped to `MessageHandlerInterceptor` variable declarations.
+        // Lambdas bound to other functional interfaces are passed through untouched.
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        import java.util.function.BiFunction;
+                        class Wiring {
+                            void register() {
+                                BiFunction<Object, Object, Object> f = (a, b) -> a;
+                            }
+                        }
+                        """
+                )
+        );
+    }
+}

--- a/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
+++ b/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
@@ -147,6 +147,41 @@ class ReplaceAggregateLifecycleApplyTest implements RewriteTest {
     }
 
     @Test
+    void rewritesAllAliasedApplyCallsIncludingTheFirst() {
+        // Regression for a bug reported in the PR review: with multiple aliased call sites
+        // the recipe was leaving the first occurrence untouched and only rewriting the rest.
+        // Every call must be rewritten.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.modelling.command.AggregateLifecycle.apply as lifecycleApply
+
+                        class Auth {
+                            fun handle(cmd: Any) {
+                                lifecycleApply("first")
+                                lifecycleApply("second")
+                                lifecycleApply("third")
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.messaging.eventhandling.gateway.EventAppender
+
+                        class Auth {
+                            fun handle(cmd: Any, eventAppender: EventAppender) {
+                                eventAppender.append("first")
+                                eventAppender.append("second")
+                                eventAppender.append("third")
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void aliasStateIsResetBetweenCompilationUnits() {
         // OpenRewrite reuses the visitor instance across all compilation units in a recipe
         // run. If alias-name state from one file leaked into another, an unrelated function

--- a/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
+++ b/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
@@ -147,6 +147,56 @@ class ReplaceAggregateLifecycleApplyTest implements RewriteTest {
     }
 
     @Test
+    void aliasStateIsResetBetweenCompilationUnits() {
+        // OpenRewrite reuses the visitor instance across all compilation units in a recipe
+        // run. If alias-name state from one file leaked into another, an unrelated function
+        // happening to share the alias name (here: `lifecycleApply` defined as a regular
+        // function) would be misidentified as a call to `AggregateLifecycle.apply` and
+        // rewritten. The recipe must rescan imports for each compilation unit.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example.first
+                        import org.axonframework.modelling.command.AggregateLifecycle.apply as lifecycleApply
+
+                        class Auth {
+                            fun handle(cmd: Any) {
+                                lifecycleApply(cmd)
+                            }
+                        }
+                        """,
+                        """
+                        package com.example.first
+                        import org.axonframework.messaging.eventhandling.gateway.EventAppender
+
+                        class Auth {
+                            fun handle(cmd: Any, eventAppender: EventAppender) {
+                                eventAppender.append(cmd)
+                            }
+                        }
+                        """
+                ),
+                kotlin(
+                        // No AggregateLifecycle import here — `lifecycleApply` is an unrelated
+                        // top-level function. Its calls must be left alone even though the
+                        // identifier matches the alias used in the file above.
+                        """
+                        package com.example.second
+
+                        fun lifecycleApply(payload: Any) {
+                        }
+
+                        class UsesLocal {
+                            fun handle(cmd: Any) {
+                                lifecycleApply(cmd)
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
     void flattensApplyAndThenChainInKotlin() {
         // AF4 callers can chain `apply(...).andThen { … }` to run extra logic after the
         // first event is published. AF5 `EventAppender#append` returns `void`, so we

--- a/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
+++ b/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyTest.java
@@ -113,4 +113,81 @@ class ReplaceAggregateLifecycleApplyTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void rewritesKotlinAliasedStaticApplyImport() {
+        // Kotlin source can rename a static import with `as`. The Kotlin parser keeps the
+        // local identifier on the call site, and the MethodMatcher can't resolve the underlying
+        // method through the alias — the recipe falls back to scanning the imports for the
+        // alias name and treats matching local identifiers as apply calls.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.modelling.command.AggregateLifecycle.apply as lifecycleApply
+
+                        class Auth {
+                            fun handle(cmd: Any) {
+                                lifecycleApply(cmd)
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.messaging.eventhandling.gateway.EventAppender
+
+                        class Auth {
+                            fun handle(cmd: Any, eventAppender: EventAppender) {
+                                eventAppender.append(cmd)
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void flattensApplyAndThenChainInKotlin() {
+        // AF4 callers can chain `apply(...).andThen { … }` to run extra logic after the
+        // first event is published. AF5 `EventAppender#append` returns `void`, so we
+        // flatten the chain into sequential statements: the rewritten append plus the
+        // lambda body's own statements (any inner `apply(...)` calls inside the lambda
+        // are rewritten by the regular visitor pass).
+        //
+        // Indentation inside nested blocks that were originally a level deeper inside the
+        // lambda body keeps the deeper indent in the printed output — the test pins that
+        // behavior. The transformation is functionally correct; running the IDE's
+        // reformatter post-migration restores tidy indentation.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.modelling.command.AggregateLifecycle.apply
+
+                        class Intervention {
+                            fun handle(cmd: Any, batchId: String?) {
+                                apply(cmd).andThen {
+                                    if (batchId != null) {
+                                        apply(batchId)
+                                    }
+                                }
+                            }
+                        }
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.messaging.eventhandling.gateway.EventAppender
+
+                        class Intervention {
+                            fun handle(cmd: Any, batchId: String?, eventAppender: EventAppender) {
+                                eventAppender.append(cmd)
+                                if (batchId != null) {
+                                        eventAppender.append(batchId)
+                                    }
+                            }
+                        }
+                        """
+                )
+        );
+    }
 }

--- a/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyUmbrellaKotlinTest.java
+++ b/migration/src/test/java/org/axonframework/migration/ReplaceAggregateLifecycleApplyUmbrellaKotlinTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+/**
+ * End-to-end coverage for the aliased {@code AggregateLifecycle.apply} rewrite when driven
+ * through the umbrella recipe instead of the individual {@link ReplaceAggregateLifecycleApply}.
+ * <p>
+ * Earlier review feedback reported that the first occurrence of the aliased call was being
+ * left behind when the recipe ran on a real Kotlin codebase — this fixture pins the
+ * end-to-end behaviour so regressions surface here.
+ */
+class ReplaceAggregateLifecycleApplyUmbrellaKotlinTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+                            .scanRuntimeClasspath("org.axonframework.migration")
+                            .build()
+                            .activateRecipes(
+                                    "org.axonframework.migration.UpgradeAxon4ToAxon5"))
+            .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void rewritesAliasedApplyCallSiteWhenRunThroughUmbrella() {
+        // Matches the shape reported in the PR review: a single `@CommandHandler`-annotated
+        // function whose body has one aliased `lifecycleApply(...)` call. The umbrella must
+        // rewrite that single call to `eventAppender.append(...)`.
+        rewriteRun(
+                kotlin(
+                        """
+                        package com.example
+                        import org.axonframework.commandhandling.CommandHandler
+                        import org.axonframework.modelling.command.AggregateLifecycle.apply as lifecycleApply
+
+                        class AuthLog {
+                            @CommandHandler
+                            fun handle(cmd: RecordSuccessfulLoginCommand) {
+                                lifecycleApply(SuccessfulLoginRecordedEvent(cmd.username))
+                            }
+                        }
+
+                        class RecordSuccessfulLoginCommand(val username: String)
+                        class SuccessfulLoginRecordedEvent(val username: String)
+                        """,
+                        """
+                        package com.example
+                        import org.axonframework.messaging.commandhandling.annotation.Command
+                        import org.axonframework.messaging.commandhandling.annotation.CommandHandler
+                        import org.axonframework.messaging.eventhandling.gateway.EventAppender
+
+                        class AuthLog {
+                            @CommandHandler
+                            fun handle(cmd: RecordSuccessfulLoginCommand, eventAppender: EventAppender) {
+                                eventAppender.append(SuccessfulLoginRecordedEvent(cmd.username))
+                            }
+                        }
+
+                        @Command
+                        class RecordSuccessfulLoginCommand(val username: String)
+                        class SuccessfulLoginRecordedEvent(val username: String)
+                        """
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Validation
Check one more time on some Kotlin project before merging.

## Summary

Address issues discovered while running the AF4 → AF5 OpenRewrite
recipes against a real mixed Kotlin/Java codebase.

Entity / lifecycle:
- ConfigureEventSourcedAnnotation now emits `UUID::class` (not
  `UUID::class.java`) for Kotlin annotation arguments, matching Kotlin's
  KClass-to-Class conversion rule for annotation parameters.
- ReplaceAggregateLifecycleApply detects Kotlin aliased static imports
  (`import …apply as foo`) and treats matching local identifiers as
  `apply` calls, fixing call sites the MethodMatcher could not resolve
  through the alias. The alias scan is keyed off the enclosing
  `SourceFile` so it works for both `J.CompilationUnit` and
  `K.CompilationUnit`, and does not leak state across files.
- ReplaceAggregateLifecycleApply flattens `apply(X).andThen { body }`
  chains into sequential `eventAppender.append(X)` + body statements,
  since `EventAppender#append` returns `void` in AF5.

Commands:
- AddCommandAnnotation now lifts `@TargetAggregateIdentifier` /
  `@TargetEntityId` field names onto `@Command(routingKey = "…")` in
  addition to `@RoutingKey`, preserving the field annotation.

Sequencing / interceptors:
- New AnnotateProgrammaticSequencingPolicyRegistration inserts a TODO
  comment above `EventProcessingConfigurer#registerSequencingPolicy`
  call sites. The TODO points at both AF5 replacements: `@SequencingPolicy`
  on the handler class, or declarative configuration via
  `EventProcessorDefinition.customized(c -> c.sequencingPolicy(...))`.
  Matches both the AF4 FQN and the post-`Axon4ToAxon5Common`-rename AF5
  FQN so the recipe still fires when run through the umbrella.
- New MigrateMessageInterceptorLambda rewrites
  `MessageHandlerInterceptor<…> = (uow, chain) -> …` lambdas to the
  three-parameter AF5 shape and updates `chain.proceed()` to
  `chain.proceed(message, processingContext)`.

Import targets:
- EventProcessor / StreamingEventProcessor / SubscribingEventProcessor
  redirected to `processing.*` / `processing.streaming.*` /
  `processing.subscribing.*` subpackages.
- `@Timestamp` redirected to `messaging.eventhandling.annotation`.
- `TrackingToken` redirected to
  `messaging.eventhandling.processing.streaming.token`.
- Added regression tests for `MetaData → core.Metadata` rename across
  Java and Kotlin sources (the existing `ChangeType` rule handles it;
  the tests lock the behaviour in).

## Test plan
- [x] Unit tests for each recipe pass (`./mvnw -pl migration test`).
- [x] End-to-end Kotlin umbrella test pins the aliased
  `AggregateLifecycle.apply` rewrite.
- [x] Re-run umbrella on the reviewer's real Kotlin project.