### PR TITLE
fix(spring-boot-autoconfigure): OpenTelemetry autoconfig to wire Spring-managed OpenTelemetry

### DIFF
--- a/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
+++ b/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
@@ -168,15 +168,55 @@ If there's currently no span active, the new span will become the root span of a
 During invocations which are normally synchronous, Axon Framework will create normal spans which become a child of the currently active one.
 For example, publishing an event from a command is synchronous, and therefore the publishing span becomes a child of the command handling span.
 
-When it comes to asynchronous invocations, the framework forces a new root trace to be created.
-For example, a streaming event processor that processes an event will not be a child of the command handling span.
-Instead, it will become its own root trace.
-This is a measure to prevent traces from becoming too time-spread, making them unreadable.
+Asynchronous invocations come in two flavours, and the framework handles them differently:
 
-Some standards, like OpenTelemetry, support linking.
-By linking one span to another, they become correlated despite being part of a different trace.
-Tooling that supports this creates links for the user to click, allowing for easy navigation between related traces.
-This is incredibly useful to see causation within your system.
+* *Network-asynchronous, caller-synchronous*: the call crosses a network boundary (typically Axon Server gRPC) but the caller still waits for a reply. Distributed commands and distributed queries fall into this category.
+* *Fire-and-forget asynchronous*: the call is dispatched and may be handled minutes, hours, or days later, often during a replay. Streaming event processors, deadline firing and subscription query updates fall into this category.
+
+For the first flavour, the receiving side joins the dispatcher's trace by default, because the caller is actively waiting and benefits from seeing the whole path. For the second flavour, the framework starts a new root trace by default, because folding a long-deferred handler into the original trace would spread that trace over arbitrary time spans and make it unreadable.
+
+The exact default per component:
+
+[cols="<,<,<,<"]
+|===
+|Component |Default behaviour |Override
+
+|Distributed command (over Axon Server)
+|Joins dispatcher's trace as a child
+|`axon.tracing.commandBus.distributedInSameTrace=false` to start a new root on the receiving side
+
+|Distributed query (over Axon Server)
+|Joins dispatcher's trace as a child
+|`axon.tracing.queryBus.distributedInSameTrace=false` to start a new root on the receiving side
+
+|Streaming event processor
+|New root trace per batch (`…batch` span), with each event handler as a child
+|`axon.tracing.eventProcessor.distributedInSameTrace=true` to nest handlers under the publishing trace (within `…distributedInSameTraceTimeLimit`, default 2 minutes); `axon.tracing.eventProcessor.disableBatchTrace=true` to drop the `…batch` span and start a separate root per event with a link back to the publishing span
+
+|Subscribing event processor
+|Child of the publishing span (synchronous invocation)
+|None (handler runs inside the publishing unit of work)
+
+|Deadline firing
+|New root trace with an OpenTelemetry link back to the scheduling span
+|Not configurable
+
+|Subscription query updates
+|New root trace with an OpenTelemetry link back to the listening query span
+|Not configurable
+
+|Snapshot creation
+|Child of the trigger's trace (command that prompted the snapshot)
+|`axon.tracing.snapshotter.separateTrace=true` to start a new root for snapshot creation
+
+|Saga
+|Same as the underlying event processor (a saga is invoked by an event processor)
+|See streaming/subscribing event processor rows
+|===
+
+Some standards, like OpenTelemetry, support *linking*. By linking one span to another, they become correlated despite being part of a different trace. Tooling that supports this creates links the user can click, allowing for easy navigation between related traces. This is incredibly useful to see causation within your system. Components in the table above marked "link back to..." rely on this feature.
+
+For OpenTelemetry-based setups, propagation across these boundaries depends on the W3C trace context being injected into the message metadata at dispatch time and extracted again at handling time. The `OpenTelemetrySpanFactory` does this automatically via its `TextMapPropagator`. Make sure the factory is wired with a real propagator (see <<Activation paths>>). Without it, none of the same-trace nesting or span-link behaviour above is observable, because the parent span context never reaches the handler. Every property described here is also listed in the <<Configuration>> table together with the rest of the Spring Boot tracing settings.
 
 === Span attribute providers
 
