### PR TITLE
fix(migration): honor skipTests property

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -32,6 +32,15 @@
     </description>
 
     <properties>
+        <!-- The AF4 recipe tests are skipped when either the standard `skipTests`
+             flag or the dedicated `skipAf4RecipeTests` flag is true. Defaulting
+             `skipAf4RecipeTests` to `${skipTests}` lets a plain `-DskipTests`
+             (or the IDE "Skip Tests" toggle) skip them like any other module,
+             while `-DskipAf4RecipeTests=true` remains available to skip *only*
+             these tests (and the AF4 stub download), e.g. during release,
+             without skipping the rest of the build. If `skipTests` is unset the
+             expression stays unresolved and parses as `false`, so tests run. -->
+        <skipAf4RecipeTests>${skipTests}</skipAf4RecipeTests>
         <rewrite-recipe-bom.version>3.30.1</rewrite-recipe-bom.version>
         <!-- Axon Framework 4.x version used to resolve types in recipe tests
              (the rename recipes match AF4 fully-qualified names, so the test


### PR DESCRIPTION
## Problem

The `migration` module binds surefire's `skipTests` to the dedicated `skipAf4RecipeTests` flag:

```xml
<skipTests>${skipAf4RecipeTests}</skipTests>
```

Because `skipAf4RecipeTests` had no default, a plain `-DskipTests` (or the IntelliJ "Skip Tests" toggle, which passes `-DskipTests`) had **no effect** on this module -- the AF4 recipe tests kept running while every other module's tests were skipped.

## Change

Default `skipAf4RecipeTests` to `${skipTests}` so the standard flag also skips these tests, while keeping `-DskipAf4RecipeTests=true` as a dedicated switch to skip *only* these tests (and the AF4 stub download).

## Behavior

| Invocation | migration recipe tests | other modules |
|---|---|---|
| normal build | run | run |
| `-DskipTests=true` / IDE "Skip Tests" | **skipped** | skipped |
| `-DskipAf4RecipeTests=true` | **skipped** | run |
| release (`-DskipAf4RecipeTests=true`) | **skipped** | run |

The release path is unchanged: it passes `-DskipAf4RecipeTests=true` explicitly (which overrides the new default), so it still skips only the migration tests, not the whole build.

When `skipTests` is unset, `${skipTests}` stays an unresolved literal and parses as `false`, so the default of running tests is preserved.