### PR TITLE
[#4632] fix(messaging): token store intit loses spring transaction pooled streaming processor 

### DIFF
--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/eventhandling/tokenstore/jpa/PooledStreamingEventProcessorJpaTokenStoreIT.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/eventhandling/tokenstore/jpa/PooledStreamingEventProcessorJpaTokenStoreIT.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.spring.eventhandling.tokenstore.jpa;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.axonframework.common.jpa.EntityManagerProvider;
+import org.axonframework.common.jpa.SimpleEntityManagerProvider;
+import org.axonframework.conversion.TestConverter;
+import org.axonframework.extension.spring.messaging.unitofwork.SpringTransactionManager;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStoreConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.TokenEntry;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
+import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.hibernate.dialect.HSQLDialect;
+import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * End-to-end regression test for <a href="https://github.com/AxonIQ/AxonFramework/issues/4632">issue #4632</a>.
+ * <p>
+ * A {@link PooledStreamingEventProcessor} backed by a Spring-managed {@link JpaTokenStore} must initialize its token
+ * segments even when the initial token resolves on a foreign thread, as the Axon Server connector does (it completes
+ * the token future on a gRPC callback thread). Before the fix the persist ran on that thread, without the thread-bound
+ * Spring transaction, and {@code start()} exhausted its retries.
+ */
+class PooledStreamingEventProcessorJpaTokenStoreIT {
+
+    private static final String PROCESSOR_NAME = "fresh-processor";
+    private static final String GRPC_THREAD_NAME = "axon-server-grpc-callback";
+
+    private EntityManagerFactory entityManagerFactory;
+    private ExecutorService grpcCallbackThread;
+    private ScheduledExecutorService coordinatorExecutor;
+    private ScheduledExecutorService workerExecutor;
+    private PooledStreamingEventProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        LocalContainerEntityManagerFactoryBean emfBean = new LocalContainerEntityManagerFactoryBean();
+        emfBean.setPersistenceProvider(new HibernatePersistenceProvider());
+        emfBean.setPackagesToScan(TokenEntry.class.getPackage().getName());
+        Map<String, Object> jpaProperties = new HashMap<>();
+        jpaProperties.put("hibernate.dialect", HSQLDialect.class.getName());
+        jpaProperties.put("hibernate.hbm2ddl.auto", "create-drop");
+        jpaProperties.put("hibernate.show_sql", "false");
+        jpaProperties.put("hibernate.connection.url", "jdbc:hsqldb:mem:bug4632-e2e-" + UUID.randomUUID());
+        emfBean.setJpaPropertyMap(jpaProperties);
+        emfBean.afterPropertiesSet();
+        entityManagerFactory = Objects.requireNonNull(emfBean.getObject(), "EntityManagerFactory");
+
+        // Spring's shared EntityManager: a persist requires a transaction bound to the current thread.
+        EntityManager sharedEntityManager = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
+        UnitOfWorkFactory unitOfWorkFactory = getUnitOfWorkFactory(sharedEntityManager);
+
+        JpaTokenStore tokenStore = new JpaTokenStore(new JpaTransactionalExecutorProvider(entityManagerFactory),
+                                                     TestConverter.JACKSON.getConverter(),
+                                                     JpaTokenStoreConfiguration.DEFAULT.nodeId("local"));
+
+        grpcCallbackThread = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
+        coordinatorExecutor = Executors.newSingleThreadScheduledExecutor(
+                runnable -> new Thread(runnable, "coordinator-executor"));
+        workerExecutor = Executors.newScheduledThreadPool(2, runnable -> new Thread(runnable, "worker-executor"));
+
+        var configuration = new PooledStreamingEventProcessorConfiguration(
+                new EventProcessorConfiguration(PROCESSOR_NAME, null))
+                .eventSource(new ForeignThreadInitialTokenEventSource(grpcCallbackThread))
+                .unitOfWorkFactory(unitOfWorkFactory)
+                .tokenStore(tokenStore)
+                .coordinatorExecutor(coordinatorExecutor)
+                .workerExecutor(workerExecutor)
+                .initialSegmentCount(1);
+
+        processor = new PooledStreamingEventProcessor(
+                PROCESSOR_NAME,
+                List.of(SimpleEventHandlingComponent.create(PROCESSOR_NAME)),
+                configuration);
+    }
+
+    private @NonNull UnitOfWorkFactory getUnitOfWorkFactory(EntityManager sharedEntityManager) {
+        EntityManagerProvider entityManagerProvider = new SimpleEntityManagerProvider(sharedEntityManager);
+        JpaTransactionManager platformTransactionManager = new JpaTransactionManager(entityManagerFactory);
+        SpringTransactionManager springTransactionManager =
+                new SpringTransactionManager(platformTransactionManager, entityManagerProvider, null);
+        return new TransactionalUnitOfWorkFactory(
+                springTransactionManager, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (processor != null) {
+            try {
+                processor.shutdown().get(5, TimeUnit.SECONDS);
+            } catch (Exception ignored) {
+                // best-effort shutdown
+            }
+        }
+        if (coordinatorExecutor != null) {
+            coordinatorExecutor.shutdownNow();
+        }
+        if (workerExecutor != null) {
+            workerExecutor.shutdownNow();
+        }
+        if (grpcCallbackThread != null) {
+            grpcCallbackThread.shutdownNow();
+        }
+        if (entityManagerFactory != null && entityManagerFactory.isOpen()) {
+            entityManagerFactory.close();
+        }
+    }
+
+    @Test
+    void startsAndInitializesJpaTokenStoreWhenInitialTokenResolvesOnForeignThread() {
+        // when starting the processor on a fresh database; the initial token resolves on the gRPC callback thread
+        CompletableFuture<Void> started = processor.start();
+
+        // then start completes and the segment is persisted. Before the fix the persist ran on the gRPC thread
+        // without a Spring transaction, so start() completed exceptionally with a ProcessRetriesExhaustedException.
+        assertThatCode(() -> started.orTimeout(20, TimeUnit.SECONDS).join())
+                .doesNotThrowAnyException();
+        assertThat(persistedSegmentCount()).isEqualTo(1);
+    }
+
+    private long persistedSegmentCount() {
+        try (EntityManager entityManager = entityManagerFactory.createEntityManager()) {
+            entityManager.getTransaction().begin();
+            Long count = entityManager.createQuery(
+                                              "SELECT COUNT(t) FROM TokenEntry t WHERE t.processorName = :processorName",
+                                              Long.class)
+                                      .setParameter("processorName", PROCESSOR_NAME)
+                                      .getSingleResult();
+            entityManager.getTransaction().commit();
+            return count;
+        }
+    }
+
+    /**
+     * A {@link StreamableEventSource} that completes its token futures on a foreign thread, mimicking the Axon Server
+     * connector's gRPC callbacks. The delay ensures the token-consuming continuation runs on that thread. The event
+     * stream is empty; this test only exercises token-store initialization.
+     */
+    @NullMarked
+    private record ForeignThreadInitialTokenEventSource(Executor grpcCallbackThread) implements StreamableEventSource {
+
+        private CompletableFuture<TrackingToken> resolvedOnCallbackThread() {
+            return CompletableFuture.supplyAsync(
+                    () -> new GlobalSequenceTrackingToken(-1),
+                    CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackThread));
+        }
+
+        @Override
+        public CompletableFuture<TrackingToken> firstToken(@Nullable ProcessingContext context) {
+            return resolvedOnCallbackThread();
+        }
+
+        @Override
+        public CompletableFuture<TrackingToken> latestToken(@Nullable ProcessingContext context) {
+            return resolvedOnCallbackThread();
+        }
+
+        @Override
+        public CompletableFuture<TrackingToken> tokenAt(Instant at, @Nullable ProcessingContext context) {
+            return resolvedOnCallbackThread();
+        }
+
+        @Override
+        public MessageStream<EventMessage> open(StreamingCondition condition, @Nullable ProcessingContext context) {
+            return MessageStream.empty();
+        }
+    }
+}

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/eventhandling/tokenstore/jpa/PooledStreamingEventProcessorJpaTokenStoreIT.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/eventhandling/tokenstore/jpa/PooledStreamingEventProcessorJpaTokenStoreIT.java
@@ -83,7 +83,7 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
     private static final String GRPC_THREAD_NAME = "axon-server-grpc-callback";
 
     private EntityManagerFactory entityManagerFactory;
