### PR TITLE
[#4634 |  Port] Register the micrometer `MetricsConfigurationEnhancer` only once when using Spring Boot

### DIFF
--- a/extensions/metrics/metrics-micrometer/src/main/java/org/axonframework/extension/metrics/micrometer/springboot/MicrometerMetricsAutoConfiguration.java
+++ b/extensions/metrics/metrics-micrometer/src/main/java/org/axonframework/extension/metrics/micrometer/springboot/MicrometerMetricsAutoConfiguration.java
@@ -65,28 +65,6 @@ public class MicrometerMetricsAutoConfiguration {
     }
 
     /**
-     * Bean creation method constructing a {@link MetricsConfigurationEnhancer} with the given {@code registry} and
-     * {@code properties}, which will attach a default set of
-     * {@link org.axonframework.messaging.monitoring.MessageMonitor MessageMonitors} to Axon's infrastructure
-     * components.
-     *
-     * @param registry   the {@code MeterRegistry} to be used by the {@link MetricsConfigurationEnhancer} to register
-     *                   metrics with
-     * @param properties the {@code MetricProperties}, used to deduce whether Micrometer should be set to
-     *                   {@link MetricsProperties.Micrometer#isDimensional() dimensional} metrics
-     * @return a {@link MetricsConfigurationEnhancer} that will attach a default set of
-     * {@link org.axonframework.messaging.monitoring.MessageMonitor MessageMonitors} to Axon's infrastructure
-     * components
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnProperty(value = "axon.metrics.enabled", havingValue = "true", matchIfMissing = true)
-    public MetricsConfigurationEnhancer metricsConfigurationEnhancer(MeterRegistry registry,
-                                                                     MetricsProperties properties) {
-        return new MetricsConfigurationEnhancer(registry, properties.getMicrometer().isDimensional());
-    }
-
-    /**
      * Bean creation method constructing a {@link ConfigurationEnhancer} that disables
      * {@link MetricsConfigurationEnhancer} that is only constructed when {@code axon.metrics.enabled} is set to
      * {@code false}.

--- a/extensions/metrics/metrics-micrometer/src/test/java/org/axonframework/extension/metrics/micrometer/springboot/MicrometerMetricsAutoConfigurationTest.java
+++ b/extensions/metrics/metrics-micrometer/src/test/java/org/axonframework/extension/metrics/micrometer/springboot/MicrometerMetricsAutoConfigurationTest.java
@@ -40,24 +40,6 @@ class MicrometerMetricsAutoConfigurationTest {
     }
 
     @Test
-    void defaultMetricAutoConfigSetsMetricRegistryBeanForEnhancer() {
-        testContext.withPropertyValues("axon.metrics.enabled=true")
-                   .run(context -> {
-                       assertThat(context).hasSingleBean(MeterRegistry.class);
-                       assertThat(context).hasSingleBean(MetricsConfigurationEnhancer.class);
-                   });
-    }
-
-    @Test
-    void defaultMetricAutoConfigSetsMetricRegistryBeanForEnhancerWorkWithoutProperty() {
-        // Deliberately not included "axon.metrics.enabled=true" per test!
-        testContext.run(context -> {
-                       assertThat(context).hasSingleBean(MeterRegistry.class);
-                       assertThat(context).hasSingleBean(MetricsConfigurationEnhancer.class);
-                   });
-    }
-
-    @Test
     void disabledMetricsDisablesMetricRegistryAndMetricsConfigurationEnhancer() {
         testContext.withPropertyValues("axon.metrics.enabled=false")
                    .run(context -> {


### PR DESCRIPTION
This **port** PR removes the `MetricsConfigurationEnhancer` bean that's added by the `MicrometerMetricsAutoConfiguration` of Spring Boot. 
Duo to the recent `ComponentRegistry` adjustments as of 5.1.0 (which ensures `ConfigurationEnhancers` are present throughout all `Modules`), the `MetricsConfigurationEnhancer` bean got merged with the Service Loaded version.
This caused the exception as shown in issue #4634.

In doing so, this PR resolves #4634.

This is a port of #4666 to the 5.1.x line