### PR TITLE
fix(messaging): disposing a Flux does not close the underlying subscription query

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/CloseCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/CloseCallbackMessageStream.java
@@ -83,8 +83,12 @@ public class CloseCallbackMessageStream<M extends Message> extends AbstractMessa
 
     @Override
     protected void onCompleted() {
-        if (!invoked.getAndSet(true)) {
-            closeHandler.run();
+        try {
+            delegate.close();
+        } finally {
+            if (!invoked.getAndSet(true)) {
+                closeHandler.run();
+            }
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/FluxUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/FluxUtils.java
@@ -51,7 +51,7 @@ public final class FluxUtils {
         return Flux.create(emitter -> {
             FluxStreamAdapter<M> fluxTask = new FluxStreamAdapter<>(source, emitter);
             emitter.onRequest(i -> fluxTask.process());
-            emitter.onCancel(source::close);
+            emitter.onDispose(source::close);
             source.setCallback(fluxTask::process);
         });
     }
@@ -126,8 +126,9 @@ public final class FluxUtils {
                         source.error().ifPresentOrElse(emitter::error, emitter::complete);
                     }
                 } catch (Exception e) {
+                    // The emitter's onDispose(source::close) closes the source once the error terminates the
+                    // sink, so no explicit close() is needed here (avoids a duplicate close).
                     emitter.error(e);
-                    source.close();
                 } finally {
                     processingGate.set(false);
                 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
@@ -169,9 +169,7 @@ public class DefaultQueryGateway implements QueryGateway {
                                                                                   context,
                                                                                   updateBufferSize);
         return FluxUtils.of(response)
-                        .mapNotNull(m -> mapper.apply(m.message()))
-                        .doOnCancel(response::close)
-                        .doOnError((e) -> response.close());
+                        .mapNotNull(m -> mapper.apply(m.message()));
     }
 
     private QueryMessage asQueryMessage(Object query) {

--- a/messaging/src/test/java/org/axonframework/messaging/core/CloseCallbackMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/CloseCallbackMessageStreamTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class CloseCallbackMessageStreamTest extends MessageStreamTest<Message> {
 
@@ -131,5 +132,49 @@ class CloseCallbackMessageStreamTest extends MessageStreamTest<Message> {
         testSubject.close();
 
         assertEquals(1, invoked.get());
+    }
+
+    @Test
+    void closingTheStreamPropagatesCloseToTheDelegate() {
+        AtomicBoolean delegateClosed = new AtomicBoolean(false);
+        // A delegate that never completes on its own, so the only way it can complete is by
+        // having close() propagated to it from the CloseCallbackMessageStream.
+        MessageStream<Message> delegate = new AbstractMessageStream<>() {
+            @Override
+            protected FetchResult<Entry<Message>> fetchNext() {
+                return FetchResult.notReady();
+            }
+
+            @Override
+            protected void onCompleted() {
+                delegateClosed.set(true);
+            }
+        };
+        MessageStream<Message> testSubject = new CloseCallbackMessageStream<>(delegate, () -> {
+        });
+
+        assertFalse(delegateClosed.get());
+
+        // A consumer closing the wrapping stream must release the delegate as well, otherwise
+        // resources held by the delegate (e.g. an Axon Server subscription query) leak.
+        testSubject.close();
+
+        assertTrue(delegateClosed.get(), "Closing the stream should propagate close() to the delegate.");
+        assertTrue(delegate.isCompleted());
+    }
+
+    @Test
+    void closeHandlerIsInvokedEvenWhenDelegateCloseThrows() {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        MessageStream<Message> delegate = mock();
+        doThrow(new MockException("close failed")).when(delegate).close();
+        MessageStream<Message> testSubject = new CloseCallbackMessageStream<>(delegate, () -> invoked.set(true));
+
+        // A failing delegate close must not prevent the close handler from running, otherwise
+        // resources tracked by the handler (e.g. a shutdown latch activity) would leak.
+        testSubject.close();
+
+        verify(delegate).close();
+        assertTrue(invoked.get(), "Close handler must run even when the delegate's close() throws.");
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/FluxUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/FluxUtilsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating {@link FluxUtils#of(MessageStream)}.
+ * <p>
+ * Guards that the source {@link MessageStream} is {@link MessageStream#close() closed} on <em>every</em> terminal
+ * signal of the resulting {@link reactor.core.publisher.Flux Flux} — completion, error, and cancellation — so resources
+ * held by the source (e.g. a subscription query registration) are always released. The completion case is a regression
+ * guard: cleanup used to be wired to cancellation only, so a normally-completing stream leaked its source.
+ *
+ * @author Allard Buijze
+ */
+class FluxUtilsTest {
+
+    @Test
+    void closesSourceWhenStreamCompletes() {
+        CloseTrackingMessageStream<Message> source = new CloseTrackingMessageStream<>(
+                MessageStream.fromItems(message("one"), message("two")));
+
+        StepVerifier.create(FluxUtils.of(source))
+                    .expectNextCount(2)
+                    .verifyComplete();
+
+        assertThat(source.timesClosed())
+                .as("source must be closed when the stream completes")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void closesSourceWhenStreamFails() {
+        CloseTrackingMessageStream<Message> source = new CloseTrackingMessageStream<>(
+                MessageStream.failed(new RuntimeException("oops")));
+
+        StepVerifier.create(FluxUtils.of(source))
+                    .expectErrorMessage("oops")
+                    .verify();
+
+        assertThat(source.timesClosed())
+                .as("source must be closed when the stream fails")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void closesSourceWhenSubscriptionIsCancelled() {
+        CloseTrackingMessageStream<Message> source = new CloseTrackingMessageStream<>(
+                MessageStream.fromItems(message("one")));
+
+        StepVerifier.create(FluxUtils.of(source), 0)
+                    .thenCancel()
+                    .verify();
+
+        assertThat(source.timesClosed())
+                .as("source must be closed when the subscription is cancelled")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void closesSourceOnceWhenProcessingThrows() {
+        CloseTrackingMessageStream<Message> source = new CloseTrackingMessageStream<>(new FailingMessageStream<>());
+
+        StepVerifier.create(FluxUtils.of(source))
+                    .expectErrorMessage("boom")
+                    .verify();
+
+        assertThat(source.timesClosed())
+                .as("source must be closed exactly once when processing throws")
+                .isEqualTo(1);
+    }
+
+    private static Message message(Object payload) {
+        return new GenericMessage(new MessageType("test"), payload);
+    }
+
+    /**
+     * {@link MessageStream} decorator that counts invocations of {@link #close()} while delegating all behavior, so a
+     * test can assert the source was closed regardless of which terminal signal triggered it.
+     */
+    private static class CloseTrackingMessageStream<M extends Message> implements MessageStream<M> {
+
+        private final MessageStream<M> delegate;
+        private final AtomicInteger timesClosed = new AtomicInteger();
+
+        private CloseTrackingMessageStream(MessageStream<M> delegate) {
+            this.delegate = delegate;
+        }
+
+        private int timesClosed() {
+            return timesClosed.get();
+        }
+
+        @Override
+        public Optional<Entry<M>> next() {
+            return delegate.next();
+        }
+
+        @Override
+        public Optional<Entry<M>> peek() {
+            return delegate.peek();
+        }
+
+        @Override
+        public void setCallback(Runnable callback) {
+            delegate.setCallback(callback);
+        }
+
+        @Override
+        public Optional<Throwable> error() {
+            return delegate.error();
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return delegate.isCompleted();
+        }
+
+        @Override
+        public boolean hasNextAvailable() {
+            return delegate.hasNextAvailable();
+        }
+
+        @Override
+        public void close() {
+            timesClosed.incrementAndGet();
+            delegate.close();
+        }
+    }
+
+    /**
+     * {@link MessageStream} that throws while being consumed, to exercise the error-handling branch of the
+     * {@link FluxUtils.FluxStreamAdapter}.
+     */
+    private static class FailingMessageStream<M extends Message> implements MessageStream<M> {
+
+        @Override
+        public Optional<Entry<M>> next() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Entry<M>> peek() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void setCallback(Runnable callback) {
+            // no-op
+        }
+
+        @Override
+        public Optional<Throwable> error() {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return false;
+        }
+
+        @Override
+        public boolean hasNextAvailable() {
+            throw new RuntimeException("boom");
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A subscription query consumed through `QueryGateway#subscriptionQuery` (e.g. bridged to an SSE response) is not released when its reactive stream goes away. In Axon Server's dashboard the active subscription-query count climbs and never drops, leaking server-side registrations, and a lingering subscription can stall graceful shutdown by never releasing its in-progress activity.

There are **two** independent defects on the close path; both have to be fixed for disposal to actually reach Axon Server.

## Root cause 1 — `FluxUtils` only closed on cancellation

`FluxUtils.of(MessageStream)` wired the source's `close()` to the emitter's `onCancel` hook:

```java
emitter.onCancel(source::close);
```

`onCancel` only fires on a downstream cancel. When the stream terminates via `onComplete`/`onError` (what an SSE bridge typically surfaces as teardown), `close()` was never called. The same defect shape existed at the gateway: `DefaultQueryGateway#subscriptionQuery` cleaned up via `doOnCancel`/`doOnError` but not on completion.

### Fix

- `FluxUtils.of`: use `emitter.onDispose(source::close)`, which fires on **completion, error, and cancellation**, so the source is always released.
- Remove the now-redundant explicit `source.close()` in `FluxStreamAdapter.process()`'s error branch (the `emitter.error(e)` already triggers `onDispose`) — avoids a double close.
- Remove the now-redundant `doOnCancel`/`doOnError` close calls in `DefaultQueryGateway#subscriptionQuery`; `FluxUtils.of` owns the source's lifecycle, so a single owner closes it exactly once.

## Root cause 2 — `CloseCallbackMessageStream` swallowed the close

Even with `FluxUtils` always calling `close()`, the close stopped at the first wrapper. The stream handed to `FluxUtils.of` for a subscription query is, outermost-first, a `CloseCallbackMessageStream` (from `.onClose(...)`) wrapping a `ConcatenatingMessageStream` (initial result `concatWith` updates) wrapping the Axon Server-backed streams.

`CloseCallbackMessageStream.onCompleted()` ran its close handler but **never closed its delegate**:

```java
protected void onCompleted() {
    if (!invoked.getAndSet(true)) {
        closeHandler.run();
    }
}
```

So a consumer-initiated `close()` invoked the handler but never propagated to the `ConcatenatingMessageStream`, hence never to the Axon Server update buffer — the unsubscribe was never sent. (This was masked on natural completion, where the delegate completes itself; it only bit on consumer-initiated close, i.e. Flux disposal.)

### Fix

Close the delegate before invoking the close handler, matching the other delegating streams (`CompletionCallbackMessageStream`, `FilteringMessageStream`, `ConcatenatingMessageStream`). The delegate is closed in a `try/finally` so the close handler still runs — releasing e.g. a shutdown-latch activity — even when the delegate's `close()` throws.

```java
protected void onCompleted() {
    try {
        delegate.close();
    } finally {
        if (!invoked.getAndSet(true)) {
            closeHandler.run();
        }
    }
}
```

## Tests

- `FluxUtilsTest` asserts the source is closed exactly once on each terminal signal: completion (regression for the leak), error, cancellation, and an exception thrown during processing (regression for the duplicate close).
- `CloseCallbackMessageStreamTest`:
  - `closingTheStreamPropagatesCloseToTheDelegate` — closing the wrapper closes its delegate (fails against the previous implementation, passes now).
  - `closeHandlerIsInvokedEvenWhenDelegateCloseThrows` — a throwing delegate close still runs the close handler.

Verified end-to-end against a live Axon Server: subscription queries are released on client disconnect and graceful shutdown completes cleanly. Surrounding messaging/query/streaming suites remain green.