@@ -275,6 +315,27 @@ For example, when a Spring REST endpoint is called it will automatically start a
 With the `axon-tracing-opentelemetry` module, this trace will be propagated to all subsequent Axon Framework messages.
 For example, if the REST call produces a command which is sent over Axon Server, handling the command will be included in the same trace as the original REST call.
 
+=== Activation paths
+
+There are three common ways to put an OpenTelemetry SDK in place. They all work with Axon Framework, but they differ in how the SDK is exposed to `OpenTelemetrySpanFactory`:
+
+[cols="<,<,<"]
+|===
+|Path |How the SDK is exposed |What Axon needs
+
+|*OpenTelemetry Java agent* (`-javaagent:opentelemetry-javaagent.jar`)
+|The agent registers an `OpenTelemetrySdk` on `GlobalOpenTelemetry` at JVM startup. No code changes.
+|`OpenTelemetrySpanFactory.builder().build()` picks up the agent-installed SDK via `GlobalOpenTelemetry`. Works out of the box.
+
+|*Manual SDK setup with `buildAndRegisterGlobal()`* (the path described in the OpenTelemetry "Getting Started" guide)
+|The application calls `OpenTelemetrySdk.builder()…buildAndRegisterGlobal()`, populating `GlobalOpenTelemetry` programmatically.
+|Same as the Java agent: builder defaults find the SDK via `GlobalOpenTelemetry`. Works out of the box.
+
+|*Spring Boot 3 with `micrometer-tracing-bridge-otel`* (the path Spring Boot's https://docs.spring.io/spring-boot/reference/actuator/observability.html[observability documentation] recommends)
+|Spring Boot creates an `OpenTelemetry` bean and exposes it via dependency injection. It is intentionally **not** registered on `GlobalOpenTelemetry` to avoid hidden static state in the container.
+|The auto-configuration injects the Spring-managed `OpenTelemetry` bean and wires its `Tracer` and `TextMapPropagator` into the `OpenTelemetrySpanFactory` builder explicitly. If no such bean is present, the builder falls back to `GlobalOpenTelemetry` (compatible with the previous two paths).
+|===
+
 === Configuration
 
 To get OpenTelemetry support enabled you will need to add the following dependency to your application's dependencies:
@@ -316,7 +377,22 @@ The following table contains all configurable settings, their defaults, and what
 |`axon.tracing.attributeProviders.messageType` |`true` |Whether to add the message type as a label when handling a message
 |`axon.tracing.attributeProviders.payloadType` |`true` |Whether to add the payload type as a label when handling a message
 |`axon.tracing.attributeProviders.metadata` |`true` |Whether to add the metadata properties as labels when handling a message
+|`axon.tracing.commandBus.distributedInSameTrace` |`true` |Whether distributed commands (handled remotely after a hop through Axon Server) should be part of the same trace as the dispatching span. Set to `false` to make the receiving side start a new root trace.
+|`axon.tracing.queryBus.distributedInSameTrace` |`true` |Whether distributed queries should be part of the same trace as the dispatching span. Set to `false` to make the receiving side start a new root trace.
+|`axon.tracing.eventProcessor.distributedInSameTrace` |`false` |Whether the spans of a `StreamingEventProcessor` handling an event should be nested under the trace that published the event (when handled within `distributedInSameTraceTimeLimit`). Off by default to keep traces from spreading over arbitrarily long time spans.
+|`axon.tracing.eventProcessor.distributedInSameTraceTimeLimit` |`PT2M` (2 minutes) |Time limit between an event being published and being processed by a `StreamingEventProcessor` for the spans to be considered part of the same trace. Only used when `distributedInSameTrace` is `true`. Events handled later than this start a new root trace.
+|`axon.tracing.eventProcessor.disableBatchTrace` |`false` |By default, a `StreamingEventProcessor` wraps a whole batch of events in a single `…batch` root span, with each event handler as a child. Set to `true` to disable the batch span and let each event handler start its own root trace, with an OpenTelemetry link back to the publishing span (clickable cause/effect navigation in the APM UI).
+|`axon.tracing.deadlineManager.deadlineIdAttributeName` |`axon.deadlineId` |Name of the span attribute used to record the deadline id.
+|`axon.tracing.deadlineManager.deadlineScopeAttributeName` |`axon.scope` |Name of the span attribute used to record the deadline scope.
+|`axon.tracing.sagaManager.sagaIdentifierAttributeName` |`axon.sagaIdentifier` |Name of the span attribute used to record the saga identifier.
+|`axon.tracing.snapshotter.separateTrace` |`false` |Whether snapshot creation should run in its own root trace instead of being a child of the command that triggered it.
+|`axon.tracing.snapshotter.aggregateTypeInSpanName` |`true` |Whether the aggregate type should appear in the `Snapshotter` span name.
 |===
+
+[NOTE]
+====
+The defaults are deliberately asymmetric: command and query buses default to *same-trace propagation* because a caller is actively waiting for a synchronous reply and benefits from seeing the whole path in a single trace. Streaming event processors default to *new root trace per event* because events can be processed far in the future (during replays, slow consumers, segment claim transfer, …) and folding them into the original trace would spread a single trace over arbitrary time spans, making it unreadable. Enable `eventProcessor.distributedInSameTrace` (with a sensible `distributedInSameTraceTimeLimit`) when you primarily care about the happy-path causal chain rather than long-running replays.
+====
 
 ==== Manual configuration
 
@@ -426,7 +502,8 @@ Please refer to the specific sections of this functionality for more information
 
 When publishing events, spans are created to indicate the event being published.
 Each event that is being published has its own specific publishing span.
-Any streaming event processor or saga handling the event in the future will be linked to the publishing spans, allowing easy click-through.
+Subscribing event processors handle the event synchronously inside the same trace.
+For streaming event processors (and sagas backed by one), the relationship to the publishing span depends on configuration: by default each batch of events forms its own root trace with no link back; setting `axon.tracing.eventProcessor.disableBatchTrace=true` makes each handler invocation a separate root trace with an OpenTelemetry link back to the publishing span (clickable in the APM UI); setting `axon.tracing.eventProcessor.distributedInSameTrace=true` makes the handler a child of the publishing trace (within the configured time limit). See <<Span nesting>> for the full matrix.
 
 |===
 |Trace name |Description
@@ -438,7 +515,7 @@ Any streaming event processor or saga handling the event in the future will be l
 === Event processors
 
 Event processor invocations are traced as well.
-Since Streaming Event Processors are asynchronous, a new root trace is created for each event.
+Since Streaming Event Processors are asynchronous, a new root trace is created for each event *by default*.
 Subscribing event processors, on the other hand, will become part of the current trace because they are invoked synchronously.
 
 ==== Streaming event processors
@@ -448,14 +525,21 @@ Subscribing event processors, on the other hand, will become part of the current
 
 |`$\{ProcessorType\}[$\{processorName\}]($\{EventClass\})` |Root trace of handling the event, includes all interceptor invocations.
 |`$\{ProcessorType\}[$\{processorName\}].process($\{EventClass\})` |Inner span of handling the event, after all interceptors have been invoked.
+|`$\{ProcessorType\}[$\{processorName\}].batch` |Wraps a batch of events handled by the processor in a single trace, with each `.process(…)` span as a child. Produced when `axon.tracing.eventProcessor.disableBatchTrace` is `false` (the default).
 |===
+
+Streaming event processor tracing exposes three configurable behaviours, controlled via the properties listed in <<Span nesting>>:
+
+* `axon.tracing.eventProcessor.distributedInSameTrace` (default `false`): when enabled, a `…process($\{EventClass\})` span becomes a child of the trace that published the event, *provided* the event is handled within `…distributedInSameTraceTimeLimit` (default 2 minutes). Older events still start a new root trace so that long-running replays do not produce arbitrarily long traces.
+* `axon.tracing.eventProcessor.disableBatchTrace` (default `false`): disables the `…batch` parent span. Each event handler then starts its own root trace, with an OpenTelemetry link back to the publishing span. Choose this when you want clickable cause/effect navigation per event in the APM UI without bundling unrelated events into one batch span.
+* These two are independent. Setting both to `false` (the default) gives you the traditional behaviour: each batch wrapped in a `…batch` root span. Setting `distributedInSameTrace=true` typically also requires `disableBatchTrace=true` to avoid a confusing mix of a batch root and same-trace nesting.
 
 ==== Subscribing event processors
 
 |===
 |Trace name |Description
 
-|`$\{ProcessorType\}[$\{processorName\}].process($\{EventClass\})` |The event is being handled by the subscribing event processor.
+|`$\{ProcessorType\}[$\{processorName\}].process($\{EventClass\})` |The event is being handled by the subscribing event processor. Always a child span of the current trace (subscribing processors are invoked synchronously inside the publishing unit of work).
 |===
 
 === Deadlines
@@ -476,9 +560,9 @@ The handling span of a deadline will be linked to the scheduling span for easy n
 
 === Snapshotting
 
-Snapshotting is done in a separate root trace, due to the fact that it's an asynchronous action and has no user impact.
-However, it can still be useful to measure the performance of snapshotting and see when it is triggered.
-The root trace of the `Snapshotter` invocation will be linked to the command handling span after which the snapshot was scheduled to be created.
+By default, the snapshot creation spans are part of the same trace as the command that triggered them. This matches the framework's runtime behaviour, where the snapshot is created right after the command's unit of work commits, and keeps the cause (the command) and the effect (snapshot creation, including its performance characteristics) visible together in a single trace.
+
+Set `axon.tracing.snapshotter.separateTrace=true` to put snapshot creation into its own root trace, linked back to the triggering command's span. This is useful when snapshot creation runs on a separate executor that you'd rather not see folded into command latency. The trade-off is the extra click to navigate from the command to the snapshot creation. See the <<Configuration>> table for the property reference.
 
 |===
 |Trace name |Description
@@ -487,7 +571,7 @@ The root trace of the `Snapshotter` invocation will be linked to the command han
 |`$\{SnapshotterClass\}.createSnapshot($aggregateClass, $aggregateIdentifier)` |The `Snapshotter` is now creating the snapshot.
 |===
 
-The root trace does not contain the aggregate identifier so the APM tool groups any `Snapshotter` calls of the same aggregate type together.
+When `separateTrace=true`, the `…createSnapshot($aggregateClass)` span becomes the root of the snapshot trace and does not contain the aggregate identifier, so the APM tool groups any `Snapshotter` calls of the same aggregate type together.
 
 === Sagas
 

--- a/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
+++ b/docs/old-reference-guide/modules/monitoring/pages/tracing.adoc
@@ -177,7 +177,7 @@ For the first flavour, the receiving side joins the dispatcher's trace by defaul
 
 The exact default per component:
 
-[cols="<,<,<,<"]
+[cols="<,<,<"]
 |===
 |Component |Default behaviour |Override
 

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -30,6 +30,10 @@
         Module providing support for auto-configuration of Axon Framework through Spring Boot.
     </description>
 
+    <properties>
+        <opentelemetry-sdk.test.version>1.52.0</opentelemetry-sdk.test.version>
+    </properties>
+
     <dependencies>
         <!-- Axon dependencies -->
         <dependency>
@@ -246,7 +250,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
-            <version>1.52.0</version>
+            <version>${opentelemetry-sdk.test.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-boot-autoconfigure/pom.xml
+++ b/spring-boot-autoconfigure/pom.xml
@@ -240,6 +240,15 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Used by OpenTelemetry autoconfig tests to build a real OpenTelemetry bean
+             with a W3C TextMapPropagator and verify the autoconfig wires it correctly. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.52.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/OpenTelemetryAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/springboot/autoconfig/OpenTelemetryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.axonframework.springboot.autoconfig;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.axonframework.tracing.SpanFactory;
 import org.axonframework.tracing.opentelemetry.OpenTelemetrySpanFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,6 +29,19 @@ import org.springframework.context.annotation.Bean;
 /**
  * Automatically configured the {@link OpenTelemetrySpanFactory} as the method of providing tracing in Axon Framework.
  * For this to take effect, the {@code axon-tracing-opentelemetry} dependency must be on the classpath.
+ * <p>
+ * When a Spring-managed {@link OpenTelemetry} bean is present (e.g. Spring Boot 3's
+ * {@code OpenTelemetryAutoConfiguration} together with {@code micrometer-tracing-bridge-otel}), its
+ * {@link io.opentelemetry.api.trace.Tracer Tracer} and
+ * {@link io.opentelemetry.context.propagation.TextMapPropagator TextMapPropagator} are passed into the
+ * {@link OpenTelemetrySpanFactory.Builder} explicitly. Without this, the builder falls back to
+ * {@link io.opentelemetry.api.GlobalOpenTelemetry}, which Spring Boot 3 does not register — leaving the
+ * factory with a no-op propagator that silently drops W3C trace context across asynchronous Axon
+ * boundaries (event processors, deadlines, distributed command/query buses).
+ * <p>
+ * If no {@link OpenTelemetry} bean is available the builder defaults are kept, preserving compatibility
+ * with the OpenTelemetry Java agent and with manual SDK installations that call
+ * {@link io.opentelemetry.sdk.OpenTelemetrySdkBuilder#buildAndRegisterGlobal()}.
  *
  * @author Mitchell Herrijgers
  * @since 4.6.0
@@ -38,7 +53,14 @@ public class OpenTelemetryAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SpanFactory.class)
-    public SpanFactory spanFactory() {
-        return OpenTelemetrySpanFactory.builder().build();
+    public SpanFactory spanFactory(ObjectProvider<OpenTelemetry> openTelemetryProvider) {
+        OpenTelemetry openTelemetry = openTelemetryProvider.getIfAvailable();
+        if (openTelemetry == null) {
+            return OpenTelemetrySpanFactory.builder().build();
+        }
+        return OpenTelemetrySpanFactory.builder()
+                                       .tracer(openTelemetry.getTracer("AxonFramework-OpenTelemetry"))
+                                       .contextPropagators(openTelemetry.getPropagators().getTextMapPropagator())
+                                       .build();
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
@@ -25,6 +25,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.axonframework.common.ReflectionUtils;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.tracing.SpanFactory;
@@ -39,8 +40,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
-
-import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -79,13 +78,20 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
 
                     // The Spring-managed OpenTelemetry's tracer must be wired into the factory,
                     // not the no-op GlobalOpenTelemetry fallback.
-                    Tracer wiredTracer = readField(spanFactory, "tracer");
+                    Tracer wiredTracer = ReflectionUtils.getFieldValue(
+                            OpenTelemetrySpanFactory.class.getDeclaredField("tracer"),
+                            spanFactory
+                    );
                     assertSame(expectedTracer, wiredTracer,
                                "Factory must use the tracer from the Spring-managed OpenTelemetry bean");
 
                     // The Spring-managed OpenTelemetry's propagator must be wired into the factory,
                     // not the no-op GlobalOpenTelemetry fallback.
-                    TextMapPropagator wired = readField(spanFactory, "textMapPropagator");
+                    TextMapPropagator wired = ReflectionUtils.getFieldValue(
+                            OpenTelemetrySpanFactory.class.getDeclaredField("textMapPropagator"),
+                            spanFactory
+                    );
+
                     assertSame(expectedPropagator, wired,
                                "Factory must use the propagator from the Spring-managed OpenTelemetry bean");
 
@@ -116,16 +122,12 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
                     // Without a Spring-managed OpenTelemetry bean, the builder defaults apply —
                     // tracer and propagator come from GlobalOpenTelemetry (Java agent / manual SDK
                     // installations that call buildAndRegisterGlobal()).
-                    TextMapPropagator wired = readField(spanFactory, "textMapPropagator");
+                    TextMapPropagator wired = ReflectionUtils.getFieldValue(
+                            OpenTelemetrySpanFactory.class.getDeclaredField("textMapPropagator"),
+                            spanFactory
+                    );
                     assertNotNull(wired, "Propagator must be set (default from GlobalOpenTelemetry)");
                 });
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> T readField(Object target, String fieldName) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return (T) field.get(target);
     }
 
     @EnableAutoConfiguration(exclude = {

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,17 @@
 
 package org.axonframework.springboot;
 
-import org.axonframework.tracing.NestingSpanFactory;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
 import org.axonframework.tracing.SpanFactory;
 import org.axonframework.tracing.opentelemetry.OpenTelemetrySpanFactory;
 import org.junit.jupiter.api.*;
@@ -26,11 +36,13 @@ import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 
-import static org.axonframework.common.ReflectionUtils.getFieldValue;
+import java.lang.reflect.Field;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AxonAutoConfigurationWithOpenTelemetryTest {
@@ -49,6 +61,74 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
                 });
     }
 
+    @Test
+    void spanFactoryUsesSpringManagedOpenTelemetryWhenAvailable() throws Exception {
+        TextMapPropagator expectedPropagator = W3CTraceContextPropagator.getInstance();
+        OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+                                                      .setTracerProvider(SdkTracerProvider.builder().build())
+                                                      .setPropagators(ContextPropagators.create(expectedPropagator))
+                                                      .build();
+        Tracer expectedTracer = openTelemetry.getTracer("AxonFramework-OpenTelemetry");
+
+        new ApplicationContextRunner()
+                .withUserConfiguration(ContextWithOpenTelemetry.class)
+                .withBean(OpenTelemetry.class, () -> openTelemetry)
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .run(context -> {
+                    SpanFactory spanFactory = context.getBean(SpanFactory.class);
+                    assertEquals(OpenTelemetrySpanFactory.class, spanFactory.getClass());
+
+                    // The Spring-managed OpenTelemetry's tracer must be wired into the factory,
+                    // not the no-op GlobalOpenTelemetry fallback.
+                    Tracer wiredTracer = readField(spanFactory, "tracer");
+                    assertSame(expectedTracer, wiredTracer,
+                               "Factory must use the tracer from the Spring-managed OpenTelemetry bean");
+
+                    // The Spring-managed OpenTelemetry's propagator must be wired into the factory,
+                    // not the no-op GlobalOpenTelemetry fallback.
+                    TextMapPropagator wired = readField(spanFactory, "textMapPropagator");
+                    assertSame(expectedPropagator, wired,
+                               "Factory must use the propagator from the Spring-managed OpenTelemetry bean");
+
+                    // Behavioural confirmation: propagateContext injects the W3C traceparent header.
+                    Tracer tracer = openTelemetry.getTracer("test");
+                    Span span = tracer.spanBuilder("root").startSpan();
+                    EventMessage<String> propagated;
+                    try (Scope ignored = span.makeCurrent()) {
+                        propagated = ((OpenTelemetrySpanFactory) spanFactory)
+                                .propagateContext(GenericEventMessage.asEventMessage("payload"));
+                    } finally {
+                        span.end();
+                    }
+                    assertTrue(propagated.getMetaData().containsKey("traceparent"),
+                               "W3C trace context must be injected into message metadata for async handlers to extract it");
+                });
+    }
+
+    @Test
+    void spanFactoryFallsBackToGlobalOpenTelemetryWhenNoBeanAvailable() throws Exception {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Context.class)
+                .withPropertyValues("axon.axonserver.enabled=false")
+                .run(context -> {
+                    SpanFactory spanFactory = context.getBean(SpanFactory.class);
+                    assertEquals(OpenTelemetrySpanFactory.class, spanFactory.getClass());
+
+                    // Without a Spring-managed OpenTelemetry bean, the builder defaults apply —
+                    // tracer and propagator come from GlobalOpenTelemetry (Java agent / manual SDK
+                    // installations that call buildAndRegisterGlobal()).
+                    TextMapPropagator wired = readField(spanFactory, "textMapPropagator");
+                    assertNotNull(wired, "Propagator must be set (default from GlobalOpenTelemetry)");
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T readField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+
     @EnableAutoConfiguration(exclude = {
             JmxAutoConfiguration.class,
             WebClientAutoConfiguration.class,
@@ -58,6 +138,18 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
     @Configuration
     public static class Context {
+
+    }
+
+    @EnableAutoConfiguration(exclude = {
+            JmxAutoConfiguration.class,
+            WebClientAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            DataSourceAutoConfiguration.class,
+    })
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    @Configuration
+    public static class ContextWithOpenTelemetry {
 
     }
 }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
@@ -36,7 +36,6 @@ import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
@@ -62,6 +62,7 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
     @Test
     void spanFactoryUsesSpringManagedOpenTelemetryWhenAvailable() {
         TextMapPropagator expectedPropagator = W3CTraceContextPropagator.getInstance();
+        //noinspection resource
         OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
                                                       .setTracerProvider(SdkTracerProvider.builder().build())
                                                       .setPropagators(ContextPropagators.create(expectedPropagator))
@@ -95,13 +96,12 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
                     assertSame(expectedPropagator, wired,
                                "Factory must use the propagator from the Spring-managed OpenTelemetry bean");
 
-                    // Behavioural confirmation: propagateContext injects the W3C traceparent header.
+                    // Behavioral confirmation: propagateContext injects the W3C "traceparent" header.
                     Tracer tracer = openTelemetry.getTracer("test");
                     Span span = tracer.spanBuilder("root").startSpan();
                     EventMessage<String> propagated;
                     try (Scope ignored = span.makeCurrent()) {
-                        propagated = ((OpenTelemetrySpanFactory) spanFactory)
-                                .propagateContext(GenericEventMessage.asEventMessage("payload"));
+                        propagated = spanFactory.propagateContext(GenericEventMessage.asEventMessage("payload"));
                     } finally {
                         span.end();
                     }

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/springboot/AxonAutoConfigurationWithOpenTelemetryTest.java
@@ -61,7 +61,7 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
     }
 
     @Test
-    void spanFactoryUsesSpringManagedOpenTelemetryWhenAvailable() throws Exception {
+    void spanFactoryUsesSpringManagedOpenTelemetryWhenAvailable() {
         TextMapPropagator expectedPropagator = W3CTraceContextPropagator.getInstance();
         OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
                                                       .setTracerProvider(SdkTracerProvider.builder().build())
@@ -105,7 +105,7 @@ class AxonAutoConfigurationWithOpenTelemetryTest {
     }
 
     @Test
-    void spanFactoryFallsBackToGlobalOpenTelemetryWhenNoBeanAvailable() throws Exception {
+    void spanFactoryFallsBackToGlobalOpenTelemetryWhenNoBeanAvailable() {
         new ApplicationContextRunner()
                 .withUserConfiguration(Context.class)
                 .withPropertyValues("axon.axonserver.enabled=false")


### PR DESCRIPTION
## Summary

`OpenTelemetryAutoConfiguration` currently builds the `OpenTelemetrySpanFactory` without passing in the application's `OpenTelemetry` instance:

```java
@Bean
@ConditionalOnMissingBean(SpanFactory.class)
public SpanFactory spanFactory() {
    return OpenTelemetrySpanFactory.builder().build();
}
```

`OpenTelemetrySpanFactory.Builder.build()` then falls back to `GlobalOpenTelemetry`:

```java
if (tracer == null) {
    tracer = GlobalOpenTelemetry.getTracer("AxonFramework-OpenTelemetry");
}
if (textMapPropagator == null) {
    textMapPropagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
}
```

This works for the OpenTelemetry **Java agent** and for setups that explicitly call `OpenTelemetrySdk.builder()…buildAndRegisterGlobal()`. It silently breaks for **Spring Boot 3** applications using `micrometer-tracing-bridge-otel`: Spring Boot creates an `OpenTelemetry` bean (intentionally not registered as global, to avoid hidden static state in the container) and the `micrometer-tracing-bridge-otel` adapter consumes it via dependency injection. Because `GlobalOpenTelemetry` is never populated, both builder defaults resolve to no-ops — `propagateContext()` silently drops the W3C trace context across every asynchronous Axon boundary (event processors, deadlines, distributed command/query buses) without any error or warning.

The symptoms are subtle: HTTP-side spans render correctly inside one trace, but `StreamingEventProcessor.process(…)`, `EventProcessor.process(…)`, `CommandBus.handleDistributedCommand(…)` etc. always start brand-new root traces with no link back to the originator. The framework's documented [linking behaviour](https://docs.axoniq.io/axon-framework-reference/4.13/monitoring/tracing/) ("asynchronous invocations are linked to their originating spans") becomes effectively unreachable, because the parent context never makes it into the message metadata in the first place.

## Fix

Inject `ObjectProvider<OpenTelemetry>` and, when a Spring-managed `OpenTelemetry` bean is available, explicitly wire its `Tracer` and `TextMapPropagator` into the builder. If no bean is present, the previous default behaviour is preserved:

```java
@Bean
@ConditionalOnMissingBean(SpanFactory.class)
public SpanFactory spanFactory(ObjectProvider<OpenTelemetry> openTelemetryProvider) {
    OpenTelemetry openTelemetry = openTelemetryProvider.getIfAvailable();
    if (openTelemetry == null) {
        return OpenTelemetrySpanFactory.builder().build();
    }
    return OpenTelemetrySpanFactory.builder()
                                   .tracer(openTelemetry.getTracer("AxonFramework-OpenTelemetry"))
                                   .contextPropagators(openTelemetry.getPropagators().getTextMapPropagator())
                                   .build();
}
```

## Backwards compatibility

| User setup                                                                               | Before                                                                                                     | After                                                                                                                                                                   | Behaviour change?  |
| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
| OpenTelemetry Java agent (`-javaagent:opentelemetry-javaagent.jar`)                      | Agent registers `GlobalOpenTelemetry`; no Spring `OpenTelemetry` bean exists → builder defaults pick it up | `ObjectProvider.getIfAvailable()` returns `null` → builder defaults pick up `GlobalOpenTelemetry`                                                                       | None               |
| Manual SDK with `buildAndRegisterGlobal()` (the path the Axon reference guide describes) | `GlobalOpenTelemetry` used                                                                                 | If `OpenTelemetry` bean is not exposed in Spring (the usual case): identical. If it *is* exposed: the same SDK instance is wired explicitly — observationally identical | None               |
| Spring Boot 3 + `micrometer-tracing-bridge-otel`                                         | Silent no-op (propagator drops W3C context, span links never emitted)                                      | Spring-managed `OpenTelemetry` wired in; W3C context propagated, span links visible across async boundaries                                                             | Fixed (was broken) |

The legacy fallback to `GlobalOpenTelemetry` remains intact for users on the Java agent or manual SDK setups. The `@ConditionalOnMissingBean(SpanFactory.class)` guard is unchanged, so users with a custom `SpanFactory` bean are unaffected.

## Notes
- I found uncoducmented properties and added it to the docs.
- Verified end-to-end in a Spring Boot 3.5 + `micrometer-tracing-bridge-otel` + `axon-tracing-opentelemetry` 4.13.1 application: after the fix, `propagateContext()` injects the W3C `traceparent` into message metadata (confirmed by inspecting stored event metadata and by the added regression test). Without this fix, message metadata stays empty and async handlers cannot reconstruct the parent context — making the documented span-linking behaviour effectively unreachable, regardless of what other tracing properties (`axon.tracing.event-processor.distributed-in-same-trace`, `…disable-batch-trace`, etc.) are configured.