### PR TITLE
Align `QualifiedName#(Class)` outcome with annotated approach for nested classes

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/ClassBasedMessageTypeResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/ClassBasedMessageTypeResolver.java
@@ -58,6 +58,6 @@ public class ClassBasedMessageTypeResolver implements MessageTypeResolver {
     @Override
     public Optional<MessageType> resolve(Class<?> payloadType) {
         Objects.requireNonNull(payloadType, "payloadType may not be null");
-        return Optional.of(new MessageType(payloadType.getName(), version));
+        return Optional.of(new MessageType(payloadType, version));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
@@ -16,9 +16,9 @@
 
 package org.axonframework.messaging.core;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.Assert;
 import org.axonframework.common.StringUtils;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 import static org.axonframework.common.ReflectionUtils.resolvePrimitiveWrapperTypeIfPrimitive;
@@ -90,20 +90,18 @@ public record QualifiedName(String name) {
      * {@link Class#getSimpleName() simple name} into the {@link #name()} of the {@code QualifiedName} under
      * construction.
      * <p>
-     * Note that for nested classes the simple name does <b>not</b> include the enclosing class(es). This aligns the
-     * resulting {@code QualifiedName} with annotation-based message naming defaults (e.g.
-     * {@code @Command}/{@code @Event}), which derive a message's name the same way. Classes without a simple name
-     * (e.g. anonymous classes) fall back to {@link Class#getName()}.
+     * Note that for nested classes the simple name does <b>not</b> include the enclosing class(es). Classes without a
+     * simple name (e.g. anonymous classes) fall back to {@link Class#getName()}.
      *
      * @param clazz The {@code Class} from which to derive the {@link #name()}.
      */
     public QualifiedName(Class<?> clazz) {
-        this(simpleQualifiedNameOf((Class<?>) resolvePrimitiveWrapperTypeIfPrimitive(requireNonNull(
+        this(deriveNameOf((Class<?>) resolvePrimitiveWrapperTypeIfPrimitive(requireNonNull(
                 clazz, "The given Class cannot be null."
         ))));
     }
 
-    private static String simpleQualifiedNameOf(Class<?> clazz) {
+    private static String deriveNameOf(Class<?> clazz) {
         String simpleName = clazz.getSimpleName();
         if (StringUtils.emptyOrNull(simpleName)) {
             // Anonymous and similar classes have no simple name; fall back to the binary name.

--- a/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
@@ -86,15 +86,30 @@ public record QualifiedName(String name) {
     }
 
     /**
-     * Constructor taking the {@link Class#getName()} as the {@link #name()} of the {@code QualifiedName} under
+     * Constructor combining the given {@code clazz}'s {@link Class#getPackageName() package name} and
+     * {@link Class#getSimpleName() simple name} into the {@link #name()} of the {@code QualifiedName} under
      * construction.
+     * <p>
+     * Note that for nested classes the simple name does <b>not</b> include the enclosing class(es). This aligns the
+     * resulting {@code QualifiedName} with annotation-based message naming defaults (e.g.
+     * {@code @Command}/{@code @Event}), which derive a message's name the same way. Classes without a simple name
+     * (e.g. anonymous classes) fall back to {@link Class#getName()}.
      *
-     * @param clazz The {@code Class} from which to use the {@link Class#getName()} as the {@link #name()}.
+     * @param clazz The {@code Class} from which to derive the {@link #name()}.
      */
     public QualifiedName(Class<?> clazz) {
-        this(((Class<?>) resolvePrimitiveWrapperTypeIfPrimitive(requireNonNull(
+        this(simpleQualifiedNameOf((Class<?>) resolvePrimitiveWrapperTypeIfPrimitive(requireNonNull(
                 clazz, "The given Class cannot be null."
-        ))).getName());
+        ))));
+    }
+
+    private static String simpleQualifiedNameOf(Class<?> clazz) {
+        String simpleName = clazz.getSimpleName();
+        if (StringUtils.emptyOrNull(simpleName)) {
+            // Anonymous and similar classes have no simple name; fall back to the binary name.
+            return clazz.getName();
+        }
+        return combineNames(clazz.getPackageName(), simpleName);
     }
 
     @Nullable

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
@@ -102,11 +102,13 @@ public class AnnotationMessageTypeResolver implements MessageTypeResolver {
         }
 
         Map<String, Object> namespaceAttributes = namespaceAttributesFor(payloadType);
+        // Single-source the class-derived naming defaults through QualifiedName(Class).
+        QualifiedName defaultName = new QualifiedName(payloadType);
         return Optional.of(new MessageType(
                 ObjectUtils.getNonEmptyOrDefault((String) namespaceAttributes.get(specification.namespaceAttribute()),
-                                                 payloadType.getPackageName()),
+                                                 defaultName.namespace()),
                 ObjectUtils.getNonEmptyOrDefault((String) nameAttributes.get(specification.nameAttribute()),
-                                                 payloadType.getSimpleName()),
+                                                 defaultName.localName()),
                 (String) versionAttributes.get(specification.versionAttribute())
         ));
     }

--- a/messaging/src/test/java/org/axonframework/messaging/core/AsyncMessageHandlerTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AsyncMessageHandlerTest.java
@@ -379,7 +379,7 @@ class AsyncMessageHandlerTest {
             @Test
             void returningCompletableFutureShouldUseItsResult() {
                 commandBus.subscribe(
-                        new QualifiedName(CheckIfPrime.class.getName()),
+                        new QualifiedName(CheckIfPrime.class),
                         (command, context) -> {
                             CommandResultMessage value = new GenericCommandResultMessage(
                                     null, isPrime(((CheckIfPrime) command.payload()).value())
@@ -395,7 +395,7 @@ class AsyncMessageHandlerTest {
             @Test
             void returningMonoShouldUseItsResult() {
                 commandBus.subscribe(
-                        new QualifiedName(CheckIfPrime.class.getName()),
+                        new QualifiedName(CheckIfPrime.class),
                         (command, context) -> {
                             CommandResultMessage data = new GenericCommandResultMessage(
                                     null, isPrime(((CheckIfPrime) command.payload()).value())
@@ -411,7 +411,7 @@ class AsyncMessageHandlerTest {
             @Test
             void returningBooleanShouldUseResult() {
                 commandBus.subscribe(
-                        new QualifiedName(CheckIfPrime.class.getName()),
+                        new QualifiedName(CheckIfPrime.class),
                         (command, context) -> MessageStream.just(new GenericCommandResultMessage(
                                 null, isPrime(((CheckIfPrime) command.payload()).value())
                         ))

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
@@ -156,4 +156,42 @@ class MessageTypeTest {
     void fromStringRejectsMissingVersion() {
         assertThrows(IllegalArgumentException.class, () -> MessageType.fromString(NAME));
     }
+
+    @Nested
+    class WithNestedClasses {
+
+        @Test
+        void classConstructorUsesPackageAndSimpleNameForNestedClasses() {
+            MessageType testSubject = new MessageType(NestedPayload.class);
+
+            assertEquals(NAMESPACE, testSubject.qualifiedName().namespace());
+            assertEquals("NestedPayload", testSubject.qualifiedName().localName());
+            assertEquals(NAMESPACE + ".NestedPayload", testSubject.name());
+        }
+
+        @Test
+        void classConstructorMatchesAnnotationBasedNamingForNestedClasses() {
+            // Annotation-based message type resolution (e.g. @Command/@Event defaults) derives a message's
+            // QualifiedName from getPackageName() + getSimpleName(), which excludes the enclosing class for
+            // nested classes. Constructing a MessageType from the same class must yield the same QualifiedName,
+            // otherwise the same nested payload class gets two different names within one application.
+            QualifiedName fromClassConstructor = new MessageType(NestedPayload.class).qualifiedName();
+            QualifiedName fromPackageAndSimpleName =
+                    new QualifiedName(NestedPayload.class.getPackageName(), NestedPayload.class.getSimpleName());
+
+            assertEquals(fromPackageAndSimpleName, fromClassConstructor);
+        }
+
+        @Test
+        void classConstructorMatchesAnnotationBasedNamingForTopLevelClasses() {
+            QualifiedName fromClassConstructor = new MessageType(MessageTypeTest.class).qualifiedName();
+            QualifiedName fromPackageAndSimpleName =
+                    new QualifiedName(MessageTypeTest.class.getPackageName(), MessageTypeTest.class.getSimpleName());
+
+            assertEquals(fromPackageAndSimpleName, fromClassConstructor);
+        }
+    }
+
+    private static class NestedPayload {
+    }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
@@ -184,9 +184,9 @@ class MessageTypeTest {
 
         @Test
         void classConstructorMatchesAnnotationBasedNamingForTopLevelClasses() {
-            QualifiedName fromClassConstructor = new MessageType(MessageTypeTest.class).qualifiedName();
+            QualifiedName fromClassConstructor = new MessageType(String.class).qualifiedName();
             QualifiedName fromPackageAndSimpleName =
-                    new QualifiedName(MessageTypeTest.class.getPackageName(), MessageTypeTest.class.getSimpleName());
+                    new QualifiedName(String.class.getPackageName(), String.class.getSimpleName());
 
             assertEquals(fromPackageAndSimpleName, fromClassConstructor);
         }

--- a/messaging/src/test/java/org/axonframework/messaging/core/QualifiedNameTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/QualifiedNameTest.java
@@ -101,4 +101,11 @@ class QualifiedNameTest {
 
         assertEquals(FULL_NAME, testSubject.toString());
     }
+
+    @Test
+    void anonymousClassReturnsGetNameAsName() {
+        Class<?> testClass = new Object() {}.getClass();
+
+        assertEquals(testClass.getName(), new QualifiedName(testClass).name());
+    }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolverTest.java
@@ -19,6 +19,7 @@ package org.axonframework.messaging.core.annotation;
 import org.axonframework.messaging.commandhandling.annotation.Command;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver.AnnotationSpecification;
 import org.axonframework.messaging.eventhandling.annotation.Event;
 import org.axonframework.messaging.queryhandling.annotation.Query;
@@ -77,8 +78,43 @@ class AnnotationMessageTypeResolverTest {
 
         }
 
+        @Test
+        void classAnnotatedWithCommandWithoutNameAndNamespaceDefaultsToQualifiedNameOfClass() {
+            // The class-derived defaults must equal QualifiedName(Class) - also for nested classes - so that
+            // annotation-based and Class-based naming always align.
+            MessageType expectedType =
+                    new MessageType(new QualifiedName(DefaultNamedCommand.class), MessageType.DEFAULT_VERSION);
+
+            Optional<MessageType> result = testSubject.resolve(DefaultNamedCommand.class);
+
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(expectedType);
+        }
+
+        @Test
+        void classAnnotatedWithCommandWithNamespaceOnlyDefaultsNameToLocalNameOfClass() {
+            MessageType expectedType = new MessageType("context",
+                                                       new QualifiedName(NamespacedDefaultNamedCommand.class).localName(),
+                                                       MessageType.DEFAULT_VERSION);
+
+            Optional<MessageType> result = testSubject.resolve(NamespacedDefaultNamedCommand.class);
+
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(expectedType);
+        }
+
         @Command(name = "test-command-domain-name", version = "1.33.7", namespace = "context")
         private record TestCommandWithNamespace(String id) {
+
+        }
+
+        @Command
+        private record DefaultNamedCommand(String id) {
+
+        }
+
+        @Command(namespace = "context")
+        private record NamespacedDefaultNamedCommand(String id) {
 
         }
     }

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/modelling/command/AggregateAnnotationCommandHandler.java
@@ -212,7 +212,7 @@ public class AggregateAnnotationCommandHandler<T> implements CommandHandlingComp
                 };
             }
             String commandName = StringUtils.emptyOrNull(cmh.commandName())
-                    ? cmh.payloadType().getName() : cmh.commandName();
+                    ? new QualifiedName(cmh.payloadType()).name() : cmh.commandName();
             handlersFound.add(messageHandler);
             supportedCommandsByName.computeIfAbsent(commandName, key -> new HashSet<>()).add(messageHandler);
             supportedCommands.add(new QualifiedName(commandName));

--- a/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
+++ b/stash/legacy-aggregate/src/main/java/org/axonframework/test/aggregate/AggregateTestFixture.java
@@ -236,7 +236,7 @@ public class AggregateTestFixture<T> implements FixtureConfiguration<T>, TestExe
     @Override
     public FixtureConfiguration<T> registerCommandHandler(Class<?> payloadType,
                                                           LegacyMessageHandler<CommandMessage, CommandResultMessage> commandHandler) {
-        return registerCommandHandler(payloadType.getName(), commandHandler);
+        return registerCommandHandler(new QualifiedName(payloadType).name(), commandHandler);
     }
 
     @Override


### PR DESCRIPTION
## Problem

The framework derives a message's qualified name from a `Class` through **three paths — and they disagreed for nested classes**:

| Path | Derivation | `pkg.Outer.Inner` became |
|---|---|---|
| `new QualifiedName(Class)` / `new MessageType(Class)` | `Class.getName()` | `pkg.Outer$Inner` |
| `@Command` / `@Event` annotation defaults (`AnnotationMessageTypeResolver`) | `getPackageName()` + `getSimpleName()` | `pkg.Inner` |
| `ClassBasedMessageTypeResolver` | `Class.getName()` — **contradicting its own javadoc**, which documents `getPackageName()` + `getSimpleName()` | `pkg.Outer$Inner` |

For top-level classes all three coincide, so the inconsistency stays invisible — until a payload class is nested.

Worth highlighting: **`ClassBasedMessageTypeResolver`'s own usage was different from the constructor sitting right next to it.** It did not call `new MessageType(payloadType, version)` — it spelled the name itself through the `String`-based constructor:

```java
return Optional.of(new MessageType(payloadType.getName(), version));   // binary name, with '$'
```

which is exactly how its implementation drifted from its javadoc: the documented policy (`getPackageName()` + `getSimpleName()`) lived in the `Class`-based constructor's *intent*, while the resolver bypassed it with a hand-spelled `getName()` string.

## How it manifested

Any `QualifiedName`-keyed comparison built with `new MessageType(MyNested.class).qualifiedName()` could **never match** a message dispatched through annotation-based naming. There is no error — the comparison is just silently false.

Concrete case that surfaced this: a `MessageHandlerInterceptor` matching commands by qualified name,

```java
public QualifiedName supportedCommand() {
    return new MessageType(MyCommand.class).qualifiedName();   // pkg.Outer$MyCommand
}
```

against a dispatched `@Command`-annotated nested record (`pkg.MyCommand`). The interceptor silently no-opped: commands that should have been rejected succeeded. The identical resolver pattern worked for a *top-level* command class purely by luck of class placement — which is exactly what makes this such a sharp edge.

This is particularly easy to hit from **Kotlin**, where nesting commands/events in sealed hierarchies is idiomatic (`sealed interface DwellingCommand { data class Build(..) : DwellingCommand }` — every member is a nested class).

Even this repository's own test suite contained the footgun: `AsyncMessageHandlerTest`'s declarative registrations subscribed handlers via `new QualifiedName(CheckIfPrime.class.getName())` while dispatching through a resolver.

## Workaround needed before this fix

Application code had to avoid the `Class`-based constructors for nested classes and hand-build the annotation-compatible spelling:

```java
// instead of: new MessageType(MyCommand.class).qualifiedName()
new QualifiedName(MyCommand.class.getPackageName(), MyCommand.class.getSimpleName());
```

— provided the developer realised the mismatch existed at all, since nothing fails loudly.

The workaround was in fact **already visible in this repository's own tests**, where authors sidestepped the `Class`-based constructor rather than relying on it:

- `DefaultCommandGatewayTest` defines an ad-hoc resolver instead of the `Class`-derived name:
  ```java
  payloadType -> Optional.of(new MessageType(payloadType.getSimpleName()));
  ```
- `AsyncMessageHandlerTest`'s declarative registrations subscribed with the raw binary-name string to match the dispatch spelling of the day:
  ```java
  commandBus.subscribe(new QualifiedName(CheckIfPrime.class.getName()), ...);
  ```

Both are symptoms of the same root cause: the `Class`-based constructor couldn't be trusted to produce the name a message would actually carry.

## Fix

Single-source the naming policy and make every `Class`-derived path agree with the annotation defaults:

- **`QualifiedName(Class)`** now combines `getPackageName()` and `getSimpleName()` (delegating to the existing `combineNames`), aligning with the `@Command`/`@Event` defaults. Primitive-wrapper resolution is preserved. Classes without a simple name (e.g. anonymous classes) fall back to `Class.getName()`. Javadoc updated.
- **`ClassBasedMessageTypeResolver`** now routes through the `Class`-based `MessageType` constructor — a one-line change that makes the implementation finally match its documented behavior.
- **`AsyncMessageHandlerTest`** declarative registrations updated to the `Class`-based constructor.
- **`AnnotationMessageTypeResolver`** (second commit) no longer spells its class-derived defaults (`getPackageName()`/`getSimpleName()`) itself — it derives them from `QualifiedName(Class)`, so the naming policy now lives in **exactly one place**. Partial annotation overrides (`namespace` without `name`, and vice versa) overlay the same class-derived name as every other path. Behavior is unchanged for regular classes (pinned by new default-name tests); the exotic edge of an annotated type without a simple name now falls back to the binary-name-derived local name instead of failing on an empty local name.

After the change, `new MessageType(Class)`, `ClassBasedMessageTypeResolver`, and the annotation defaults produce the **same** name for the same class — nested or not — and all of them derive it from the single policy in `QualifiedName(Class)`. The `String`-based constructors remain verbatim by design.

## Tests

Written TDD — they fail on the previous implementation with:

```
expected: <org.axonframework.messaging.core.NestedPayload>
 but was: <org.axonframework.messaging.core.MessageTypeTest$NestedPayload>
```

See `MessageTypeTest.WithNestedClasses`:
- `classConstructorUsesPackageAndSimpleNameForNestedClasses` — pins the concrete namespace/localName/name for a nested payload.
- `classConstructorMatchesAnnotationBasedNamingForNestedClasses` — pins the contract: `MessageType(Class)` equals the annotation-default spelling.
- `classConstructorMatchesAnnotationBasedNamingForTopLevelClasses` — documents that top-level behavior is unchanged.

And `AnnotationMessageTypeResolverTest.CommandMessageResolution`:
- `classAnnotatedWithCommandWithoutNameAndNamespaceDefaultsToQualifiedNameOfClass` — pins that the annotation defaults equal `QualifiedName(Class)`.
- `classAnnotatedWithCommandWithNamespaceOnlyDefaultsNameToLocalNameOfClass` — pins the partial-override case (namespace overridden, name defaulted).

## Verification

- messaging: 3530 tests ✅ (2 unrelated `PooledStreamingEventProcessorTest` timing flakes pass in isolation)
- eventsourcing: 489 ✅, modelling: 370 ✅, conversion: 174 ✅
- The only fallout in ~4,500 tests was the `AsyncMessageHandlerTest` registration mentioned above — itself a demonstration of the footgun.

## Notes for review

- **Behavioral change / stored data**: nested, un-annotated payload classes resolved through `ClassBasedMessageTypeResolver` change their name from `pkg.Outer$Inner` to `pkg.Inner`. Events already persisted under the old spelling will no longer match handlers/criteria without a mapping — needs a release note and/or migration guidance. The alternative direction (making the annotation defaults include the enclosing class) was considered, but would change the documented, intentional `@Command`/`@Event` behavior instead.
- **Collisions**: two nested classes with the same simple name in the same package now map to the same name — the same trade-off the annotation defaults already made; explicit `@Command`/`@Event` `name`/`namespace` attributes remain the escape hatch.
- **Kotlin**: `KClass.qualifiedName` renders nested classes with dots (`pkg.Outer.Inner`) and matches neither spelling — Kotlin users should pass `::class.java`. A small Kotlin-extension helper (`KClass.toQualifiedName()`) could be a follow-up.
- ~~Follow-up candidate: single-source `AnnotationMessageTypeResolver`'s defaults~~ — **done in this PR** (second commit); the consolidation is complete.
