### PR TITLE
Combine all the `ListAppender` using Snapshotting tests in single `@Nested` class

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -118,7 +118,6 @@ class SnapshottingEntityLifecycleHandlerTest {
     );
 
     @Nested
-    @LoggerContextSource("log4j2-list-appender.xml")
     class WhenSourcedFromEvents {
 
         @Test
@@ -128,16 +127,6 @@ class SnapshottingEntityLifecycleHandlerTest {
             Account account = source();
 
             assertThat(account.balance()).isEqualTo(100);
-        }
-
-        @Test
-        void noWarningWhenNoSnapshotExists(@Named("TestAppender") ListAppender appender) {
-            publish(new AccountCreated(ACCOUNT_ID, "Alice"), new FundsDeposited(ACCOUNT_ID, 100));
-
-            appender.clear();
-            source();
-
-            assertThat(appender.getEvents()).isEmpty();
         }
     }
 
@@ -180,10 +169,20 @@ class SnapshottingEntityLifecycleHandlerTest {
 
     @Nested
     @LoggerContextSource("log4j2-list-appender.xml")
-    class WhenSnapshotVersionMismatches {
+    class WhenObservingLogOutput {
 
         @Test
-        void fallsBackToFullReconstructionAndLogsWarning(@Named("TestAppender") ListAppender appender) {
+        void noWarningWhenNoSnapshotExists(@Named("TestAppender") ListAppender appender) {
+            publish(new AccountCreated(ACCOUNT_ID, "Alice"), new FundsDeposited(ACCOUNT_ID, 100));
+
+            appender.clear();
+            source();
+
+            assertThat(appender.getEvents()).isEmpty();
+        }
+
+        @Test
+        void fallsBackToFullReconstructionAndLogsWarningOnVersionMismatch(@Named("TestAppender") ListAppender appender) {
             publish(new AccountCreated(ACCOUNT_ID, "Alice"), new FundsDeposited(ACCOUNT_ID, 100));
             storeSnapshot(new Account(ACCOUNT_ID, "Alice", 999), GlobalIndexPositions.of(2), "42.0");
 
@@ -200,14 +199,9 @@ class SnapshottingEntityLifecycleHandlerTest {
                         + ACCOUNT_ID + " had unsupported version: 42.0"
                 );
         }
-    }
-
-    @Nested
-    @LoggerContextSource("log4j2-list-appender.xml")
-    class WhenSnapshotPayloadIsIncompatible {
 
         @Test
-        void fallsBackToFullReconstructionAndLogsWarning(@Named("TestAppender") ListAppender appender) {
+        void fallsBackToFullReconstructionAndLogsWarningOnIncompatiblePayload(@Named("TestAppender") ListAppender appender) {
             publish(
                 new AccountCreated(ACCOUNT_ID, "Alice"),
                 new FundsDeposited(ACCOUNT_ID, 100)


### PR DESCRIPTION
This pull request combines all the `ListAppender` using tests in the `SnapshottingEntityLifecycleHandlerTest`. 
For some of the Framework developers, a plain `mvn clean install` fails for tests in this class.
By combining all `ListAppender` tests into a single `@Nested` class instead of three separate once, they succeed as anticipated.