-    private ExecutorService grpcCallbackThread;
+    private ExecutorService grpcCallbackExecutor;
     private ScheduledExecutorService coordinatorExecutor;
     private ScheduledExecutorService workerExecutor;
     private PooledStreamingEventProcessor processor;
@@ -110,14 +110,14 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
                                                      TestConverter.JACKSON.getConverter(),
                                                      JpaTokenStoreConfiguration.DEFAULT.nodeId("local"));
 
-        grpcCallbackThread = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
+        grpcCallbackExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
         coordinatorExecutor = Executors.newSingleThreadScheduledExecutor(
                 runnable -> new Thread(runnable, "coordinator-executor"));
         workerExecutor = Executors.newScheduledThreadPool(2, runnable -> new Thread(runnable, "worker-executor"));
 
         var configuration = new PooledStreamingEventProcessorConfiguration(
                 new EventProcessorConfiguration(PROCESSOR_NAME, null))
-                .eventSource(new ForeignThreadInitialTokenEventSource(grpcCallbackThread))
+                .eventSource(new ForeignThreadInitialTokenEventSource(grpcCallbackExecutor))
                 .unitOfWorkFactory(unitOfWorkFactory)
                 .tokenStore(tokenStore)
                 .coordinatorExecutor(coordinatorExecutor)
