### PR TITLE
Allow a segment claim to trigger an ad-hoc replay

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -883,16 +883,25 @@ class Coordinator {
                                 for (Map.Entry<Segment, TrackingToken> entry : newSegments.entrySet()) {
                                     Segment segment = entry.getKey();
                                     TrackingToken token = entry.getValue();
-                                    TrackingToken otherUnwrapped = WrappedToken.unwrapLowerBound(token);
-                                    position.updateAndGet(p -> p == null || otherUnwrapped == null
-                                            ? null : p.lowerBound(otherUnwrapped));
                                     int segmentId = segment.getSegmentId();
-                                    if (!workPackages.containsKey(segmentId)) {
-                                        chain = chain.thenCompose(ignored ->
-                                                createWorkPackage(segment, token)
-                                                        .thenAccept(wp -> workPackages.putIfAbsent(segmentId, wp))
-                                        );
+                                    if (workPackages.containsKey(segmentId)) {
+                                        // Defensive: a work package for this segment already exists. Skip the
+                                        // listener and update the stream start position from the raw token.
+                                        TrackingToken otherUnwrapped = WrappedToken.unwrapLowerBound(token);
+                                        position.updateAndGet(p -> p == null || otherUnwrapped == null
+                                                ? null : p.lowerBound(otherUnwrapped));
+                                        continue;
                                     }
+                                    chain = chain.thenCompose(ignored ->
+                                            applyReset(segment, token).thenAccept(effectiveToken -> {
+                                                TrackingToken otherUnwrapped =
+                                                        WrappedToken.unwrapLowerBound(effectiveToken);
+                                                position.updateAndGet(p -> p == null || otherUnwrapped == null
+                                                        ? null : p.lowerBound(otherUnwrapped));
+                                                workPackages.putIfAbsent(segmentId,
+                                                                         createWorkPackage(segment, effectiveToken));
+                                            })
+                                    );
                                 }
                                 if (logger.isInfoEnabled() && !newSegments.isEmpty()) {
                                     logger.info(
@@ -1036,21 +1045,41 @@ class Coordinator {
             }
         }
 
-        private CompletableFuture<WorkPackage> createWorkPackage(Segment segment, TrackingToken token) {
+        private WorkPackage createWorkPackage(Segment segment, TrackingToken token) {
             WorkPackage workPackage = workPackageFactory.apply(segment, token);
             workPackage.onBatchProcessed(() -> resetRetryExponentialBackoff(segment.getSegmentId()));
+            return workPackage;
+        }
+
+        /**
+         * Invokes the {@link SegmentChangeListener#onSegmentClaimed(Segment) onSegmentClaimed} listener and
+         * applies the returned reset position: if it is strictly behind the stored {@code token}, the token is
+         * wrapped in a {@link ReplayToken} so the segment streams from the reset position. The returned future
+         * completes with the effective {@link TrackingToken} to use for the new work package.
+         * <p>
+         * On a first-ever claim ({@code token == null}) the listener is still invoked, but any returned reset
+         * position is ignored — a reset is only meaningful relative to a position the processor has already
+         * moved past.
+         */
+        private CompletableFuture<@Nullable TrackingToken> applyReset(Segment segment,
+                                                                      @Nullable TrackingToken token) {
             return segmentChangeListener.onSegmentClaimed(segment)
-                                        .handle((ignored, e) -> {
-                                            if (e != null) {
-                                                logger.info(
-                                                        "Processor [{}] (Coordination Task [{}]). An exception occurred while invoking claim listeners for [{}].",
-                                                        name,
-                                                        generation,
-                                                        segment,
-                                                        e
-                                                );
+                                        .thenApply(resetPosition -> {
+                                            if (token == null) {
+                                                return null;
                                             }
-                                            return workPackage;
+                                            if (resetPosition == null
+                                                    || !token.covers(resetPosition)
+                                                    || resetPosition.covers(token)) {
+                                                return token;
+                                            }
+                                            logger.info(
+                                                    "Processor [{}] (Coordination Task [{}]). Wrapping segment [{}] token with reset position [{}].",
+                                                    name,
+                                                    generation,
+                                                    segment,
+                                                    resetPosition);
+                                            return ReplayToken.createReplayToken(token, resetPosition);
                                         });
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/HandlerAwareProcessorCustomization.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/HandlerAwareProcessorCustomization.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
+
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.messaging.eventhandling.EventHandlingComponent;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentChangeListener;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link PooledStreamingEventProcessorConfiguration} customization invoked when a
+ * {@link PooledStreamingEventProcessor} is being built, granting access to that specific processor's resolved
+ * {@link EventHandlingComponent} list in addition to its configuration.
+ * <p>
+ * Unlike the unnamed configuration customizer registered through
+ * {@link PooledStreamingEventProcessorModule#customized}, this hook fires <em>after</em> the handler list has
+ * been resolved, so it can derive configuration from the handlers themselves (for example, registering a
+ * {@link SegmentChangeListener} that observes capabilities declared by individual handlers). The hook
+ * customizes the <strong>processor configuration</strong>, not the handlers &mdash; to wrap or decorate
+ * handlers, use the existing {@code EventHandlingComponent}-typed decorator registration.
+ * <p>
+ * Customizations are <em>discovered</em> from the root {@link Configuration} via
+ * {@code getComponents(HandlerAwareProcessorCustomization.class).values()}. Register them at the top-level
+ * configurer (e.g. through a {@code ConfigurationEnhancer}); the module walks up to the root configuration so
+ * the lookup is independent of where the module itself sits in the configuration tree.
+ * <p>
+ * Multiple instances may co-exist; each receives the configuration returned by the previous customization
+ * before the {@link PooledStreamingEventProcessor} is constructed. The order in which customizations are
+ * applied is not part of the contract &mdash; implementations must be designed to be applied independently
+ * of one another. To impose a deterministic order, compose customizations with {@link #andThen} and register
+ * the composed instance as a single component.
+ * <p>
+ * Implementations typically mutate the supplied {@code processorConfig} in place and return the same instance
+ * (the common "mutate-and-return-this" pattern):
+ * <pre>{@code
+ * (config, name, handlers, processorConfig) -> {
+ *     processorConfig.addSegmentChangeListener(deriveListener(handlers));
+ *     return processorConfig;
+ * }
+ * }</pre>
+ * Returning a <em>different</em> {@code PooledStreamingEventProcessorConfiguration} instance is permitted but
+ * affects only the processor under construction; the configuration registered as a component in the wider
+ * {@link Configuration} is unchanged.
+ *
+ * @author Allard Buijze
+ * @since 5.2.0
+ */
+@FunctionalInterface
+public interface HandlerAwareProcessorCustomization {
+
+    /**
+     * Customizes the given {@code processorConfig} with knowledge of the {@code handlers} assigned to the
+     * processor identified by {@code processorName}.
+     *
+     * @param config          the surrounding {@link Configuration}
+     * @param processorName   the name of the processor under construction
+     * @param handlers        the {@link EventHandlingComponent}s assigned to this processor, in registration
+     *                        order, with all configuration-level decorators already applied
+     * @param processorConfig the current {@link PooledStreamingEventProcessorConfiguration}, possibly already
+     *                        modified by earlier customizations
+     * @return the {@link PooledStreamingEventProcessorConfiguration} to use for processor construction &mdash;
+     *         typically the same {@code processorConfig} instance after in-place mutation
+     */
+    PooledStreamingEventProcessorConfiguration customize(Configuration config,
+                                                        String processorName,
+                                                        List<EventHandlingComponent> handlers,
+                                                        PooledStreamingEventProcessorConfiguration processorConfig);
+
+    /**
+     * Returns a customization that applies {@code this} first and {@code next} second, threading the
+     * configuration returned by {@code this} into {@code next}.
+     *
+     * @param next the customization to apply after {@code this}
+     * @return a composed customization
+     */
+    default HandlerAwareProcessorCustomization andThen(HandlerAwareProcessorCustomization next) {
+        Objects.requireNonNull(next, "Next customization may not be null");
+        return (config, processorName, handlers, processorConfig) -> {
+            PooledStreamingEventProcessorConfiguration after =
+                    this.customize(config, processorName, handlers, processorConfig);
+            return next.customize(config, processorName, handlers, after);
+        };
+    }
+
+    /**
+     * Returns a no-op customization that returns the supplied {@code processorConfig} unchanged.
+     *
+     * @return a no-op customization
+     */
+    static HandlerAwareProcessorCustomization noOp() {
+        return (config, processorName, handlers, processorConfig) -> processorConfig;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
@@ -146,11 +146,16 @@ public class PooledStreamingEventProcessorModule extends BaseModule<PooledStream
     private void registerEventProcessor() {
         var processorComponentDefinition = ComponentDefinition
                 .ofTypeAndName(StreamingEventProcessor.class, processorName)
-                .withBuilder(cfg -> new PooledStreamingEventProcessor(
-                        processorName,
-                        getEventHandlingComponents(cfg),
-                        cfg.getComponent(PooledStreamingEventProcessorConfiguration.class)
-                ))
+                .withBuilder(cfg -> {
+                    var handlers = getEventHandlingComponents(cfg);
+                    var processorConfig = cfg.getComponent(PooledStreamingEventProcessorConfiguration.class);
+                    for (var customization : rootConfiguration(cfg)
+                            .getComponents(HandlerAwareProcessorCustomization.class)
+                            .values()) {
+                        processorConfig = customization.customize(cfg, processorName, handlers, processorConfig);
+                    }
+                    return new PooledStreamingEventProcessor(processorName, handlers, processorConfig);
+                })
                 .onStart(Phase.INBOUND_EVENT_CONNECTORS, (cfg, component) -> {
                     return component.start();
                 })
@@ -159,6 +164,22 @@ public class PooledStreamingEventProcessorModule extends BaseModule<PooledStream
                 });
 
         componentRegistry(cr -> cr.registerComponent(processorComponentDefinition));
+    }
+
+    /**
+     * Walks up the {@link Configuration#getParent() parent chain} to the root configuration.
+     * {@link Configuration#getComponents(Class)} only searches the current configuration and its module
+     * configurations, so an {@link HandlerAwareProcessorCustomization} registered at the top level is not
+     * visible when called from within a module's component builder. Looking up from the root makes them
+     * discoverable regardless of where they were registered.
+     */
+    private static Configuration rootConfiguration(Configuration cfg) {
+        Configuration current = cfg;
+        Configuration parent;
+        while ((parent = current.getParent()) != null) {
+            current = parent;
+        }
+        return current;
     }
 
     private void registerEventHandlingComponents() {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListener.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListener.java
@@ -16,13 +16,22 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.segmenting;
 
-import java.util.concurrent.CompletableFuture;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
  * Listener invoked when a processor claims or releases a {@link Segment}.
+ * <p>
+ * On claim, a listener may return a <em>reset position</em>: a {@link TrackingToken} the segment should be reset
+ * to so that events are replayed from that position. The coordinator merges the reset positions returned by the
+ * registered listener chain and, if the result is strictly behind the stored tracking token, wraps that token in
+ * a {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken ReplayToken} so the
+ * segment streams from the reset position instead of the stored position.
  *
  * @author Mateusz Nowak
  * @since 5.1.0
@@ -30,13 +39,36 @@ import java.util.function.Function;
 public interface SegmentChangeListener {
 
     /**
-     * Creates a listener that reacts only to claim events.
+     * Creates a listener that reacts only to claim events. The returned listener requests no reset
+     * (it always resolves to {@code null}).
      *
      * @param onClaim asynchronous claim callback
      * @return listener reacting to claim events
      */
-        static SegmentChangeListener onClaim(Function<Segment, CompletableFuture<Void>> onClaim) {
-        return new SimpleSegmentChangeListener(onClaim, segment -> CompletableFuture.completedFuture(null));
+    static SegmentChangeListener onClaim(Function<Segment, CompletableFuture<Void>> onClaim) {
+        Objects.requireNonNull(onClaim, "Claim listener may not be null");
+        return new SimpleSegmentChangeListener(
+                segment -> onClaim.apply(segment).thenApply(unused -> null),
+                segment -> CompletableFuture.completedFuture(null)
+        );
+    }
+
+    /**
+     * Creates a listener that returns a reset position on claim. The supplied function is invoked on every
+     * claim and its returned {@link TrackingToken} (or {@code null}) is merged with reset positions returned
+     * by other listeners.
+     *
+     * @param onClaim asynchronous claim callback returning a reset position or {@code null}
+     * @return listener reacting to claim events that requests a reset
+     */
+    static SegmentChangeListener onClaimWithReset(
+            Function<Segment, CompletableFuture<@Nullable TrackingToken>> onClaim
+    ) {
+        Objects.requireNonNull(onClaim, "Claim listener may not be null");
+        return new SimpleSegmentChangeListener(
+                onClaim,
+                segment -> CompletableFuture.completedFuture(null)
+        );
     }
 
     /**
@@ -45,22 +77,30 @@ public interface SegmentChangeListener {
      * @param onRelease asynchronous release callback
      * @return listener reacting to release events
      */
-        static SegmentChangeListener onRelease(Function<Segment, CompletableFuture<Void>> onRelease) {
-        return new SimpleSegmentChangeListener(segment -> CompletableFuture.completedFuture(null), onRelease);
+    static SegmentChangeListener onRelease(Function<Segment, CompletableFuture<Void>> onRelease) {
+        Objects.requireNonNull(onRelease, "Release listener may not be null");
+        return new SimpleSegmentChangeListener(
+                segment -> CompletableFuture.completedFuture(null),
+                onRelease
+        );
     }
 
     /**
-     * Creates a listener that executes synchronously on claim events.
+     * Creates a listener that executes synchronously on claim events. The returned listener requests no
+     * reset.
      *
      * @param onClaim synchronous claim callback
      * @return listener reacting to claim events
      */
-        static SegmentChangeListener runOnClaim(Consumer<Segment> onClaim) {
+    static SegmentChangeListener runOnClaim(Consumer<Segment> onClaim) {
         Objects.requireNonNull(onClaim, "Claim listener may not be null");
-        return new SimpleSegmentChangeListener(segment -> {
-            onClaim.accept(segment);
-            return CompletableFuture.completedFuture(null);
-        }, segment -> CompletableFuture.completedFuture(null));
+        return new SimpleSegmentChangeListener(
+                segment -> {
+                    onClaim.accept(segment);
+                    return CompletableFuture.completedFuture(null);
+                },
+                segment -> CompletableFuture.completedFuture(null)
+        );
     }
 
     /**
@@ -69,12 +109,15 @@ public interface SegmentChangeListener {
      * @param onRelease synchronous release callback
      * @return listener reacting to release events
      */
-        static SegmentChangeListener runOnRelease(Consumer<Segment> onRelease) {
+    static SegmentChangeListener runOnRelease(Consumer<Segment> onRelease) {
         Objects.requireNonNull(onRelease, "Release listener may not be null");
-        return new SimpleSegmentChangeListener(segment -> CompletableFuture.completedFuture(null), segment -> {
-            onRelease.accept(segment);
-            return CompletableFuture.completedFuture(null);
-        });
+        return new SimpleSegmentChangeListener(
+                segment -> CompletableFuture.completedFuture(null),
+                segment -> {
+                    onRelease.accept(segment);
+                    return CompletableFuture.completedFuture(null);
+                }
+        );
     }
 
     /**
@@ -82,7 +125,7 @@ public interface SegmentChangeListener {
      *
      * @return no-op segment change listener
      */
-        static SegmentChangeListener noOp() {
+    static SegmentChangeListener noOp() {
         return new SimpleSegmentChangeListener(
                 segment -> CompletableFuture.completedFuture(null),
                 segment -> CompletableFuture.completedFuture(null)
@@ -91,11 +134,24 @@ public interface SegmentChangeListener {
 
     /**
      * Invoked when a segment has been claimed and processing for that segment is started.
+     * <p>
+     * The returned {@link TrackingToken} is a <em>reset position</em>: a position the segment should be reset
+     * to so that events are replayed from there. The coordinator compares this position against the segment's
+     * stored tracking token and, if it is strictly behind, wraps the stored token in a
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken ReplayToken} so
+     * the segment streams from the reset position.
+     * <p>
+     * Returning {@code null} requests no reset.
+     * <p>
+     * On a first-ever claim of a segment (i.e. when the stored token is {@code null}), any returned reset
+     * position is ignored; a reset is only meaningful relative to a position the processor has already moved
+     * past. The listener is still invoked in that case for any observational side effects it performs.
      *
      * @param segment claimed {@link Segment}
-     * @return {@link CompletableFuture} that completes when handling has finished
+     * @return {@link CompletableFuture} that completes with the reset position for this segment, or
+     *         {@code null} if the listener requests no reset
      */
-    CompletableFuture<Void> onSegmentClaimed(Segment segment);
+    CompletableFuture<@Nullable TrackingToken> onSegmentClaimed(Segment segment);
 
     /**
      * Invoked when a segment has been released.
@@ -107,14 +163,28 @@ public interface SegmentChangeListener {
 
     /**
      * Compose this listener with {@code next}, invoking this listener first and the next listener second.
+     * <p>
+     * Reset positions returned by both listeners are merged via
+     * {@link TrackingToken#lowerBound(TrackingToken)} so the resulting listener requests the lowest position
+     * required by either of its constituents.
      *
      * @param next listener to invoke after this listener
      * @return composed listener invoking listeners sequentially for claim and release events
      */
-        default SegmentChangeListener andThen(SegmentChangeListener next) {
+    default SegmentChangeListener andThen(SegmentChangeListener next) {
         Objects.requireNonNull(next, "Next listener may not be null");
         return new SimpleSegmentChangeListener(
-                segment -> onSegmentClaimed(segment).thenCompose(unused -> next.onSegmentClaimed(segment)),
+                segment -> onSegmentClaimed(segment).thenCompose(
+                        first -> next.onSegmentClaimed(segment).thenApply(second -> {
+                            if (first == null) {
+                                return second;
+                            }
+                            if (second == null) {
+                                return first;
+                            }
+                            return first.lowerBound(second);
+                        })
+                ),
                 segment -> onSegmentReleased(segment).thenCompose(unused -> next.onSegmentReleased(segment))
         );
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SimpleSegmentChangeListener.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SimpleSegmentChangeListener.java
@@ -16,6 +16,9 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.segmenting;
 
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -28,27 +31,25 @@ import java.util.function.Function;
  */
 public class SimpleSegmentChangeListener implements SegmentChangeListener {
 
-    private final Function<Segment, CompletableFuture<Void>> onClaim;
+    private final Function<Segment, CompletableFuture<@Nullable TrackingToken>> onClaim;
     private final Function<Segment, CompletableFuture<Void>> onRelease;
 
     /**
      * Creates a listener with explicit claim and release handlers.
      *
-     * @param onClaim   The claim handler.
-     * @param onRelease The release handler.
+     * @param onClaim   the claim handler returning a reset position (or {@code null})
+     * @param onRelease the release handler
      */
     public SimpleSegmentChangeListener(
-            Function<Segment, CompletableFuture<Void>> onClaim,
+            Function<Segment, CompletableFuture<@Nullable TrackingToken>> onClaim,
             Function<Segment, CompletableFuture<Void>> onRelease
     ) {
-        Objects.requireNonNull(onClaim, "Claim listener may not be null");
-        Objects.requireNonNull(onRelease, "Release listener may not be null");
-        this.onClaim = onClaim;
-        this.onRelease = onRelease;
+        this.onClaim = Objects.requireNonNull(onClaim, "Claim listener may not be null");
+        this.onRelease = Objects.requireNonNull(onRelease, "Release listener may not be null");
     }
 
     @Override
-    public CompletableFuture<Void> onSegmentClaimed(Segment segment) {
+    public CompletableFuture<@Nullable TrackingToken> onSegmentClaimed(Segment segment) {
         return onClaim.apply(segment);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -476,14 +476,14 @@ class CoordinatorTest {
     }
 
     /**
-     * Tests for the {@code createWorkPackage} method, specifically the error-handling path
-     * in which the {@link SegmentChangeListener#onSegmentClaimed} callback throws.
+     * Tests for the claim-loop error-handling path in which the
+     * {@link SegmentChangeListener#onSegmentClaimed} callback throws.
      */
     @Nested
     class CreateWorkPackage {
 
         @Test
-        void stillRegistersWorkPackageWhenOnSegmentClaimedFails() {
+        void doesNotRegisterWorkPackageWhenOnSegmentClaimedFails() {
             // given - coordinator with a claim listener that always fails
             GlobalSequenceTrackingToken token = new GlobalSequenceTrackingToken(0);
             Coordinator coordinator = Coordinator.builder()
@@ -505,6 +505,120 @@ class CoordinatorTest {
             doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
             doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+                    .when(messageSource).open(any(StreamingCondition.class), isNull());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            // when
+            awaitStart(coordinator);
+
+            // then - the listener failure aborts the claim; the work package must not be scheduled
+            verify(workPackage, never()).scheduleWorker();
+        }
+    }
+
+    /**
+     * Tests for the reset behavior added to
+     * {@link SegmentChangeListener#onSegmentClaimed(Segment) onSegmentClaimed}: when a listener returns a
+     * reset position strictly behind the stored tracking token, the coordinator wraps that token in a
+     * {@link ReplayToken} so the segment streams from the reset position.
+     */
+    @Nested
+    class Reset {
+
+        @Test
+        void resetPositionStrictlyBehindStoredTokenWrapsInReplayToken() {
+            // given - stored token at position 5, reset position at position 2
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(5);
+            GlobalSequenceTrackingToken resetPosition = new GlobalSequenceTrackingToken(2);
+            AtomicReference<TrackingToken> capturedToken = new AtomicReference<>();
+            Coordinator coordinator = coordinatorWith(resetListener(resetPosition), capturedToken);
+
+            stubClaimFor(storedToken);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - the work package was created with a ReplayToken: stored token as target,
+            //        reset position as starting position
+            TrackingToken token = capturedToken.get();
+            assertNotNull(token);
+            assertThat(token).isInstanceOf(ReplayToken.class);
+            ReplayToken replayToken = (ReplayToken) token;
+            assertThat(replayToken.getTokenAtReset()).isEqualTo(storedToken);
+            assertThat(replayToken.getCurrentToken()).isEqualTo(resetPosition);
+        }
+
+        @Test
+        void resetPositionAtOrAheadOfStoredTokenLeavesTokenUnchanged() {
+            // given - stored token at position 2, reset position at position 5 (ahead)
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(2);
+            GlobalSequenceTrackingToken resetPosition = new GlobalSequenceTrackingToken(5);
+            AtomicReference<TrackingToken> capturedToken = new AtomicReference<>();
+            Coordinator coordinator = coordinatorWith(resetListener(resetPosition), capturedToken);
+
+            stubClaimFor(storedToken);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - reset position is ignored; work package gets the stored token unchanged
+            assertThat(capturedToken.get()).isEqualTo(storedToken);
+        }
+
+        @Test
+        void resetPositionEqualToStoredTokenLeavesTokenUnchanged() {
+            // given - stored token and reset position are the same position
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(5);
+            GlobalSequenceTrackingToken resetPosition = new GlobalSequenceTrackingToken(5);
+            AtomicReference<TrackingToken> capturedToken = new AtomicReference<>();
+            Coordinator coordinator = coordinatorWith(resetListener(resetPosition), capturedToken);
+
+            stubClaimFor(storedToken);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - bidirectional coverage means reset position is not strictly behind; no wrapping
+            assertThat(capturedToken.get()).isEqualTo(storedToken);
+        }
+
+        @Test
+        void noResetPositionDoesNotWrapToken() {
+            // given - listener returns no reset position
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(5);
+            AtomicReference<TrackingToken> capturedToken = new AtomicReference<>();
+            Coordinator coordinator = coordinatorWith(SegmentChangeListener.noOp(), capturedToken);
+
+            stubClaimFor(storedToken);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - work package gets the stored token unchanged
+            assertThat(capturedToken.get()).isEqualTo(storedToken);
+        }
+
+        @Test
+        void firstEverClaimInvokesListenerButIgnoresReset() {
+            // given - stored token is null (first-ever claim) but listener returns a reset position
+            GlobalSequenceTrackingToken resetPosition = new GlobalSequenceTrackingToken(2);
+            GlobalSequenceTrackingToken resolvedFirstToken = new GlobalSequenceTrackingToken(0);
+            AtomicReference<TrackingToken> capturedToken = new AtomicReference<>();
+            AtomicBoolean listenerInvoked = new AtomicBoolean(false);
+            SegmentChangeListener listener = SegmentChangeListener.onClaimWithReset(segment -> {
+                listenerInvoked.set(true);
+                return completedFuture(resetPosition);
+            });
+            Coordinator coordinator = coordinatorWith(listener, capturedToken);
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                             .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(null)).when(tokenStore)
+                                            .fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
+            // override default so firstToken resolves to a real token
+            doReturn(completedFuture(resolvedFirstToken)).when(messageSource).firstToken(null);
             doReturn(SEGMENT_ZERO).when(workPackage).segment();
             doReturn(false).when(workPackage).isAbortTriggered();
             doReturn(true).when(workPackage).hasRemainingCapacity();
@@ -516,8 +630,49 @@ class CoordinatorTest {
             // when
             awaitStart(coordinator);
 
-            // then - the work package is still registered and scheduled despite the failing claim listener
-            verify(workPackage).scheduleWorker();
+            // then - listener was invoked, but the captured token is null (reset position ignored)
+            assertTrue(listenerInvoked.get(), "Listener should still be invoked on first-ever claim");
+            assertNull(capturedToken.get(), "Reset position must be ignored when stored token is null");
+        }
+
+        private Coordinator coordinatorWith(SegmentChangeListener listener,
+                                            AtomicReference<TrackingToken> capturedToken) {
+            return Coordinator.builder()
+                              .name(PROCESSOR_NAME)
+                              .eventSource(messageSource)
+                              .tokenStore(tokenStore)
+                              .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+                              .executorService(executorService)
+                              .workPackageFactory((segment, trackingToken) -> {
+                                  capturedToken.set(trackingToken);
+                                  return workPackage;
+                              })
+                              .processingStatusUpdater((id, updater) -> {})
+                              .initialToken(es -> es.firstToken(null).thenApply(ReplayToken::createReplayToken))
+                              .maxSegmentProvider(e -> SEGMENTS.size())
+                              .segmentChangeListener(listener)
+                              .build();
+        }
+
+        private SegmentChangeListener resetListener(TrackingToken resetPosition) {
+            return SegmentChangeListener.onClaimWithReset(
+                    segment -> completedFuture(resetPosition)
+            );
+        }
+
+        private void stubClaimFor(TrackingToken storedToken) {
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                             .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(storedToken)).when(tokenStore)
+                                                   .fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).hasRemainingCapacity();
+            doReturn(false).when(workPackage).isDone();
+            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+                    .when(messageSource).open(any(StreamingCondition.class), isNull());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/HandlerAwareProcessorCustomizationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/HandlerAwareProcessorCustomizationTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
+
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ComponentDefinition;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.AsyncInMemoryStreamableEventSource;
+import org.axonframework.messaging.eventhandling.EventHandlingComponent;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.configuration.EventHandlingComponentsConfigurer;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentChangeListener;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the {@link HandlerAwareProcessorCustomization} hook on
+ * {@link PooledStreamingEventProcessorModule}: that registered customizations are invoked at processor build
+ * time, scoped to the handlers assigned to that specific processor, and that their mutations to the
+ * {@link PooledStreamingEventProcessorConfiguration} are picked up by the constructed processor.
+ *
+ * @author Allard Buijze
+ * @since 5.2.0
+ */
+class HandlerAwareProcessorCustomizationTest {
+
+    @Nested
+    class Invocation {
+
+        @Test
+        void invokedOnceWithThisProcessorsHandlers() {
+            // given
+            var capturedProcessorNames = new ArrayList<String>();
+            var capturedHandlerLists = new ArrayList<List<EventHandlingComponent>>();
+            HandlerAwareProcessorCustomization customization =
+                    (cfg, processorName, handlers, processorConfig) -> {
+                        capturedProcessorNames.add(processorName);
+                        capturedHandlerLists.add(handlers);
+                        return processorConfig;
+                    };
+
+            // when
+            AxonConfiguration configuration = buildConfigurationWithModule(
+                    "alpha",
+                    singleComponent("componentA"),
+                    customization
+            );
+            triggerProcessorBuild(configuration, "alpha");
+
+            // then
+            assertThat(capturedProcessorNames).containsExactly("alpha");
+            assertThat(capturedHandlerLists).hasSize(1);
+            assertThat(capturedHandlerLists.get(0)).hasSize(1);
+        }
+
+        @Test
+        void scopedPerProcessorWhenMultipleModulesExist() {
+            // given - two processors with distinct handler component names; both should each see only their own
+            var byProcessor = new java.util.LinkedHashMap<String, List<EventHandlingComponent>>();
+            HandlerAwareProcessorCustomization customization =
+                    (cfg, processorName, handlers, processorConfig) -> {
+                        byProcessor.put(processorName, handlers);
+                        return processorConfig;
+                    };
+
+            var configurer = MessagingConfigurer.create();
+            configurer.componentRegistry(cr -> cr.registerComponent(
+                    ComponentDefinition
+                            .ofTypeAndName(HandlerAwareProcessorCustomization.class, "test-customization")
+                            .withInstance(customization)
+            ));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(ps -> ps
+                    .processor(moduleFor("alpha", singleComponent("componentA")))
+                    .processor(moduleFor("beta", singleComponent("componentB")))
+            ));
+            var configuration = configurer.build();
+            triggerProcessorBuild(configuration, "alpha");
+            triggerProcessorBuild(configuration, "beta");
+
+            // then - each processor saw exactly its own handler list
+            assertThat(byProcessor).containsOnlyKeys("alpha", "beta");
+            assertThat(byProcessor.get("alpha")).hasSize(1);
+            assertThat(byProcessor.get("beta")).hasSize(1);
+            // and the two handler instances are distinct
+            assertThat(byProcessor.get("alpha").get(0))
+                    .isNotSameAs(byProcessor.get("beta").get(0));
+        }
+
+        @Test
+        void multipleCustomizationsAreAllApplied() {
+            // given - two customizations recording their invocations
+            var invoked = new ArrayList<String>();
+            HandlerAwareProcessorCustomization first =
+                    (cfg, name, handlers, processorConfig) -> {
+                        invoked.add("first");
+                        return processorConfig;
+                    };
+            HandlerAwareProcessorCustomization second =
+                    (cfg, name, handlers, processorConfig) -> {
+                        invoked.add("second");
+                        return processorConfig;
+                    };
+
+            // when - register both customizations under different names
+            var configurer = MessagingConfigurer.create();
+            configurer.componentRegistry(cr -> cr.registerComponent(
+                    ComponentDefinition
+                            .ofTypeAndName(HandlerAwareProcessorCustomization.class, "first")
+                            .withInstance(first)
+            ));
+            configurer.componentRegistry(cr -> cr.registerComponent(
+                    ComponentDefinition
+                            .ofTypeAndName(HandlerAwareProcessorCustomization.class, "second")
+                            .withInstance(second)
+            ));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(
+                    ps -> ps.processor(moduleFor("alpha", singleComponent("componentA")))
+            ));
+            var configuration = configurer.build();
+            triggerProcessorBuild(configuration, "alpha");
+
+            // then - both customizations were invoked; the order is not guaranteed
+            assertThat(invoked).containsExactlyInAnyOrder("first", "second");
+        }
+    }
+
+    @Nested
+    class SideEffects {
+
+        @Test
+        void registeredSegmentChangeListenerIsObservedByCoordinator() {
+            // given - a customization that registers a SegmentChangeListener returning a fixed reset position
+            TrackingToken resetPosition = new GlobalSequenceTrackingToken(42);
+            var listenerInvocations = new AtomicInteger();
+            var capturedConfig = new java.util.concurrent.atomic.AtomicReference<PooledStreamingEventProcessorConfiguration>();
+            HandlerAwareProcessorCustomization customization =
+                    (cfg, name, handlers, processorConfig) -> {
+                        processorConfig.addSegmentChangeListener(
+                                SegmentChangeListener.onClaimWithReset(segment -> {
+                                    listenerInvocations.incrementAndGet();
+                                    return CompletableFuture.completedFuture(resetPosition);
+                                })
+                        );
+                        capturedConfig.set(processorConfig);
+                        return processorConfig;
+                    };
+
+            AxonConfiguration configuration = buildConfigurationWithModule(
+                    "alpha",
+                    singleComponent("componentA"),
+                    customization
+            );
+            triggerProcessorBuild(configuration, "alpha");
+
+            // when - drive the composed listener directly
+            TrackingToken result =
+                    capturedConfig.get()
+                                  .segmentChangeListener()
+                                  .onSegmentClaimed(Segment.ROOT_SEGMENT)
+                                  .join();
+
+            // then - the customization's listener was invoked and contributed the reset position
+            assertThat(listenerInvocations).hasValue(1);
+            assertThat(result).isEqualTo(resetPosition);
+        }
+
+        @Test
+        void returnedConfigurationIsThreadedToNextCustomization() {
+            // given - first customization records the original config; second checks identity
+            var firstSeen = new java.util.concurrent.atomic.AtomicReference<PooledStreamingEventProcessorConfiguration>();
+            var secondSeen = new java.util.concurrent.atomic.AtomicReference<PooledStreamingEventProcessorConfiguration>();
+
+            HandlerAwareProcessorCustomization first = (cfg, name, handlers, processorConfig) -> {
+                firstSeen.set(processorConfig);
+                return processorConfig;
+            };
+            HandlerAwareProcessorCustomization second = (cfg, name, handlers, processorConfig) -> {
+                secondSeen.set(processorConfig);
+                return processorConfig;
+            };
+
+            // when
+            var configurer = MessagingConfigurer.create();
+            configurer.componentRegistry(cr -> cr.registerComponent(
+                    ComponentDefinition
+                            .ofTypeAndName(HandlerAwareProcessorCustomization.class, "first")
+                            .withInstance(first)
+            ));
+            configurer.componentRegistry(cr -> cr.registerComponent(
+                    ComponentDefinition
+                            .ofTypeAndName(HandlerAwareProcessorCustomization.class, "second")
+                            .withInstance(second)
+            ));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(
+                    ps -> ps.processor(moduleFor("alpha", singleComponent("componentA")))
+            ));
+            var configuration = configurer.build();
+            triggerProcessorBuild(configuration, "alpha");
+
+            // then - the second customization received the same instance the first one returned (mutate-and-return-this)
+            assertThat(firstSeen.get()).isNotNull();
+            assertThat(secondSeen.get()).isSameAs(firstSeen.get());
+        }
+    }
+
+    private static void triggerProcessorBuild(AxonConfiguration configuration, String processorName) {
+        // Resolving the StreamingEventProcessor component materialises the processor, which is what
+        // fires the HandlerAwareProcessorCustomization chain.
+        configuration.getModuleConfiguration("EventProcessor[" + processorName + "]")
+                     .flatMap(m -> m.getOptionalComponent(StreamingEventProcessor.class, processorName))
+                     .orElseThrow();
+    }
+
+    private static AxonConfiguration buildConfigurationWithModule(
+            String processorName,
+            Function<EventHandlingComponentsConfigurer.RequiredComponentPhase,
+                    EventHandlingComponentsConfigurer.CompletePhase> componentsConfigurer,
+            HandlerAwareProcessorCustomization customization
+    ) {
+        var configurer = MessagingConfigurer.create();
+        configurer.componentRegistry(cr -> cr.registerComponent(
+                ComponentDefinition
+                        .ofTypeAndName(HandlerAwareProcessorCustomization.class, "test-customization")
+                        .withInstance(customization)
+        ));
+        configurer.eventProcessing(ep -> ep.pooledStreaming(
+                ps -> ps.processor(moduleFor(processorName, componentsConfigurer))
+        ));
+        return configurer.build();
+    }
+
+    private static PooledStreamingEventProcessorModule moduleFor(
+            String processorName,
+            Function<EventHandlingComponentsConfigurer.RequiredComponentPhase,
+                    EventHandlingComponentsConfigurer.CompletePhase> componentsConfigurer
+    ) {
+        return EventProcessorModule
+                .pooledStreaming(processorName)
+                .eventHandlingComponents(componentsConfigurer)
+                .customized((cfg, c) -> c.eventSource(
+                        cfg.getOptionalComponent(StreamableEventSource.class)
+                           .orElse(new AsyncInMemoryStreamableEventSource())
+                ));
+    }
+
+    private static @NonNull
+    Function<EventHandlingComponentsConfigurer.RequiredComponentPhase,
+            EventHandlingComponentsConfigurer.CompletePhase> singleComponent(String componentName) {
+        return components -> components.declarative(componentName, cfg -> {
+            var component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(new QualifiedName(String.class), (e, c) -> MessageStream.empty());
+            return component;
+        });
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListenerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListenerTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.segmenting;
+
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SegmentChangeListener} factory methods and {@link SegmentChangeListener#andThen(SegmentChangeListener)}
+ * composition behaviour around reset-position handling.
+ */
+class SegmentChangeListenerTest {
+
+    private static final Segment SEGMENT = Segment.ROOT_SEGMENT;
+
+    @Nested
+    class Factories {
+
+        @Test
+        void onClaimReturnsNoReset() {
+            // given
+            SegmentChangeListener listener = SegmentChangeListener.onClaim(
+                    segment -> CompletableFuture.completedFuture(null)
+            );
+
+            // when
+            TrackingToken reset = listener.onSegmentClaimed(SEGMENT).join();
+
+            // then
+            assertThat(reset).isNull();
+        }
+
+        @Test
+        void runOnClaimReturnsNoResetAndExecutesCallback() {
+            // given
+            List<Integer> observed = new CopyOnWriteArrayList<>();
+            SegmentChangeListener listener = SegmentChangeListener.runOnClaim(
+                    segment -> observed.add(segment.getSegmentId())
+            );
+
+            // when
+            TrackingToken reset = listener.onSegmentClaimed(SEGMENT).join();
+
+            // then
+            assertThat(reset).isNull();
+            assertThat(observed).containsExactly(SEGMENT.getSegmentId());
+        }
+
+        @Test
+        void noOpReturnsNoReset() {
+            // given
+            SegmentChangeListener listener = SegmentChangeListener.noOp();
+
+            // when / then
+            assertThat(listener.onSegmentClaimed(SEGMENT).join()).isNull();
+            assertThat(listener.onSegmentReleased(SEGMENT).join()).isNull();
+        }
+
+        @Test
+        void onClaimWithResetPlumbsSuppliedResetPosition() {
+            // given
+            TrackingToken resetPosition = new GlobalSequenceTrackingToken(7);
+            SegmentChangeListener listener = SegmentChangeListener.onClaimWithReset(
+                    segment -> CompletableFuture.completedFuture(resetPosition)
+            );
+
+            // when
+            TrackingToken reported = listener.onSegmentClaimed(SEGMENT).join();
+
+            // then
+            assertThat(reported).isEqualTo(resetPosition);
+        }
+
+        @Test
+        void onReleaseDoesNotAffectReset() {
+            // given
+            SegmentChangeListener listener = SegmentChangeListener.onRelease(
+                    segment -> CompletableFuture.completedFuture(null)
+            );
+
+            // when / then - claim side returns null, release side completes
+            assertThat(listener.onSegmentClaimed(SEGMENT).join()).isNull();
+            assertThat(listener.onSegmentReleased(SEGMENT).join()).isNull();
+        }
+    }
+
+    @Nested
+    class AndThen {
+
+        @Test
+        void mergesTwoResetPositionsViaLowerBound() {
+            // given - first listener returns position 5, second returns position 2
+            TrackingToken first = new GlobalSequenceTrackingToken(5);
+            TrackingToken second = new GlobalSequenceTrackingToken(2);
+            SegmentChangeListener listener = listenerReturning(first)
+                    .andThen(listenerReturning(second));
+
+            // when
+            TrackingToken merged = listener.onSegmentClaimed(SEGMENT).join();
+
+            // then - lower of the two positions wins
+            assertThat(merged).isEqualTo(second);
+        }
+
+        @Test
+        void nullFirstReturnsSecond() {
+            // given
+            TrackingToken second = new GlobalSequenceTrackingToken(2);
+            SegmentChangeListener listener = SegmentChangeListener.noOp()
+                                                                  .andThen(listenerReturning(second));
+
+            // when / then
+            assertThat(listener.onSegmentClaimed(SEGMENT).join()).isEqualTo(second);
+        }
+
+        @Test
+        void nullSecondReturnsFirst() {
+            // given
+            TrackingToken first = new GlobalSequenceTrackingToken(5);
+            SegmentChangeListener listener = listenerReturning(first)
+                    .andThen(SegmentChangeListener.noOp());
+
+            // when / then
+            assertThat(listener.onSegmentClaimed(SEGMENT).join()).isEqualTo(first);
+        }
+
+        @Test
+        void invokesListenersSequentially() {
+            // given
+            List<String> calls = new CopyOnWriteArrayList<>();
+            SegmentChangeListener listener =
+                    SegmentChangeListener.runOnClaim(s -> calls.add("first"))
+                                         .andThen(SegmentChangeListener.runOnClaim(s -> calls.add("second")));
+
+            // when
+            listener.onSegmentClaimed(SEGMENT).join();
+
+            // then
+            assertThat(calls).containsExactly("first", "second");
+        }
+
+        @Test
+        void mergesReleaseFutures() {
+            // given
+            List<String> calls = new CopyOnWriteArrayList<>();
+            SegmentChangeListener listener =
+                    SegmentChangeListener.runOnRelease(s -> calls.add("first"))
+                                         .andThen(SegmentChangeListener.runOnRelease(s -> calls.add("second")));
+
+            // when
+            listener.onSegmentReleased(SEGMENT).join();
+
+            // then
+            assertThat(calls).containsExactly("first", "second");
+        }
+    }
+
+    private static SegmentChangeListener listenerReturning(TrackingToken resetPosition) {
+        return SegmentChangeListener.onClaimWithReset(
+                segment -> CompletableFuture.completedFuture(resetPosition)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds two building blocks to the pooled streaming event processor so that a component can request an ad-hoc replay of a single segment at the moment it is claimed.

### Segment claim can return a reset position

`SegmentChangeListener#onSegmentClaimed` now returns a `TrackingToken` — the position the segment should be reset to. When that token is strictly behind the segment's stored token, the `Coordinator` wraps the stored token in a `ReplayToken`, so the segment streams from the returned position instead of the stored one. Returning `null` leaves the stored position untouched.

- On a first-ever claim (stored token is `null`) the returned position is ignored — a reset is only meaningful relative to a position the processor has already moved past. The listener is still invoked for any side effects.
- Positions returned by composed (`andThen`) listeners are merged via `TrackingToken#lowerBound`, so the chain requests the lowest position any constituent requires.
- `SegmentChangeListener#onClaimWithReset(...)` is added for listeners that supply such a position.

### Handler-aware processor customization

`HandlerAwareProcessorCustomization` is a new hook invoked when a `PooledStreamingEventProcessor` is built, with access to the resolved `EventHandlingComponent` list. This lets processor configuration (such as registering a `SegmentChangeListener`) be derived from the handlers assigned to that processor. `PooledStreamingEventProcessorModule` discovers these customizations from the root configuration, so where they are registered does not matter.

## Testing

`./mvnw -pl messaging test -Dtest='SegmentChangeListenerTest,HandlerAwareProcessorCustomizationTest,CoordinatorTest'` — 40 tests, all green.