### PR TITLE
Add collect, flatMap and mapMulti methods to MessageStream API

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStream.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ContinuousMessageStream.java
@@ -81,12 +81,12 @@ public final class ContinuousMessageStream<E> extends AbstractMessageStream<Even
     }
 
     @Override
-    protected synchronized void onCompleted() {
+    protected void onCompleted() {
         seal();
     }
 
     @Override
-    protected synchronized FetchResult<Entry<EventMessage>> fetchNext() {
+    protected FetchResult<Entry<EventMessage>> fetchNext() {
         if (callbackRegistration == null) {
             this.callbackRegistration = callbackTracker.apply(this, this::signalProgress);
         }

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -557,6 +557,11 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
     /**
      * Attempts to fetch the next available {@link Entry} from the underlying source.
      * <p>
+     * This method is invoked exclusively by the enclosing AbstractMessageStream implementation. Calls are
+     * serialized under a single internal lock; the method is never executed concurrently with itself or
+     * other lifecycle methods of this instance. Implementations may assume single-threaded access and do
+     * not need to provide their own synchronization for correctness of this method.
+     * <p>
      * This method is invoked by {@link #next()} when no previously peeked entry is available. Implementations must
      * return a {@link FetchResult} describing the current state of the stream:
      * <ul>
@@ -593,6 +598,11 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
     /**
      * Callback invoked when the stream is about to transition to a completed state, either successfully or
      * exceptionally. Subclasses may override this method to perform custom actions on completion.
+     * <p>
+     * This method is invoked exclusively by the enclosing AbstractMessageStream implementation. Calls are
+     * serialized under a single internal lock; the method is never executed concurrently with itself or
+     * other lifecycle methods of this instance. Implementations may assume single-threaded access and do
+     * not need to provide their own synchronization for correctness of this method.
      * <p>
      * If the implementation throws an exception, the stream still completes, but it will complete with the thrown
      * exception. If the stream was about to complete with an error, and the callback fails as well, the exception is

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -118,8 +118,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * This method inspects the provided {@code delegate} in a non-blocking manner and translates its state into a
          * corresponding {@code FetchResult}:
          * <ul>
-         *     <li>If {@link MessageStream#hasNextAvailable()} returns {@code true}, this method
-         *     retrieves the next entry via {@link MessageStream#next()} and returns a
+         *     <li>If there is a {@link MessageStream#next()} element, it returns a
          *     {@link FetchResult.Value}.</li>
          *     <li>If no entry is currently available and the stream is not completed, a
          *     {@link FetchResult.NotReady} is returned.</li>
@@ -142,27 +141,25 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @throws NullPointerException if {@code delegate} is {@code null}
          */
         static <M extends Message> FetchResult<Entry<M>> of(MessageStream<M> delegate) {
-            if (delegate.hasNextAvailable()) {
-                return FetchResult.of(delegate.next().orElse(null));
-            }
-
-            if (!delegate.isCompleted()) {
-                return FetchResult.notReady();
-            }
-
-            return delegate.error()
-                           .map(FetchResult::<Entry<M>>error)
-                           .orElse(FetchResult.completed());
+            return delegate.next()
+                .map(FetchResult::of)
+                .orElseGet(() -> delegate.isCompleted()
+                    ? delegate.error()
+                        .map(FetchResult::<Entry<M>>error)
+                        .orElse(FetchResult.completed())
+                    : FetchResult.notReady()
+                );
         }
 
         /**
          * Creates a {@code FetchResult} representing a successfully fetched value.
          *
          * @param <T>   the entry type
-         * @param value the non-{@code null} value
+         * @param value the value, cannot be {@code null}
          * @return a {@link Value} containing the given value, never {@code null}
+         * @throws NullPointerException if {@code value} is {@code null}
          */
-        static <T extends @Nullable Entry<?>> FetchResult<T> of(@Nullable T value) {
+        static <T extends Entry<?>> FetchResult<T> of(T value) {
             return new Value<>(value);
         }
 
@@ -172,6 +169,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param <T>   the entry type
          * @param error the non-{@code null} error
          * @return an {@link Error} representing the failure, never {@code null}
+         * @throws NullPointerException if {@code error} is {@code null}
          */
         static <T extends Entry<?>> FetchResult<T> error(Throwable error) {
             return new Error<>(error);
@@ -207,7 +205,17 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * @param <T>   the entry type
          * @param value the value
          */
-        record Value<T extends Entry<?>>(T value) implements FetchResult<T> {}
+        record Value<T extends Entry<?>>(T value) implements FetchResult<T> {
+
+            /**
+             * Compact constructor ensuring the given {@code value} is not {@code null}.
+             *
+             * @param value the non-{@code null} value
+             */
+            public Value {
+                Objects.requireNonNull(value, "value");
+            }
+        }
 
         /**
          * A {@link FetchResult} representing a terminal error in the stream.

--- a/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
@@ -82,7 +82,7 @@ class ConcatenatingMessageStream<M extends Message> extends AbstractMessageStrea
     }
 
     @Override
-    protected synchronized FetchResult<Entry<M>> fetchNext() {
+    protected FetchResult<Entry<M>> fetchNext() {
         do {
             switch (FetchResult.of(active)) {
                 case FetchResult.Completed():
@@ -114,7 +114,7 @@ class ConcatenatingMessageStream<M extends Message> extends AbstractMessageStrea
     }
 
     @Override
-    protected synchronized void onCompleted() {
+    protected void onCompleted() {
         active.close();
         streams.forEach(MessageStream::close);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/FlatMappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/FlatMappedMessageStream.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Implementation of the {@link MessageStream} that maps each {@link Entry entry} from an outer stream to
+ * a new inner {@link MessageStream} using a mapper function, then concatenates the entries of all inner streams in
+ * order.
+ * <p>
+ * Each outer entry produces exactly one inner stream. Entries of successive inner streams are emitted in the order the
+ * outer entries appear. The next inner stream is not started until the current one completes. If any inner stream
+ * completes with an error, that error is propagated and no further entries are emitted.
+ * <p>
+ * This is the {@code MessageStream} equivalent of {@link java.util.stream.Stream#flatMap(Function)}.
+ *
+ * @param <M> the type of {@link Message} carried by the outer stream's entries
+ * @param <N> the type of {@link Message} carried by the inner streams' entries and this stream's entries
+ * @author John Hendrikx
+ * @since 5.2.0
+ */
+class FlatMappedMessageStream<M extends Message, N extends Message> extends AbstractMessageStream<N> {
+
+    private final MessageStream<M> outer;
+    private final Function<? super Entry<M>, ? extends MessageStream<? extends N>> mapper;
+
+    @Nullable
+    private MessageStream<? extends N> inner;
+
+    /**
+     * Constructs a {@link MessageStream} that maps each entry from {@code outer} to an inner stream using
+     * {@code mapper}, emitting all inner entries in sequence.
+     *
+     * @param outer  the outer stream whose entries are mapped to inner streams, cannot be {@code null}
+     * @param mapper the function mapping each outer {@link Entry} to a {@link MessageStream}, cannot be {@code null}
+     * @throws NullPointerException when any argument is {@code null}
+     */
+    FlatMappedMessageStream(MessageStream<M> outer,
+                            Function<? super Entry<M>, ? extends MessageStream<? extends N>> mapper) {
+        this.outer = Objects.requireNonNull(outer, "The outer parameter must not be null.");
+        this.mapper = Objects.requireNonNull(mapper, "The mapper parameter must not be null.");
+
+        initialize(outer.error().map(FetchResult::<Entry<N>>error).orElse(FetchResult.notReady()));
+
+        outer.setCallback(this::signalProgress);
+    }
+
+    @Override
+    protected FetchResult<Entry<N>> fetchNext() {
+        for (;;) {
+            if (inner != null) {
+                FetchResult<Entry<N>> innerResult = FetchResult.of(inner.cast());
+
+                switch (innerResult) {
+                    case FetchResult.Completed() -> {
+                        inner.setCallback(() -> {});
+                        inner.close();
+                        inner = null;
+                    }
+                    default -> {
+                        return innerResult;
+                    }
+                }
+            }
+
+            Entry<M> outerEntry = outer.next().orElse(null);
+
+            if (outerEntry == null) {
+                return outer.error()
+                    .map(FetchResult::<Entry<N>>error)
+                    .orElse(outer.isCompleted() ? FetchResult.completed() : FetchResult.notReady());
+            }
+
+            inner = mapper.apply(outerEntry);
+
+            inner.setCallback(this::signalProgress);
+        }
+    }
+
+    @Override
+    protected void onCompleted() {
+        if (inner != null) {
+            inner.close();
+        }
+        outer.close();
+    }
+
+    @Override
+    protected String describeDelegates() {
+        return inner == null ? outer.toString() : outer + ", *" + inner;
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/MapMultiMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MapMultiMessageStream.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Implementation of the {@link MessageStream} that maps each {@link Entry entry} to zero or more
+ * output entries using a {@link BiConsumer} mapper.
+ * <p>
+ * For each entry from the delegate stream, the mapper is invoked with the entry and a {@link Consumer} it can call
+ * zero or more times to emit output entries. The emitted entries are buffered and returned one at a time from
+ * subsequent {@link MessageStream#next()} calls.
+ * <p>
+ * This is the {@code MessageStream} equivalent of {@link java.util.stream.Stream#mapMulti(BiConsumer)}. Unlike
+ * {@link FlatMappedMessageStream}, the mapper is invoked synchronously: all output entries for a given input are
+ * pushed to the consumer during the same {@code fetchNext} call. This makes it more efficient for the common
+ * 1-to-1 case because no inner stream object is allocated per entry.
+ *
+ * @param <M> the type of {@link Message} carried by the delegate stream's entries
+ * @param <N> the type of {@link Message} carried by this stream's output entries
+ * @author John Hendrikx
+ * @since 5.2.0
+ */
+class MapMultiMessageStream<M extends Message, N extends Message> extends AbstractMessageStream<N> {
+
+    private final MessageStream<M> delegate;
+    private final BiConsumer<? super Entry<M>, ? super Consumer<Entry<N>>> mapper;
+    private final ArrayDeque<Entry<N>> buffer = new ArrayDeque<>();
+
+    /**
+     * Constructs a {@link MessageStream} that maps each entry from {@code delegate} to zero or more output entries
+     * using {@code mapper}.
+     *
+     * @param delegate the stream whose entries are expanded by the mapper, cannot be {@code null}
+     * @param mapper   a {@link BiConsumer} receiving each input {@link Entry} and a {@link Consumer}
+     *                 to push zero or more output entries to, cannot be {@code null}
+     * @throws NullPointerException when any argument is {@code null}
+     */
+    MapMultiMessageStream(MessageStream<M> delegate,
+                          BiConsumer<? super Entry<M>, ? super Consumer<Entry<N>>> mapper) {
+        this.delegate = Objects.requireNonNull(delegate, "The delegate parameter must not be null.");
+        this.mapper = Objects.requireNonNull(mapper, "The mapper parameter must not be null.");
+
+        initialize(delegate.error().map(FetchResult::<Entry<N>>error).orElse(FetchResult.notReady()));
+
+        delegate.setCallback(this::signalProgress);
+    }
+
+    @Override
+    protected FetchResult<Entry<N>> fetchNext() {
+        for (;;) {
+
+            /*
+             * First drain any messages from the buffer that were added from
+             * a previous map operation (which may be none):
+             */
+
+            if (!buffer.isEmpty()) {
+                return FetchResult.of(buffer.poll());
+            }
+
+            /*
+             * Buffer is empty now, if the main stream has messages, apply the map
+             * operation to its next message to fill the buffer:
+             */
+
+            MessageStream.Entry<M> next = delegate.next().orElse(null);
+
+            if (next == null) {
+                return delegate.error()
+                    .map(FetchResult::<Entry<N>>error)
+                    .orElse(delegate.isCompleted() ? FetchResult.completed() : FetchResult.notReady());
+            }
+
+            /*
+             * Fill buffer with mapper:
+             */
+
+            mapper.accept(next, (Consumer<Entry<N>>) buffer::add);
+        }
+    }
+
+    @Override
+    protected void onCompleted() {
+        delegate.close();
+    }
+
+    @Override
+    protected String describeDelegates() {
+        return delegate.toString();
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -19,8 +19,10 @@ package org.axonframework.messaging.core;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -453,6 +455,52 @@ public interface MessageStream<M extends Message> {
     }
 
     /**
+     * Returns a stream that maps each {@link Entry entry} from this stream to an inner {@link MessageStream} using the
+     * given {@code mapper}, then concatenates all inner stream entries in order.
+     * <p>
+     * Each outer entry produces exactly one inner stream. Inner streams are drained in sequence: the next inner stream
+     * is not started until the current one completes normally. If any inner stream completes with an error, that error
+     * is propagated and no further entries are emitted.
+     * <p>
+     * The returned stream completes the same way {@code this} stream completes, unless an inner stream completes with
+     * an error.
+     *
+     * @param <N>    the type of {@link Message} contained in the inner streams and the returned stream
+     * @param mapper the function mapping each {@link Entry} of type {@code M} to a {@link MessageStream} of type
+     *               {@code N}, cannot be {@code null}
+     * @return a stream that is the concatenation of all inner streams produced by {@code mapper}
+     * @throws NullPointerException when any argument is {@code null}
+     * @since 5.2.0
+     */
+    default <N extends Message> MessageStream<N> flatMap(
+            Function<? super Entry<M>, ? extends MessageStream<? extends N>> mapper) {
+        return new FlatMappedMessageStream<>(this, Objects.requireNonNull(mapper, "The mapper parameter must not be null."));
+    }
+
+    /**
+     * Returns a stream that maps each {@link Entry entry} from this stream to zero or more output entries of type
+     * {@code N}, using the given {@code mapper}.
+     * <p>
+     * For each input entry, {@code mapper} is called with the entry and a {@link Consumer} it may invoke zero or more
+     * times to emit output entries. All output entries for a given input are emitted synchronously during the same
+     * processing step, making this more efficient than {@link #flatMap(Function)} for the common case of synchronous
+     * 0-to-N expansion.
+     * <p>
+     * The returned stream completes the same way {@code this} stream completes.
+     *
+     * @param <N>    the type of {@link Message} contained in the returned stream's entries
+     * @param mapper a {@link BiConsumer} that receives each input {@link Entry} and a {@link Consumer} to push
+     *               zero or more output {@link Entry entries} of type {@code N} to, cannot be {@code null}
+     * @return a stream of output entries produced by {@code mapper} for each input entry
+     * @throws NullPointerException when any argument is {@code null}
+     * @since 5.2.0
+     */
+    default <N extends Message> MessageStream<N> mapMulti(
+            BiConsumer<? super Entry<M>, ? super Consumer<Entry<N>>> mapper) {
+        return new MapMultiMessageStream<>(this, Objects.requireNonNull(mapper, "The mapper parameter must not be null."));
+    }
+
+    /**
      * Returns a {@link CompletableFuture} of type {@code R}, using the given {@code identity} as the initial value for
      * the given {@code accumulator}. Throws an exception if this stream is unbounded.
      * <p>
@@ -473,6 +521,41 @@ public interface MessageStream<M extends Message> {
     default <R> CompletableFuture<@Nullable R> reduce(@Nullable R identity,
                                                       BiFunction<@Nullable R, ? super Entry<M>, @Nullable R> accumulator) {
         return MessageStreamUtils.reduce(this, identity, accumulator);
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} containing the container produced by {@code containerSupplier}, populated
+     * by passing each message in this stream to {@code accumulator}.
+     * <p>
+     * Unlike {@link #reduce(Object, BiFunction)}, the accumulator receives the message directly (not the
+     * {@link Entry}), and its return value is ignored -- it is expected to mutate the container in place. This makes
+     * method references like {@code List::add} directly usable:
+     * <pre>{@code
+     * CompletableFuture<List<MyMessage>> result = stream.collect(ArrayList::new, List::add);
+     * }</pre>
+     * <p>
+     * Note that parallel processing <b>is not</b> supported.
+     *
+     * @param containerSupplier a {@link Supplier} that creates the initial container; invoked exactly once, cannot
+     *                          be {@code null}
+     * @param accumulator       a {@link BiConsumer} that receives the container and each message; expected to mutate
+     *                          the container in place, cannot be {@code null}
+     * @param <C>               the type of the result container
+     * @return a {@link CompletableFuture} carrying the populated container after all messages are consumed
+     * @throws UnsupportedOperationException if this stream is unbounded
+     * @throws NullPointerException when any argument is {@code null}
+     * @see #reduce(Object, BiFunction)
+     * @since 5.2.0
+     */
+    default <C> CompletableFuture<C> collect(Supplier<C> containerSupplier, BiConsumer<? super C, M> accumulator) {
+        Objects.requireNonNull(containerSupplier, "The containerSupplier parameter must not be null.");
+        Objects.requireNonNull(accumulator, "The accumulator parameter must not be null.");
+
+        return reduce(containerSupplier.get(), (container, entry) -> {
+            accumulator.accept(container, entry.message());
+
+            return container;
+        });
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/core/OnErrorContinueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/OnErrorContinueMessageStream.java
@@ -55,7 +55,7 @@ class OnErrorContinueMessageStream<M extends Message> extends AbstractMessageStr
     }
 
     @Override
-    protected synchronized FetchResult<Entry<M>> fetchNext() {
+    protected FetchResult<Entry<M>> fetchNext() {
         do {
             FetchResult<Entry<M>> result = FetchResult.of(current);
 
@@ -81,7 +81,7 @@ class OnErrorContinueMessageStream<M extends Message> extends AbstractMessageStr
     }
 
     @Override
-    protected synchronized void onCompleted() {
+    protected void onCompleted() {
         current.close();
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/TruncateFirstMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/TruncateFirstMessageStream.java
@@ -48,7 +48,7 @@ class TruncateFirstMessageStream<M extends Message>
     }
 
     @Override
-    protected synchronized FetchResult<Entry<M>> fetchNext() {
+    protected FetchResult<Entry<M>> fetchNext() {
         if (consumed) {
             return FetchResult.completed();
         }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventSink.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/InterceptingEventSink.java
@@ -99,8 +99,8 @@ public class InterceptingEventSink implements EventSink {
             this.interceptorChain = new DefaultMessageDispatchInterceptorChain<>(interceptors);
         }
 
-        private CompletableFuture<Void> interceptAndPublish(
-                List<? extends EventMessage> events,
+        private <M extends EventMessage> CompletableFuture<Void> interceptAndPublish(
+                List<M> events,
                 @Nullable ProcessingContext context
         ) {
 
@@ -108,23 +108,12 @@ public class InterceptingEventSink implements EventSink {
              * Captures events in a batch. A fast path for when there
              * is only a single event here is not possible because the
              * interceptor may produce more than one event.
-             *
-             * Note: this could benefit from having a flatMap method
-             * on MessageStream.
              */
 
-            List<EventMessage> interceptedEvents = new ArrayList<>();
-            MessageStream<EventMessage> resultStream = MessageStream.empty();
-
-            for (EventMessage event : events) {
-                resultStream = resultStream.concatWith(interceptorChain.proceed(event, context).cast());
-            }
-
-            return resultStream
-                .onNext(entry -> interceptedEvents.add(entry.message()))
-                .ignoreEntries()
-                .asCompletableFuture()
-                .thenCompose(v -> delegate.publish(context, interceptedEvents));
+            return MessageStream.fromIterable(events)
+                .flatMap(entry -> interceptorChain.proceed(entry.message(), context).<M>cast())
+                .collect(ArrayList<M>::new, List::add)
+                .thenCompose(interceptedEvents -> delegate.publish(context, interceptedEvents));
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
@@ -107,10 +107,7 @@ public class DefaultQueryGateway implements QueryGateway {
         QueryMessage queryMessage = asQueryMessage(query);
         MessageStream<QueryResponseMessage> resultStream = queryBus.query(queryMessage, context);
         CompletableFuture<List<R>> resultFuture =
-                resultStream.reduce(new ArrayList<>(), (list, entry) -> {
-                    list.add(entry.message().payloadAs(responseType, converter));
-                    return list;
-                });
+                resultStream.collect(ArrayList::new, (list, message) -> list.add(message.payloadAs(responseType, converter)));
         // We cannot chain the whenComplete call, as otherwise CompletableFuture#cancel is not propagated to the lambda.
         resultFuture.whenComplete((r, e) -> {
             if (!resultStream.isCompleted()) {

--- a/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
@@ -161,13 +161,6 @@ class AbstractMessageStreamTest {
         }
 
         @Test
-        void whenNullValueAvailableThenReturnsEmptyOptional() {
-            stream.enqueue(FetchResult.of((Entry<Message>) null));
-
-            assertThat(stream.next()).isEmpty();
-        }
-
-        @Test
         void whenNotReadyThenReturnsEmptyAndDoesNotComplete() {
             assertThat(stream.next()).isEmpty();
             assertThat(stream.isCompleted()).isFalse();
@@ -577,6 +570,69 @@ class AbstractMessageStreamTest {
 
             assertThat(stream.isCompleted()).isTrue();
             assertThat(stream.error()).isEmpty();
+        }
+    }
+
+    @Nested
+    class WhenBridgingFromDelegate {
+
+        /*
+         * Tests for FetchResult.of(MessageStream<M> delegate) -- the static bridge that maps a
+         * delegate stream's current state to the FetchResult model.
+         */
+
+        @Test
+        void withValueAvailableThenReturnsValueResult() {
+            // given
+            ControllableStream delegate = new ControllableStream();
+            Entry<Message> entry = entryOf("msg");
+            delegate.enqueue(FetchResult.of(entry));
+
+            // when
+            FetchResult<Entry<Message>> result = FetchResult.of(delegate);
+
+            // then
+            assertThat(result).isEqualTo(new FetchResult.Value<>(entry));
+        }
+
+        @Test
+        void withNoValueAndNotCompletedThenReturnsNotReady() {
+            // given: nothing enqueued, not closed -- next() returns empty while isCompleted()=false
+            ControllableStream delegate = new ControllableStream();
+
+            // when
+            FetchResult<Entry<Message>> result = FetchResult.of(delegate);
+
+            // then: must not throw, and must signal the stream is temporarily unavailable
+            assertThat(result).isEqualTo(FetchResult.notReady());
+        }
+
+        @Test
+        void withCompletedDelegateThenReturnsCompleted() {
+            // given
+            ControllableStream delegate = new ControllableStream();
+            delegate.close();
+
+            // when
+            FetchResult<Entry<Message>> result = FetchResult.of(delegate);
+
+            // then
+            assertThat(result).isEqualTo(FetchResult.completed());
+        }
+
+        @Test
+        void withFailedDelegateThenReturnsError() {
+            // given: enqueue an error result; next() will process it, completing the stream exceptionally
+            ControllableStream delegate = new ControllableStream();
+            RuntimeException failure = new RuntimeException("stream failed");
+            delegate.enqueue(FetchResult.error(failure));
+
+            // when: bridge calls next() which processes the error; bridge then reads isCompleted()+error()
+            FetchResult<Entry<Message>> result = FetchResult.of(delegate);
+
+            // then
+            assertThat(result).isInstanceOf(FetchResult.Error.class);
+            assertThat(((FetchResult.Error<?>) result).error()).isSameAs(failure);
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/FlatMappedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/FlatMappedMessageStreamTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import org.axonframework.messaging.core.MessageStream.Entry;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link FlatMappedMessageStream} through the {@link MessageStreamTest} suite and
+ * with additional flatMap-specific scenarios.
+ *
+ * @author John Hendrikx
+ */
+class FlatMappedMessageStreamTest extends MessageStreamTest<Message> {
+
+    @Override
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
+        return new FlatMappedMessageStream<>(MessageStream.fromIterable(messages),
+                                             entry -> MessageStream.just(entry.message()));
+    }
+
+    @Override
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+        Assumptions.abort("FlatMappedMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+        Assumptions.abort("FlatMappedMessageStream doesn't support explicit empty streams");
+        return null;
+    }
+
+    @Override
+    protected MessageStream<Message> failingTestSubject(List<Message> messages, RuntimeException failure) {
+        return completedTestSubject(messages).concatWith(MessageStream.failed(failure));
+    }
+
+    @Override
+    protected Message createRandomMessage() {
+        return new GenericMessage(new MessageType("message"), "test-" + ThreadLocalRandom.current().nextInt(10000));
+    }
+
+    @Nested
+    class ZeroEmissionsPerEntry {
+
+        @Test
+        void mapperReturningEmptyStreamSkipsEntry() {
+            // given
+            Message kept = createRandomMessage();
+            Message skipped = createRandomMessage();
+            MessageStream<Message> outer = MessageStream.fromIterable(List.of(skipped, kept));
+
+            // when
+            MessageStream<Message> stream = outer.flatMap(
+                    entry -> entry.message().equals(skipped) ? MessageStream.empty() : MessageStream.just(entry.message())
+            );
+
+            // then
+            assertThat(stream.next()).map(Entry::message).contains(kept);
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+
+        @Test
+        void allEntriesFilteredOutCompletesNormally() {
+            // given
+            MessageStream<Message> outer = MessageStream.fromIterable(List.of(createRandomMessage(), createRandomMessage()));
+
+            // when
+            MessageStream<Message> stream = outer.flatMap(entry -> MessageStream.empty());
+
+            // then
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(stream.error()).isEmpty();
+        }
+    }
+
+    @Nested
+    class MultipleEmissionsPerEntry {
+
+        @Test
+        void mapperReturningTwoEntriesEmitsBoth() {
+            // given
+            Message a = createRandomMessage();
+            Message b = createRandomMessage();
+            Message c = createRandomMessage();
+            Message d = createRandomMessage();
+
+            // when -- each outer entry expands to two inner entries
+            MessageStream<Message> stream = MessageStream.fromIterable(List.of(a, b))
+                                                         .flatMap(entry -> MessageStream.fromItems(c, d));
+
+            // then
+            assertThat(stream.next()).map(Entry::message).contains(c);
+            assertThat(stream.next()).map(Entry::message).contains(d);
+            assertThat(stream.next()).map(Entry::message).contains(c);
+            assertThat(stream.next()).map(Entry::message).contains(d);
+            assertThat(stream.next()).isEmpty();
+        }
+    }
+
+    @Nested
+    class AsyncOuterStream {
+
+        @Test
+        void callbackFiredWhenOuterBecomesAvailable() {
+            // given
+            QueueMessageStream<Message> outer = new QueueMessageStream<>();
+            Message msg = createRandomMessage();
+            AtomicBoolean callbackCalled = new AtomicBoolean();
+            MessageStream<Message> stream = outer.flatMap(entry -> MessageStream.just(entry.message()));
+            stream.setCallback(() -> callbackCalled.set(true));
+
+            // when
+            assertThat(callbackCalled.getAndSet(false)).isFalse();
+            outer.offer(msg, Context.empty());
+
+            // then
+            assertThat(callbackCalled.get()).isTrue();
+            assertThat(stream.next()).map(Entry::message).contains(msg);
+        }
+
+        @Test
+        void callbackFiredWhenOuterCompletes() {
+            // given
+            QueueMessageStream<Message> outer = new QueueMessageStream<>();
+            AtomicBoolean callbackCalled = new AtomicBoolean();
+            MessageStream<Message> stream = outer.flatMap(entry -> MessageStream.just(entry.message()));
+            stream.setCallback(() -> callbackCalled.set(true));
+
+            // when
+            assertThat(callbackCalled.getAndSet(false)).isFalse();
+            outer.seal();
+
+            // then -- callback fires because outer sealed, notifying downstream
+            assertThat(callbackCalled.get()).isTrue();
+
+            // advance stream state to surface the completion
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    class AsyncInnerStream {
+
+        @Test
+        void callbackFiredWhenInnerBecomesAvailable() {
+            // given
+            Message outerMsg = createRandomMessage();
+            Message innerMsg = createRandomMessage();
+            QueueMessageStream<Message> innerStream = new QueueMessageStream<>();
+            AtomicBoolean callbackCalled = new AtomicBoolean();
+
+            MessageStream<Message> stream = MessageStream.just(outerMsg)
+                                                         .flatMap(entry -> innerStream);
+            stream.setCallback(() -> callbackCalled.set(true));
+
+            // outer entry is consumed immediately but inner stream is not yet ready
+            assertThat(stream.hasNextAvailable()).isFalse();
+            assertThat(callbackCalled.getAndSet(false)).isFalse();
+
+            // when inner becomes available
+            innerStream.offer(innerMsg, Context.empty());
+            innerStream.seal();
+
+            // then
+            assertThat(callbackCalled.get()).isTrue();
+            assertThat(stream.next()).map(Entry::message).contains(innerMsg);
+            assertThat(stream.next()).isEmpty();
+        }
+    }
+
+    @Nested
+    class ErrorPropagation {
+
+        @Test
+        void errorFromOuterStreamPropagates() {
+            // given
+            RuntimeException failure = new RuntimeException("outer failure");
+            MessageStream<Message> stream = MessageStream.<Message>failed(failure)
+                    .flatMap(entry -> MessageStream.just(entry.message()));
+
+            // then
+            assertThat(stream.error()).contains(failure);
+        }
+
+        @Test
+        void errorFromInnerStreamPropagates() {
+            // given
+            RuntimeException failure = new RuntimeException("inner failure");
+            MessageStream<Message> stream = MessageStream.just(createRandomMessage())
+                                                         .flatMap(entry -> MessageStream.failed(failure));
+
+            // when
+            assertThat(stream.next()).isEmpty();
+
+            // then
+            assertThat(stream.error()).contains(failure);
+        }
+
+        @Test
+        void subsequentEntriesNotEmittedAfterInnerError() {
+            // given
+            Message second = createRandomMessage();
+            RuntimeException failure = new RuntimeException("inner failure");
+            MessageStream<Message> stream = MessageStream.fromItems(createRandomMessage(), second)
+                                                         .flatMap(entry -> entry.message().equals(second)
+                                                                  ? MessageStream.just(entry.message())
+                                                                  : MessageStream.failed(failure));
+
+            // when
+            assertThat(stream.next()).isEmpty();
+
+            // then -- second entry never reached
+            assertThat(stream.error()).contains(failure);
+            assertThat(stream.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    class CloseAndCancel {
+
+        @Test
+        void closingStreamClosesInnerAndOuter() {
+            // given
+            QueueMessageStream<Message> outer = new QueueMessageStream<>();
+            QueueMessageStream<Message> inner = new QueueMessageStream<>();
+            outer.offer(createRandomMessage(), Context.empty());
+            MessageStream<Message> stream = outer.flatMap(entry -> inner);
+
+            // advance into the inner stream
+            assertThat(stream.hasNextAvailable()).isFalse();
+
+            // when
+            stream.close();
+
+            // then
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(inner.isCompleted()).isTrue();
+            assertThat(outer.isCompleted()).isTrue();
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/core/MapMultiMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MapMultiMessageStreamTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import org.axonframework.messaging.core.MessageStream.Entry;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link MapMultiMessageStream} through the {@link MessageStreamTest} suite and
+ * with additional mapMulti-specific scenarios.
+ *
+ * @author John Hendrikx
+ */
+class MapMultiMessageStreamTest extends MessageStreamTest<Message> {
+
+    @Override
+    protected MessageStream<Message> completedTestSubject(List<Message> messages) {
+        return new MapMultiMessageStream<>(MessageStream.fromIterable(messages),
+                                          (entry, consumer) -> consumer.accept(entry));
+    }
+
+    @Override
+    protected MessageStream.Single<Message> completedSingleStreamTestSubject(Message message) {
+        Assumptions.abort("MapMultiMessageStream doesn't support explicit single-value streams");
+        return null;
+    }
+
+    @Override
+    protected MessageStream.Empty<Message> completedEmptyStreamTestSubject() {
+        Assumptions.abort("MapMultiMessageStream doesn't support explicit empty streams");
+        return null;
+    }
+
+    @Override
+    protected MessageStream<Message> failingTestSubject(List<Message> messages, RuntimeException failure) {
+        return completedTestSubject(messages).concatWith(MessageStream.failed(failure));
+    }
+
+    @Override
+    protected Message createRandomMessage() {
+        return new GenericMessage(new MessageType("message"), "test-" + ThreadLocalRandom.current().nextInt(10000));
+    }
+
+    @Nested
+    class ZeroEmissionsPerEntry {
+
+        @Test
+        void mapperEmittingNothingSkipsEntry() {
+            // given
+            Message kept = createRandomMessage();
+            Message skipped = createRandomMessage();
+            MessageStream<Message> delegate = MessageStream.fromIterable(List.of(skipped, kept));
+
+            // when
+            MessageStream<Message> stream = delegate.mapMulti(
+                    (entry, consumer) -> {
+                        if (!entry.message().equals(skipped)) {
+                            consumer.accept(entry);
+                        }
+                    }
+            );
+
+            // then
+            assertThat(stream.next()).map(Entry::message).contains(kept);
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+
+        @Test
+        void allEntriesFilteredOutCompletesNormally() {
+            // given
+            MessageStream<Message> delegate = MessageStream.fromIterable(
+                    List.of(createRandomMessage(), createRandomMessage()));
+
+            // when
+            MessageStream<Message> stream = delegate.mapMulti((entry, consumer) -> { /* emit nothing */ });
+
+            // then
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(stream.error()).isEmpty();
+        }
+    }
+
+    @Nested
+    class MultipleEmissionsPerEntry {
+
+        @Test
+        void mapperEmittingTwoValuesPerEntryExpandsStream() {
+            // given
+            Message a = createRandomMessage();
+            Message b = createRandomMessage();
+            Message expansion1 = createRandomMessage();
+            Message expansion2 = createRandomMessage();
+
+            // when -- each outer entry expands to two different messages
+            MessageStream<Message> stream = MessageStream.fromItems(a, b)
+                                                         .mapMulti((entry, consumer) -> {
+                                                             consumer.accept(entry.map(m -> expansion1));
+                                                             consumer.accept(entry.map(m -> expansion2));
+                                                         });
+
+            // then
+            assertThat(stream.next()).map(Entry::message).contains(expansion1);
+            assertThat(stream.next()).map(Entry::message).contains(expansion2);
+            assertThat(stream.next()).map(Entry::message).contains(expansion1);
+            assertThat(stream.next()).map(Entry::message).contains(expansion2);
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+
+        @Test
+        void bufferedEntriesReturnedBeforeNextDelegatePull() {
+            // given -- verify that expansion entries are buffered and returned in order
+            Message original = createRandomMessage();
+            Message first = createRandomMessage();
+            Message second = createRandomMessage();
+            Message third = createRandomMessage();
+
+            // when
+            MessageStream<Message> stream = MessageStream.just(original)
+                                                         .mapMulti((entry, consumer) -> {
+                                                             consumer.accept(entry.map(m -> first));
+                                                             consumer.accept(entry.map(m -> second));
+                                                             consumer.accept(entry.map(m -> third));
+                                                         });
+
+            // then -- all three arrive in order before the stream completes
+            assertThat(stream.next()).map(Entry::message).contains(first);
+            assertThat(stream.next()).map(Entry::message).contains(second);
+            assertThat(stream.next()).map(Entry::message).contains(third);
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    class AsyncDelegate {
+
+        @Test
+        void callbackFiredWhenDelegateBecomesAvailable() {
+            // given
+            QueueMessageStream<Message> delegate = new QueueMessageStream<>();
+            Message msg = createRandomMessage();
+            AtomicBoolean callbackCalled = new AtomicBoolean();
+            MessageStream<Message> stream = delegate.mapMulti((entry, consumer) -> consumer.accept(entry));
+            stream.setCallback(() -> callbackCalled.set(true));
+
+            // when
+            assertThat(callbackCalled.getAndSet(false)).isFalse();
+            delegate.offer(msg, Context.empty());
+
+            // then
+            assertThat(callbackCalled.get()).isTrue();
+            assertThat(stream.next()).map(Entry::message).contains(msg);
+        }
+
+        @Test
+        void callbackFiredWhenDelegateCompletes() {
+            // given
+            QueueMessageStream<Message> delegate = new QueueMessageStream<>();
+            AtomicBoolean callbackCalled = new AtomicBoolean();
+            MessageStream<Message> stream = delegate.mapMulti((entry, consumer) -> consumer.accept(entry));
+            stream.setCallback(() -> callbackCalled.set(true));
+
+            // when
+            assertThat(callbackCalled.getAndSet(false)).isFalse();
+            delegate.seal();
+
+            // then -- callback fires because delegate sealed, notifying downstream
+            assertThat(callbackCalled.get()).isTrue();
+
+            // advance stream state to surface the completion
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    class ErrorPropagation {
+
+        @Test
+        void errorFromDelegateStreamPropagates() {
+            // given
+            RuntimeException failure = new RuntimeException("delegate failure");
+            MessageStream<Message> stream = MessageStream.<Message>failed(failure)
+                    .mapMulti((entry, consumer) -> consumer.accept(entry));
+
+            // then
+            assertThat(stream.error()).contains(failure);
+        }
+
+        @Test
+        void errorFromDelegateAfterEntriesPropagates() {
+            // given
+            RuntimeException failure = new RuntimeException("late failure");
+            MessageStream<Message> stream = MessageStream.just(createRandomMessage())
+                                                         .concatWith(MessageStream.failed(failure))
+                                                         .mapMulti((entry, consumer) -> consumer.accept(entry));
+
+            // when -- consume the first entry
+            assertThat(stream.next()).isPresent();
+
+            // then -- next pull surfaces the error
+            assertThat(stream.next()).isEmpty();
+            assertThat(stream.error()).contains(failure);
+        }
+    }
+
+    @Nested
+    class CloseAndCancel {
+
+        @Test
+        void closingStreamClosesDelegate() {
+            // given
+            QueueMessageStream<Message> delegate = new QueueMessageStream<>();
+            MessageStream<Message> stream = delegate.mapMulti((entry, consumer) -> consumer.accept(entry));
+
+            // when
+            stream.close();
+
+            // then
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(delegate.isCompleted()).isTrue();
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageStreamTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 import reactor.test.StepVerifier;
 import reactor.test.StepVerifier.Step;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -1323,6 +1324,88 @@ public abstract class MessageStreamTest<M extends Message> {
         assertNotNull(first.getNow(null));
 
         verify(mock).close();
+    }
+
+    @Nested
+    class Collect {
+
+        @Test
+        void shouldCollectMessagesIntoContainer() {
+            // given
+            Assumptions.assumeTrue(isBoundedStream());
+            M first = createRandomMessage();
+            M second = createRandomMessage();
+            MessageStream<M> testSubject = completedTestSubject(List.of(first, second));
+
+            // when
+            var result = testSubject.collect(ArrayList::new, List::add);
+
+            // then
+            assertTrue(result.isDone());
+            assertThat(result.join()).containsExactly(first, second);
+        }
+
+        @Test
+        void shouldReturnEmptyContainerForEmptyStream() {
+            // given
+            Assumptions.assumeTrue(isBoundedStream());
+            MessageStream<M> testSubject = completedTestSubject(List.of());
+
+            // when
+            var result = testSubject.collect(ArrayList::new, List::add);
+
+            // then
+            assertTrue(result.isDone());
+            assertThat(result.join()).isEmpty();
+        }
+
+        @Test
+        void errorInAccumulatorLeadsToFailedFuture() {
+            // given
+            RuntimeException expected = new RuntimeException("oops");
+            MessageStream<M> testSubject = completedTestSubject(List.of(createRandomMessage()));
+
+            // when
+            var result = testSubject.collect(ArrayList::new, (list, message) -> { throw expected; });
+
+            // then
+            assertTrue(result.isCompletedExceptionally());
+            assertEquals(expected, result.exceptionNow());
+        }
+
+        @Test
+        void shouldNotCollectForEmptyFailingStream() {
+            // given
+            Assumptions.assumeTrue(isBoundedStream());
+            AtomicBoolean invoked = new AtomicBoolean();
+            RuntimeException expected = new RuntimeException("oops");
+            MessageStream<M> testSubject = failingTestSubject(List.of(), expected);
+
+            // when
+            var result = testSubject.collect(ArrayList::new, (list, message) -> invoked.set(true));
+
+            // then
+            assertTrue(result.isCompletedExceptionally());
+            assertEquals(expected, result.exceptionNow());
+            assertFalse(invoked.get());
+        }
+
+        @Test
+        void shouldCompleteExceptionallyAfterCollectingForFailedStream() {
+            // given
+            AtomicBoolean invoked = new AtomicBoolean();
+            RuntimeException expected = new RuntimeException("oops");
+            MessageStream<M> testSubject =
+                    failingTestSubject(List.of(createRandomMessage(), createRandomMessage()), expected);
+
+            // when
+            var result = testSubject.collect(ArrayList::new, (list, message) -> invoked.set(true));
+
+            // then
+            assertTrue(result.isCompletedExceptionally());
+            assertEquals(expected, result.exceptionNow());
+            assertTrue(invoked.get());
+        }
     }
 
     @Nested

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageStreamTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageStreamTestSuite.java
@@ -202,6 +202,12 @@ public abstract class MessageStreamTestSuite {
 
     @ParameterizedTest(allowZeroInvocations = true, name = "{0}")
     @MethodSource("cases")
+    void collectTest(Case c) throws Exception {
+        assertThat(collect(c)).describedAs("collect").isEqualTo(range(0, c.expectedSize));
+    }
+
+    @ParameterizedTest(allowZeroInvocations = true, name = "{0}")
+    @MethodSource("cases")
     void mapTest(Case c) throws Exception {
         assertThat(iterate(map(c))).describedAs("map").isEqualTo(range(100, c.expectedSize));
     }
@@ -312,6 +318,14 @@ public abstract class MessageStreamTestSuite {
             List.<Message>of(),
             (s, entry) -> Stream.concat(s.stream(), Stream.of(entry == null ? null : entry.message())).toList()
         ).get(10, TimeUnit.SECONDS);
+    }
+
+    private List<? extends Message> collect(Case c) throws Exception {
+        return collect(c.stream);
+    }
+
+    private List<? extends Message> collect(MessageStream<?> stream) throws Exception {
+        return stream.collect(ArrayList<Message>::new, List::add).get(10, TimeUnit.SECONDS);
     }
 
     private MessageStream<? extends Message> map(Case c) throws Exception {
@@ -600,6 +614,50 @@ public abstract class MessageStreamTestSuite {
             return List.of(
                 new ErrorCase(0, new TruncateFirstMessageStream<>(MessageStream.failed(new RuntimeException("oops")))),
                 new ErrorCase(0, new TruncateFirstMessageStream<>(new SingleValueMessageStream<>(CompletableFuture.failedFuture(new RuntimeException("oops")))))
+            );
+        }
+    }
+
+    static class FlatMappedTest extends MessageStreamTestSuite {
+        @Override
+        protected List<Case> cases() {
+            return List.of(
+                new Case(0, new FlatMappedMessageStream<>(MessageStream.empty(), e -> MessageStream.just(e.message()))),
+                new Case(1, new FlatMappedMessageStream<>(MessageStream.just(msg(0)), e -> MessageStream.just(e.message()))),
+                new Case(3, new FlatMappedMessageStream<>(MessageStream.fromItems(msg(0), msg(1), msg(2)), e -> MessageStream.just(e.message()))),
+                new Case("filtered-all", 0, new FlatMappedMessageStream<>(MessageStream.fromItems(msg(0), msg(1)), e -> MessageStream.empty())),
+                new Case("1-to-3", 3, new FlatMappedMessageStream<>(MessageStream.just(msg(0)), e -> MessageStream.fromItems(msg(0), msg(1), msg(2)))),
+                new Case("async-inner", 1, new FlatMappedMessageStream<>(MessageStream.just(msg(0)), e -> new SingleValueMessageStream<>(delayedEntry(0))))
+            );
+        }
+
+        @Override
+        protected List<ErrorCase> errorCases() {
+            return List.of(
+                new ErrorCase(0, new FlatMappedMessageStream<>(MessageStream.failed(new RuntimeException("oops")), e -> MessageStream.just(e.message()))),
+                new ErrorCase(2, new FlatMappedMessageStream<>(MessageStream.fromItems(msg(0), msg(1)).concatWith(MessageStream.failed(new RuntimeException("oops"))), e -> MessageStream.just(e.message()))),
+                new ErrorCase("inner-error", 0, new FlatMappedMessageStream<>(MessageStream.just(msg(0)), e -> MessageStream.failed(new RuntimeException("inner-oops"))))
+            );
+        }
+    }
+
+    static class MapMultiTest extends MessageStreamTestSuite {
+        @Override
+        protected List<Case> cases() {
+            return List.of(
+                new Case(0, new MapMultiMessageStream<>(MessageStream.empty(), (e, c) -> c.accept(e))),
+                new Case(1, new MapMultiMessageStream<>(MessageStream.just(msg(0)), (e, c) -> c.accept(e))),
+                new Case(3, new MapMultiMessageStream<>(MessageStream.fromItems(msg(0), msg(1), msg(2)), (e, c) -> c.accept(e))),
+                new Case("filtered-all", 0, new MapMultiMessageStream<>(MessageStream.fromItems(msg(0), msg(1)), (e, c) -> {})),
+                new Case("async", 1, new MapMultiMessageStream<>(new SingleValueMessageStream<>(delayedEntry(0)), (e, c) -> c.accept(e)))
+            );
+        }
+
+        @Override
+        protected List<ErrorCase> errorCases() {
+            return List.of(
+                new ErrorCase(0, new MapMultiMessageStream<>(MessageStream.failed(new RuntimeException("oops")), (e, c) -> c.accept(e))),
+                new ErrorCase(2, new MapMultiMessageStream<>(MessageStream.fromItems(msg(0), msg(1)).concatWith(MessageStream.failed(new RuntimeException("oops"))), (e, c) -> c.accept(e)))
             );
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -145,11 +145,8 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         MessageStream<QueryResponseMessage> query = queryBus.query(testQuery, null);
         queryBus.completeSubscriptions(s -> true, null);
-        List<String> result = query.reduce(new ArrayList<String>(), (list, entry) -> {
-                                          list.add(entry.message().payloadAs(String.class));
-                                          return list;
-                                      })
-                                      .get();
+        List<String> result = query.collect(ArrayList<String>::new, (list, message) -> list.add(message.payloadAs(String.class)))
+                                   .get();
         assertEquals(asList("Response1", "Response2"), result);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -268,10 +268,7 @@ class SimpleQueryBusTest {
             // when...
             CompletableFuture<List<String>> result =
                     testSubject.query(testQuery, null)
-                               .reduce(new ArrayList<>(), (results, entry) -> {
-                                   results.add(entry.message().payloadAs(String.class));
-                                   return results;
-                               });
+                               .collect(ArrayList::new, (results, message) -> results.add(message.payloadAs(String.class)));
             // then...
             assertTrue(result.isDone());
             List<String> completedResult = result.get();

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponentTest.java
@@ -240,10 +240,7 @@ class AnnotatedQueryHandlingComponentTest {
         ProcessingContext testContext = StubProcessingContext.forMessage(testQuery);
         // when...
         List<Object> results = testSubject.handle(testQuery, testContext)
-                                          .reduce(new ArrayList<>(), (list, entry) -> {
-                                              list.add(entry.message().payload());
-                                              return list;
-                                          })
+                                          .collect(ArrayList::new, (list, message) -> list.add(message.payload()))
                                           .join();
         // then...
         assertThat(results.size()).isEqualTo(desiredResponsesCount);


### PR DESCRIPTION
The addition of these methods further complete the MessageStream API and can avoid some of awkward `conactWith` / `reduce` situations.

This PR also contains a 2nd commit that fixes a merge error; `FetchResult.Value` no longer needs to accept `null` values now that `IgnoreEntriesMessageStream` no longer produces `null` elements (it just skips them internally which was fixed in a previous PR)