### PR TITLE
[#4625] Introduce the `EventTypeResolver` for `EventStorageEngines` | Allows for default versions

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -206,7 +206,7 @@ import jakarta.persistence.EntityManagerFactory;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
 import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
-import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
+import org.axonframework.messaging.core.unitofwork.transaction.jpa.JpaTransactionalExecutorProvider;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 
 public class AxonConfig {

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -180,6 +180,87 @@ public class AxonConfig {
 --
 ====
 
+[#missing-revision]
+== Events without a revision (AF4 migration concern)
+
+Axon Framework 4 allowed events to be stored without a revision (the field was nullable).
+Axon Framework 5 requires every event to carry a version as part of its `MessageType`, so reading AF4 events with a missing revision would throw an `IllegalArgumentException` with the message "The given version is unsupported because it is empty."
+
+The framework resolves this at read time through the `EventTypeResolver`.
+The default resolver substitutes `0.0.0` for any missing or empty stored version, so no schema change or data migration is needed.
+The value `0.0.0` is chosen deliberately: it is distinct from `MessageType.DEFAULT_VERSION` (`0.0.1`) so that legacy events without a revision always sort as older than any explicitly versioned event.
+
+The default resolver is active out of the box.
+If `0.0.0` does not suit your needs, configure a different fallback version.
+
+When using the `AggregateBasedJpaEventStorageEngine`, consider the following example to configure a custom `EventTypeResolver`:
+
+[tabs]
+====
+Configuration API::
++
+--
+[source,java]
+----
+import jakarta.persistence.EntityManagerFactory;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
+import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.jpa.JpaTransactionalExecutorProvider;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+
+public class AxonConfig {
+
+    public void configureStorageEngine(
+            EventSourcingConfigurer configurer,
+            EntityManagerFactory factory,
+            EventConverter eventConverter
+    ) {
+        configurer.registerEventStorageEngine(
+                config -> new AggregateBasedJpaEventStorageEngine(
+                        new JpaTransactionalExecutorProvider(factory),
+                        eventConverter,
+                        engineConfig -> engineConfig.eventTypeResolver(
+                            EventTypeResolver.withDefaultVersion("0.0.1")
+                        )
+                )
+        );
+    }
+}
+----
+--
+
+Spring Boot::
++
+--
+Provide an `AggregateBasedJpaEventStorageEngineConfiguration` bean with the custom resolver:
+
+[source,java]
+----
+import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
+import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngineConfiguration;
+
+@Configuration
+public class AxonConfig {
+
+    @Bean
+    public AggregateBasedJpaEventStorageEngineConfiguration storageEngineConfiguration() {
+        return AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT
+                .eventTypeResolver(
+                    EventTypeResolver.withDefaultVersion("0.0.1")
+                );
+    }
+}
+----
+--
+====
+
+[NOTE]
+====
+This substitution happens only at read time.
+Stored events are never modified; the missing version is resolved in memory when the event is read from the store.
+====
+
 [#jpa-migration]
 == JPA event storage migration
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
  * (possibly {@code null} or empty) {@code version}, it returns the {@link MessageType} to use when reading a stored
  * event.
  * <p>
- * The default resolver, obtained from {@link #defaultResolver()}, substitutes {@value #MISSING_VERSION_DEFAULT} for any
+ * The default resolver, obtained from {@link #DEFAULT}, substitutes {@value #MISSING_VERSION_DEFAULT} for any
  * missing or empty stored version. This ensures that events stored by Axon Framework 4 (which allowed a {@code null}
  * revision) can be read by Axon Framework 5 without any schema migration. Use
  * {@link #withDefaultVersion(String)} to override the substituted version when {@value #MISSING_VERSION_DEFAULT}
@@ -49,8 +49,7 @@ import static java.util.Objects.requireNonNull;
 public interface EventTypeResolver {
 
     /**
-     * The version substituted for {@code null} or empty versions by the {@link #DEFAULT} and
-     * {@link #withDefaultVersion(String)}.
+     * The version substituted for {@code null} or empty versions by the {@link #DEFAULT} event type resolver.
      * <p>
      * Set to {@value}, deliberately distinct from {@link MessageType#DEFAULT_VERSION} ({@code 0.0.1}), so legacy AF4
      * events without a revision always sort as older than any explicitly versioned event.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
@@ -16,11 +16,10 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.BuilderUtils;
 import org.axonframework.common.StringUtils;
 import org.axonframework.messaging.core.MessageType;
 import org.jspecify.annotations.Nullable;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Read-side resolver that constructs a {@link MessageType} from the stored qualified name and version of a stored
@@ -32,11 +31,10 @@ import static java.util.Objects.requireNonNull;
  * (possibly {@code null} or empty) {@code version}, it returns the {@link MessageType} to use when reading a stored
  * event.
  * <p>
- * The default resolver, obtained from {@link #DEFAULT}, substitutes {@value #MISSING_VERSION_DEFAULT} for any
- * missing or empty stored version. This ensures that events stored by Axon Framework 4 (which allowed a {@code null}
- * revision) can be read by Axon Framework 5 without any schema migration. Use
- * {@link #withDefaultVersion(String)} to override the substituted version when {@value #MISSING_VERSION_DEFAULT}
- * does not suit your needs.
+ * The default resolver, obtained from {@link #DEFAULT}, substitutes {@value #MISSING_VERSION_DEFAULT} for any missing
+ * or empty stored version. This ensures that events stored by Axon Framework 4 (which allowed a {@code null} revision)
+ * can be read by Axon Framework 5 without any schema migration. Use {@link #withDefaultVersion(String)} to override the
+ * substituted version when {@value #MISSING_VERSION_DEFAULT} does not suit your needs.
  * <p>
  * Implementations are permitted to rewrite the {@code qualifiedName}, but doing so is discouraged: semantic event
  * evolution belongs in the transformation layer, not in version normalization. This interface is intentionally narrow;
@@ -69,10 +67,11 @@ public interface EventTypeResolver {
      * @param defaultVersion the version to use when the stored version is absent; must not be {@code null} or empty
      * @return a {@code EventTypeResolver} that substitutes the given {@code defaultVersion} for any {@code null} or
      * empty stored version, and passes the stored version through unchanged when present
-     * @throws NullPointerException if {@code defaultVersion} is {@code null}
+     * @throws org.axonframework.common.AxonConfigurationException if the given {@code defaultVersion} is {@code null}
+     *                                                             or empty
      */
     static EventTypeResolver withDefaultVersion(String defaultVersion) {
-        requireNonNull(defaultVersion, "The defaultVersion may not be null.");
+        BuilderUtils.assertNonEmpty(defaultVersion, "The defaultVersion may not be null or empty.");
         //noinspection DataFlowIssue
         return (qualifiedName, version) -> new MessageType(
                 qualifiedName,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventTypeResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.common.StringUtils;
+import org.axonframework.messaging.core.MessageType;
+import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Read-side resolver that constructs a {@link MessageType} from the stored qualified name and version of a stored
+ * event.
+ * <p>
+ * The write-side counterpart, {@link org.axonframework.messaging.core.MessageTypeResolver}, derives a
+ * {@link MessageType} from a payload class at dispatch time. This interface handles the opposite direction,
+ * specifically for events that are reconstructed from a storage solution. Given the stored {@code qualifiedName} and
+ * (possibly {@code null} or empty) {@code version}, it returns the {@link MessageType} to use when reading a stored
+ * event.
+ * <p>
+ * The default resolver, obtained from {@link #defaultResolver()}, substitutes {@value #MISSING_VERSION_DEFAULT} for any
+ * missing or empty stored version. This ensures that events stored by Axon Framework 4 (which allowed a {@code null}
+ * revision) can be read by Axon Framework 5 without any schema migration. Use
+ * {@link #withDefaultVersion(String)} to override the substituted version when {@value #MISSING_VERSION_DEFAULT}
+ * does not suit your needs.
+ * <p>
+ * Implementations are permitted to rewrite the {@code qualifiedName}, but doing so is discouraged: semantic event
+ * evolution belongs in the transformation layer, not in version normalization. This interface is intentionally narrow;
+ * keep implementations focused on resolving a missing version.
+ *
+ * @author Steven van Beelen
+ * @since 5.1.2
+ */
+@FunctionalInterface
+public interface EventTypeResolver {
+
+    /**
+     * The version substituted for {@code null} or empty versions by the {@link #DEFAULT} and
+     * {@link #withDefaultVersion(String)}.
+     * <p>
+     * Set to {@value}, deliberately distinct from {@link MessageType#DEFAULT_VERSION} ({@code 0.0.1}), so legacy AF4
+     * events without a revision always sort as older than any explicitly versioned event.
+     */
+    String MISSING_VERSION_DEFAULT = "0.0.0";
+
+    /**
+     * A {@code EventTypeResolver} that substitutes {@value MISSING_VERSION_DEFAULT} for any {@code null} or empty
+     * stored version, and passes the stored version through unchanged when present.
+     */
+    EventTypeResolver DEFAULT = withDefaultVersion(MISSING_VERSION_DEFAULT);
+
+    /**
+     * Returns a {@code EventTypeResolver} that substitutes the given {@code defaultVersion} for any {@code null} or
+     * empty stored version, and passes the stored version through unchanged when present.
+     *
+     * @param defaultVersion the version to use when the stored version is absent; must not be {@code null} or empty
+     * @return a {@code EventTypeResolver} that substitutes the given {@code defaultVersion} for any {@code null} or
+     * empty stored version, and passes the stored version through unchanged when present
+     * @throws NullPointerException if {@code defaultVersion} is {@code null}
+     */
+    static EventTypeResolver withDefaultVersion(String defaultVersion) {
+        requireNonNull(defaultVersion, "The defaultVersion may not be null.");
+        //noinspection DataFlowIssue
+        return (qualifiedName, version) -> new MessageType(
+                qualifiedName,
+                StringUtils.nonEmptyOrNull(version) ? version : defaultVersion
+        );
+    }
+
+    /**
+     * Resolves the {@link MessageType} for an event read from the event store.
+     *
+     * @param qualifiedName the qualified name of the event as stored; never {@code null}
+     * @param version       the version of the event as stored; may be {@code null} or empty for events written by Axon
+     *                      Framework 4, which allowed a {@code null} revision
+     * @return the {@link MessageType} to use for the event; never {@code null}
+     */
+    MessageType resolve(String qualifiedName, @Nullable String version);
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -24,6 +24,7 @@ import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.common.tx.TransactionalExecutor;
 import org.axonframework.conversion.Converter;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker;
+import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedConsistencyMarker.AggregateSequencer;
 import org.axonframework.eventsourcing.eventstore.AggregateBasedEventStorageEngineUtils;
 import org.axonframework.eventsourcing.eventstore.AggregateSequenceNumberPosition;
@@ -42,7 +43,6 @@ import org.axonframework.eventsourcing.eventstore.TerminalEventMessage;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.MessageStream;
-import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -140,6 +140,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private final int gapCleaningThreshold;
     private final int maxGapOffset;
     private final long lowestGlobalSequence;
+    private final EventTypeResolver eventTypeResolver;
 
     private final GapAwareTrackingTokenOperations tokenOperations;
     private final Predicate<Throwable> isConflictException;
@@ -175,6 +176,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         this.gapCleaningThreshold = config.gapCleaningThreshold();
         this.lowestGlobalSequence = config.lowestGlobalSequence();
         this.maxGapOffset = config.maxGapOffset();
+        this.eventTypeResolver = config.eventTypeResolver();
 
         this.tokenOperations = new GapAwareTrackingTokenOperations(config.gapTimeout(), logger);
         this.eventCoordinatorHandle = config.eventCoordinator().startCoordination(this::onAppendDetected);
@@ -426,7 +428,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     private GenericEventMessage convertToEventMessage(AggregateEventEntry event) {
         return new GenericEventMessage(event.identifier(),
-                                       new MessageType(event.type(), event.version()),
+                                       eventTypeResolver.resolve(event.type(), event.version()),
                                        event.payload(),
                                        converter.convert(event.metadata(), METADATA_MAP_TYPE_REF.getType()),
                                        event.timestamp()

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
@@ -313,7 +313,7 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * @param eventTypeResolver the resolver to use; must not be {@code null}
      * @return a new configuration instance, for fluent interfacing
      */
-    public AggregateBasedJpaEventStorageEngineConfiguration storedMessageTypeResolver(
+    public AggregateBasedJpaEventStorageEngineConfiguration eventTypeResolver(
             EventTypeResolver eventTypeResolver
     ) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
@@ -16,11 +16,12 @@
 
 package org.axonframework.eventsourcing.eventstore.jpa;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.jdbc.PersistenceExceptionResolver;
 import org.axonframework.eventsourcing.eventstore.EventCoordinator;
+import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -54,6 +55,12 @@ import static org.axonframework.common.BuilderUtils.assertStrictPositive;
  *                                     {@link AggregateEventEntry}. Defaults to {@code 1}.
  * @param gapTimeout                   The amount of time until a gap in a {@link GapAwareTrackingToken} may be
  *                                     considered timed out and thus ready for removal. Defaults to {@code 60000}ms.
+ * @param eventTypeResolver            The {@link EventTypeResolver} used to construct a
+ *                                     {@link org.axonframework.messaging.core.MessageType} from the stored qualified
+ *                                     name and version when reading events. Defaults to
+ *                                     {@link EventTypeResolver#DEFAULT}, which substitutes
+ *                                     {@link EventTypeResolver#MISSING_VERSION_DEFAULT} for any missing or empty stored
+ *                                     version, enabling AF4 events without a revision to be read.
  * @author Mateusz Nowak
  * @author Steven van Beelen
  * @since 4.0.0
@@ -66,7 +73,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
         int gapCleaningThreshold,
         int maxGapOffset,
         long lowestGlobalSequence,
-        int gapTimeout
+        int gapTimeout,
+        EventTypeResolver eventTypeResolver
 ) {
 
     private static final Predicate<List<? extends AggregateEventEntry>> DEFAULT_BATCH_PREDICATE = List::isEmpty;
@@ -88,7 +96,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                  DEFAULT_GAP_CLEANING_THRESHOLD,
                                                                  DEFAULT_MAX_GAP_OFFSET,
                                                                  DEFAULT_LOWEST_GLOBAL_SEQUENCE,
-                                                                 DEFAULT_GAP_TIMEOUT);
+                                                                 DEFAULT_GAP_TIMEOUT,
+                                                                 EventTypeResolver.DEFAULT);
 
     /**
      * Compact constructor validating that the given {@code key} and {@code value} are not {@code null}.
@@ -102,6 +111,7 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
         assertPositive(maxGapOffset, "The maxGapOffset must be a positive number.");
         assertPositive(lowestGlobalSequence, "The lowestGlobalSequence must be a positive number.");
         assertPositive(gapTimeout, "gapTimeout");
+        requireNonNull(eventTypeResolver, "The eventTypeResolver must not be null.");
     }
 
     /**
@@ -112,9 +122,9 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <p>
      * Can be set to the {@link SQLErrorCodesResolver}, for example.
      *
-     * @param persistenceExceptionResolver The {@link PersistenceExceptionResolver} used to detect concurrency
-     *                                     exceptions from the backing database.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param persistenceExceptionResolver the {@link PersistenceExceptionResolver} used to detect concurrency
+     *                                     exceptions from the backing database
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration persistenceExceptionResolver(
             @Nullable PersistenceExceptionResolver persistenceExceptionResolver
@@ -126,7 +136,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -135,9 +146,9 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <p>
      * Defaults to the first empty batch.
      *
-     * @param finalBatchPredicate The predicate that indicates whether a given batch is to be considered the final batch
-     *                            of an event stream.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param finalBatchPredicate the predicate that indicates whether a given batch is to be considered the final batch
+     *                            of an event stream
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration finalBatchPredicate(
             Predicate<List<? extends AggregateEventEntry>> finalBatchPredicate
@@ -149,7 +160,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -157,8 +169,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <p>
      * Defaults to {@link EventCoordinator#SIMPLE}.
      *
-     * @param eventCoordinator The {@link EventCoordinator} to use, cannot be {@code null}.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param eventCoordinator the {@link EventCoordinator} to use, cannot be {@code null}
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration eventCoordinator(
             EventCoordinator eventCoordinator) {
@@ -169,7 +181,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -182,8 +195,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <b>Tip:</b> When using a snapshotter, make sure to choose snapshot trigger and batch size such that a single
      * batch will generally retrieve all events required to rebuild an aggregate's state.
      *
-     * @param batchSize An {@code int} specifying the number of events that should be read at each database access.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param batchSize an {@code int} specifying the number of events that should be read at each database access
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration batchSize(int batchSize) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
@@ -193,7 +206,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -203,7 +217,7 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      *
      * @param gapCleaningThreshold an {@code int} specifying the threshold of number of gaps in a token before an
      *                             attempt to clean gaps up is taken
-     * @return A new configuration instance, for fluent interfacing.
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration gapCleaningThreshold(int gapCleaningThreshold) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
@@ -213,7 +227,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -225,9 +240,9 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <p>
      * Defaults to {@code 10000}.
      *
-     * @param maxGapOffset An {@code int} specifying the maximum distance in sequence numbers between a missing event
-     *                     and the event with the highest known index.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param maxGapOffset an {@code int} specifying the maximum distance in sequence numbers between a missing event
+     *                     and the event with the highest known index
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration maxGapOffset(int maxGapOffset) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
@@ -237,7 +252,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     maxGapOffset,
                                                                     this.lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -247,7 +263,7 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * Defaults to {@code 1}.
      *
      * @param lowestGlobalSequence a {@code long} specifying the first expected auto generated sequence number
-     * @return A new configuration instance, for fluent interfacing.
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration lowestGlobalSequence(long lowestGlobalSequence) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
@@ -257,7 +273,8 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     lowestGlobalSequence,
-                                                                    this.gapTimeout);
+                                                                    this.gapTimeout,
+                                                                    this.eventTypeResolver);
     }
 
     /**
@@ -269,9 +286,9 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * <p>
      * Defaults to {@code 60000}ms.
      *
-     * @param gapTimeout An {@code int} specifying the amount of time in milliseconds until a 'gap' in a TrackingToken
-     *                   may be considered timed out.
-     * @return A new configuration instance, for fluent interfacing.
+     * @param gapTimeout an {@code int} specifying the amount of time in milliseconds until a 'gap' in a TrackingToken
+     *                   may be considered timed out
+     * @return a new configuration instance, for fluent interfacing
      */
     public AggregateBasedJpaEventStorageEngineConfiguration gapTimeout(int gapTimeout) {
         return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
@@ -281,6 +298,32 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
                                                                     lowestGlobalSequence,
-                                                                    gapTimeout);
+                                                                    gapTimeout,
+                                                                    this.eventTypeResolver);
+    }
+
+    /**
+     * Sets the {@link EventTypeResolver} used to construct a {@link org.axonframework.messaging.core.MessageType} from
+     * the stored qualified name and version when reading events.
+     * <p>
+     * Defaults to {@link EventTypeResolver#DEFAULT}, which substitutes
+     * {@link EventTypeResolver#MISSING_VERSION_DEFAULT} for any missing or empty stored version. Override this when the
+     * default substituted version does not suit your migration needs.
+     *
+     * @param eventTypeResolver the resolver to use; must not be {@code null}
+     * @return a new configuration instance, for fluent interfacing
+     */
+    public AggregateBasedJpaEventStorageEngineConfiguration storedMessageTypeResolver(
+            EventTypeResolver eventTypeResolver
+    ) {
+        return new AggregateBasedJpaEventStorageEngineConfiguration(this.persistenceExceptionResolver,
+                                                                    this.finalBatchPredicate,
+                                                                    this.eventCoordinator,
+                                                                    this.batchSize,
+                                                                    this.gapCleaningThreshold,
+                                                                    this.maxGapOffset,
+                                                                    this.lowestGlobalSequence,
+                                                                    this.gapTimeout,
+                                                                    eventTypeResolver);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
@@ -297,7 +297,7 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
                                                                     this.batchSize,
                                                                     this.gapCleaningThreshold,
                                                                     this.maxGapOffset,
-                                                                    lowestGlobalSequence,
+                                                                    this.lowestGlobalSequence,
                                                                     gapTimeout,
                                                                     this.eventTypeResolver);
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventTypeResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventTypeResolverTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.core.MessageType;
 import org.junit.jupiter.api.*;
 
@@ -110,8 +111,15 @@ class EventTypeResolverTest {
 
         @Test
         void nullDefaultVersionThrowsException() {
+            //noinspection DataFlowIssue
             assertThatThrownBy(() -> EventTypeResolver.withDefaultVersion(null))
-                    .isInstanceOf(NullPointerException.class);
+                    .isInstanceOf(AxonConfigurationException.class);
+        }
+
+        @Test
+        void emptyDefaultVersionThrowsException() {
+            assertThatThrownBy(() -> EventTypeResolver.withDefaultVersion(""))
+                    .isInstanceOf(AxonConfigurationException.class);
         }
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventTypeResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/EventTypeResolverTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.messaging.core.MessageType;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test class validating the {@link EventTypeResolver}.
+ *
+ * @author Steven van Beelen
+ */
+class EventTypeResolverTest {
+
+    @Nested
+    class DefaultResolver {
+
+        @Test
+        void passesStoredVersionThroughWhenPresent() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.DEFAULT;
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", "1.2.3");
+
+            // then
+            assertThat(result).isEqualTo(new MessageType("com.example.OrderPlaced", "1.2.3"));
+        }
+
+        @Test
+        void substitutesMissingVersionDefaultForNullVersion() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.DEFAULT;
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", null);
+
+            // then
+            assertThat(result.version()).isEqualTo(EventTypeResolver.MISSING_VERSION_DEFAULT);
+        }
+
+        @Test
+        void substitutesMissingVersionDefaultForEmptyVersion() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.DEFAULT;
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", "");
+
+            // then
+            assertThat(result.version()).isEqualTo(EventTypeResolver.MISSING_VERSION_DEFAULT);
+        }
+    }
+
+    @Nested
+    class WithDefaultVersion {
+
+        @Test
+        void passesStoredVersionThroughWhenPresent() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.withDefaultVersion("custom");
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", "2.0.0");
+
+            // then
+            assertThat(result.version()).isEqualTo("2.0.0");
+        }
+
+        @Test
+        void substitutesConfiguredDefaultForNullVersion() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.withDefaultVersion("custom");
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", null);
+
+            // then
+            assertThat(result.version()).isEqualTo("custom");
+        }
+
+        @Test
+        void substitutesConfiguredDefaultForEmptyVersion() {
+            // given
+            EventTypeResolver resolver = EventTypeResolver.withDefaultVersion("custom");
+
+            // when
+            MessageType result = resolver.resolve("com.example.OrderPlaced", "");
+
+            // then
+            assertThat(result.version()).isEqualTo("custom");
+        }
+
+        @Test
+        void nullDefaultVersionThrowsException() {
+            assertThatThrownBy(() -> EventTypeResolver.withDefaultVersion(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
@@ -74,21 +74,21 @@ class AggregateBasedJpaEventStorageEngineConfigurationTest {
     }
 
     @Test
-    void nullStoredMessageTypeResolverThrowsException() {
+    void nullEventTypeResolverThrowsException() {
         //noinspection DataFlowIssue
-        assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.storedMessageTypeResolver(null))
+        assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.eventTypeResolver(null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void storedMessageTypeResolverWitherReplacesTheResolver() {
+    void eventTypeResolverSetsGivenEventTypeResolver() {
         // given
         EventTypeResolver custom = (qualifiedName, version) -> EventTypeResolver
                 .withDefaultVersion("custom").resolve(qualifiedName, version);
 
         // when
         AggregateBasedJpaEventStorageEngineConfiguration result =
-                AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.storedMessageTypeResolver(custom);
+                AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.eventTypeResolver(custom);
 
         // then
         assertThat(result.eventTypeResolver()).isSameAs(custom);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
@@ -17,8 +17,10 @@
 package org.axonframework.eventsourcing.eventstore.jpa;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventsourcing.eventstore.EventTypeResolver;
 import org.junit.jupiter.api.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -69,5 +71,26 @@ class AggregateBasedJpaEventStorageEngineConfigurationTest {
     void negativeGapTimeoutThrowsException() {
         assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.gapTimeout(-1))
                 .isInstanceOf(AxonConfigurationException.class);
+    }
+
+    @Test
+    void nullStoredMessageTypeResolverThrowsException() {
+        //noinspection DataFlowIssue
+        assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.storedMessageTypeResolver(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void storedMessageTypeResolverWitherReplacesTheResolver() {
+        // given
+        EventTypeResolver custom = (qualifiedName, version) -> EventTypeResolver
+                .withDefaultVersion("custom").resolve(qualifiedName, version);
+
+        // when
+        AggregateBasedJpaEventStorageEngineConfiguration result =
+                AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.storedMessageTypeResolver(custom);
+
+        // then
+        assertThat(result.eventTypeResolver()).isSameAs(custom);
     }
 }


### PR DESCRIPTION
This PR introduces the `EventTypeResolver`. 
The `EventTypeResolver` should be used by `EventStorageEngines` to derive the `MessageType` when reconstructing stored events into `EventMessages`.
In doing so, it allows an avenue to default the version (the revision in AF4) whenever the given version is `null`.

The `EventTypeResolver` that is used by default sets the version to `0.0.0` whenever `null` is given.
This default is chosen on purpose, as the `MessageType` upon bland construction sets the version to `0.0.1`.

Next to providing the `EventTypeResolver`, this PR integrates the `EventTypeResolver` in the `AggregateBasedJpaEventStorageEngine`, as well as documenting this pointer in the `event-store.adoc` migration path.

This PR works towards resolving issue #4625. We still require a port to `axon-5.1.x` and a fix in Axoniq Framework to utilize the `EventTypeResolver`.