@@ -154,8 +154,8 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
         if (workerExecutor != null) {
             workerExecutor.shutdownNow();
         }
-        if (grpcCallbackThread != null) {
-            grpcCallbackThread.shutdownNow();
+        if (grpcCallbackExecutor != null) {
+            grpcCallbackExecutor.shutdownNow();
         }
         if (entityManagerFactory != null && entityManagerFactory.isOpen()) {
             entityManagerFactory.close();
@@ -193,12 +193,12 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
      * stream is empty; this test only exercises token-store initialization.
      */
     @NullMarked
-    private record ForeignThreadInitialTokenEventSource(Executor grpcCallbackThread) implements StreamableEventSource {
+    private record ForeignThreadInitialTokenEventSource(Executor grpcCallbackExecutor) implements StreamableEventSource {
 
         private CompletableFuture<TrackingToken> resolvedOnCallbackThread() {
             return CompletableFuture.supplyAsync(
                     () -> new GlobalSequenceTrackingToken(-1),
-                    CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackThread));
+                    CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackExecutor));
         }
 
         @Override

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/tokenstore/PooledStreamingEventProcessorJpaTokenStoreIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/eventhandling/tokenstore/PooledStreamingEventProcessorJpaTokenStoreIT.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.axonframework.extension.spring.eventhandling.tokenstore.jpa;
+package org.axonframework.integrationtests.eventhandling.tokenstore;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 import org.axonframework.common.jpa.EntityManagerProvider;
-import org.axonframework.common.jpa.SimpleEntityManagerProvider;
-import org.axonframework.conversion.TestConverter;
-import org.axonframework.extension.spring.messaging.unitofwork.SpringTransactionManager;
+import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.transaction.jpa.EntityManagerTransactionManager;
 import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
@@ -38,28 +38,19 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.Glob
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStoreConfiguration;
-import org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.TokenEntry;
 import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
-import org.hibernate.dialect.HSQLDialect;
-import org.hibernate.jpa.HibernatePersistenceProvider;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.orm.jpa.JpaTransactionManager;
-import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.orm.jpa.SharedEntityManagerCreator;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -70,12 +61,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * End-to-end regression test for <a href="https://github.com/AxonIQ/AxonFramework/issues/4632">issue #4632</a>.
+ * Verifies a {@link PooledStreamingEventProcessor} on a JPA {@link JpaTokenStore} initializes its token segments when
+ * the initial token resolves on a foreign thread, as the Axon Server connector's gRPC callbacks do.
  * <p>
- * A {@link PooledStreamingEventProcessor} backed by a Spring-managed {@link JpaTokenStore} must initialize its token
- * segments even when the initial token resolves on a foreign thread, as the Axon Server connector does (it completes
- * the token future on a gRPC callback thread). Before the fix the persist ran on that thread, without the thread-bound
- * Spring transaction, and {@code start()} exhausted its retries.
+ * Reproduced with {@link EntityManagerTransactionManager} and a thread-bound {@link EntityManagerProvider}, the
+ * vendor-neutral stand-in for Spring's shared {@code EntityManager}.
  */
 class PooledStreamingEventProcessorJpaTokenStoreIT {
 
@@ -83,6 +73,7 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
     private static final String GRPC_THREAD_NAME = "axon-server-grpc-callback";
 
     private EntityManagerFactory entityManagerFactory;
+    private ThreadBoundEntityManagerProvider entityManagerProvider;
     private ExecutorService grpcCallbackExecutor;
     private ScheduledExecutorService coordinatorExecutor;
     private ScheduledExecutorService workerExecutor;
@@ -90,24 +81,17 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
 
     @BeforeEach
     void setUp() {
-        LocalContainerEntityManagerFactoryBean emfBean = new LocalContainerEntityManagerFactoryBean();
-        emfBean.setPersistenceProvider(new HibernatePersistenceProvider());
-        emfBean.setPackagesToScan(TokenEntry.class.getPackage().getName());
-        Map<String, Object> jpaProperties = new HashMap<>();
-        jpaProperties.put("hibernate.dialect", HSQLDialect.class.getName());
-        jpaProperties.put("hibernate.hbm2ddl.auto", "create-drop");
-        jpaProperties.put("hibernate.show_sql", "false");
-        jpaProperties.put("hibernate.connection.url", "jdbc:hsqldb:mem:bug4632-e2e-" + UUID.randomUUID());
-        emfBean.setJpaPropertyMap(jpaProperties);
-        emfBean.afterPropertiesSet();
-        entityManagerFactory = Objects.requireNonNull(emfBean.getObject(), "EntityManagerFactory");
+        entityManagerFactory = Persistence.createEntityManagerFactory("tokenStore");
 
-        // Spring's shared EntityManager: a persist requires a transaction bound to the current thread.
-        EntityManager sharedEntityManager = SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory);
-        UnitOfWorkFactory unitOfWorkFactory = getUnitOfWorkFactory(sharedEntityManager);
+        // A thread-bound EntityManager: a persist requires a transaction bound to the current thread, exactly like
+        // Spring's shared EntityManager, but without depending on Spring.
+        entityManagerProvider = new ThreadBoundEntityManagerProvider(entityManagerFactory);
+        UnitOfWorkFactory unitOfWorkFactory = new TransactionalUnitOfWorkFactory(
+                new EntityManagerTransactionManager(entityManagerProvider),
+                new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE));
 
         JpaTokenStore tokenStore = new JpaTokenStore(new JpaTransactionalExecutorProvider(entityManagerFactory),
-                                                     TestConverter.JACKSON.getConverter(),
+                                                     new JacksonConverter(),
                                                      JpaTokenStoreConfiguration.DEFAULT.nodeId("local"));
 
         grpcCallbackExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
@@ -130,15 +114,6 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
                 configuration);
     }
 
