### PR TITLE
[#4652] Decorate `CommandBus` in `RetryingCommandBus` when a `RetryScheduler` is present

### DIFF
--- a/docs/reference-guide/modules/commands/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/commands/pages/infrastructure.adoc
@@ -260,8 +260,10 @@ Failures that do not match are propagated immediately without retrying.
 [source,java]
 ----
 // Only retry when the failure is not a validation error
-RetryPolicy policy = new FilteringRetryPolicy(delegate,
-        e -> !(e instanceof IllegalArgumentException));
+RetryPolicy policy = new FilteringRetryPolicy(
+        delegate,
+        e -> !(e instanceof IllegalArgumentException)
+);
 ----
 
 Compose them to express the exact behavior you need.

--- a/docs/reference-guide/modules/commands/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/commands/pages/infrastructure.adoc
@@ -223,6 +223,166 @@ See xref:messaging-concepts:message-intercepting.adoc#command-interceptors[Comma
 For customization options, see xref:tuning:command-processing.adoc#command-sequencing[Command sequencing].
 ====
 
+=== Retry behavior
+
+When a command dispatch fails, the framework can automatically retry it if a `RetryScheduler` is registered in the
+configuration.
+The `RetryScheduler` decides, based on the failure and the dispatch history, whether another attempt is warranted
+and how long to wait before trying again.
+No additional wiring is required: registering the scheduler is enough for the framework to activate retry behavior.
+
+The built-in `AsyncRetryScheduler` executes retries on a `ScheduledExecutorService` according to a `RetryPolicy`.
+Axon Framework provides three composable `RetryPolicy` implementations:
+
+`ExponentialBackOffRetryPolicy`::
+Doubles the retry delay after each attempt, starting from a given initial wait time in milliseconds.
+Retries indefinitely on its own, so combine it with `MaxAttemptsPolicy` to cap the number of attempts.
++
+[source,java]
+----
+// Retry with delays of 100ms, 200ms, 400ms, 800ms, ...
+RetryPolicy policy = new ExponentialBackOffRetryPolicy(100);
+----
+
+`MaxAttemptsPolicy`::
+Wraps any other policy and stops retrying once the maximum number of attempts is reached.
++
+[source,java]
+----
+// Retry at most 3 times using the given delegate policy
+RetryPolicy policy = new MaxAttemptsPolicy(delegate, 3);
+----
+
+`FilteringRetryPolicy`::
+Wraps any other policy and only delegates to it when the latest exception matches a given predicate.
+Failures that do not match are propagated immediately without retrying.
++
+[source,java]
+----
+// Only retry when the failure is not a validation error
+RetryPolicy policy = new FilteringRetryPolicy(delegate,
+        e -> !(e instanceof IllegalArgumentException));
+----
+
+Compose them to express the exact behavior you need.
+A common combination is exponential backoff, capped at a maximum number of retries, filtered to transient errors only:
+
+[source,java]
+----
+RetryPolicy policy = new MaxAttemptsPolicy(
+        new FilteringRetryPolicy(
+                new ExponentialBackOffRetryPolicy(100),
+                e -> !(e instanceof IllegalArgumentException)
+        ),
+        3
+);
+----
+
+Register an `AsyncRetryScheduler` with the policy to enable automatic retry behavior:
+
+[tabs]
+====
+Configuration API::
++
+--
+[source,java]
+----
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.core.retry.AsyncRetryScheduler;
+import org.axonframework.messaging.core.retry.ExponentialBackOffRetryPolicy;
+import org.axonframework.messaging.core.retry.FilteringRetryPolicy;
+import org.axonframework.messaging.core.retry.MaxAttemptsPolicy;
+import org.axonframework.messaging.core.retry.RetryScheduler;
+
+import java.util.concurrent.Executors;
+
+public class AxonConfig {
+
+    public void configureRetryScheduler(MessagingConfigurer configurer) {
+        configurer.componentRegistry(cr -> cr.registerComponent(
+                RetryScheduler.class,
+                config -> new AsyncRetryScheduler(
+                        new MaxAttemptsPolicy(
+                                new FilteringRetryPolicy(
+                                        new ExponentialBackOffRetryPolicy(100),
+                                        e -> !(e instanceof IllegalArgumentException)
+                                ),
+                                3
+                        ),
+                        Executors.newSingleThreadScheduledExecutor()
+                )
+        ));
+    }
+}
+----
+--
+
+Spring Boot::
++
+--
+[source,java]
+----
+import org.axonframework.messaging.core.retry.AsyncRetryScheduler;
+import org.axonframework.messaging.core.retry.ExponentialBackOffRetryPolicy;
+import org.axonframework.messaging.core.retry.FilteringRetryPolicy;
+import org.axonframework.messaging.core.retry.MaxAttemptsPolicy;
+import org.axonframework.messaging.core.retry.RetryScheduler;
+
+import java.util.concurrent.Executors;
+
+@Configuration
+public class AxonConfig {
+
+    @Bean
+    public RetryScheduler retryScheduler() {
+        return new AsyncRetryScheduler(
+                new MaxAttemptsPolicy(
+                        new FilteringRetryPolicy(
+                                new ExponentialBackOffRetryPolicy(100),
+                                e -> !(e instanceof IllegalArgumentException)
+                        ),
+                        3
+                ),
+                Executors.newSingleThreadScheduledExecutor()
+        );
+    }
+}
+----
+--
+====
+
+When the built-in policies do not cover your requirements, implement `RetryPolicy` directly.
+The interface receives the failed message, the current exception, and the exception types from all previous attempts,
+and returns a `RetryPolicy.Outcome` that either schedules the next attempt or aborts:
+
+[source,java]
+----
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.retry.RetryPolicy;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class CustomRetryPolicy implements RetryPolicy {
+
+    @Override
+    public Outcome defineFor(Message message, Throwable failure,
+                             List<Class<? extends Throwable>[]> previousFailures) {
+        if (failure instanceof IllegalArgumentException || previousFailures.size() >= 3) {
+            return Outcome.doNotReschedule();
+        }
+        return Outcome.rescheduleIn(2, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("maxRetries", 3);
+        descriptor.describeProperty("retryDelay", "2 SECONDS");
+    }
+}
+----
+
 == Command gateway
 
 The command gateway provides a convenient, type-safe API for dispatching commands.

--- a/docs/reference-guide/modules/commands/pages/infrastructure.adoc
+++ b/docs/reference-guide/modules/commands/pages/infrastructure.adoc
@@ -329,6 +329,8 @@ import org.axonframework.messaging.core.retry.ExponentialBackOffRetryPolicy;
 import org.axonframework.messaging.core.retry.FilteringRetryPolicy;
 import org.axonframework.messaging.core.retry.MaxAttemptsPolicy;
 import org.axonframework.messaging.core.retry.RetryScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.concurrent.Executors;
 

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -68,8 +68,7 @@ public class RetryingCommandBus implements CommandBus {
      */
     public RetryingCommandBus(CommandBus delegate,
                               RetryScheduler retryScheduler) {
-        this.delegate = requireNonNull(delegate, "The command bus delegate must be null.");
-         this.delegate = requireNonNull(delegate, "The command bus delegate must not be null.");
+        this.delegate = requireNonNull(delegate, "The command bus delegate must not be null.");
         this.retryScheduler = requireNonNull(retryScheduler, "The RetryScheduler must not be null.");
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -57,7 +57,7 @@ public class RetryingCommandBus implements CommandBus {
      * {@link org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus} (order
      * {@code Integer.MIN_VALUE + 100}), so that retries also pass through the interceptor chain.
      */
-    public static final int DECORATION_ORDER = Integer.MIN_VALUE + 200;
+    public static final int DECORATION_ORDER = Integer.MIN_VALUE + 1000;
 
     private final CommandBus delegate;
     private final RetryScheduler retryScheduler;

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -39,10 +39,7 @@ import static org.axonframework.common.FutureUtils.unwrap;
  * <p>
  * A {@link RetryScheduler} is used to determine if and how retries are performed. A {@code CommandBus} is automatically
  * decorated whenever a {@code RetryScheduler} is present in the
- * {@link org.axonframework.common.configuration.Configuration}. For manual decoration, be sure to use a
- * {@link
- * org.axonframework.common.configuration.ComponentRegistry#registerDecorator(org.axonframework.common.configuration.DecoratorDefinition)
- * decorator} with an order close to the {@link #DECORATION_ORDER} to ensure other components are not overtaken.
+ * {@link org.axonframework.common.configuration.Configuration}.
  *
  * @author Allard Buijze
  * @since 5.0.0

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -53,7 +53,7 @@ public class RetryingCommandBus implements CommandBus {
      * The order in which the {@link RetryingCommandBus} decorator is applied to the {@link CommandBus} relative to
      * other decorators.
      * <p>
-     * Set to {@code Integer.MIN_VALUE + 200} to ensure it wraps the
+     * Set to {@code Integer.MIN_VALUE + 1000} to ensure it wraps the
      * {@link org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus} (order
      * {@code Integer.MIN_VALUE + 100}), so that retries also pass through the interceptor chain.
      */

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -16,17 +16,17 @@
 
 package org.axonframework.messaging.commandhandling.retry;
 
-import org.jspecify.annotations.Nullable;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.commandhandling.CommandHandler;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
-import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageStream.Entry;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.retry.RetryScheduler;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -37,12 +37,27 @@ import static org.axonframework.common.FutureUtils.unwrap;
 /**
  * A {@code CommandBus} wrapper that will retry dispatching {@link CommandMessage commands} that resulted in a failure.
  * <p>
- * A {@link RetryScheduler} is used to determine if and how retries are performed.
+ * A {@link RetryScheduler} is used to determine if and how retries are performed. A {@code CommandBus} is automatically
+ * decorated whenever a {@code RetryScheduler} is present in the
+ * {@link org.axonframework.common.configuration.Configuration}. For manual decoration, be sure to use a
+ * {@link
+ * org.axonframework.common.configuration.ComponentRegistry#registerDecorator(org.axonframework.common.configuration.DecoratorDefinition)
+ * decorator} with an order close to the {@link #DECORATION_ORDER} to ensure other components are not overtaken.
  *
  * @author Allard Buijze
  * @since 5.0.0
  */
 public class RetryingCommandBus implements CommandBus {
+
+    /**
+     * The order in which the {@link RetryingCommandBus} decorator is applied to the {@link CommandBus} relative to
+     * other decorators.
+     * <p>
+     * Set to {@code Integer.MIN_VALUE + 200} to ensure it wraps the
+     * {@link org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus} (order
+     * {@code Integer.MIN_VALUE + 100}), so that retries also pass through the interceptor chain.
+     */
+    public static final int DECORATION_ORDER = Integer.MIN_VALUE + 200;
 
     private final CommandBus delegate;
     private final RetryScheduler retryScheduler;

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/retry/RetryingCommandBus.java
@@ -72,7 +72,8 @@ public class RetryingCommandBus implements CommandBus {
     public RetryingCommandBus(CommandBus delegate,
                               RetryScheduler retryScheduler) {
         this.delegate = requireNonNull(delegate, "The command bus delegate must be null.");
-        this.retryScheduler = requireNonNull(retryScheduler, "the RetryScheduler must not be null.");
+         this.delegate = requireNonNull(delegate, "The command bus delegate must not be null.");
+        this.retryScheduler = requireNonNull(retryScheduler, "The RetryScheduler must not be null.");
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
@@ -120,7 +120,7 @@ import java.util.List;
  * Furthermore, this enhancer will decorate the:
  * <ul>
  *     <li>The {@link CommandGateway} in a {@link ConvertingCommandGateway} with the present {@link MessageConverter}.</li>
- *     <li>The {@link CommandBus} in a {@link RetryingCommandBus} <b>if</b> a {@link RetryScheduler} is present in the
+ *     <li>The {@link CommandBus} is a {@link RetryingCommandBus} <b>if</b> a {@link RetryScheduler} is present in the
  *     registry. The {@link RetryingCommandBus} is applied outside the {@link InterceptingCommandBus} so that retries
  *     also traverse the interceptor chain.</li>
  *     <li>The {@link CommandBus} in a {@link InterceptingCommandBus} <b>if</b> there are any

--- a/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
@@ -117,7 +117,7 @@ import java.util.List;
  *     <li>Registers a {@link DefaultMessageMonitorRegistry} for class {@link MessageMonitorRegistry}</li>
  * </ul>
  * <p>
- * Furthermore, this enhancer will decorate the:
+* Furthermore, this enhancer will decorate the following components:
  * <ul>
  *     <li>The {@link CommandGateway} in a {@link ConvertingCommandGateway} with the present {@link MessageConverter}.</li>
  *     <li>The {@link CommandBus} is a {@link RetryingCommandBus} <b>if</b> a {@link RetryScheduler} is present in the

--- a/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaults.java
@@ -34,6 +34,8 @@ import org.axonframework.messaging.commandhandling.gateway.ConvertingCommandGate
 import org.axonframework.messaging.commandhandling.gateway.DefaultCommandGateway;
 import org.axonframework.messaging.commandhandling.interception.CommandSequencingInterceptor;
 import org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus;
+import org.axonframework.messaging.commandhandling.retry.RetryingCommandBus;
+import org.axonframework.messaging.core.retry.RetryScheduler;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.ConfigurationApplicationContext;
 import org.axonframework.messaging.core.MessageDispatchInterceptor;
@@ -118,6 +120,9 @@ import java.util.List;
  * Furthermore, this enhancer will decorate the:
  * <ul>
  *     <li>The {@link CommandGateway} in a {@link ConvertingCommandGateway} with the present {@link MessageConverter}.</li>
+ *     <li>The {@link CommandBus} in a {@link RetryingCommandBus} <b>if</b> a {@link RetryScheduler} is present in the
+ *     registry. The {@link RetryingCommandBus} is applied outside the {@link InterceptingCommandBus} so that retries
+ *     also traverse the interceptor chain.</li>
  *     <li>The {@link CommandBus} in a {@link InterceptingCommandBus} <b>if</b> there are any
  *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry} or
  *     {@link MessageHandlerInterceptor MessageHandlerInterceptors} present in the {@link HandlerInterceptorRegistry}.</li>
@@ -393,6 +398,13 @@ public class MessagingConfigurationDefaults implements ConfigurationEnhancer {
                         delegate,
                         config.getComponent(MessageConverter.class)
                 )
+        );
+        registry.registerDecorator(
+                CommandBus.class,
+                RetryingCommandBus.DECORATION_ORDER,
+                (config, name, delegate) -> config.getOptionalComponent(RetryScheduler.class)
+                        .<CommandBus>map(retryScheduler -> new RetryingCommandBus(delegate, retryScheduler))
+                        .orElse(delegate)
         );
         registry.registerDecorator(
                 CommandBus.class,

--- a/messaging/src/test/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaultsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/configuration/MessagingConfigurationDefaultsTest.java
@@ -35,6 +35,8 @@ import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.commandhandling.gateway.ConvertingCommandGateway;
 import org.axonframework.messaging.commandhandling.interception.CommandSequencingInterceptor;
 import org.axonframework.messaging.commandhandling.interception.InterceptingCommandBus;
+import org.axonframework.messaging.commandhandling.retry.RetryingCommandBus;
+import org.axonframework.messaging.core.retry.RetryScheduler;
 import org.axonframework.messaging.core.MessageDispatchInterceptor;
 import org.axonframework.messaging.core.MessageHandlerInterceptor;
 import org.axonframework.messaging.core.MessageTypeResolver;
@@ -358,6 +360,32 @@ class MessagingConfigurationDefaultsTest {
         MessagingConfigurer configurer = MessagingConfigurer.create();
         Configuration resultConfig = configurer.build();
         assertInstanceOf(ConvertingCommandGateway.class, resultConfig.getComponent(CommandGateway.class));
+    }
+
+    @Test
+    void decoratesCommandBusAsRetryingCommandBusWhenRetrySchedulerIsPresent() {
+        // given
+        RetryScheduler retryScheduler = mock(RetryScheduler.class);
+        ApplicationConfigurer configurer = MessagingConfigurer.enhance(new DefaultAxonApplication());
+        configurer.componentRegistry(cr -> cr.registerComponent(RetryScheduler.class, c -> retryScheduler));
+
+        // when
+        Configuration resultConfig = configurer.build();
+
+        // then
+        assertThat(resultConfig.getComponent(CommandBus.class)).isInstanceOf(RetryingCommandBus.class);
+    }
+
+    @Test
+    void doesNotDecorateCommandBusAsRetryingCommandBusWhenNoRetrySchedulerIsPresent() {
+        // given
+        ApplicationConfigurer configurer = MessagingConfigurer.enhance(new DefaultAxonApplication());
+
+        // when
+        Configuration resultConfig = configurer.build();
+
+        // then
+        assertThat(resultConfig.getComponent(CommandBus.class)).isNotInstanceOf(RetryingCommandBus.class);
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces a `DecoratorDefinition` for the `CommandBus`.
Whenever a `RetryScheduler` is present in the `ComponentRegistry`, it will decorate a `CommandBus` in a `RetryingCommandBus`. 

In doing so, it appends retry behaviour to `CommandBuses` whenever a user provides a `RetryScheduler`.
Note that the `RetryScheduler` can be provided directly to the `ApplicationConfigurer` or be present in the Spring Application Context to make this work.

Lastly, I have added documentation to the command-specific `infrastructure.adoc` how users can enable retry behavior for commands.

In doing the above, this PR resolve #4652.