### PR TITLE
fix(#4625): reading events/snapshots stored without a revision [DRAFT - reproduction, solution under discussion]

### DIFF
--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
@@ -156,4 +156,41 @@ class MessageTypeTest {
     void fromStringRejectsMissingVersion() {
         assertThrows(IllegalArgumentException.class, () -> MessageType.fromString(NAME));
     }
+
+    /**
+     * Reproduction of <a href="https://github.com/AxonIQ/AxonFramework/issues/4625">#4625</a>.
+     * <p>
+     * Axon Framework 4 events and snapshots may be stored without a revision (the revision was nullable, and Axon
+     * Server stores it as an empty {@code String}). Reconstructing a {@link MessageType} from such stored data - as the
+     * Axon Server connector and the JPA event storage engine do via {@code new MessageType(payloadType, payloadRevision)}
+     * - currently fails because the compact constructor rejects an empty or {@code null} version.
+     * <p>
+     * These tests pin that current (broken) behavior. The chosen fix will determine whether and how these expectations
+     * change.
+     */
+    @Nested
+    class GivenStoredMessageWithoutVersion {
+
+        @Test
+        void rejectsEmptyVersion() {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new MessageType(QUALIFIED_NAME, "")
+            );
+
+            assertEquals("The given version is unsupported because it is empty.", exception.getMessage());
+        }
+
+        @Test
+        void rejectsNullVersion() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class, () -> new MessageType(QUALIFIED_NAME, null));
+        }
+
+        @Test
+        void rejectsEmptyVersionThroughStringConstructorAsUsedByStorageEngines() {
+            // Exactly the call a storage engine makes when reading a stored event/snapshot with an absent revision.
+            assertThrows(IllegalArgumentException.class, () -> new MessageType(NAME, ""));
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Reading **Axon Framework 4** events/snapshots that were stored **without a revision** crashes under AF5 with:

```
java.lang.IllegalArgumentException: The given version is unsupported because it is empty.
    at org.axonframework.messaging.core.MessageType.<init>(MessageType.java:64)
    ...
```

Reported in #4625 (and hit by at least one other user). AF4 never required a revision — `SimpleSerializedType` allowed a `null` revision and Axon Server stores an absent revision as an empty `String`. AF5's `MessageType` compact constructor instead **rejects** both `null` and `""` versions, so any read path that rebuilds a `MessageType` from stored data (`new MessageType(payloadType, payloadRevision)`) blows up on legacy data.

## What this (DRAFT) PR contains

**Only a reproduction — no fix yet.** It adds unit tests pinning the root cause: `MessageType`'s compact constructor rejecting an empty version, a `null` version, and the exact `new MessageType(name, "")` call the storage engines make.

`MessageTypeTest.GivenStoredMessageWithoutVersion` — ✅ passing (asserts the *current, broken* behavior).

The companion runtime reproduction (store an event without a revision in Axon Server, then read it back) lives in the connector repo's matching `fix/4625_MessageWithoutRevision` branch.

> These tests are written as **acceptance gates**: once a fix is agreed, the assertions flip from "expect the exception" to "read succeeds with the resolved version."

## Solution — under discussion ⚠️

The obvious fix is to default an absent (`null`/empty) version to `MessageType.DEFAULT_VERSION` (`"0.0.1"`) on read. **But that may not be safe for everyone**, and that's the open question:

- **Defaulting `null`/`""` → `"0.0.1"` is lossy.** Applications that already, deliberately, treat *"no revision"* (legacy/AF4) **differently** from an explicit `"0.0.1"` would suddenly see legacy data masquerading as `0.0.1`. The two become indistinguishable. Today the only behavioral consumer of `version` is the snapshot compatibility gate (`SnapshottingEntityLifecycleHandler`), which degrades safely (mismatch → full replay) — but we shouldn't assume version stays purely informational forever, or that downstream apps see it that way.
- Candidate shapes still being weighed:
  1. **Loosen the compact constructor** — normalize `null`/`""` → `DEFAULT_VERSION`. One-place fix; every read path inherits it; removes fail-fast on a genuinely missing version in new code.
  2. **Factory / string helper on `MessageType`** (e.g. `ofNullableVersion` / `versionOrDefault`) — keeps the constructor strict; each read site opts in.
  3. **Dedicated legacy factory** (e.g. `LegacyMessageTypes.messageType(type, revision)`) — strongest "legacy only" signal; but the read paths are normal framework code, so the `Legacy*` label is debatable.
  4. **A distinct legacy sentinel** instead of reusing `0.0.1`, so legacy data stays distinguishable from genuinely-`0.0.1` data (trade-off: legacy snapshots would never be trusted by the version gate).

Feedback welcome on which direction to take before this leaves draft.

Relates to #4625.
