### PR TITLE
[#137] Message Transformation - Drop / Filter support (phase 5)

### DIFF
--- a/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
@@ -22,13 +22,15 @@ public final class CourseCatalogTransformations {
                                     .register(CoursePublishedV2ToV3.build())
                                     .register(StudentRegisteredV1ToV2.build())
                                     .register(WelcomeMessageBetaCleanup.build())
-                                    .build();                                // <3>
+                                    .register(SystemHeartbeatDrop.build())   // <3>
+                                    .build();                                // <4>
     }
 }
 ----
 <1> Start building the chain.
 <2> Each transformation runs in the order it is registered. See <<_why_ordering_matters>>.
-<3> `build()` produces an immutable chain, ready to register as a component.
+<3> A drop is registered like any other transformation; it removes its matching event from the read stream.
+<4> `build()` produces an immutable chain, ready to register as a component.
 
 Then make that chain available to your configuration as an `EventTransformerChain` component.
 You only ever supply the chain. The framework's configuration detects the chain and installs decorates the event store with transformation logic for you. Hence, there is nothing to wire on the event store itself for users.
@@ -69,7 +71,7 @@ Both approaches do the same thing: they provide one `EventTransformerChain` comp
 Register no chain and the event store is left untouched.
 
 The chain is built once at startup and is immutable afterwards.
-The `chain()` shown above is the one assembled in the xref:message-transformation:demo.adoc[course catalog example].
+The xref:message-transformation:demo.adoc[course catalog example] assembles a fuller chain the same way, adding a rename and more version hops alongside the drop shown here.
 
 [NOTE]
 .Transformation runs before interceptors

