### PR TITLE
Avoid costly stack walk on every task start in AxonTimeLimitedTask

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/timeout/AxonTimeLimitedTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/AxonTimeLimitedTask.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a task with a timeout. The task will be interrupted when the {@code timeout} is reached. If the
  * {@code warningThreshold} is lower than the timeout, warnings will be logged at the configured {@code warningInterval}
@@ -47,12 +49,13 @@ class AxonTimeLimitedTask {
     private final ScheduledExecutorService scheduledExecutorService;
     private final Logger logger;
     private final Object lock = new Object();
+    @Nullable
+    private final String callerClassName; // stored as name to avoid getName() on every stack frame check
     private boolean completed = false;
     private boolean interrupted = false;
     private boolean interruptedExternally = false;
     private long startTimeMs = -1;
     private Future<?> currentScheduledFuture = null;
-    private String startStackTrace;
 
 
     /**
@@ -73,12 +76,37 @@ class AxonTimeLimitedTask {
                                int timeout,
                                int warningThreshold,
                                int warningInterval) {
+        this(taskName, timeout, warningThreshold, warningInterval, AxonTaskJanitor.INSTANCE, AxonTaskJanitor.LOGGER, null);
+    }
+
+    /**
+     * Creates a new {@link AxonTimeLimitedTask} for the given {@code task} with the given {@code timeout},
+     * {@code warningThreshold} and {@code warningInterval}. Runs the provided task on the current thread after
+     * scheduling a timeout and warnings on another thread.
+     * <p>
+     * The {@code callerClass} is used to trim the stack trace in timeout/warning logs, cutting off framework internals
+     * below the caller. If you do not need trimming, use
+     * {@link #AxonTimeLimitedTask(String, int, int, int)}.
+     *
+     * @param taskName         The task's name to be included in the logging
+     * @param timeout          The timeout in milliseconds
+     * @param warningThreshold The threshold in milliseconds after which a warning is logged. Setting this to a value
+     *                         equal or higher than {@code timeout} will disable warnings.
+     * @param warningInterval  The interval in milliseconds between warnings.
+     * @param callerClass      the class of the direct caller, used to trim the stack trace in timeout/warning logs
+     */
+    public AxonTimeLimitedTask(String taskName,
+                               int timeout,
+                               int warningThreshold,
+                               int warningInterval,
+                               Class<?> callerClass) {
         this(taskName,
              timeout,
              warningThreshold,
              warningInterval,
              AxonTaskJanitor.INSTANCE,
-             AxonTaskJanitor.LOGGER
+             AxonTaskJanitor.LOGGER,
+             callerClass
         );
     }
 
@@ -98,8 +126,8 @@ class AxonTimeLimitedTask {
      * @param warningThreshold         The threshold in milliseconds after which a warning is logged. Setting this to a
      *                                 value equal or higher than {@code timeout} will disable warnings.
      * @param warningInterval          The interval in milliseconds between warnings.
-     * @param scheduledExecutorService The executor service to schedule the timeout and warnings
-     * @param logger                   The logger to log the warnings and errors
+     * @param scheduledExecutorService the executor service to schedule the timeout and warnings
+     * @param logger                   the logger to log the warnings and errors
      */
     public AxonTimeLimitedTask(String taskName,
                                int timeout,
@@ -107,6 +135,36 @@ class AxonTimeLimitedTask {
                                int warningInterval,
                                ScheduledExecutorService scheduledExecutorService,
                                Logger logger) {
+        this(taskName, timeout, warningThreshold, warningInterval, scheduledExecutorService, logger, null);
+    }
+
+    /**
+     * Creates a new {@link AxonTimeLimitedTask} for the given {@code task} with the given {@code timeout},
+     * {@code warningThreshold} and {@code warningInterval}. For scheduling, the provided
+     * {@code scheduledExecutorService} will be used. To log warnings and errors, the provided {@code logger} will be
+     * used.
+     * <p>
+     * The {@code callerClass} is used to trim the stack trace in timeout/warning logs, cutting off framework internals
+     * below the caller. If you do not need trimming, use
+     * {@link #AxonTimeLimitedTask(String, int, int, int, ScheduledExecutorService, Logger)}.
+     *
+     * @param taskName                 The task's name to be included in the logging
+     * @param timeout                  The timeout in milliseconds
+     * @param warningThreshold         The threshold in milliseconds after which a warning is logged. Setting this to a
+     *                                 value equal or higher than {@code timeout} will disable warnings.
+     * @param warningInterval          The interval in milliseconds between warnings.
+     * @param scheduledExecutorService the executor service to schedule the timeout and warnings
+     * @param logger                   the logger to log the warnings and errors
+     * @param callerClass              the class of the direct caller, used to trim the stack trace in timeout/warning
+     *                                 logs
+     */
+    public AxonTimeLimitedTask(String taskName,
+                               int timeout,
+                               int warningThreshold,
+                               int warningInterval,
+                               ScheduledExecutorService scheduledExecutorService,
+                               Logger logger,
+                               Class<?> callerClass) {
         if (taskName == null || taskName.isEmpty()) {
             throw new IllegalArgumentException("Task name cannot be null or empty");
         }
@@ -116,6 +174,7 @@ class AxonTimeLimitedTask {
         this.warningInterval = warningInterval;
         this.scheduledExecutorService = scheduledExecutorService;
         this.logger = logger;
+        this.callerClassName = callerClass != null ? callerClass.getName() : null;
         this.thread = Thread.currentThread();
     }
 
@@ -131,7 +190,6 @@ class AxonTimeLimitedTask {
             throw new IllegalStateException("Task can only be run once");
         }
         startTimeMs = System.currentTimeMillis();
-        startStackTrace = thread.getStackTrace()[2].getClassName();
 
         if (warningThreshold < 0 || warningThreshold >= timeout) {
             scheduleImmediateInterrupt();
@@ -321,8 +379,7 @@ class AxonTimeLimitedTask {
         StringBuilder sb = new StringBuilder();
         for (StackTraceElement element : stackTrace) {
             sb.append(element).append("\n");
-            // This is the start of the stack trace of the framework internals calling the method
-            if (element.toString().contains(startStackTrace)) {
+            if (callerClassName != null && element.getClassName().equals(callerClassName)) {
                 break;
             }
         }

--- a/messaging/src/main/java/org/axonframework/messaging/timeout/TimeoutWrappedMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/timeout/TimeoutWrappedMessageHandlingMember.java
@@ -69,7 +69,8 @@ class TimeoutWrappedMessageHandlingMember<T> extends WrappedMessageHandlingMembe
                 taskName,
                 timeout,
                 warningThreshold,
-                warningInterval
+                warningInterval,
+                getClass()
         );
         task.start();
         try {


### PR DESCRIPTION
Thread.getStackTrace() was called on every start() to capture the caller class name for log trimming, even though that information is only used when a timeout fires. Callers already know their own class, so the name is now passed as a Class<?> constructor parameter and stored once. The stack frame comparison is also tightened from a substring search on toString() to an exact match on getClassName().

Resolves #4637
This is a port of the fix made on `main`.