### PR TITLE
Move AF4 dependencies inside profile for `axon-migration` module

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.axonframework</groupId>
@@ -102,52 +103,70 @@
             <artifactId>rewrite-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- Axon Framework 4.x type stubs for recipe tests. These are scoped
-             to test only so they do not pollute the published recipe artifact. -->
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-messaging</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-modelling</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-eventsourcing</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-spring</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-test</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-micrometer</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.axonframework</groupId>
-            <artifactId>axon-server-connector</artifactId>
-            <version>${axon4.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Axon Framework 4.x type stubs for recipe tests. The stubs share the
+             org.axonframework groupId with this reactor's own modules, so the
+             maven-release-plugin treats any reference to them as an internal
+             artifact and fails if the version does not match the release version.
+             Wrapping them in a profile that is deactivated during release
+             (via -DskipAf4RecipeTests) hides them from the release-plugin's
+             version-consistency check while keeping them available for every
+             normal build and CI run. -->
+        <profile>
+            <id>af4-recipe-test-stubs</id>
+            <activation>
+                <property>
+                    <name>!skipAf4RecipeTests</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-messaging</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-modelling</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-eventsourcing</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-spring</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-test</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-micrometer</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-server-connector</artifactId>
+                    <version>${axon4.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,12 @@
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <localCheckout>true</localCheckout>
                     <releaseProfiles>javadoc,sources,sign</releaseProfiles>
+                    <!-- The migration module's AF4 test-stub dependencies share the
+                         org.axonframework groupId with reactor modules, which causes
+                         the release plugin's version-consistency check to fail.
+                         Deactivating the profile that provides those stubs removes
+                         the conflict; the stubs are validated in CI before release. -->
+                    <arguments>-DskipAf4RecipeTests</arguments>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This pull requests moves all the Axon Framework 4 dependencies used by the `axon-migration` module under a profile. 
The release flow will otherwise spot the framework dependencies, which have the same `groupId`, and expect the version of those dependencies to align with the version to be released.