-    private @NonNull UnitOfWorkFactory getUnitOfWorkFactory(EntityManager sharedEntityManager) {
-        EntityManagerProvider entityManagerProvider = new SimpleEntityManagerProvider(sharedEntityManager);
-        JpaTransactionManager platformTransactionManager = new JpaTransactionManager(entityManagerFactory);
-        SpringTransactionManager springTransactionManager =
-                new SpringTransactionManager(platformTransactionManager, entityManagerProvider, null);
-        return new TransactionalUnitOfWorkFactory(
-                springTransactionManager, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE));
-    }
-
     @AfterEach
     void tearDown() {
         if (processor != null) {
@@ -157,6 +132,9 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
         if (grpcCallbackExecutor != null) {
             grpcCallbackExecutor.shutdownNow();
         }
+        if (entityManagerProvider != null) {
+            entityManagerProvider.closeAll();
+        }
         if (entityManagerFactory != null && entityManagerFactory.isOpen()) {
             entityManagerFactory.close();
         }
@@ -167,30 +145,64 @@ class PooledStreamingEventProcessorJpaTokenStoreIT {
         // when starting the processor on a fresh database; the initial token resolves on the gRPC callback thread
         CompletableFuture<Void> started = processor.start();
 
-        // then start completes and the segment is persisted. Before the fix the persist ran on the gRPC thread
-        // without a Spring transaction, so start() completed exceptionally with a ProcessRetriesExhaustedException.
+        // then start completes and the segment is persisted. Before the fix the persist ran on the gRPC thread,
+        // whose EntityManager has no bound transaction, so start() completed exceptionally after exhausting retries.
         assertThatCode(() -> started.orTimeout(20, TimeUnit.SECONDS).join())
                 .doesNotThrowAnyException();
         assertThat(persistedSegmentCount()).isEqualTo(1);
     }
 
     private long persistedSegmentCount() {
-        try (EntityManager entityManager = entityManagerFactory.createEntityManager()) {
-            entityManager.getTransaction().begin();
-            Long count = entityManager.createQuery(
-                                              "SELECT COUNT(t) FROM TokenEntry t WHERE t.processorName = :processorName",
-                                              Long.class)
-                                      .setParameter("processorName", PROCESSOR_NAME)
-                                      .getSingleResult();
-            entityManager.getTransaction().commit();
-            return count;
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        try {
+            return entityManager.createQuery(
+                                         "SELECT COUNT(t) FROM TokenEntry t WHERE t.processorName = :processorName",
+                                         Long.class)
+                                 .setParameter("processorName", PROCESSOR_NAME)
+                                 .getSingleResult();
+        } finally {
+            entityManager.close();
         }
     }
 
     /**
-     * A {@link StreamableEventSource} that completes its token futures on a foreign thread, mimicking the Axon Server
-     * connector's gRPC callbacks. The delay ensures the token-consuming continuation runs on that thread. The event
-     * stream is empty; this test only exercises token-store initialization.
+     * Hands every thread its own {@link EntityManager}, so a transaction begun on one thread is invisible to others.
+     */
+    @NullMarked
+    private static final class ThreadBoundEntityManagerProvider implements EntityManagerProvider {
+
+        private final EntityManagerFactory entityManagerFactory;
+        private final ThreadLocal<EntityManager> threadEntityManager = new ThreadLocal<>();
+        private final Queue<EntityManager> created = new ConcurrentLinkedQueue<>();
+
+        private ThreadBoundEntityManagerProvider(EntityManagerFactory entityManagerFactory) {
+            this.entityManagerFactory = entityManagerFactory;
+        }
+
+        @Override
+        public EntityManager getEntityManager() {
+            EntityManager entityManager = threadEntityManager.get();
+            if (entityManager == null || !entityManager.isOpen()) {
+                entityManager = entityManagerFactory.createEntityManager();
+                threadEntityManager.set(entityManager);
+                created.add(entityManager);
+            }
+            return entityManager;
+        }
+
+        private void closeAll() {
+            EntityManager entityManager;
+            while ((entityManager = created.poll()) != null) {
+                if (entityManager.isOpen()) {
+                    entityManager.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * A {@link StreamableEventSource} whose token futures complete on a foreign thread, mimicking the Axon Server
+     * connector's gRPC callbacks. The stream itself is empty.
      */
     @NullMarked
     private record ForeignThreadInitialTokenEventSource(Executor grpcCallbackExecutor) implements StreamableEventSource {

--- a/integrationtests/src/test/resources/META-INF/persistence.xml
+++ b/integrationtests/src/test/resources/META-INF/persistence.xml
@@ -34,6 +34,18 @@
         </properties>
     </persistence-unit>
 
+    <persistence-unit name="tokenStore" transaction-type="RESOURCE_LOCAL">
+        <class>org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.TokenEntry</class>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+            <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:bug4632tokenstore"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+
     <persistence-unit name="polymorphic" transaction-type="RESOURCE_LOCAL">
         <class>org.axonframework.integrationtests.polymorphic.ParentAggregate</class>
         <class>org.axonframework.integrationtests.polymorphic.Child1Aggregate</class>

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -330,31 +330,37 @@ class Coordinator {
     }
 
     private CompletableFuture<Boolean> initializeTokenStore() {
-        return unitOfWorkFactory.create().executeWithResult(
-                context -> tokenStore.fetchSegments(name, context)
-                                     .thenCompose(segments -> {
-                                         if (!segments.isEmpty()) {
-                                             return CompletableFuture.completedFuture(true);
-                                         }
-                                         logger.info("Processor [{}]. Initializing ({}) segments",
-                                                     name, initialSegmentCount);
-                                         return initialToken.apply(eventSource)
-                                                            .thenCompose(token -> tokenStore.initializeTokenSegments(
-                                                                    name, initialSegmentCount, token, context
-                                                            ))
-                                                            .thenApply(ignored -> true);
-                                     })
-        ).exceptionally(e -> {
-            Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
-            if (cause instanceof Error error) {
-                throw error;
-            }
-            logger.warn(
-                    "Error while initializing the Token Store. This may simply indicate concurrent attempts to initialize.",
-                    cause
-            );
-            return false;
-        });
+        // The initial TrackingToken can resolve on a foreign thread: the Axon Server connector completes its future on
+        // a gRPC callback thread. Persisting on that thread fails, because the unit of work's transaction is bound to
+        // the thread that began it (issue #4632). So we resolve the token first, then dispatch the persist to this
+        // coordinator's executor in its own unit of work, keeping begin-transaction, persist, and commit on one thread.
+        return unitOfWorkFactory.create()
+                                .executeWithResult(context -> tokenStore.fetchSegments(name, context))
+                                .thenCompose(segments -> {
+                                    if (!segments.isEmpty()) {
+                                        return CompletableFuture.completedFuture(true);
+                                    }
+                                    logger.info("Processor [{}]. Initializing ({}) segments",
+                                                name, initialSegmentCount);
+                                    return initialToken.apply(eventSource)
+                                                       .thenComposeAsync(
+                                                               token -> unitOfWorkFactory.create().executeWithResult(
+                                                                       context -> tokenStore.initializeTokenSegments(
+                                                                               name, initialSegmentCount, token, context
+                                                                       ).thenApply(ignored -> true)),
+                                                               executorService);
+                                })
+                                .exceptionally(e -> {
+                                    Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
+                                    if (cause instanceof Error error) {
+                                        throw error;
+                                    }
+                                    logger.warn(
+                                            "Error while initializing the Token Store. This may simply indicate concurrent attempts to initialize.",
+                                            cause
+                                    );
+                                    return false;
+                                });
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -343,12 +343,8 @@ class Coordinator {
                                     logger.info("Processor [{}]. Initializing ({}) segments",
                                                 name, initialSegmentCount);
                                     return initialToken.apply(eventSource)
-                                                       .thenComposeAsync(
-                                                               token -> unitOfWorkFactory.create().executeWithResult(
-                                                                       context -> tokenStore.initializeTokenSegments(
-                                                                               name, initialSegmentCount, token, context
-                                                                       ).thenApply(ignored -> true)),
-                                                               executorService);
+                                                       .thenComposeAsync(this::persistInitialSegments,
+                                                                         executorService);
                                 })
                                 .exceptionally(e -> {
                                     Throwable cause = e instanceof CompletionException ce ? ce.getCause() : e;
@@ -361,6 +357,21 @@ class Coordinator {
                                     );
                                     return false;
                                 });
+    }
+
+    /**
+     * Persists the initial token segments in their own unit of work. Invoked on this coordinator's executor (see
+     * {@link #initializeTokenStore()}) so that begin-transaction, persist, and commit all run on the same thread, even
+     * when the initial token resolved on a foreign thread.
+     *
+     * @param token the resolved initial {@link TrackingToken} to store for every initial segment
+     * @return a {@link CompletableFuture} completing with {@code true} once the segments are persisted
+     */
+    private CompletableFuture<Boolean> persistInitialSegments(TrackingToken token) {
+        return unitOfWorkFactory.create()
+                                .executeWithResult(context -> tokenStore.initializeTokenSegments(
+                                        name, initialSegmentCount, token, context
+                                ).thenApply(ignored -> true));
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -330,10 +330,11 @@ class Coordinator {
     }
 
     private CompletableFuture<Boolean> initializeTokenStore() {
-        // The initial TrackingToken can resolve on a foreign thread: the Axon Server connector completes its future on
-        // a gRPC callback thread. Persisting on that thread fails, because the unit of work's transaction is bound to
-        // the thread that began it (issue #4632). So we resolve the token first, then dispatch the persist to this
-        // coordinator's executor in its own unit of work, keeping begin-transaction, persist, and commit on one thread.
+        // The initial TrackingToken can resolve on a foreign thread (e.g. the Axon Server connector completes its
+        // future on a gRPC callback thread). A unit of work's transaction is bound to the thread that began it,
+        // so the persist may not run as a continuation inside a unit of work started on another thread.
+        //  Therefore, the token is resolved first, and the persist runs in its own unit of work, dispatched to this coordinator's executor,
+        //  so the database work never occupies the connector's callback thread.
         return unitOfWorkFactory.create()
                                 .executeWithResult(context -> tokenStore.fetchSegments(name, context))
                                 .thenCompose(segments -> {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -161,6 +161,12 @@ class CoordinatorTest {
         doReturn(completedFuture(token)).when(tokenStore).fetchToken(eq(PROCESSOR_NAME), any(Segment.class), any());
         doReturn(SEGMENT_ZERO).when(workPackage).segment();
         doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+        // Token-store initialization runs the persist in its own unit of work dispatched via
+        // executorService.execute(...).
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
 
         //act
         awaitStart(testSubject);

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
@@ -73,13 +73,13 @@ class CoordinatorTokenStoreInitializationTransactionTest {
     private final AtomicBoolean transactionBoundDuringInitialize = new AtomicBoolean(false);
     private final AtomicReference<String> initializeThread = new AtomicReference<>();
 
-    private ExecutorService grpcCallbackThread;
+    private ExecutorService grpcCallbackExecutor;
     private ScheduledExecutorService executorService;
     private Coordinator coordinator;
 
     @BeforeEach
     void setUp() {
-        grpcCallbackThread = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
+        grpcCallbackExecutor = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
 
         // Faithful double of SpringTransactionManager: thread-bound transaction + same-thread-invocation requirement.
         UnitOfWorkFactory unitOfWorkFactory = getUnitOfWorkFactory();
@@ -106,7 +106,7 @@ class CoordinatorTokenStoreInitializationTransactionTest {
         Function<TrackingTokenSource, CompletableFuture<TrackingToken>> initialToken = source ->
                 CompletableFuture.supplyAsync(
                         () -> new GlobalSequenceTrackingToken(0),
-                        CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackThread));
+                        CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackExecutor));
 
         // Real scheduler for the token-store-init retry loop, but the asynchronous CoordinationTask is suppressed:
         // this test only exercises token-store initialization, not event coordination. Its worker thread carries a
@@ -170,16 +170,11 @@ class CoordinatorTokenStoreInitializationTransactionTest {
         if (executorService != null) {
             executorService.shutdownNow();
         }
-        if (grpcCallbackThread != null) {
-            grpcCallbackThread.shutdownNow();
+        if (grpcCallbackExecutor != null) {
+            grpcCallbackExecutor.shutdownNow();
         }
     }
 
-    /**
-     * Starting a fresh processor must initialize its token segments even though the initial token resolves on the
-     * Axon Server gRPC callback thread. This currently fails (issue #4632) because the persist is run on that foreign
-     * thread, where no transaction is bound; it will pass once the token is resolved on the transaction-owning thread.
-     */
     @Test
     void startInitializesTokenStoreWhenInitialTokenResolvesOnForeignThread() {
         // given a fresh token store and an initial-token source completing on the gRPC callback thread (see setUp)

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
+
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
+import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
+import org.axonframework.messaging.eventstreaming.TrackingTokenSource;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression guard for <a href="https://github.com/AxonIQ/AxonFramework/issues/4632">issue #4632</a>, driving the real
+ * {@link Coordinator}. It must initialize its token segments even when the initial {@link TrackingToken} resolves on a
+ * foreign thread, as with the Axon Server connector (token futures complete on a gRPC callback thread). The
+ * collaborators model the failing contract: a {@link TransactionManager} that requires same-thread invocations and
+ * binds its transaction to the starting thread, and a {@link TokenStore} whose {@code initializeTokenSegments} fails
+ * when run without a bound transaction (like Spring's shared {@code EntityManager}).
+ */
+class CoordinatorTokenStoreInitializationTransactionTest {
+
+    private static final String PROCESSOR_NAME = "fresh-processor";
+    private static final String GRPC_THREAD_NAME = "axon-server-grpc-callback";
+    private static final String COORDINATOR_THREAD_NAME = "coordinator-executor";
+
+    private final ThreadLocal<Boolean> transactionBoundToThread = ThreadLocal.withInitial(() -> false);
+    private final AtomicBoolean transactionBoundDuringInitialize = new AtomicBoolean(false);
+    private final AtomicReference<String> initializeThread = new AtomicReference<>();
+
+    private ExecutorService grpcCallbackThread;
+    private ScheduledExecutorService executorService;
+    private Coordinator coordinator;
+
+    @BeforeEach
+    void setUp() {
+        grpcCallbackThread = Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, GRPC_THREAD_NAME));
+
+        // Faithful double of SpringTransactionManager: thread-bound transaction + same-thread-invocation requirement.
+        UnitOfWorkFactory unitOfWorkFactory = getUnitOfWorkFactory();
+
+        // Fresh token store: no segments yet, so the initialization path runs. The persist requires a transaction
+        // bound to the *current* thread, exactly like Spring's shared EntityManager.
+        TokenStore tokenStore = mock(TokenStore.class);
+        when(tokenStore.fetchSegments(eq(PROCESSOR_NAME), any())).thenReturn(completedFuture(List.of()));
+        doAnswer(invocation -> {
+            boolean bound = transactionBoundToThread.get();
+            transactionBoundDuringInitialize.set(bound);
+            initializeThread.set(Thread.currentThread().getName());
+            if (!bound) {
+                return CompletableFuture.failedFuture(new IllegalStateException(
+                        "No transaction bound to thread [" + Thread.currentThread().getName()
+                                + "] - cannot reliably process 'persist' call"));
+            }
+            return completedFuture(List.of(Segment.ROOT_SEGMENT));
+        }).when(tokenStore).initializeTokenSegments(eq(PROCESSOR_NAME), anyInt(), any(), any());
+
+        // The Axon Server connector resolves the initial token over gRPC and completes its future on the callback
+        // thread. The 50ms delay guarantees the thenCompose continuation is registered before completion, so it runs
+        // on the callback thread.
+        Function<TrackingTokenSource, CompletableFuture<TrackingToken>> initialToken = source ->
+                CompletableFuture.supplyAsync(
+                        () -> new GlobalSequenceTrackingToken(0),
+                        CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS, grpcCallbackThread));
+
+        // Real scheduler for the token-store-init retry loop, but the asynchronous CoordinationTask is suppressed:
+        // this test only exercises token-store initialization, not event coordination. Its worker thread carries a
+        // recognizable name so the persist can be asserted to run here, on the coordinator's executor, and never on
+        // the gRPC callback thread.
+        executorService = new ScheduledThreadPoolExecutor(1, runnable -> new Thread(runnable, COORDINATOR_THREAD_NAME)) {
+            @Override
+            public @NonNull Future<?> submit(@NonNull Runnable task) {
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        StreamableEventSource eventSource = mock(StreamableEventSource.class);
+        WorkPackage workPackage = mock(WorkPackage.class);
+
+        coordinator = Coordinator.builder()
+                                 .name(PROCESSOR_NAME)
+                                 .eventSource(eventSource)
+                                 .tokenStore(tokenStore)
+                                 .unitOfWorkFactory(unitOfWorkFactory)
+                                 .executorService(executorService)
+                                 .workPackageFactory((segment, trackingToken) -> workPackage)
+                                 .processingStatusUpdater((id, updater) -> {})
+                                 .initialToken(initialToken)
+                                 .initialSegmentCount(1)
+                                 .tokenStoreInitRetryInterval(5)
+                                 .tokenStoreInitMaxRetries(2)
+                                 .maxSegmentProvider(name -> 1)
+                                 .build();
+    }
+
+    private @NonNull UnitOfWorkFactory getUnitOfWorkFactory() {
+        TransactionManager transactionManager = new TransactionManager() {
+            @Override
+            public @NonNull Transaction startTransaction() {
+                transactionBoundToThread.set(true);
+                return new Transaction() {
+                    @Override
+                    public void commit() {
+                        transactionBoundToThread.set(false);
+                    }
+
+                    @Override
+                    public void rollback() {
+                        transactionBoundToThread.set(false);
+                    }
+                };
+            }
+
+            @Override
+            public boolean requiresSameThreadInvocations() {
+                return true;
+            }
+        };
+        return new TransactionalUnitOfWorkFactory(
+                transactionManager, new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+        if (grpcCallbackThread != null) {
+            grpcCallbackThread.shutdownNow();
+        }
+    }
+
+    /**
+     * Starting a fresh processor must initialize its token segments even though the initial token resolves on the
+     * Axon Server gRPC callback thread. This currently fails (issue #4632) because the persist is run on that foreign
+     * thread, where no transaction is bound; it will pass once the token is resolved on the transaction-owning thread.
+     */
+    @Test
+    void startInitializesTokenStoreWhenInitialTokenResolvesOnForeignThread() {
+        // given a fresh token store and an initial-token source completing on the gRPC callback thread (see setUp)
+
+        // when starting the processor
+        CompletableFuture<Void> started = coordinator.start();
+
+        // then initialization completes successfully and the persist observed a bound transaction. The precise
+        // correctness invariant is that initializeTokenSegments runs on a thread that owns the transaction (which it
+        // began); any fix satisfying that passes, regardless of which thread that turns out to be.
+        assertThatCode(() -> started.orTimeout(5, TimeUnit.SECONDS).join())
+                .doesNotThrowAnyException();
+        assertThat(transactionBoundDuringInitialize)
+                .as("initializeTokenSegments must run on a thread that owns the transaction, but ran on [%s]",
+                    initializeThread.get())
+                .isTrue();
+        assertThat(initializeThread)
+                .as("""
+                    initializeTokenSegments must be dispatched to the coordinator's executor, not run on the \
+                    connector thread that completed the initial-token future""")
+                .hasValue(COORDINATOR_THREAD_NAME);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTokenStoreInitializationTransactionTest.java
@@ -182,9 +182,9 @@ class CoordinatorTokenStoreInitializationTransactionTest {
         // when starting the processor
         CompletableFuture<Void> started = coordinator.start();
 
-        // then initialization completes successfully and the persist observed a bound transaction. The precise
-        // correctness invariant is that initializeTokenSegments runs on a thread that owns the transaction (which it
-        // began); any fix satisfying that passes, regardless of which thread that turns out to be.
+        // then initialization completes successfully and the persist observed a bound transaction. The persist is
+        // deliberately dispatched to the coordinator's executor (a thread we control), which keeps it off the
+        // connector's gRPC callback thread and co-locates begin, persist, and commit on the transaction-owning thread.
         assertThatCode(() -> started.orTimeout(5, TimeUnit.SECONDS).join())
                 .doesNotThrowAnyException();
         assertThat(transactionBoundDuringInitialize)


### PR DESCRIPTION
## Fix: PooledStreamingEventProcessor JPA token-store init loses Spring transaction on Axon Server ([#4632](https://github.com/AxonIQ/AxonFramework/issues/4632))

### Problem
On a fresh database, a `PooledStreamingEventProcessor` using Axon Server (DCB) for events with a JPA `TokenStore` fails to start: token-store initialization throws `TransactionRequiredException`, retries 30 times, and the application context fails to start.

### Root cause
`Coordinator.initializeTokenStore()` chained the JPA persist onto the Axon Server token future:

```java
initialToken.apply(eventSource)
            .thenCompose(token -> tokenStore.initializeTokenSegments(name, count, token, context))
```

The connector resolves the initial token over gRPC and completes that future on its own gRPC callback thread, so the `.thenCompose` persist runs there too. The unit of work began its Spring transaction on a different thread, and Spring transactions are bound to the starting thread, so the connector thread has no bound transaction => `TransactionRequiredException`.

### Fix
Resolve the token first, then run the persist in its own unit of work dispatched to the coordinator's executor. This stays non-blocking (blocking was removed from the PSEP in #3773) and keeps begin/persist/commit off the connector's gRPC thread. `thenComposeAsync(..., executorService)` is used rather than `thenCompose` so the persist runs on a thread we control, not on whichever thread completed the token future.

As a consequence, `initialToken.apply(eventSource)` now resolves outside the token-store unit of work. This is not a behavior change for any released version, since async initialization is itself unreleased #3773 work; custom `initialToken` functions run without a thread-bound transaction and must manage their own resources (the default function and the `StreamableEventSource` token methods already do).

### bug and enhancement

Marked as bug and enhancement since it was a bug in an enhancement that was not released yet #3773