--- a/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/configuring-transformations.adoc
@@ -33,7 +33,7 @@ public final class CourseCatalogTransformations {
 <4> `build()` produces an immutable chain, ready to register as a component.
 
 Then make that chain available to your configuration as an `EventTransformerChain` component.
-You only ever supply the chain. The framework's configuration detects the chain and installs decorates the event store with transformation logic for you. Hence, there is nothing to wire on the event store itself for users.
+You only ever supply the chain. The framework's configuration detects the chain and decorates the event store with transformation logic for you. Hence, there is nothing to wire on the event store itself for users.
 How you register the component depends on your setup:
 
 [tabs]

--- a/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/defining-transformations.adoc
@@ -257,6 +257,39 @@ A type-filtering read for the new name still finds events stored under the old o
 So a projection that sources only `CoursePublished` events also receives the historic `CourseOffered` ones, and nothing is silently missed.
 ====
 
+[#_dropping_an_event]
+== Dropping an event
+
+Sometimes a stored event should no longer reach any handler at all.
+An old monitoring sidecar might have written `SystemHeartbeat` pings into the stream, or a class of event might now be regulated and must be suppressed from processing without being deleted from storage.
+`drop(...)` removes every matching event from the read stream:
+
+[source,java]
+----
+private static final MessageType FROM = new MessageType("coursecatalog.SystemHeartbeat", "1.0.0");
+
+public static EventTransformation build() {
+    return EventTransformation.drop(FROM); // <1>
+}
+----
+<1> `drop(from)` takes only the identity to match. There is no `to` and no mapper: a matched event produces no output, the 1:0 case.
+
+A drop matches its `from` by exact identity, like a concrete `from(...)`; it does not take a predicate.
+No payload conversion happens, because nothing is produced.
+
+The stored events stay exactly as they were written; only the read path is affected.
+A dropped event never reaches a handler, and surviving events keep their original tracking token: once a streaming processor reads an event after a drop, the dropped position is covered, so a restart does not reprocess it.
+
+Unlike a <<_renaming_an_event,rename>>, a drop declares no `to`, so it adds no read-time widening: a type-filtering read is never broadened to fetch a dropped event.
+
+[NOTE]
+.Dropping an event versus dropping a field
+====
+`drop(...)` removes a whole _event_ from the read stream.
+To drop a _field_ that handlers no longer read, let the xref:ROOT:conversion.adoc[converter] ignore it instead: that is a conversion concern, not a transformation.
+See xref:message-transformation:index.adoc[the overview] for when each applies.
+====
+
 == Next steps
 
 With your transformations defined, the next step is to assemble and register them.

--- a/docs/reference-guide/modules/message-transformation/pages/demo.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/demo.adoc
@@ -43,8 +43,12 @@ The demo composes a chain of transformations, each illustrating a technique cove
 | `WelcomeMessageBetaCleanup`
 | every `0.x` beta version folds up to `1.0.0`
 | xref:defining-transformations.adoc#_matching_multiple_event_versions[a version-only predicate scoped with `declaringFromTypes`]
+
+| `SystemHeartbeatDrop`
+| `SystemHeartbeat` pings are removed from the read stream, so the projection's heartbeat count stays at zero
+| a xref:defining-transformations.adoc#_dropping_an_event[drop], one event in and none out
 |===
 
 A further class, `WelcomeMessageBetaCleanupWithoutPreFilter`, expresses that last rule without `declaringFromTypes(...)` to contrast the xref:defining-transformations.adoc#_matching_multiple_event_versions[two predicate-`from` styles]. It is not registered in the chain.
 
-The chain is assembled in `CourseCatalogTransformations` and registered as an `EventTransformerChain` component, exactly as shown in xref:configuring-transformations.adoc[Configuring transformations].
+The chain is assembled in `CourseCatalogTransformations` and registered as an `EventTransformerChain` component, as shown in xref:configuring-transformations.adoc[Configuring transformations].

--- a/docs/reference-guide/modules/message-transformation/pages/index.adoc
+++ b/docs/reference-guide/modules/message-transformation/pages/index.adoc
@@ -52,7 +52,7 @@ The structural form needs no extra classes, the typed form gives compile-time sa
 
 From here:
 
-* xref:message-transformation:defining-transformations.adoc[] shows how to write the individual transformations, map straight to a typed event, work with generic payloads, match several event versions at once, and rename an event.
+* xref:message-transformation:defining-transformations.adoc[] shows how to write the individual transformations, map straight to a typed event, work with generic payloads, match several event versions at once, rename an event, and drop one entirely.
 * xref:message-transformation:configuring-transformations.adoc[] shows how to assemble them into a chain, register it, and test it.
 * xref:message-transformation:demo.adoc[] is a runnable example that exercises every technique on a course catalog end to end.
 

--- a/examples/university-message-transformation/README.md
+++ b/examples/university-message-transformation/README.md
@@ -18,6 +18,7 @@ through schema evolution, and exercises them end to end.
 | `StudentRegisteredV1ToV2` | `StudentRegistered#1.0.0` / `#2.0.0` | `TypeReference<Map<String,Object>>` overload, no Jackson dependency in user code. |
 | `SystemAnnouncementLegacyUplift` | `SystemAnnouncement#0.0.1` / `#1.0.0` | Unversioned legacy events: `@Event` without a `version` defaults to `0.0.1`. |
 | `WelcomeMessageBetaCleanup` | `WelcomeMessageSent#0.*` / `#1.0.0` | Predicate-based source, one transformation matches every beta version. |
+| `SystemHeartbeatDrop` | `SystemHeartbeat#1.0.0` / _(none)_ | A drop (`EventTransformation.drop`): the event is removed from the read stream before any handler sees it, while staying in storage. The projection counts heartbeats, so the printed `System heartbeats seen: 0` shows the suppression (it would be non-zero without the drop). |
 
 The chain is composed in
 [`CourseCatalogTransformations`](src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java).
@@ -66,8 +67,9 @@ mvn compile exec:java
 Or run `CourseCatalogApplication#main` from your IDE.
 
 The bootstrap seeds the legacy history, dispatches a few sample commands, awaits
-the projection, prints the resulting catalog view, and shuts down. The printed
-view ends with a `Welcome messages` section: which shows which students were registered in the past.
+the projection, prints the resulting catalog view, and shuts down. The printed view ends with the
+`Welcome messages` section and a `System heartbeats seen: 0` line: the heartbeats are in storage, but
+the drop keeps the projection from ever counting them.
 
 The bundled `logback.xml` enables `DEBUG` for `io.axoniq.framework.messaging.transformation`,
 so the chain build log naming every registered transformation shows up on startup.
@@ -131,6 +133,7 @@ Welcome messages (3):
   - Student:alice: Welcome to the catalog, Alice.
   - Student:bob: Hi Bob, welcome to the catalog.
   - Student:carol: Welcome Carol.
+System heartbeats seen by the projection: 0 (stored but dropped on read, so none are processed)
 
 course-catalog> welcome alice
   Student:alice: Welcome to the catalog, Alice.

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/CourseCatalogApplication.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/CourseCatalogApplication.java
@@ -202,6 +202,8 @@ public class CourseCatalogApplication {
         for (WelcomeMessageView message : view.welcomeMessages()) {
             report.append("  - ").append(message.studentId()).append(": ").append(message.body()).append('\n');
         }
+        report.append("System heartbeats seen by the projection: ").append(view.heartbeatsSeen())
+              .append(" (pings are stored but dropped on read, so none are processed)\n");
         String reportAsString = report.toString();
         logger.info(reportAsString);
     }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/InteractiveShell.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/InteractiveShell.java
@@ -245,6 +245,8 @@ final class InteractiveShell {
         for (WelcomeMessageView message : view.welcomeMessages()) {
             print("  - " + message.studentId() + ": " + message.body());
         }
+        print("System heartbeats seen by the projection: " + view.heartbeatsSeen()
+                      + " (stored but dropped on read, so none are processed)");
     }
 
     private CourseCatalogView queryCatalog() {

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/CourseCatalogMessageNames.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/CourseCatalogMessageNames.java
@@ -43,6 +43,8 @@ public final class CourseCatalogMessageNames {
     public static final String SYSTEM_ANNOUNCEMENT       = NAMESPACE + ".SystemAnnouncement";
     /** Qualified name of {@code WelcomeMessageSent}. */
     public static final String WELCOME_MESSAGE_SENT      = NAMESPACE + ".WelcomeMessageSent";
+    /** Qualified name of the legacy {@code SystemHeartbeat} event, dropped on read. */
+    public static final String SYSTEM_HEARTBEAT          = NAMESPACE + ".SystemHeartbeat";
     /** Qualified name of {@code CatalogSeeded}; written by the seeder as an idempotency marker. */
     public static final String CATALOG_SEEDED            = NAMESPACE + ".CatalogSeeded";
 

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/events/SystemHeartbeat.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/events/SystemHeartbeat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.events;
+
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogTags;
+import org.axonframework.examples.demo.coursecatalog.shared.ids.CatalogId;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.messaging.eventhandling.annotation.Event;
+
+/**
+ * An operational liveness ping from a retired monitoring sidecar. The catalog projection counts the
+ * heartbeats it sees, but the {@code SystemHeartbeatDrop} transformation removes these pings on read,
+ * so that count stays at zero while the pings remain in storage.
+ *
+ * @param catalogId the catalog the ping belongs to
+ * @param sequence  the ping's sequence number
+ */
+@Event(namespace = CourseCatalogMessageNames.NAMESPACE, name = "SystemHeartbeat", version = "1.0.0")
+public record SystemHeartbeat(
+        @EventTag(key = CourseCatalogTags.CATALOG_ID) CatalogId catalogId,
+        int sequence
+) {
+}

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CatalogViewProjection.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CatalogViewProjection.java
@@ -22,6 +22,7 @@ import org.axonframework.examples.demo.coursecatalog.catalog.events.Registration
 import org.axonframework.examples.demo.coursecatalog.catalog.events.StudentEnrolledInCourse;
 import org.axonframework.examples.demo.coursecatalog.catalog.events.StudentRegistered;
 import org.axonframework.examples.demo.coursecatalog.catalog.events.SystemAnnouncement;
+import org.axonframework.examples.demo.coursecatalog.catalog.events.SystemHeartbeat;
 import org.axonframework.examples.demo.coursecatalog.catalog.events.WelcomeMessageSent;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 
@@ -81,5 +82,12 @@ class CatalogViewProjection {
     @EventHandler
     void on(WelcomeMessageSent event) {
         repository.recordWelcomeMessage(event.studentId(), event.body());
+    }
+
+    @EventHandler
+    void on(SystemHeartbeat event) {
+        // Never reached while the SystemHeartbeat drop is registered: the chain removes the ping
+        // before it gets here, so the recorded count stays at zero.
+        repository.recordHeartbeat(event.sequence());
     }
 }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CatalogViewRepository.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CatalogViewRepository.java
@@ -55,6 +55,9 @@ public interface CatalogViewRepository {
      */
     void recordWelcomeMessage(StudentId studentId, String body);
 
+    /** @param sequence the heartbeat's sequence number (re-recording the same sequence is a no-op) */
+    void recordHeartbeat(int sequence);
+
     /** @return the full snapshot of the catalog */
     CourseCatalogView snapshot();
 }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CourseCatalogView.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/CourseCatalogView.java
@@ -28,12 +28,15 @@ import java.util.List;
  * @param announcements       every system announcement, in arrival order
  * @param registeredStudents  total number of students registered in the catalog
  * @param welcomeMessages     every welcome message, lifted to the current shape by the chain
+ * @param heartbeatsSeen      number of {@code SystemHeartbeat} pings the projection recorded; stays
+ *                            zero while the heartbeat drop is registered, even though pings are stored
  */
 public record CourseCatalogView(
         List<CatalogViewReadModel> courses,
         List<EnrolmentReadModel> enrolments,
         List<String> announcements,
         int registeredStudents,
-        List<WelcomeMessageView> welcomeMessages
+        List<WelcomeMessageView> welcomeMessages,
+        int heartbeatsSeen
 ) {
 }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/InMemoryCatalogViewRepository.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/read/catalogview/InMemoryCatalogViewRepository.java
@@ -40,6 +40,7 @@ class InMemoryCatalogViewRepository implements CatalogViewRepository {
     private final Set<String> announcements = new LinkedHashSet<>();
     private final Set<StudentId> registeredStudents = new HashSet<>();
     private final Map<StudentId, String> welcomeMessages = new LinkedHashMap<>();
+    private final Set<Integer> heartbeatSequences = new HashSet<>();
 
     @Override
     public synchronized void saveCourse(CatalogViewReadModel course) {
@@ -78,6 +79,11 @@ class InMemoryCatalogViewRepository implements CatalogViewRepository {
     }
 
     @Override
+    public synchronized void recordHeartbeat(int sequence) {
+        heartbeatSequences.add(sequence);
+    }
+
+    @Override
     public synchronized CourseCatalogView snapshot() {
         List<EnrolmentReadModel> enrolmentRows = new ArrayList<>();
         enrolments.forEach((courseId, byStudent) -> byStudent.forEach(
@@ -89,7 +95,8 @@ class InMemoryCatalogViewRepository implements CatalogViewRepository {
                 registeredStudents.size(),
                 welcomeMessages.entrySet().stream()
                                .map(entry -> new WelcomeMessageView(entry.getKey(), entry.getValue()))
-                               .toList()
+                               .toList(),
+                heartbeatSequences.size()
         );
     }
 }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/LegacyEventSeeder.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/LegacyEventSeeder.java
@@ -19,6 +19,7 @@ package org.axonframework.examples.demo.coursecatalog.catalog.seed;
 import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
 import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogTags;
 import org.axonframework.examples.demo.coursecatalog.catalog.events.CatalogSeeded;
+import org.axonframework.examples.demo.coursecatalog.catalog.events.SystemHeartbeat;
 import org.axonframework.examples.demo.coursecatalog.shared.ids.CatalogId;
 import org.axonframework.examples.demo.coursecatalog.shared.ids.CourseId;
 import org.axonframework.examples.demo.coursecatalog.shared.ids.StudentId;
@@ -41,7 +42,8 @@ import java.util.UUID;
  * so the application boots into a state with v1/v2 {@code CoursePublished}
  * payloads, v1 {@code StudentRegistered} payloads, beta-versioned
  * {@code WelcomeMessageSent} payloads, and an unversioned {@code SystemAnnouncement}
- * waiting for the transformation chain to lift them on read.
+ * waiting for the transformation chain to lift them on read. It also writes a couple of
+ * {@code SystemHeartbeat} pings, which the chain drops on read so the projection never counts them.
  * <p>
  * Idempotent: state-sourced from the catalog's {@link CatalogSeeded} marker. Calling
  * the {@link SeedCatalog} command a second time is a no-op.
@@ -86,6 +88,11 @@ public class LegacyEventSeeder {
                                             "Welcome Carol."),
 
                 new SystemAnnouncementUnversioned(catalogId, "Catalog launched in 2023"),
+
+                // Operational noise from a retired monitoring sidecar. The projection counts heartbeats,
+                // but the SystemHeartbeat drop suppresses them on read, so the count stays at zero.
+                new SystemHeartbeat(catalogId, 1),
+                new SystemHeartbeat(catalogId, 2),
 
                 new CatalogSeeded(catalogId, UUID.randomUUID().toString())
         );

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/CourseCatalogTransformations.java
@@ -24,6 +24,9 @@ import io.axoniq.framework.messaging.transformation.events.EventTransformerChain
  * v2 to v3 so a stored v1 event reaches a handler as the current shape. The
  * {@code CourseOffered} rename runs first, so a renamed event then flows through the
  * {@code CoursePublished} version chain.
+ * <p>
+ * The {@code SystemHeartbeat} drop is order-independent: no other transformation matches that
+ * event, so it removes the legacy heartbeats from the read stream wherever it sits.
  */
 public final class CourseCatalogTransformations {
 
@@ -40,6 +43,7 @@ public final class CourseCatalogTransformations {
                                     .register(StudentRegisteredV1ToV2.build())
                                     .register(StudentRegisteredV2ToV3.build())
                                     .register(WelcomeMessageBetaCleanup.build())
+                                    .register(SystemHeartbeatDrop.build())
                                     .build();
     }
 }

--- a/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/SystemHeartbeatDrop.java
+++ b/examples/university-message-transformation/src/main/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/SystemHeartbeatDrop.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.transformations;
+
+import io.axoniq.framework.messaging.transformation.events.EventTransformation;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.messaging.core.MessageType;
+
+/**
+ * Drops the {@code SystemHeartbeat} event. An old monitoring sidecar wrote these liveness pings into
+ * the catalog stream; the projection still counts them, but they are operational noise that should be
+ * suppressed from processing. {@link EventTransformation#drop(MessageType)} removes every matching
+ * event from the read stream while leaving it untouched in storage, so the projection's heartbeat
+ * count stays at zero without rewriting history.
+ * <p>
+ * Surviving events keep their tracking token, so once a streaming processor reads an event after a
+ * drop the dropped position is covered and not revisited. Matching is by exact identity, like a
+ * concrete {@code from(...)}; a drop takes no predicate.
+ */
+public final class SystemHeartbeatDrop {
+
+    private static final MessageType FROM =
+            new MessageType(CourseCatalogMessageNames.SYSTEM_HEARTBEAT, "1.0.0");
+
+    private SystemHeartbeatDrop() {
+    }
+
+    /** @return the transformation registered into the chain */
+    public static EventTransformation build() {
+        return EventTransformation.drop(FROM);
+    }
+}

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/ChainBuildLogTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/ChainBuildLogTest.java
@@ -60,13 +60,14 @@ class ChainBuildLogTest {
                                                         .toList();
         assertThat(debugEntries).hasSize(1);
         assertThat(debugEntries.getFirst().getFormattedMessage())
-                .contains("7 transformation(s)",
+                .contains("8 transformation(s)",
                           "coursecatalog.CourseOffered#1.0.0",
                           "coursecatalog.CoursePublished#1.0.0",
                           "coursecatalog.CoursePublished#2.0.0",
                           "coursecatalog.StudentRegistered#1.0.0",
                           "coursecatalog.StudentRegistered#2.0.0",
                           "coursecatalog.SystemAnnouncement#0.0.1",
-                          "coursecatalog.WelcomeMessageSent#1.0.0");
+                          "coursecatalog.WelcomeMessageSent#1.0.0",
+                          "coursecatalog.SystemHeartbeat#1.0.0");
     }
 }

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/DropTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/chain/DropTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.chain;
+
+import io.axoniq.framework.messaging.transformation.events.EventTransformerChain;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.testutil.ChainTester;
+import org.axonframework.examples.demo.coursecatalog.catalog.transformations.CourseCatalogTransformations;
+import org.axonframework.messaging.core.MessageType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@code drop(...)} removes a matched event from the read stream entirely (the 1:0 case), while
+ * the rest of the chain keeps lifting the events it handles. These tests run the full assembled
+ * catalog chain to show both sides of that behavior.
+ */
+class DropTest {
+
+    @Test
+    void systemHeartbeatIsDroppedByTheAssembledChain() {
+        // The catalog chain registers a drop for the legacy SystemHeartbeat, so a stored heartbeat
+        // produces no output and reaches no handler.
+        ChainTester.forChain(CourseCatalogTransformations.chain())
+                   .given()
+                   .messageType(CourseCatalogMessageNames.SYSTEM_HEARTBEAT, "1.0.0")
+                   .payloadFromResource("/transformations/systemheartbeat/v1.json")
+                   .when()
+                   .then()
+                   .noOutput();
+    }
+
+    @Test
+    void aHandledEventStillTransformsThroughAChainThatRegistersADrop() {
+        // Contrast: with the drop registered in the chain, a stored CoursePublished v1 still reaches
+        // its current 3.0.0 shape; the drop only suppresses its own SystemHeartbeat.
+        ChainTester.forChain(CourseCatalogTransformations.chain())
+                   .given()
+                   .messageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "1.0.0")
+                   .payloadFromResource("/transformations/coursepublished/v1.json")
+                   .when()
+                   .then()
+                   .success()
+                   .outputType(new MessageType(CourseCatalogMessageNames.COURSE_PUBLISHED, "3.0.0"))
+                   .outputPayloadStructurallyEquals("/transformations/coursepublished/v3.json");
+    }
+
+    @Test
+    void withoutTheDropAHeartbeatWouldReachHandlers() {
+        // Negative control: a chain without the drop lets the heartbeat through unchanged, so it would
+        // reach the projection's handler. Registering the drop is what keeps it out.
+        ChainTester.forChain(EventTransformerChain.builder().build())
+                   .given()
+                   .messageType(CourseCatalogMessageNames.SYSTEM_HEARTBEAT, "1.0.0")
+                   .payloadFromResource("/transformations/systemheartbeat/v1.json")
+                   .when()
+                   .then()
+                   .success()
+                   .outputType(new MessageType(CourseCatalogMessageNames.SYSTEM_HEARTBEAT, "1.0.0"));
+    }
+}

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/SystemHeartbeatDropProjectionTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/SystemHeartbeatDropProjectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.seed;
+
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogAxonTestFixture;
+import org.axonframework.examples.demo.coursecatalog.catalog.Ids;
+import org.axonframework.examples.demo.coursecatalog.catalog.events.SystemHeartbeat;
+import org.axonframework.examples.demo.coursecatalog.catalog.read.catalogview.CatalogViewReadModel;
+import org.axonframework.examples.demo.coursecatalog.catalog.read.catalogview.CourseCatalogView;
+import org.axonframework.examples.demo.coursecatalog.catalog.read.catalogview.GetCourseCatalogView;
+import org.axonframework.examples.demo.coursecatalog.shared.ids.CourseId;
+import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+import org.axonframework.test.fixture.AxonTestFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Console-visible proof of the drop: the catalog projection has a {@code SystemHeartbeat} handler that
+ * counts pings, but the {@code SystemHeartbeatDrop} transformation suppresses them on read. So the
+ * projection's {@code heartbeatsSeen} count stays at zero even though heartbeats are stored and
+ * interleaved with events the projection does process.
+ */
+class SystemHeartbeatDropProjectionTest {
+
+    private AxonTestFixture fixture;
+
+    @BeforeEach
+    void beforeEach() {
+        fixture = CourseCatalogAxonTestFixture.app();
+    }
+
+    @AfterEach
+    void afterEach() {
+        fixture.stop();
+    }
+
+    @Test
+    void heartbeatsAreDroppedBeforeReachingTheProjectionWhileSiblingEventsStillLand() {
+        fixture.given()
+               .events(new SystemHeartbeat(Ids.CATALOG_ID, 1),
+                       new LegacyEventSeeder.CoursePublishedV1(
+                               Ids.CATALOG_ID, CourseId.of("hb-course"), "Heartbeat Neighbour", 10),
+                       new SystemHeartbeat(Ids.CATALOG_ID, 2))
+               .then()
+               .await(r -> r.expect(cfg -> {
+                   CourseCatalogView view = queryView(cfg);
+                   // The course interleaved with the heartbeats is projected, so the processor has
+                   // consumed the stream...
+                   assertThat(view.courses())
+                           .extracting(CatalogViewReadModel::courseId)
+                           .contains(CourseId.of("hb-course"));
+                   // ...yet the heartbeats around it were dropped before the projection's handler ran.
+                   assertThat(view.heartbeatsSeen()).isZero();
+               }));
+    }
+
+    private static CourseCatalogView queryView(Configuration configuration) {
+        return configuration.getComponent(QueryGateway.class)
+                            .query(new GetCourseCatalogView(), CourseCatalogView.class, null)
+                            .orTimeout(5, TimeUnit.SECONDS)
+                            .join();
+    }
+}

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/SystemHeartbeatDropStreamingIntegrationTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/seed/SystemHeartbeatDropStreamingIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.seed;
+
+import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogAxonTestFixture;
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.Ids;
+import org.axonframework.examples.demo.coursecatalog.catalog.events.SystemHeartbeat;
+import org.axonframework.examples.demo.coursecatalog.shared.ids.CourseId;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.axonframework.test.fixture.AxonTestFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end proof that the drop fires on the streaming read path: a stored {@code SystemHeartbeat}
+ * is removed by the {@code SystemHeartbeatDrop} transformation, and surviving events keep their original
+ * tracking token, so a reader resuming from a survivor's token after the drop is not re-delivered the
+ * heartbeat (it never reaches a handler). This test re-opens the store from a token rather than
+ * restarting a real processor.
+ * <p>
+ * Unlike the catalog projection (which type-filters to the events it handles and so never reads a
+ * heartbeat), this test opens the configured {@link EventStore} directly with no type filter, so the
+ * heartbeat really is read from storage and the chain must drop it on the way out.
+ */
+class SystemHeartbeatDropStreamingIntegrationTest {
+
+    private AxonTestFixture fixture;
+
+    @BeforeEach
+    void beforeEach() {
+        fixture = CourseCatalogAxonTestFixture.app();
+    }
+
+    @AfterEach
+    void afterEach() {
+        fixture.stop();
+    }
+
+    @Test
+    void droppedHeartbeatIsAbsentFromTheStreamAndARestartReprocessesNothing() {
+        fixture.given()
+               .events(new LegacyEventSeeder.CoursePublishedV1(
+                               Ids.CATALOG_ID, CourseId.of("streaming-1"), "Course One", 10),
+                       new SystemHeartbeat(Ids.CATALOG_ID, 1),
+                       new LegacyEventSeeder.CoursePublishedV1(
+                               Ids.CATALOG_ID, CourseId.of("streaming-2"), "Course Two", 20))
+               .then()
+               .await(r -> r.expect(cfg -> {
+                   EventStore store = cfg.getComponent(EventStore.class);
+                   TrackingToken head = store.firstToken(null).join();
+
+                   // Reading the whole stream from its head with no type filter: the heartbeat is
+                   // dropped, while both courses surface (lifted to their current shape).
+                   List<MessageStream.Entry<EventMessage>> all =
+                           drain(store, StreamingCondition.startingFrom(head));
+                   assertThat(all).as("dropped heartbeat must not reach the stream")
+                                  .noneMatch(SystemHeartbeatDropStreamingIntegrationTest::isHeartbeat);
+                   assertThat(all).filteredOn(SystemHeartbeatDropStreamingIntegrationTest::isCoursePublished)
+                                  .hasSize(2);
+
+                   // Resuming from the first course's token skips the dropped heartbeat that sits next
+                   // in storage: the heartbeat is never re-delivered, while the later course still
+                   // arrives. So a reader resuming after the drop does not reprocess it.
+                   TrackingToken afterFirstCourse = TrackingToken.fromContext(all.getFirst()).orElseThrow();
+                   List<MessageStream.Entry<EventMessage>> afterRestart =
+                           drain(store, StreamingCondition.startingFrom(afterFirstCourse));
+                   assertThat(afterRestart).noneMatch(SystemHeartbeatDropStreamingIntegrationTest::isHeartbeat);
+                   assertThat(afterRestart).anyMatch(SystemHeartbeatDropStreamingIntegrationTest::isCoursePublished);
+               }));
+    }
+
+    /**
+     * Drains every entry currently available from a streaming read, then closes the stream. A
+     * streaming read does not complete (it tails for new events), so the entries are pulled with
+     * {@link MessageStream#next()} until none remain rather than reduced to completion.
+     */
+    private static List<MessageStream.Entry<EventMessage>> drain(EventStore store, StreamingCondition condition) {
+        MessageStream<EventMessage> stream = store.open(condition, null);
+        try {
+            List<MessageStream.Entry<EventMessage>> entries = new ArrayList<>();
+            Optional<MessageStream.Entry<EventMessage>> next;
+            while ((next = stream.next()).isPresent()) {
+                entries.add(next.get());
+            }
+            return entries;
+        } finally {
+            stream.close();
+        }
+    }
+
+    private static boolean isHeartbeat(MessageStream.Entry<EventMessage> entry) {
+        return entry.message().type().qualifiedName().name().equals(CourseCatalogMessageNames.SYSTEM_HEARTBEAT);
+    }
+
+    private static boolean isCoursePublished(MessageStream.Entry<EventMessage> entry) {
+        return entry.message().type().qualifiedName().name().equals(CourseCatalogMessageNames.COURSE_PUBLISHED);
+    }
+}

--- a/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/SystemHeartbeatDropTest.java
+++ b/examples/university-message-transformation/src/test/java/org/axonframework/examples/demo/coursecatalog/catalog/transformations/SystemHeartbeatDropTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.coursecatalog.catalog.transformations;
+
+import org.axonframework.examples.demo.coursecatalog.catalog.CourseCatalogMessageNames;
+import org.axonframework.examples.demo.coursecatalog.catalog.testutil.TransformationTester;
+import org.junit.jupiter.api.Test;
+
+class SystemHeartbeatDropTest {
+
+    @Test
+    void dropsSystemHeartbeatSoNoEventIsProduced() {
+        // A drop is the 1:0 case: the matched event yields no output, so no handler ever sees it.
+        TransformationTester.forTransformation(SystemHeartbeatDrop.build())
+                            .given()
+                            .messageType(CourseCatalogMessageNames.SYSTEM_HEARTBEAT, "1.0.0")
+                            .payloadFromResource("/transformations/systemheartbeat/v1.json")
+                            .when()
+                            .then()
+                            .noOutput();
+    }
+}

--- a/examples/university-message-transformation/src/test/resources/transformations/systemheartbeat/v1.json
+++ b/examples/university-message-transformation/src/test/resources/transformations/systemheartbeat/v1.json
@@ -1,0 +1,4 @@
+{
+  "catalogId": "Catalog:axoniq-university",
+  "sequence": 1
+}


### PR DESCRIPTION
https://github.com/AxonIQ/axoniq-framework/issues/137

## Review first in following order
base implementation => https://github.com/AxonIQ/axoniq-framework/pull/153 + https://github.com/AxonIQ/AxonFramework/pull/4629 + https://github.com/AxonIQ/AxonFramework/pull/4624
criteria widening (making rename later and filtering for predicates possible) => https://github.com/AxonIQ/axoniq-framework/pull/160 and https://github.com/AxonIQ/AxonFramework/pull/4638
renaming https://github.com/AxonIQ/axoniq-framework/pull/164 and https://github.com/AxonIQ/AxonFramework/pull/4642


## demo + docs for the event drop transformation

Demonstrates the drop in the `university-message-transformation` example and the reference guide. Depends on the axoniq-framework drop PR => https://github.com/AxonIQ/axoniq-framework/pull/167.

- `SystemHeartbeatDrop` registered in the catalog chain; `SystemHeartbeat` events seeded; the projection counts them but the drop suppresses them on read, so the printed view shows `System heartbeats seen: 0`.
- Tests: unit (`noOutput`), full-chain `DropTest` (+ negative control), projection (`heartbeatsSeen == 0` while a sibling course lands), streaming integration (dropped from the stream + restart skip).
- Docs: "Dropping an event" section, registration example, demo table + index mention; README updated.

