### PR TITLE
Port (5.1.x): [#4647] Propagate all entry resources to per-event ProcessingContext

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -20,6 +20,7 @@ import org.axonframework.common.FutureUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
@@ -82,21 +83,24 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     /**
      * Processes a batch of events in the given processing context.
      * <p>
-     * Each entry carries its own {@link TrackingToken} in its {@link org.axonframework.messaging.core.Context} under
-     * {@link TrackingToken#RESOURCE_KEY}. Before invoking the event handling components for a given entry, that
-     * per-event token is written into the shared {@code context} under the same key, overriding the batch-end token
-     * that the caller placed there. The {@code context} itself — including its transaction lifecycle and all other
-     * resources — is the same object for every event in the batch; only {@link TrackingToken#RESOURCE_KEY} is
-     * temporarily overridden for the duration of each event's handling. The batch-end token remains accessible under
+     * Each entry may carry per-event resources in its {@link org.axonframework.messaging.core.Context}, such as a
+     * {@link TrackingToken} under {@link TrackingToken#RESOURCE_KEY} and legacy aggregate metadata (aggregate
+     * identifier, sequence number, type) under
+     * {@link org.axonframework.messaging.core.LegacyResources#AGGREGATE_IDENTIFIER_KEY} and related keys. Before
+     * invoking the event handling components for a given entry, all resources from the entry are overlaid on top of the
+     * shared batch {@code context}. The {@code context} itself -- including its transaction lifecycle -- is the same
+     * object for every event in the batch; the per-event resources override specific keys for the duration of each
+     * event's handling only. The batch-end token remains accessible under
      * {@link TrackingToken#BATCH_END_RESOURCE_KEY} throughout.
      * <p>
      * This ensures that per-event replay detection (
      * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#isReplay(TrackingToken)} and
      * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken#concludesReplay(TrackingToken)}) observes
-     * the correct position for each individual event rather than the shared batch-end token. When an entry carries no
-     * per-event token (e.g. from a
-     * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor} which has no
-     * stream position), the context is used as-is.
+     * the correct position for each individual event, and that aggregate-sourced resources such as
+     * {@code @SourceId} parameters and {@code SequentialPerAggregatePolicy} resolve correctly. When an entry carries no
+     * per-event resources (e.g. from a
+     * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor} which has an
+     * empty entry context), the batch context is used as-is.
      * <p>
      * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that events with the same
      * {@link #sequenceIdentifiersFor(EventMessage, ProcessingContext)} value are processed by a single component in the
@@ -113,9 +117,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     ) {
         MessageStream<Message> batchResult = MessageStream.empty().cast();
         for (var entry : entries) {
-            ProcessingContext perEventContext = TrackingToken.fromContext(entry)
-                    .map(token -> context.withResource(TrackingToken.RESOURCE_KEY, token))
-                    .orElse(context);
+            ProcessingContext perEventContext = withEntryResources(entry, context);
             var eventResult = handle(entry.message(), perEventContext);
             batchResult = batchResult.concatWith(eventResult.cast());
         }
@@ -247,6 +249,17 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
         return result.ignoreEntries()
                      .asCompletableFuture()
                      .thenApply(FutureUtils::ignoreResult);
+    }
+
+    private static ProcessingContext withEntryResources(MessageStream.Entry<?> entry,
+                                                        ProcessingContext context) {
+        ProcessingContext result = context;
+        for (var resource : entry.resources().entrySet()) {
+            //noinspection unchecked
+            result = result.withResource((Context.ResourceKey<Object>) resource.getKey(),
+                                         resource.getValue());
+        }
+        return result;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventhandling.processing;
+
+import org.axonframework.messaging.core.Context;
+import org.axonframework.messaging.core.LegacyResources;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.SimpleEntry;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventTestUtils;
+import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link ProcessorEventHandlingComponents} event handling behaviour.
+ *
+ * @author Jakob Hatzl
+ * @since 5.1.2
+ */
+class ProcessorEventHandlingComponentsTest {
+
+    @Nested
+    class WhenHandlingBatch {
+
+        @Test
+        void aggregateResourcesFromEntryAreAvailableInPerEventContext() {
+            // given
+            EventMessage event = EventTestUtils.createEvent(0);
+            AtomicReference<ProcessingContext> capturedContext = new AtomicReference<>();
+
+            SimpleEventHandlingComponent component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(event.type().qualifiedName(), (e, c) -> {
+                capturedContext.set(c);
+                return MessageStream.empty();
+            });
+
+            ProcessorEventHandlingComponents testSubject =
+                    new ProcessorEventHandlingComponents(List.of(component));
+
+            Context entryContext = Context.with(LegacyResources.AGGREGATE_IDENTIFIER_KEY, "agg-123")
+                                          .withResource(LegacyResources.AGGREGATE_SEQUENCE_NUMBER_KEY, 7L)
+                                          .withResource(LegacyResources.AGGREGATE_TYPE_KEY, "MyAggregate");
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, entryContext);
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> testSubject.handle(List.of(entry), ctx)
+                                                                    .asCompletableFuture())
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then
+            assertThat(capturedContext.get()).isNotNull();
+            assertThat(capturedContext.get().getResource(LegacyResources.AGGREGATE_IDENTIFIER_KEY))
+                    .isEqualTo("agg-123");
+            assertThat(capturedContext.get().getResource(LegacyResources.AGGREGATE_SEQUENCE_NUMBER_KEY))
+                    .isEqualTo(7L);
+            assertThat(capturedContext.get().getResource(LegacyResources.AGGREGATE_TYPE_KEY))
+                    .isEqualTo("MyAggregate");
+        }
+
+        @Test
+        void trackingTokenFromEntryIsAvailableInPerEventContext() {
+            // given
+            EventMessage event = EventTestUtils.createEvent(0);
+            AtomicReference<ProcessingContext> capturedContext = new AtomicReference<>();
+
+            SimpleEventHandlingComponent component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(event.type().qualifiedName(), (e, c) -> {
+                capturedContext.set(c);
+                return MessageStream.empty();
+            });
+
+            ProcessorEventHandlingComponents testSubject =
+                    new ProcessorEventHandlingComponents(List.of(component));
+
+            TrackingToken perEventToken = new GlobalSequenceTrackingToken(42L);
+            Context entryContext = Context.with(TrackingToken.RESOURCE_KEY, perEventToken);
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, entryContext);
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> testSubject.handle(List.of(entry), ctx)
+                                                                    .asCompletableFuture())
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then
+            assertThat(capturedContext.get()).isNotNull();
+            assertThat(capturedContext.get().getResource(TrackingToken.RESOURCE_KEY))
+                    .isEqualTo(perEventToken);
+        }
+
+        @Test
+        void batchContextResourcesAreAvailableWhenEntryHasNoResources() {
+            // given
+            EventMessage event = EventTestUtils.createEvent(0);
+            Context.ResourceKey<String> batchKey = Context.ResourceKey.withLabel("batchResource");
+            AtomicReference<ProcessingContext> capturedContext = new AtomicReference<>();
+
+            SimpleEventHandlingComponent component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(event.type().qualifiedName(), (e, c) -> {
+                capturedContext.set(c);
+                return MessageStream.empty();
+            });
+
+            ProcessorEventHandlingComponents testSubject =
+                    new ProcessorEventHandlingComponents(List.of(component));
+
+            // entry with empty context (subscribing processor pattern)
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, Context.empty());
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   ProcessingContext batchContext = ctx.withResource(batchKey, "batch-value");
+                                   return testSubject.handle(List.of(entry), batchContext)
+                                                     .asCompletableFuture();
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then - batch context resources are preserved when entry context is empty
+            assertThat(capturedContext.get()).isNotNull();
+            assertThat(capturedContext.get().getResource(batchKey)).isEqualTo("batch-value");
+        }
+
+        @Test
+        void batchContextResourcesAreMergedWithEntryResources() {
+            // given
+            EventMessage event = EventTestUtils.createEvent(0);
+            Context.ResourceKey<String> batchKey = Context.ResourceKey.withLabel("batchResource");
+            AtomicReference<ProcessingContext> capturedContext = new AtomicReference<>();
+
+            SimpleEventHandlingComponent component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(event.type().qualifiedName(), (e, c) -> {
+                capturedContext.set(c);
+                return MessageStream.empty();
+            });
+
+            ProcessorEventHandlingComponents testSubject =
+                    new ProcessorEventHandlingComponents(List.of(component));
+
+            TrackingToken perEventToken = new GlobalSequenceTrackingToken(42L);
+            Context entryContext = Context.with(TrackingToken.RESOURCE_KEY, perEventToken);
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, entryContext);
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   ProcessingContext batchContext = ctx.withResource(batchKey, "batch-value");
+                                   return testSubject.handle(List.of(entry), batchContext)
+                                                     .asCompletableFuture();
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then - batch context resources are preserved when entry context is empty
+            assertThat(capturedContext.get()).isNotNull();
+            assertThat(capturedContext.get().getResource(batchKey)).isEqualTo("batch-value");
+            assertThat(capturedContext.get().getResource(TrackingToken.RESOURCE_KEY))
+                    .isEqualTo(perEventToken);
+        }
+    }
+}


