### PR TITLE
[#137] Message Transformation - Rename support (phase 4)

### DIFF
--- a/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
@@ -131,8 +131,8 @@ Swap the two registrations and the broad predicate would win for `0.9.0` instead
 [NOTE]
 .What the chain validates, and when
 ====
-A transformation that changes an event's qualified name (a rename) is rejected when the chain is built.
-With a predicate `from`, that rejection happens when a matching event is read instead.
+A `transform(...)` whose `to` changes the qualified name is rejected: at build time for a concrete `from`, or when a matching event is read for a predicate `from`.
+To change the name on purpose, use xref:defining-transformations.adoc#_renaming_an_event[`rename(...)`] instead.
 A typed mapper whose output identity differs from its declared `to`, and a cycle that exceeds the safety bound, are likewise reported as a `ChainConfigurationException`, but only when the offending event is read.
 Overlapping matches are not an error: they resolve by last-match-wins, as above.
 ====

--- a/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
@@ -48,10 +48,22 @@ public final class CoursePublishedV1ToV2 {
 <1> `from(...)` matches the stored event identity by its `MessageType`, a qualified name plus a version. Only events with this exact identity are passed to the mapper.
 <2> `to(...)` declares the identity of the event the mapper produces. It must keep the same qualified name as `from`, and only the version may change.
 <3> `transform(...)` converts the stored payload to the requested type before calling your mapper, which returns the new payload.
-<4> The mapper takes just the converted payload and returns the new one. Most mappers need nothing else; if yours does, see <<_reading_from_the_processing_context>>.
+<4> The mapper takes just the converted payload and returns the new one. Most mappers need nothing else. If yours does, see <<_reading_from_the_processing_context>>.
 
 [NOTE]
 The `JsonNode` used here is the Jackson 3 type (`tools.jackson.databind.JsonNode`), the same representation Axon Framework's default converter works with.
+
+[IMPORTANT]
+.`transform(...)` changes the version, not the name
+====
+A `transform(...)` may change an event's _version_ and _payload_, but not its qualified name: the `to` identity must share the qualified name of `from`.
+To change the name itself, with the payload carried over unchanged, use a <<_renaming_an_event,rename>> instead.
+
+If a `transform(...)`'s `from` and `to` qualified names differ, the chain raises a `ChainConfigurationException`:
+
+* with a concrete `from`, the mismatch is detected when the chain is built, so the failure surfaces at startup.
+* with a <<_matching_multiple_event_versions,predicate `from`>>, a match can only be resolved per event, so the failure surfaces when such an event is read.
+====
 
 == Working with generic payloads
 
@@ -174,8 +186,8 @@ public static EventTransformation build() {
                               .transform(JsonNode.class, WelcomeMessageBetaCleanup::map);
 }
 ----
-<1> The predicate matches on version alone; the pre-filter takes care of the name.
-<2> `to` keeps the same qualified name, only bumping the version, since renaming an event is not supported.
+<1> The predicate matches on version alone. The pre-filter takes care of the name.
+<2> `to` keeps the same qualified name and bumps only the version. A `transform(...)` does not change the name (use a <<_renaming_an_event,rename>> for that).
 <3> Pass the predicate to the `from(...)` overload instead of a concrete `MessageType`.
 <4> `declaringFromTypes(...)` declares the names the predicate runs against. The predicate is only ever evaluated for events of these names, so a type-filtering read for `WelcomeMessageSent` stays scoped to that name rather than scanning every stored event.
 
@@ -204,7 +216,46 @@ Both forms produce the same result, but it is typically preferred to use `declar
 The predicate stays simpler (version only) and more importantly, the Framework can optimize reads from the event store as it knows the types that are expected..
 Because the chain cannot look inside a predicate, the form without `declaringFromTypes(...)` drops the type filter on reads, a broader read that returns every stored event so the predicate can run against each.
 
-Keep the matched names aligned with the `to` identity's name either way, since renaming an event is not supported.
+Keep the matched names aligned with the `to` identity's name either way: a `transform(...)` changes the version, not the name (use a <<_renaming_an_event,rename>> to change the name).
+
+[#_renaming_an_event]
+== Renaming an event
+
+The transformations above change an event's payload and version while keeping its qualified name.
+When the _name itself_ must change and the payload stays the same, use `rename(...)` instead of `transform(...)`.
+
+An early version of the catalog published courses with a `CourseOffered` event. A later refinement renamed it to `CoursePublished`.
+A single `rename(...)` reads every stored `CourseOffered` back as a `CoursePublished`, with its payload untouched:
+
+[source,java]
+----
+private static final MessageType FROM = new MessageType("coursecatalog.CourseOffered", "1.0.0");
+private static final MessageType TO   = new MessageType("coursecatalog.CoursePublished", "1.0.0");
+
+public static EventTransformation build() {
+    return EventTransformation.rename(FROM, TO); // <1>
+}
+----
+<1> `rename(from, to)` takes the two identities and nothing else: there is no mapper, because the payload is carried over unchanged.
+
+A rename may change the qualified name, the version, or both.
+Handlers registered for the new identity receive the event. Handlers still on the old identity no longer match it.
+A `rename(...)` whose `from` and `to` are identical is rejected, since it would leave the event unchanged.
+
+[NOTE]
+.Renames compose with payload transformations
+====
+A renamed event keeps flowing through the chain.
+Renaming `CourseOffered` to `CoursePublished` `1.0.0` lets the existing `CoursePublished` `1.0.0` -> `2.0.0` -> `3.0.0` transformers apply in turn, so a stored `CourseOffered` reaches your handler as the current `CoursePublished`.
+Register the rename alongside those `transform(...)` steps and the chain applies them in sequence.
+====
+
+[NOTE]
+.Reads are widened to the old name
+====
+A type-filtering read for the new name still finds events stored under the old one: the chain widens the read to include every name that renames into a queried type, following the full rename chain.
+So a projection that sources only `CoursePublished` events also receives the historic `CourseOffered` ones, and nothing is silently missed.
+====
 
 == Next steps
 

--- a/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
@@ -213,7 +213,7 @@ public static EventTransformation build() {
 <1> Without a pre-filter, the name guard must live inside the predicate.
 
 Both forms produce the same result, but it is typically preferred to use `declaringFromTypes(...)`.
-The predicate stays simpler (version only) and more importantly, the Framework can optimize reads from the event store as it knows the types that are expected..
+The predicate stays simpler (version only) and more importantly, the Framework can optimize reads from the event store as it knows the types that are expected.
 Because the chain cannot look inside a predicate, the form without `declaringFromTypes(...)` drops the type filter on reads, a broader read that returns every stored event so the predicate can run against each.
 
 Keep the matched names aligned with the `to` identity's name either way: a `transform(...)` changes the version, not the name (use a <<_renaming_an_event,rename>> to change the name).
@@ -251,10 +251,10 @@ Register the rename alongside those `transform(...)` steps and the chain applies
 ====
 
 [NOTE]
-.Reads are widened to the old name
+.Custom criteria still find renamed events
 ====
-A type-filtering read for the new name still finds events stored under the old one: the chain widens the read to include every name that renames into a queried type, following the full rename chain.
-So a projection that sources only `CoursePublished` events also receives the historic `CourseOffered` ones, and nothing is silently missed.
+If you write a custom xref:events:event-store-internals.adoc#event_criteria[`EventCriteria`] (through an `@EventCriteriaBuilder` method or a `CriteriaResolver`) that filters by type, list only the current name.
+A filter on `CoursePublished` also matches events stored as `CourseOffered`: Axon adds the old names for you, so renamed events are never missed.
 ====
 
 == Next steps

--- a/docs/reference-guide/modules/message-transformation/pages/demo.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/demo.adoc
@@ -10,11 +10,15 @@ Its link:https://github.com/AxonFramework/AxonFramework/blob/main/examples/unive
 
 == What it demonstrates
 
-The demo composes five transformations into one chain, each illustrating a technique covered here:
+The demo composes a chain of transformations, each illustrating a technique covered here:
 
 [cols="2,3,2", options="header"]
 |===
 | Transformation | Change | Technique
+
+| `CourseOfferedToCoursePublished`
+| the legacy `CourseOffered` event is renamed to `CoursePublished`
+| a xref:defining-transformations.adoc#_renaming_an_event[rename] whose output then flows through the `CoursePublished` version chain
 
 | `CoursePublishedV1ToV2`
 | a single `capacity` field becomes `minCapacity` and `maxCapacity`
@@ -22,11 +26,15 @@ The demo composes five transformations into one chain, each illustrating a techn
 
 | `CoursePublishedV2ToV3`
 | `minCapacity`/`maxCapacity` are wrapped into a `range`, producing the current `CoursePublished` event
-| a xref:defining-transformations.adoc#_mapping_to_a_typed_event[typed mapper] to the current event; with the previous transformation it shows xref:configuring-transformations.adoc#_why_ordering_matters[chaining in version order]
+| a xref:defining-transformations.adoc#_mapping_to_a_typed_event[typed mapper] to the current event that, with the previous transformation, shows xref:configuring-transformations.adoc#_why_ordering_matters[chaining in version order]
 
 | `StudentRegisteredV1ToV2`
 | separate `firstName` and `lastName` become a single `fullName`
 | the xref:defining-transformations.adoc[`TypeReference` overload], with no Jackson dependency in user code
+
+| `StudentRegisteredV2ToV3`
+| a `region` field, absent when the events were written, is backfilled
+| a mapper that xref:defining-transformations.adoc#_reading_from_the_processing_context[reads from the `ProcessingContext`]
 
 | `SystemAnnouncementLegacyUplift`
 | an unversioned legacy event is lifted onto `1.0.0`
@@ -37,6 +45,6 @@ The demo composes five transformations into one chain, each illustrating a techn
 | xref:defining-transformations.adoc#_matching_multiple_event_versions[a version-only predicate scoped with `declaringFromTypes`]
 |===
 
-A sixth class, `WelcomeMessageBetaCleanupWithoutPreFilter`, expresses that last rule without `declaringFromTypes(...)` to contrast the xref:defining-transformations.adoc#_matching_multiple_event_versions[two predicate-`from` styles]; it is not registered in the chain.
+A further class, `WelcomeMessageBetaCleanupWithoutPreFilter`, expresses that last rule without `declaringFromTypes(...)` to contrast the xref:defining-transformations.adoc#_matching_multiple_event_versions[two predicate-`from` styles]. It is not registered in the chain.
 
 The chain is assembled in `CourseCatalogTransformations` and registered as an `EventTransformerChain` component, exactly as shown in xref:configuring-transformations.adoc[Configuring transformations].

--- a/docs/reference-guide/modules/message-transformation/pages/index.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/index.adoc
@@ -5,7 +5,7 @@ When an event's stored structure no longer matches what your handlers and projec
 The stored events stay exactly as they were written.
 The transformation runs every time those events are read, handing each handler the shape it expects.
 
-A transformation is the tool for the structural changes that xref:events:event-versioning.adoc[payload conversion] cannot express on its own: combining two fields into one, wrapping values in a new object, or lifting a historic event onto a new version.
+A transformation is the tool for the structural changes that xref:events:event-versioning.adoc[payload conversion] cannot express on its own: combining two fields into one, wrapping values in a new object, lifting a historic event onto a new version, or renaming an event whose identity changed.
 
 == When to reach for a transformation
 
@@ -52,7 +52,7 @@ The structural form needs no extra classes, the typed form gives compile-time sa
 
 From here:
 
-* xref:message-transformation:defining-transformations.adoc[] shows how to write the individual transformations, map straight to a typed event, work with generic payloads, and match several event versions at once.
+* xref:message-transformation:defining-transformations.adoc[] shows how to write the individual transformations, map straight to a typed event, work with generic payloads, match several event versions at once, and rename an event.
 * xref:message-transformation:configuring-transformations.adoc[] shows how to assemble them into a chain, register it, and test it.
 * xref:message-transformation:demo.adoc[] is a runnable example that exercises every technique on a course catalog end to end.
 

--- a/docs/reference-guide/modules/migration/pages/paths/upcasters.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/upcasters.adoc
@@ -6,7 +6,7 @@ The most common form was the `SingleEventUpcaster`: a one-to-one transform from 
 Axon Framework 5 replaces the single-event upcaster with an xref:message-transformation:index.adoc[event transformation]: the same idea, rewriting a stored event on the way out, expressed through a small declarative API.
 
 This path covers migrating one-to-one `SingleEventUpcaster` implementations to event transformations.
-Like the single-event upcaster, a transformation is strictly one-to-one and keeps the event's qualified name: it may change the version and payload, but not the name, so renaming an event is not supported.
+Like the single-event upcaster, a payload-mapping transformation is one-to-one and keeps the event's qualified name: it may change the version and payload, but not the name. To change the name itself, use a <<_renaming_an_event,rename>>, which carries the payload over unchanged.
 You map a _deserialized_ payload (`JsonNode`, `Map<String, Object>`, ...) rather than an `IntermediateEventRepresentation`, and mappers must be deterministic and side-effect-free, exactly as upcasters were expected to be.
 
 [NOTE]
@@ -120,6 +120,32 @@ The identity also differs: Axon Framework 4 keyed off the payload's class name, 
 Events stored without a version are treated as version `0.0.1` in Axon Framework 5.
 Match that version in `from(...)` when lifting legacy events, as shown above.
 ====
+
+[#_renaming_an_event]
+== Renaming an event
+
+Axon Framework 4 keyed an event off its payload _class name_ (the `SerializedType` name defaulted to the fully qualified class name), so a name change had to be bridged at the serialization layer or by an upcaster that rewrote the stored `SerializedType`.
+Axon Framework 5 keys off a logical `MessageType` decoupled from the class, so a rename becomes a first-class operation: declare the old and new identity and the payload is carried over unchanged.
+
+A payload-mapping `transform(...)` may only change the version, never the name.
+A rename uses the dedicated `rename(...)` factory instead, with no mapper:
+
+[source,java]
+----
+public final class CourseOfferedToCoursePublished {
+
+    private static final MessageType FROM = new MessageType("coursecatalog.CourseOffered", "1.0.0");
+    private static final MessageType TO   = new MessageType("coursecatalog.CoursePublished", "1.0.0");
+
+    public static EventTransformation build() {
+        return EventTransformation.rename(FROM, TO); // <1>
+    }
+}
+----
+<1> `rename(from, to)` takes the two identities and nothing else: there is no mapper, because the payload is unchanged. The new identity may change the qualified name, the version, or both.
+
+A renamed event keeps flowing through the chain, so a rename can sit in front of the version-step transformations that lift it the rest of the way.
+See xref:message-transformation:defining-transformations.adoc#_renaming_an_event[Renaming an event] for the full detail.
 
 == Registering the transformations
 

--- a/docs/reference-guide/modules/migration/pages/paths/upcasters.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/upcasters.adoc
@@ -127,11 +127,13 @@ Match that version in `from(...)` when lifting legacy events, as shown above.
 Axon Framework 4 keyed an event off its payload _class name_ (the `SerializedType` name defaulted to the fully qualified class name), so a name change had to be bridged at the serialization layer or by an upcaster that rewrote the stored `SerializedType`.
 Axon Framework 5 keys off a logical `MessageType` decoupled from the class, so a rename becomes a first-class operation: declare the old and new identity and the payload is carried over unchanged.
 
-A payload-mapping `transform(...)` may only change the version, never the name.
-A rename uses the dedicated `rename(...)` factory instead, with no mapper:
+A payload-mapping `transform(...)` may only change the version, never the name. For renames, use the dedicated `rename(...)` factory instead, which does not require a mapper:
 
 [source,java]
 ----
+import io.axoniq.framework.messaging.transformation.events.EventTransformation;
+import org.axonframework.messaging.core.MessageType;
+
 public final class CourseOfferedToCoursePublished {
 
     private static final MessageType FROM = new MessageType("coursecatalog.CourseOffered", "1.0.0");
@@ -142,7 +144,7 @@ public final class CourseOfferedToCoursePublished {
     }
 }
 ----
-<1> `rename(from, to)` takes the two identities and nothing else: there is no mapper, because the payload is unchanged. The new identity may change the qualified name, the version, or both.
+<1> `rename(from, to)` takes the two identities and nothing else: there is no mapper, because the payload is carried over unchanged. The new identity may change the qualified name, the version, or both.
 
 A renamed event keeps flowing through the chain, so a rename can sit in front of the version-step transformations that lift it the rest of the way.
 See xref:message-transformation:defining-transformations.adoc#_renaming_an_event[Renaming an event] for the full detail.

--- a/examples/university-message-transformation/README.md
+++ b/examples/university-message-transformation/README.md
@@ -12,6 +12,7 @@ through schema evolution, and exercises them end to end.
 
 | Transformation | From / To | What it teaches |
 |---|---|---|
+| `CourseOfferedToCoursePublished` | `CourseOffered#1.0.0` / `CoursePublished#1.0.0` | A rename (`EventTransformation.rename`): only the identity changes, the payload is carried over. The renamed event then flows through the `CoursePublished` version chain. |
 | `CoursePublishedV1ToV2` | `CoursePublished#1.0.0` / `#2.0.0` | A single `capacity` field becomes `minCapacity` + `maxCapacity`. |
 | `CoursePublishedV2ToV3` | `CoursePublished#2.0.0` / `#3.0.0` | Two-hop chain: a stored v1 event reaches handlers as v3. |
 | `StudentRegisteredV1ToV2` | `StudentRegistered#1.0.0` / `#2.0.0` | `TypeReference<Map<String,Object>>` overload, no Jackson dependency in user code. |
@@ -172,7 +173,7 @@ Tests live next to the production code they cover, in the matching package:
 | Where | What you'll find |
 |---|---|
 | `catalog/transformations/` | each transformation in isolation, with fixture JSON under `src/test/resources/transformations/` |
-| `catalog/chain/` | the composed chain (build log, locking, identity check, concurrency, decoration order) |
+| `catalog/chain/` | the composed chain (build log, locking, identity check, concurrency, decoration order, rename behavior) |
 | `catalog/write/<slice>/` | one write slice per package, full app fixture |
 | `catalog/read/catalogview/` | the catalog projection and query |
 | `catalog/automation/overbookingnotifier/` | the overbooking notifier |

--- a/examples/university-message-transformation/pom.xml
+++ b/examples/university-message-transformation/pom.xml
@@ -38,11 +38,12 @@
     <properties>
         <!-- AxonIQ Framework -->
         <!--
-        The axoniq-framework-bom imported by examples/pom.xml is at 5.1.1-SNAPSHOT and
-        does not yet manage axoniq-message-transformation (introduced in 5.2.0-SNAPSHOT).
-        Until the BOM catches up, declare the version explicitly here.
+        The event transformation feature lives in the 5.2.0-SNAPSHOT line, which is ahead of the
+        released Axon core the examples parent manages. The axoniq-framework BOM imported below
+        aligns every Axon module (org.axonframework core and io.axoniq.framework) on this version,
+        so the whole demo builds against one consistent line until 5.2.0 is the examples baseline.
         -->
-        <axoniq-message-transformation.version>5.2.0-SNAPSHOT</axoniq-message-transformation.version>
+        <axoniq-framework.version>5.2.0-SNAPSHOT</axoniq-framework.version>
         <axoniq-platform-framework-client.version>5.1.0</axoniq-platform-framework-client.version>
 
         <!-- Runtime libraries -->
@@ -57,6 +58,23 @@
         <!-- Build plugins -->
         <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            Align every Axon module on ${axoniq-framework.version}, overriding the older line
+            managed by the examples parent. Required because the event transformation feature uses
+            APIs only present in the 5.2.0-SNAPSHOT line.
+            -->
+            <dependency>
+                <groupId>io.axoniq.framework</groupId>
+                <artifactId>axoniq-framework-bom</artifactId>
+                <version>${axoniq-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Axon Framework Dependencies -->
@@ -79,11 +97,10 @@
             <artifactId>axon-server-connector</artifactId>
         </dependency>
 
-        <!-- The feature under demonstration -->
+        <!-- The feature under demonstration (version managed by the axoniq-framework BOM above) -->
         <dependency>
             <groupId>io.axoniq.framework</groupId>
             <artifactId>axoniq-message-transformation</artifactId>
-            <version>${axoniq-message-transformation.version}</version>
         </dependency>
 
         <!--

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/CourseCatalogMessageNames.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/CourseCatalogMessageNames.java
@@ -29,6 +29,8 @@ public final class CourseCatalogMessageNames {
 
     /** Qualified name of {@code CoursePublished}. */
     public static final String COURSE_PUBLISHED          = NAMESPACE + ".CoursePublished";
+    /** Qualified name of the legacy {@code CourseOffered} event, renamed to {@code CoursePublished}. */
+    public static final String COURSE_OFFERED            = NAMESPACE + ".CourseOffered";
     /** Qualified name of {@code CourseCapacityChanged}. */
     public static final String COURSE_CAPACITY_CHANGED   = NAMESPACE + ".CourseCapacityChanged";
     /** Qualified name of {@code StudentRegistered}. */

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/LegacyEventSeeder.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/LegacyEventSeeder.java
@@ -58,6 +58,9 @@ public class LegacyEventSeeder {
         }
         CatalogId catalogId = command.catalogId();
         appender.append(
+                new CourseOfferedV1(catalogId, CourseId.of("legacy-foundations"),
+                                    "Legacy Foundations", 40),
+
                 new CoursePublishedV1(catalogId, CourseId.of("event-sourcing-101"),
                                       "Event Sourcing in Practice", 30),
                 new CoursePublishedV1(catalogId, CourseId.of("ddd-fundamentals"),
@@ -119,6 +122,21 @@ public class LegacyEventSeeder {
     // that pretends to have been written years ago. Kept private to this seeder
     // so users browsing the codebase cannot mistake them for the current shape.
     // ------------------------------------------------------------------------
+
+    /**
+     * The catalog's earliest course event, written under the name {@code CourseOffered} before the
+     * domain renamed it to {@code CoursePublished}. Same payload shape as {@link CoursePublishedV1};
+     * a {@code rename(...)} reads it back as {@code CoursePublished} {@code 1.0.0}, which the version
+     * chain then lifts to the current shape.
+     */
+    @Event(namespace = CourseCatalogMessageNames.NAMESPACE, name = "CourseOffered", version = "1.0.0")
+    record CourseOfferedV1(
+            @EventTag(key = CourseCatalogTags.CATALOG_ID) CatalogId catalogId,
+            @EventTag(key = CourseCatalogTags.COURSE_ID) CourseId courseId,
+            String name,
+            int capacity
+    ) {
+    }
 
     @Event(namespace = CourseCatalogMessageNames.NAMESPACE, name = "CoursePublished", version = "1.0.0")
     record CoursePublishedV1(

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
@@ -21,7 +21,9 @@ import io.axoniq.framework.messaging.transformation.events.EventTransformerChain
 /**
  * Composes the catalog's event transformations into a single
  * {@link EventTransformerChain}. Registration order matters: v1 to v2 must precede
- * v2 to v3 so a stored v1 event reaches a handler as the current shape.
+ * v2 to v3 so a stored v1 event reaches a handler as the current shape. The
+ * {@code CourseOffered} rename runs first, so a renamed event then flows through the
+ * {@code CoursePublished} version chain.
  */
 public final class CourseCatalogTransformations {
 
@@ -31,6 +33,7 @@ public final class CourseCatalogTransformations {
     /** @return the chain registered with the catalog's configuration */
     public static EventTransformerChain chain() {
         return EventTransformerChain.builder()
+                                    .register(CourseOfferedToCoursePublished.build())
                                     .register(SystemAnnouncementLegacyUplift.build())
                                     .register(CoursePublishedV1ToV2.build())
                                     .register(CoursePublishedV2ToV3.build())

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
@@ -17,13 +17,14 @@
 package org.axonframework.examples.demo.coursecatalog.catalog.transformations;
 
 import io.axoniq.framework.messaging.transformation.events.EventTransformerChain;
+import org.axonframework.examples.demo.coursecatalog.catalog.events.CoursePublished;
 
 /**
  * Composes the catalog's event transformations into a single
  * {@link EventTransformerChain}. Registration order matters: v1 to v2 must precede
  * v2 to v3 so a stored v1 event reaches a handler as the current shape. The
  * {@code CourseOffered} rename runs first, so a renamed event then flows through the
- * {@code CoursePublished} version chain.
+ * {@link CoursePublished} version chain.
  */
 public final class CourseCatalogTransformations {
 

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublished.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublished.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.transformations;
+
+import io.axoniq.framework.messaging.transformation.events.EventTransformation;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.messaging.core.MessageType;
+
+/**
+ * Renames the catalog's earliest event, {@code CourseOffered} {@code 1.0.0}, to the name the
+ * domain settled on, {@code CoursePublished} {@code 1.0.0}.
+ * <p>
+ * A pure rename: only the identity changes, the payload is carried over unchanged, so there is no
+ * mapper. The renamed {@code CoursePublished} {@code 1.0.0} then flows through
+ * {@link CoursePublishedV1ToV2} and {@link CoursePublishedV2ToV3}, so a historic {@code CourseOffered}
+ * reaches handlers as the current {@code CoursePublished}. Because a {@code transform(...)} may only
+ * change the version, a name change like this needs {@code rename(...)}.
+ */
+public final class CourseOfferedToCoursePublished {
+
+    private static final MessageType FROM = new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0");
+    private static final MessageType TO   = new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0");
+
+    private CourseOfferedToCoursePublished() {
+    }
+
+    /** @return the transformation registered into the chain */
+    public static EventTransformation build() {
+        return EventTransformation.rename(FROM, TO);
+    }
+}

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublished.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublished.java
@@ -27,8 +27,9 @@ import org.axonframework.messaging.core.MessageType;
  * A pure rename: only the identity changes, the payload is carried over unchanged, so there is no
  * mapper. The renamed {@code CoursePublished} {@code 1.0.0} then flows through
  * {@link CoursePublishedV1ToV2} and {@link CoursePublishedV2ToV3}, so a historic {@code CourseOffered}
- * reaches handlers as the current {@code CoursePublished}. Because a {@code transform(...)} may only
- * change the version, a name change like this needs {@code rename(...)}.
+ * reaches handlers as the current {@code CoursePublished}. Because a
+ * {@link EventTransformation.TransformStep#transform transform(...)} may only change the version, a
+ * name change like this needs {@link EventTransformation#rename rename(...)}.
  */
 public final class CourseOfferedToCoursePublished {
 

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/ChainBuildLogTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/ChainBuildLogTest.java
@@ -60,7 +60,8 @@ class ChainBuildLogTest {
                                                         .toList();
         assertThat(debugEntries).hasSize(1);
         assertThat(debugEntries.getFirst().getFormattedMessage())
-                .contains("6 transformation(s)",
+                .contains("7 transformation(s)",
+                          "coursecatalog.CourseOffered#1.0.0",
                           "coursecatalog.CoursePublished#1.0.0",
                           "coursecatalog.CoursePublished#2.0.0",
                           "coursecatalog.StudentRegistered#1.0.0",

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.chain;
+
+import io.axoniq.framework.messaging.transformation.events.EventTransformation;
+import io.axoniq.framework.messaging.transformation.events.EventTransformerChain;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.testutil.ChainTester;
+import org.axonframework.examples.demo.coursecatalog.catalog.transformations.CourseCatalogTransformations;
+import org.axonframework.messaging.core.MessageType;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A {@code rename(...)} changes an event's identity while carrying the payload over unchanged.
+ * Unlike a {@code transform(...)} (see {@link RenameViaTransformRejectedTest}), it may change the
+ * qualified name, the version, or both.
+ */
+class RenameTest {
+
+    @Test
+    void renamedCourseOfferedFlowsThroughTheVersionChainToTheCurrentShape() {
+        // The catalog chain renames CourseOffered to CoursePublished 1.0.0, then the version
+        // transformers lift it to the current 3.0.0 shape, all in one read.
+        ChainTester.forChain(CourseCatalogTransformations.chain())
+                   .given()
+                   .messageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0")
+                   .payloadFromResource("/transformations/coursepublished/v1.json")
+                   .when()
+                   .then()
+                   .success()
+                   .outputType(new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "3.0.0"))
+                   .outputPayloadStructurallyEquals("/transformations/coursepublished/v3.json");
+    }
+
+    @Test
+    void renameCanChangeTheVersionOnly() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("text", "Catalog launched");
+        EventTransformerChain chain = EventTransformerChain.builder()
+                .register(EventTransformation.rename(
+                        new MessageType(CourseCatalogMessageNames.SYSTEM_ANNOUNCEMENT, "1.0.0"),
+                        new MessageType(CourseCatalogMessageNames.SYSTEM_ANNOUNCEMENT, "2.0.0")))
+                .build();
+
+        ChainTester.forChain(chain)
+                   .given()
+                   .messageType(CourseCatalogMessageNames.SYSTEM_ANNOUNCEMENT, "1.0.0")
+                   .payload(payload)
+                   .when()
+                   .then()
+                   .success()
+                   .outputType(new MessageType(CourseCatalogMessageNames.SYSTEM_ANNOUNCEMENT, "2.0.0"))
+                   .outputPayload(payload);
+    }
+
+    @Test
+    void renameCanChangeBothNameAndVersionInOneStep() {
+        ObjectNode payload = JsonNodeFactory.instance.objectNode().put("name", "Legacy Foundations");
+        EventTransformerChain chain = EventTransformerChain.builder()
+                .register(EventTransformation.rename(
+                        new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0"),
+                        new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "2.0.0")))
+                .build();
+
+        ChainTester.forChain(chain)
+                   .given()
+                   .messageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0")
+                   .payload(payload)
+                   .when()
+                   .then()
+                   .success()
+                   .outputType(new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "2.0.0"))
+                   .outputPayload(payload);
+    }
+
+    @Test
+    void renameWithIdenticalSourceAndTargetIsRejected() {
+        MessageType courseOffered = new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0");
+        assertThatThrownBy(() -> EventTransformation.rename(courseOffered, courseOffered))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("identical");
+    }
+}

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameTest.java
@@ -92,8 +92,9 @@ class RenameTest {
 
     @Test
     void renameWithIdenticalSourceAndTargetIsRejected() {
-        MessageType courseOffered = new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0");
-        assertThatThrownBy(() -> EventTransformation.rename(courseOffered, courseOffered))
+        MessageType source = new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0");
+        MessageType target = new MessageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0");
+        assertThatThrownBy(() -> EventTransformation.rename(source, target))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("identical");
     }

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameViaTransformRejectedTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/RenameViaTransformRejectedTest.java
@@ -32,20 +32,21 @@ import java.util.concurrent.CompletionException;
 import static org.assertj.core.api.Assertions.*;
 
 /**
- * Event renaming (a qualified-name change) is not supported; only a same-name
- * version bump is. The chain rejects a rename because the transformation runs at read time,
- * after the store has filtered the stream by the stored (old) name, so the events a rename
- * targets are never surfaced. A concrete {@code from} is rejected at registration; a predicate
- * {@code from} only at read time, as its matched name is known per-event.
+ * A payload-mapping {@code transform(...)} may only change an event's version, not its qualified
+ * name. To change the name itself, use {@link EventTransformation#rename(MessageType, MessageType)}
+ * instead (see {@link RenameTest}). This test pins the guard: a {@code transform(...)} whose {@code to}
+ * changes the name is rejected, while a same-name version bump is allowed. A concrete {@code from} is
+ * rejected at registration; a predicate {@code from} only at read time, as its matched name is known
+ * per-event.
  */
-class RenameRejectedTest {
+class RenameViaTransformRejectedTest {
 
     @Nested
     class ConcreteFrom {
 
         @Test
-        void renamingOneEventTypeToAnotherIsRejectedAtRegistration() {
-            // given: a transformation that would rename CoursePublished into StudentRegistered
+        void changingTheNameViaTransformIsRejectedAtRegistration() {
+            // given: a transform that would change CoursePublished into StudentRegistered
             EventTransformation renameTransformation =
                     EventTransformation.from(new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0"))
                                        .to(new MessageType(CourseCatalogMessageNames.STUDENT_REGISTERED, "1.0.0"))
@@ -55,7 +56,7 @@ class RenameRejectedTest {
             // when / then
             assertThatThrownBy(() -> builder.register(renameTransformation))
                     .isInstanceOf(ChainConfigurationException.class)
-                    .hasMessageContaining("renaming")
+                    .hasMessageContaining("rename")
                     .hasMessageContaining(CourseCatalogMessageNames.COURSE_PUBLISHED)
                     .hasMessageContaining(CourseCatalogMessageNames.STUDENT_REGISTERED);
         }
@@ -79,9 +80,9 @@ class RenameRejectedTest {
     class PredicateFrom {
 
         @Test
-        void renamingViaPredicateIsRejectedAtReadTime() {
+        void changingTheNameViaTransformPredicateIsRejectedAtReadTime() {
             // given: registration is allowed because a predicate's matched source name is not
-            // known statically; the rename only surfaces once a CoursePublished event matches.
+            // known statically; the name change only surfaces once a CoursePublished event matches.
             MessageType coursePublishedV1 = new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0");
             EventTransformation renameTransformation =
                     EventTransformation.from(type -> type.equals(coursePublishedV1))
@@ -91,7 +92,7 @@ class RenameRejectedTest {
                                                                .register(renameTransformation)
                                                                .build();
 
-            // when / then: the rename is rejected as the matching event flows through the chain
+            // when / then: the name change is rejected as the matching event flows through the chain
             ChainTester.forChain(chain)
                        .given()
                        .messageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0")
@@ -102,7 +103,7 @@ class RenameRejectedTest {
                                .isInstanceOf(CompletionException.class)
                                .cause()
                                .isInstanceOf(ChainConfigurationException.class)
-                               .hasMessageContaining("renaming")
+                               .hasMessageContaining("rename")
                                .hasMessageContaining(CourseCatalogMessageNames.COURSE_PUBLISHED)
                                .hasMessageContaining(CourseCatalogMessageNames.STUDENT_REGISTERED));
         }

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/HistoricEventsUpcastingIntegrationTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/HistoricEventsUpcastingIntegrationTest.java
@@ -79,6 +79,19 @@ class HistoricEventsUpcastingIntegrationTest {
     }
 
     @Test
+    void courseOfferedReadsAsCurrentCoursePublishedAfterRenameAndUpcast() {
+        // A historic CourseOffered event is renamed to CoursePublished, then lifted through the
+        // version chain, so it reaches the projection as a current course.
+        CourseId courseId = CourseId.of("integration-rename");
+        fixture.given()
+               .events(new LegacyEventSeeder.CourseOfferedV1(
+                       Ids.CATALOG_ID, courseId, "Offered Course", 15))
+               .then()
+               .await(r -> r.expect(cfg -> assertViewContainsClosedCourseWithoutEnrollments(
+                       cfg, courseId, "Offered Course", new CapacityRange(15, 15))));
+    }
+
+    @Test
     void studentRegisteredV1ContributesToCurrentCount() {
         fixture.given()
                .events(new LegacyEventSeeder.StudentRegisteredV1(
@@ -125,7 +138,7 @@ class HistoricEventsUpcastingIntegrationTest {
                .then()
                .await(r -> r.expect(cfg -> {
                    CourseCatalogView view = queryView(cfg);
-                   assertThat(view.courses()).hasSize(5);
+                   assertThat(view.courses()).hasSize(6);
                    assertThat(view.registeredStudents()).isEqualTo(4);
                    assertThat(view.announcements()).containsExactly("Catalog launched in 2023");
                    // Three beta WelcomeMessageSent versions (0.5 / 0.7 / 0.9) folded to 1.0.0,
@@ -136,6 +149,10 @@ class HistoricEventsUpcastingIntegrationTest {
                                    "Welcome to the catalog, Alice.",
                                    "Hi Bob, welcome to the catalog.",
                                    "Welcome Carol.");
+                   // Legacy CourseOffered renamed to CoursePublished, then upcast: range collapses to [40,40]
+                   assertThat(view.courses()).contains(new CatalogViewReadModel(
+                           CourseId.of("legacy-foundations"), "Legacy Foundations",
+                           new CapacityRange(40, 40), 0, false));
                    // V1 single-capacity course: range collapses to [n,n]
                    assertThat(view.courses()).contains(new CatalogViewReadModel(
                            CourseId.of("event-sourcing-101"), "Event Sourcing in Practice",
@@ -157,7 +174,7 @@ class HistoricEventsUpcastingIntegrationTest {
                .then()
                .await(r -> r.expect(cfg -> {
                    CourseCatalogView view = queryView(cfg);
-                   assertThat(view.courses()).hasSize(5);
+                   assertThat(view.courses()).hasSize(6);
                    assertThat(view.registeredStudents()).isEqualTo(4);
                    assertThat(view.announcements()).hasSize(1);
                }));

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/TypeFilteredSourcingUpcastIntegrationTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/TypeFilteredSourcingUpcastIntegrationTest.java
@@ -72,6 +72,26 @@ class TypeFilteredSourcingUpcastIntegrationTest {
     }
 
     @Test
+    void historicCourseOfferedIsFoundWhenEnrollSourcesByTheRenamedType() {
+        // given: a course stored under the legacy CourseOffered name (renamed to CoursePublished)
+        // and a registered student
+        CourseId courseId = CourseId.of("sourcing-rename");
+        StudentId studentId = StudentId.of("linus");
+        fixture.given()
+               .event(new LegacyEventSeeder.CourseOfferedV1(
+                       Ids.CATALOG_ID, courseId, "Offered Course", 30))
+               .event(new StudentRegistered(Ids.CATALOG_ID, studentId, "Linus Torvalds"))
+               // when: enrolling sources the course through criteria filtered to CoursePublished; the
+               // read is widened to also fetch the old CourseOffered name so the rename is not missed
+               .when()
+               .command(new EnrollStudent(courseId, studentId))
+               // then: the renamed-and-upcast course is recognized as published
+               .then()
+               .success()
+               .events(new StudentEnrolledInCourse(courseId, studentId));
+    }
+
+    @Test
     void v1CapacityIsCarriedThroughTheUpcastSoEnrollingIntoAFullCourseIsRejected() {
         // given: a v1 course with capacity 1 (upcasts to range [1,1]) that already has one enrolment
         CourseId courseId = CourseId.of("sourcing-upcast-full");

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublishedTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseOfferedToCoursePublishedTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.transformations;
+
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.testutil.TransformationTester;
+import org.axonframework.messaging.core.MessageType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The legacy {@code CourseOffered} event is renamed to {@code CoursePublished} with its payload
+ * carried over unchanged. Composition with the version chain is covered by the chain-level rename
+ * tests.
+ */
+class CourseOfferedToCoursePublishedTest {
+
+    @Test
+    void readsCourseOfferedAsCoursePublishedWithThePayloadUnchanged() {
+        TransformationTester.forTransformation(CourseOfferedToCoursePublished.build())
+                            .given()
+                            .messageType(CourseCatalogMessageNames.COURSE_OFFERED, "1.0.0")
+                            .payloadFromResource("/transformations/coursepublished/v1.json")
+                            .when()
+                            .then()
+                            .success()
+                            .outputType(new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0"))
+                            .outputPayloadFromResource("/transformations/coursepublished/v1.json");
+    }
+}


### PR DESCRIPTION
first review: [demo](https://github.com/AxonIQ/AxonFramework/pull/4624/changes) and [docs](https://github.com/AxonIQ/AxonFramework/pull/4629) and   [criteria widening](https://github.com/AxonIQ/AxonFramework/pull/4638) so the changes are better visible 

review this together with https://github.com/AxonIQ/axoniq-framework/pull/164. In this pr the demo is adapted and the docs as well for showing the renaming + criteria widening needed for renames