### PR TITLE
fix: RevisionSnapshotFilter#type(Class) never matched stored snapshots, silently disabling revision filtering

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.axonframework.eventsourcing.snapshotting;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventData;
+import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
 
 import java.util.Objects;
 
@@ -25,12 +26,13 @@ import static org.axonframework.common.BuilderUtils.assertNonBlank;
 import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 
 /**
- * A {@link SnapshotFilter} implementation which based on a configurable allowed revision will only {@link
- * #allow(DomainEventData)} {@link DomainEventData} containing that revision. True will also be returned if the {@link
- * DomainEventData#getType()} does not match the given {@code type}, as in compliance with the {@code SnapshotFilter}
- * documentation.
+ * A {@link SnapshotFilter} implementation which based on a configurable allowed revision will only
+ * {@link #allow(DomainEventData)} {@link DomainEventData} containing that revision. True will also be returned if the
+ * {@link DomainEventData#getType()} does not match the given {@code type}, as in compliance with the
+ * {@code SnapshotFilter} documentation.
  *
  * @author Steven van Beelen
+ * @author Mateusz Nowak
  * @since 4.5
  */
 public class RevisionSnapshotFilter implements SnapshotFilter {
@@ -41,8 +43,8 @@ public class RevisionSnapshotFilter implements SnapshotFilter {
     /**
      * Instantiate a Builder to be able to create a {@link RevisionSnapshotFilter}.
      * <p>
-     * The {@code type} is <b>hard requirements</b> and as such should be provided.
-     * The {@code revision} should not be an empty String
+     * The {@code type} is <b>hard requirements</b> and as such should be provided. The {@code revision} should not be
+     * an empty String
      *
      * @return a Builder to be able to create a {@link RevisionSnapshotFilter}
      */
@@ -53,8 +55,8 @@ public class RevisionSnapshotFilter implements SnapshotFilter {
     /**
      * Instantiate a {@link RevisionSnapshotFilter} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@code type} is not {@code null} or an empty String and the {@code revision} is not an empty String and will throw an {@link
-     * AxonConfigurationException} if this is the case.
+     * Will assert that the {@code type} is not {@code null} or an empty String and the {@code revision} is not an empty
+     * String and will throw an {@link AxonConfigurationException} if this is the case.
      *
      * @param builder the {@link Builder} used to instantiate a {@link RevisionSnapshotFilter} instance
      */
@@ -98,22 +100,29 @@ public class RevisionSnapshotFilter implements SnapshotFilter {
         private String revision;
 
         /**
-         * Sets the aggregate {@code type} this {@link SnapshotFilter} will allow using the outcome of {@link
-         * Class#getName()} on the given {@code type}. Note that if the {@code type} does not match the {@link
-         * DomainEventData#getType()}, the filter will return {@code true} as per the {@code SnapshotFilter}
-         * documentation.
+         * Sets the aggregate {@code type} this {@link SnapshotFilter} will allow, resolving it to the aggregate's
+         * <em>declared type</em> - exactly the value stored as a snapshot's {@link DomainEventData#getType()}. This is
+         * the {@link org.axonframework.modelling.command.AggregateRoot#type()} when present and non-empty, and
+         * otherwise the {@link Class#getSimpleName() simple name} of the given {@code type}.
+         * <p>
+         * Note that if the resolved {@code type} does not match the {@link DomainEventData#getType()} stored as the
+         * snapshot, the filter will return {@code true} as per the {@code SnapshotFilter} documentation.
+         * <p>
+         * For a polymorphic aggregate hierarchy, snapshots are stored under the declared type of the concrete subtype.
+         * Hence, configuring this filter with the parent class only matches snapshots stored under the parent's
+         * declared type. Use {@link #type(String)} to match a specific subtype's declared type.
          *
-         * @param type defines aggregate type this {@link SnapshotFilter} allows
+         * @param type defines the aggregate type this {@link SnapshotFilter} allows
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder type(Class<?> type) {
-            return type(type.getName());
+            return type(AnnotatedAggregateMetaModelFactory.declaredTypeOf(type));
         }
 
         /**
          * Sets the aggregate {@code type} this {@link SnapshotFilter} will allow. Note that if the {@code type} does
-         * not match the {@link DomainEventData#getType()}, the filter will return {@code true} as per the {@code
-         * SnapshotFilter} documentation.
+         * not match the {@link DomainEventData#getType()}, the filter will return {@code true} as per the
+         * {@code SnapshotFilter} documentation.
          *
          * @param type defines aggregate type this {@link SnapshotFilter} allows
          * @return the current Builder instance, for fluent interfacing

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilter.java
@@ -18,7 +18,7 @@ package org.axonframework.eventsourcing.snapshotting;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.DomainEventData;
-import org.axonframework.modelling.command.inspection.AnnotatedAggregateMetaModelFactory;
+import org.axonframework.modelling.command.inspection.AggregateTypeUtils;
 
 import java.util.Objects;
 
@@ -116,7 +116,7 @@ public class RevisionSnapshotFilter implements SnapshotFilter {
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder type(Class<?> type) {
-            return type(AnnotatedAggregateMetaModelFactory.declaredTypeOf(type));
+            return type(AggregateTypeUtils.declaredTypeOf(type));
         }
 
         /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterSerializerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterSerializerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.snapshotting;
+
+import org.axonframework.eventhandling.DomainEventData;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventsourcing.eventstore.jpa.SnapshotEventEntry;
+import org.axonframework.eventsourcing.utils.TestSerializer;
+import org.axonframework.serialization.Revision;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.json.JacksonSerializer;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating that {@link RevisionSnapshotFilter} behaves identically regardless of the {@link Serializer}
+ * used for snapshots.
+ * <p>
+ * A snapshot's revision is determined at serialization time by the serializer's {@code RevisionResolver} (defaulting to
+ * the {@code AnnotationRevisionResolver}, which reads {@link Revision @Revision}) and stored as separate metadata - not
+ * embedded in the serialized body. The filter reads it back from that metadata, so revision-based filtering works the
+ * same for XML (XStream) and JSON (Jackson).
+ *
+ * @author Mateusz Nowak
+ */
+class RevisionSnapshotFilterSerializerTest {
+
+    private static final String STORED_REVISION = "1";
+    private static final String NEW_REVISION = "2";
+
+    @Test
+    void rejectsSnapshotWithOutdatedRevisionUsingXStream() {
+        assertOutdatedSnapshotRejected(TestSerializer.xStreamSerializer());
+    }
+
+    @Test
+    void rejectsSnapshotWithOutdatedRevisionUsingJackson() {
+        assertOutdatedSnapshotRejected(JacksonSerializer.defaultSerializer());
+    }
+
+    @Test
+    void allowsSnapshotWithMatchingRevisionUsingXStream() {
+        assertMatchingSnapshotAllowed(TestSerializer.xStreamSerializer());
+    }
+
+    @Test
+    void allowsSnapshotWithMatchingRevisionUsingJackson() {
+        assertMatchingSnapshotAllowed(JacksonSerializer.defaultSerializer());
+    }
+
+    private void assertOutdatedSnapshotRejected(Serializer serializer) {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(SnapshottedAggregate.class)
+                                      .revision(NEW_REVISION) // the stored snapshot still carries STORED_REVISION
+                                      .build();
+
+        DomainEventData<?> snapshot = snapshotUsing(serializer);
+
+        assertEquals(STORED_REVISION, snapshot.getPayload().getType().getRevision(),
+                     "Revision must be available as metadata regardless of the serializer");
+        assertFalse(testSubject.allow(snapshot));
+    }
+
+    private void assertMatchingSnapshotAllowed(Serializer serializer) {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(SnapshottedAggregate.class)
+                                      .revision(STORED_REVISION)
+                                      .build();
+
+        assertTrue(testSubject.allow(snapshotUsing(serializer)));
+    }
+
+    private DomainEventData<byte[]> snapshotUsing(Serializer serializer) {
+        DomainEventMessage<Object> snapshot = new GenericDomainEventMessage<>(
+                SnapshottedAggregate.class.getSimpleName(), "aggregate-id", 0, new SnapshottedAggregate());
+        return new SnapshotEventEntry(snapshot, serializer);
+    }
+
+    @Revision(STORED_REVISION)
+    private static class SnapshottedAggregate {
+
+        private String state = "state";
+
+        public String getState() {
+            return state;
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshotting/RevisionSnapshotFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.axonframework.eventhandling.DomainEventMessage;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventsourcing.eventstore.jpa.SnapshotEventEntry;
 import org.axonframework.eventsourcing.utils.TestSerializer;
+import org.axonframework.modelling.command.AggregateRoot;
 import org.axonframework.serialization.Revision;
 import org.axonframework.serialization.Serializer;
 import org.junit.jupiter.api.*;
@@ -30,65 +31,100 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class validating the {@link RevisionSnapshotFilter}.
+ * <p>
+ * Snapshots are stored under an aggregate's <em>declared type</em> (its {@link DomainEventData#getType()}), which
+ * defaults to the simple class name and can be overridden through {@link AggregateRoot#type()}. The fixtures below
+ * therefore store snapshots under that declared type, mirroring how snapshots are physically stored.
  *
  * @author Steven van Beelen
  */
 class RevisionSnapshotFilterTest {
 
     private static final String EXPECTED_REVISION = "LET ME IN";
+    private static final String OTHER_REVISION = "some-other-revision";
 
     private final Serializer serializer = TestSerializer.xStreamSerializer();
 
     @Test
-    void allowsDomainEventDataContainingTheAllowedAggregateTypeAndRevision() {
-        RevisionSnapshotFilter testSubject =
-                RevisionSnapshotFilter.builder()
-                                      .type(RightAggregateTypeAndRevision.class.getSimpleName())
-                                      .revision(EXPECTED_REVISION)
-                                      .build();
+    void allowsSnapshotMatchingDeclaredTypeAndRevision() {
+        RevisionSnapshotFilter testSubject = filterFor(AggregateWithExpectedRevision.class, EXPECTED_REVISION);
 
-        DomainEventMessage<RightAggregateTypeAndRevision> snapshotEvent = new GenericDomainEventMessage<>(
-                RightAggregateTypeAndRevision.class.getName(),
-                "some-aggregate-id",
-                0,
-                new RightAggregateTypeAndRevision("some-state")
-        );
-        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
+        assertTrue(testSubject.allow(snapshotOf(AggregateWithExpectedRevision.class,
+                                                new AggregateWithExpectedRevision())));
+    }
 
-        assertTrue(testSubject.allow(testDomainEventData));
+    /**
+     * A filter only votes on its own aggregate type; snapshots of other aggregates must be allowed through, as filters
+     * are combined in an AND operation across all aggregates.
+     */
+    @Test
+    void allowsSnapshotOfAnotherAggregateType() {
+        RevisionSnapshotFilter testSubject = filterFor(AggregateWithExpectedRevision.class, EXPECTED_REVISION);
+
+        assertTrue(testSubject.allow(snapshotOf(AggregateWithOtherRevision.class,
+                                                new AggregateWithOtherRevision())));
     }
 
     @Test
-    void allowsDomainEventDataContainingTheWrongAggregateTypeAndAllowedRevision() {
-        RevisionSnapshotFilter testSubject =
-                RevisionSnapshotFilter.builder()
-                                      .type(RightAggregateTypeAndRevision.class.getSimpleName())
-                                      .revision(EXPECTED_REVISION)
-                                      .build();
+    void disallowsSnapshotMatchingDeclaredTypeButWithWrongRevision() {
+        RevisionSnapshotFilter testSubject = filterFor(AggregateWithOtherRevision.class, EXPECTED_REVISION);
 
-        DomainEventMessage<WrongAggregateType> snapshotEvent = new GenericDomainEventMessage<>(
-                WrongAggregateType.class.getName(), "some-aggregate-id", 0, new WrongAggregateType("some-state")
-        );
-        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
-
-        assertTrue(testSubject.allow(testDomainEventData));
+        assertFalse(testSubject.allow(snapshotOf(AggregateWithOtherRevision.class,
+                                                 new AggregateWithOtherRevision())));
     }
 
+    /**
+     * {@code type(Class)} must resolve to the declared type - the simple name here - to match the stored snapshot.
+     */
     @Test
-    void disallowsDomainEventDataContainingTheAllowedAggregateTypeAndWrongRevision() {
+    void typeByClassResolvesToSimpleNameWhenNoAggregateRootTypeOverride() {
         RevisionSnapshotFilter testSubject =
                 RevisionSnapshotFilter.builder()
-                                      .type(RightAggregateTypeAndWrongRevision.class)
+                                      .type(AggregateWithExpectedRevision.class)
                                       .revision(EXPECTED_REVISION)
                                       .build();
 
-        DomainEventMessage<RightAggregateTypeAndWrongRevision> snapshotEvent = new GenericDomainEventMessage<>(
-                RightAggregateTypeAndWrongRevision.class.getName(), "some-aggregate-id", 0,
-                new RightAggregateTypeAndWrongRevision("some-state")
-        );
-        DomainEventData<byte[]> testDomainEventData = new SnapshotEventEntry(snapshotEvent, serializer);
+        assertTrue(testSubject.allow(snapshotOf(AggregateWithExpectedRevision.class,
+                                                new AggregateWithExpectedRevision())));
+    }
 
-        assertFalse(testSubject.allow(testDomainEventData));
+    /**
+     * The snapshot is stored under the {@link AggregateRoot#type()} value, which is what {@code type(Class)} must
+     * resolve to.
+     */
+    @Test
+    void typeByClassHonorsAggregateRootTypeOverride() {
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(CustomTypedAggregate.class)
+                                      .revision(EXPECTED_REVISION)
+                                      .build();
+
+        assertTrue(testSubject.allow(snapshotOf("custom-type", new CustomTypedAggregate())));
+    }
+
+    /**
+     * Configuring the filter with a fully-qualified class name while snapshots are stored under the declared (simple)
+     * type is a misconfiguration: the types never match, so the filter abstains (returns {@code true}) without
+     * evaluating the revision, and an outdated snapshot is kept.
+     */
+    @Test
+    void fullyQualifiedTypeDoesNotMatchDeclaredTypeAndAllowsSnapshot() {
+        String fullyQualifiedType = AggregateWithOtherRevision.class.getName();
+        assertNotEquals(fullyQualifiedType, AggregateWithOtherRevision.class.getSimpleName());
+
+        RevisionSnapshotFilter testSubject =
+                RevisionSnapshotFilter.builder()
+                                      .type(fullyQualifiedType)
+                                      .revision(EXPECTED_REVISION)
+                                      .build();
+
+        DomainEventData<byte[]> outdatedSnapshot =
+                snapshotOf(AggregateWithOtherRevision.class, new AggregateWithOtherRevision());
+
+        assertTrue(testSubject.allow(outdatedSnapshot),
+                   "A fully-qualified filter type never matches the stored simple-name type, "
+                           + "so the filter keeps the outdated snapshot");
     }
 
     @Test
@@ -117,50 +153,41 @@ class RevisionSnapshotFilterTest {
     @Test
     void buildWithBlankRevisionThrowsAxonConfigurationException() {
         assertThrows(AxonConfigurationException.class, () -> RevisionSnapshotFilter.builder()
-                                                                                   .type(RightAggregateTypeAndRevision.class)
+                                                                                   .type(AggregateWithExpectedRevision.class)
                                                                                    .revision("")
                                                                                    .build());
     }
 
+    private RevisionSnapshotFilter filterFor(Class<?> aggregateType, String revision) {
+        return RevisionSnapshotFilter.builder()
+                                     .type(aggregateType.getSimpleName())
+                                     .revision(revision)
+                                     .build();
+    }
+
+    private DomainEventData<byte[]> snapshotOf(Class<?> aggregateType, Object payload) {
+        return snapshotOf(aggregateType.getSimpleName(), payload);
+    }
+
+    private DomainEventData<byte[]> snapshotOf(String storedAggregateType, Object payload) {
+        DomainEventMessage<Object> snapshot =
+                new GenericDomainEventMessage<>(storedAggregateType, "aggregate-id", 0, payload);
+        return new SnapshotEventEntry(snapshot, serializer);
+    }
+
     @Revision(EXPECTED_REVISION)
-    private static class RightAggregateTypeAndRevision {
+    private static class AggregateWithExpectedRevision {
 
-        private final String state;
-
-        private RightAggregateTypeAndRevision(String state) {
-            this.state = state;
-        }
-
-        public String getState() {
-            return state;
-        }
     }
 
-    @Revision("some-other-revision")
-    private static class WrongAggregateType {
+    @Revision(OTHER_REVISION)
+    private static class AggregateWithOtherRevision {
 
-        private final String state;
-
-        private WrongAggregateType(String state) {
-            this.state = state;
-        }
-
-        public String getState() {
-            return state;
-        }
     }
 
-    @Revision("some-other-revision")
-    private static class RightAggregateTypeAndWrongRevision {
+    @Revision(EXPECTED_REVISION)
+    @AggregateRoot(type = "custom-type")
+    private static class CustomTypedAggregate {
 
-        private final String state;
-
-        private RightAggregateTypeAndWrongRevision(String state) {
-            this.state = state;
-        }
-
-        public String getState() {
-            return state;
-        }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateTypeUtils.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AggregateTypeUtils.java
@@ -1,0 +1,37 @@
+package org.axonframework.modelling.command.inspection;
+
+import org.axonframework.modelling.command.AggregateRoot;
+
+import static org.axonframework.common.annotation.AnnotationUtils.findAnnotationAttributes;
+
+/**
+ * Utility class providing static methods to retrieve the type as a {@link String} for a given aggregate {@link Class}.
+ *
+ * @author Mateusz Nowak
+ * @since 4.13.2
+ */
+public class AggregateTypeUtils {
+
+    /**
+     * Resolves the declared type of the given aggregate {@code type}. This is the {@link AggregateRoot#type()} when it
+     * is present and non-empty, and otherwise the {@link Class#getSimpleName() simple name} of the {@code type}.
+     * <p>
+     * The declared type is the value used to identify an aggregate's snapshots and events (it is stored as the
+     * {@link org.axonframework.eventhandling.DomainEventData#getType() type} of a snapshot). As such, it is the value a
+     * {@code SnapshotFilter} should match against.
+     *
+     * @param type the aggregate class to resolve the declared type for
+     * @return the declared type of the given aggregate {@code type}
+     * @since 4.13.2
+     */
+    public static String declaredTypeOf(Class<?> type) {
+        return findAnnotationAttributes(type, AggregateRoot.class)
+                .map(attributes -> (String) attributes.get("type"))
+                .filter(declaredType -> !declaredType.isEmpty())
+                .orElse(type.getSimpleName());
+    }
+
+    private AggregateTypeUtils() {
+        // Utility class
+    }
+}

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -29,7 +29,6 @@ import org.axonframework.messaging.annotation.HandlerDefinition;
 import org.axonframework.messaging.annotation.MessageHandlerInvocationException;
 import org.axonframework.messaging.annotation.MessageHandlingMember;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
-import org.axonframework.modelling.command.AggregateRoot;
 import org.axonframework.modelling.command.AggregateVersion;
 import org.axonframework.modelling.command.EntityId;
 import org.slf4j.Logger;
@@ -153,25 +152,6 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
                                                          Set<Class<? extends T>> subtypes) {
         return new AnnotatedAggregateMetaModelFactory(parameterResolverFactory, handlerDefinition)
                 .createModel(aggregateType, subtypes);
-    }
-
-    /**
-     * Resolves the declared type of the given aggregate {@code type}. This is the {@link AggregateRoot#type()} when it
-     * is present and non-empty, and otherwise the {@link Class#getSimpleName() simple name} of the {@code type}.
-     * <p>
-     * The declared type is the value used to identify an aggregate's snapshots and events (it is stored as the
-     * {@link org.axonframework.eventhandling.DomainEventData#getType() type} of a snapshot). As such, it is the value a
-     * {@code SnapshotFilter} should match against.
-     *
-     * @param type the aggregate class to resolve the declared type for
-     * @return the declared type of the given aggregate {@code type}
-     * @since 4.13.2
-     */
-    public static String declaredTypeOf(Class<?> type) {
-        return findAnnotationAttributes(type, AggregateRoot.class)
-                .map(attributes -> (String) attributes.get("type"))
-                .filter(declaredType -> !declaredType.isEmpty())
-                .orElse(type.getSimpleName());
     }
 
     /**
@@ -368,7 +348,7 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
 
         private void inspectAggregateTypes() {
             for (Class<?> type : handlerInspector.getAllHandlers().keySet()) {
-                String declaredType = declaredTypeOf(type);
+                String declaredType = AggregateTypeUtils.declaredTypeOf(type);
                 types.put(declaredType, type);
                 declaredTypes.put(type, declaredType);
             }

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -67,7 +67,6 @@ import static org.axonframework.common.annotation.AnnotationUtils.findAnnotation
  * meta-model of the aggregate.
  *
  * @author Allard Buijze
- * @author Mateusz Nowak
  * @since 3.1
  */
 public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFactory {

--- a/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2026. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ import static org.axonframework.common.annotation.AnnotationUtils.findAnnotation
  * meta-model of the aggregate.
  *
  * @author Allard Buijze
+ * @author Mateusz Nowak
  * @since 3.1
  */
 public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFactory {
@@ -152,6 +153,25 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
                                                          Set<Class<? extends T>> subtypes) {
         return new AnnotatedAggregateMetaModelFactory(parameterResolverFactory, handlerDefinition)
                 .createModel(aggregateType, subtypes);
+    }
+
+    /**
+     * Resolves the declared type of the given aggregate {@code type}. This is the {@link AggregateRoot#type()} when it
+     * is present and non-empty, and otherwise the {@link Class#getSimpleName() simple name} of the {@code type}.
+     * <p>
+     * The declared type is the value used to identify an aggregate's snapshots and events (it is stored as the
+     * {@link org.axonframework.eventhandling.DomainEventData#getType() type} of a snapshot). As such, it is the value a
+     * {@code SnapshotFilter} should match against.
+     *
+     * @param type the aggregate class to resolve the declared type for
+     * @return the declared type of the given aggregate {@code type}
+     * @since 4.13.2
+     */
+    public static String declaredTypeOf(Class<?> type) {
+        return findAnnotationAttributes(type, AggregateRoot.class)
+                .map(attributes -> (String) attributes.get("type"))
+                .filter(declaredType -> !declaredType.isEmpty())
+                .orElse(type.getSimpleName());
     }
 
     /**
@@ -348,16 +368,10 @@ public class AnnotatedAggregateMetaModelFactory implements AggregateMetaModelFac
 
         private void inspectAggregateTypes() {
             for (Class<?> type : handlerInspector.getAllHandlers().keySet()) {
-                String declaredType = findDeclaredType(type);
+                String declaredType = declaredTypeOf(type);
                 types.put(declaredType, type);
                 declaredTypes.put(type, declaredType);
             }
-        }
-
-        private String findDeclaredType(Class<?> type) {
-            return findAnnotationAttributes(type, AggregateRoot.class)
-                    .map(map -> (String) map.get("type")).filter(i -> i.length() > 0)
-                    .orElse(type.getSimpleName());
         }
 
         private void inspectFieldsAndMethods() {

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AggregateTypeUtilsTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AggregateTypeUtilsTest.java
@@ -1,0 +1,35 @@
+package org.axonframework.modelling.command.inspection;
+
+import org.axonframework.modelling.command.AggregateRoot;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link AggregateTypeUtils}.
+ *
+ * @author Steven van Beelen
+ */
+class AggregateTypeUtilsTest {
+
+    @Test
+    void declaredTypeOfDefaultsToSimpleName() {
+        assertEquals("SimpleNameType",
+                     AggregateTypeUtils.declaredTypeOf(SimpleNameType.class));
+    }
+
+    @Test
+    void declaredTypeOfHonorsAggregateRootTypeOverride() {
+        assertEquals("customType",
+                     AggregateTypeUtils.declaredTypeOf(AggregateRootType.class));
+    }
+
+    private static class SimpleNameType {
+
+    }
+
+    @AggregateRoot(type = "customType")
+    private static class AggregateRootType extends SimpleNameType {
+
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
@@ -262,18 +262,6 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
-    void declaredTypeOfDefaultsToSimpleName() {
-        assertEquals("SomeAnnotatedHandlers",
-                     AnnotatedAggregateMetaModelFactory.declaredTypeOf(SomeAnnotatedHandlers.class));
-    }
-
-    @Test
-    void declaredTypeOfHonorsAggregateRootTypeOverride() {
-        assertEquals("SomeOtherName",
-                     AnnotatedAggregateMetaModelFactory.declaredTypeOf(SomeSubclass.class));
-    }
-
-    @Test
     void findGetterIdentifier() {
         AggregateModel<SomeGetterIdAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeGetterIdAnnotatedHandlers.class);

--- a/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/inspection/AnnotatedAggregateMetaModelFactoryTest.java
@@ -262,6 +262,18 @@ class AnnotatedAggregateMetaModelFactoryTest {
     }
 
     @Test
+    void declaredTypeOfDefaultsToSimpleName() {
+        assertEquals("SomeAnnotatedHandlers",
+                     AnnotatedAggregateMetaModelFactory.declaredTypeOf(SomeAnnotatedHandlers.class));
+    }
+
+    @Test
+    void declaredTypeOfHonorsAggregateRootTypeOverride() {
+        assertEquals("SomeOtherName",
+                     AnnotatedAggregateMetaModelFactory.declaredTypeOf(SomeSubclass.class));
+    }
+
+    @Test
     void findGetterIdentifier() {
         AggregateModel<SomeGetterIdAnnotatedHandlers> inspector =
                 AnnotatedAggregateMetaModelFactory.inspectAggregate(SomeGetterIdAnnotatedHandlers.class);


### PR DESCRIPTION
### Background

This was reported by a customer: they configured the filter with their aggregate class via `type(Class)`, but the resolved fully-qualified class name never matched the type their snapshots were actually stored under — and there was no warning or any other signal of the mismatch. The filter appeared correctly configured while revision filtering was silently not happening.

### The bug

`RevisionSnapshotFilter.Builder#type(Class)` resolved the type via `Class#getName()` — the fully-qualified class name. Snapshots, however, are stored under the aggregate's **declared type**: `@AggregateRoot#type()` when set, and the simple class name otherwise.

Since a fully-qualified name never equals the declared type, the filter's type check never matched any stored snapshot. Per the `SnapshotFilter` contract, a type mismatch makes the filter abstain (return `true`) so that filters for different aggregates can be AND-combined. The result: **every `type(Class)`-configured filter was a silent no-op** — it looked installed, but never evaluated the revision, allowing outdated or corrupt snapshots through.

### The fix

`type(Class)` now resolves the declared type exactly the way the framework stores it. The resolution lives in a new public `AnnotatedAggregateMetaModelFactory#declaredTypeOf(Class)`, to which the metamodel's internal `findDeclaredType` now delegates — a single source of truth for declared-type resolution. This also makes the manual builder path consistent with `AggregateConfigurer`, which already resolves the declared type via the metamodel.

### Why this is safe for a patch release, despite changing behavior

The commit carries a `BREAKING CHANGE` marker for visibility, but **the previous behavior could not work**: there was no configuration in which `type(Class)` produced a filter that actually filtered. Anyone using it had a no-op filter without knowing it. After this fix:

- Users with `type(Class)` get the revision filtering they always intended to have — outdated snapshots are now correctly rejected (and the aggregate is rebuilt from events, the standard recovery path).
- The only conceivable regression would be a custom snapshotter that stores snapshots under the fully-qualified class name *and* configures the filter via `type(Class)`. Such a setup would have had a working filter by accident; it can keep the old behavior explicitly with `type(MyAggregate.class.getName())` via the unchanged `type(String)` overload.

### Tests

- `type(Class)` resolution: simple name and `@AggregateRoot(type = ...)` override
- The FQCN misconfiguration case, pinning down the abstain semantics
- `declaredTypeOf` defaults and override
- Serializer-independence of revision filtering (XStream and Jackson), since the revision is stored as metadata by the `RevisionResolver`, not in the serialized body

### Notes for reviewers

- A Javadoc note documents the polymorphic-aggregate limitation: snapshots of a polymorphic hierarchy are stored under the concrete subtype's declared type, so `type(ParentClass)` only matches parent-typed snapshots — same as the existing `AggregateConfigurer` behavior, not a regression.