### PR DESCRIPTION
This PR Fixes [#4647](https://github.com/AxonIQ/AxonFramework/issues/4647): aggregate metadata resources from `MessageStream.Entry` were not propagated to the per-event `ProcessingContext` in `ProcessorEventHandlingComponents.handle()` resulting in a regression for the resolution of `@SourceId` handler parameters and the usage of the `SequentialPerAggregate` sequencing policy when using `PooledStreamingEventProcessor` with aggregate based event store implementations.

* `@SourceId` parameter resolution now works correctly with `PooledStreamingEventProcessor` + aggregate-based event stores
- `SequentialPerAggregatePolicy` (and the derived default policy) now resolves the aggregate identifier correctly, restoring parallel event processing

## Root cause

`handle()` only copied the `TrackingToken` from each entry into the per-event context. Any other resources on the entry — specifically `AGGREGATE_IDENTIFIER_KEY`, `AGGREGATE_SEQUENCE_NUMBER_KEY`, and `AGGREGATE_TYPE_KEY` set by `AggregateBasedJpaEventStorageEngine` — were silently discarded.

## Fix

Replaced the single-key `TrackingToken` override with a `withEntryResources()` helper that overlays **all** resources from the entry onto the batch context. 

The pattern mirrors `WorkPackage.copyResources()` already in the codebase, but uses `withResource` (non-mutating) since the shared batch context must not be modified.

The PR adds additional tests in `org.axonframework.messaging.eventhandling.processing.ProcessorEventHandlingComponentsTest` to cover the existing and new behaviour. 


This is a port of #4669 to the 5.1.x patch line