### PR TITLE
[#4659] Wrap `LockingRepository#doLoadOrCreate` try-catch in outer try-catch to ensure locks are released

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/command/LockingRepository.java
@@ -150,16 +150,18 @@ public abstract class LockingRepository<T, A extends Aggregate<T>> extends
         Lock lock = spanFactory.createObtainLockSpan(aggregateIdentifier)
                                .runSupplier(() -> lockFactory.obtainLock(aggregateIdentifier));
         try {
-            final A aggregate = doLoadWithLock(aggregateIdentifier, null);
-            CurrentUnitOfWork.get().onCleanup(u -> lock.release());
-            return new LockAwareAggregate<>(aggregate, lock);
-        } catch (AggregateNotFoundException ex) {
-            if (isExactAggregateNotFound(ex.getClass())) {
-                final A aggregate = doCreateNewForLock(factoryMethod);
+            try {
+                final A aggregate = doLoadWithLock(aggregateIdentifier, null);
                 CurrentUnitOfWork.get().onCleanup(u -> lock.release());
                 return new LockAwareAggregate<>(aggregate, lock);
-            } else {
-                throw ex;
+            } catch (AggregateNotFoundException ex) {
+                if (isExactAggregateNotFound(ex.getClass())) {
+                    final A aggregate = doCreateNewForLock(factoryMethod);
+                    CurrentUnitOfWork.get().onCleanup(u -> lock.release());
+                    return new LockAwareAggregate<>(aggregate, lock);
+                } else {
+                    throw ex;
+                }
             }
         } catch (Throwable ex) {
             logger.debug("Exception occurred while trying to load/create an aggregate. Releasing lock.", ex);

--- a/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
@@ -186,15 +186,6 @@ class LockingRepositoryTest {
      */
     @Test
     void loadOrCreateAggregateReleasesLockWhenLoadThrowsAggregateNotFoundSubclass() throws Exception {
-        // Arrange: create and then "delete" an aggregate
-        startAndGetUnitOfWork();
-        StubAggregate aggregate = new StubAggregate();
-        testSubject.newInstance(() -> aggregate).execute(StubAggregate::doSomething);
-        CurrentUnitOfWork.commit();
-        reset(lockFactory);
-
-        testSubject.markDeleted(aggregate.getIdentifier());
-
         // Use a real PessimisticLockFactory so the lock leak is detectable from another thread
         PessimisticLockFactory realLockFactory = PessimisticLockFactory.builder()
                                                                        .acquireAttempts(3)
@@ -204,6 +195,7 @@ class LockingRepositoryTest {
                                                                                   .lockFactory(realLockFactory)
                                                                                   .eventBus(eventBus)
                                                                                   .build();
+        StubAggregate aggregate = new StubAggregate();
         subjectWithRealLocks.markDeleted(aggregate.getIdentifier());
 
         // Act: loadOrCreate on a "deleted" aggregate — throws a subclass of AggregateNotFoundException

--- a/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/command/LockingRepositoryTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.modelling.command;
 
 import org.axonframework.common.lock.Lock;
+import org.axonframework.common.lock.LockAcquisitionFailedException;
 import org.axonframework.common.lock.LockFactory;
 import org.axonframework.common.lock.PessimisticLockFactory;
 import org.axonframework.eventhandling.EventBus;
@@ -34,8 +35,14 @@ import org.axonframework.tracing.TestSpanFactory;
 import org.junit.jupiter.api.*;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -174,6 +181,53 @@ class LockingRepositoryTest {
         verify(lock).release();
     }
 
+    /**
+     * This test ensure #4659 is covered as intended.
+     */
+    @Test
+    void loadOrCreateAggregateReleasesLockWhenLoadThrowsAggregateNotFoundSubclass() throws Exception {
+        // Arrange: create and then "delete" an aggregate
+        startAndGetUnitOfWork();
+        StubAggregate aggregate = new StubAggregate();
+        testSubject.newInstance(() -> aggregate).execute(StubAggregate::doSomething);
+        CurrentUnitOfWork.commit();
+        reset(lockFactory);
+
+        testSubject.markDeleted(aggregate.getIdentifier());
+
+        // Use a real PessimisticLockFactory so the lock leak is detectable from another thread
+        PessimisticLockFactory realLockFactory = PessimisticLockFactory.builder()
+                                                                       .acquireAttempts(3)
+                                                                       .lockAttemptTimeout(50)
+                                                                       .build();
+        InMemoryLockingRepository subjectWithRealLocks = InMemoryLockingRepository.builder()
+                                                                                  .lockFactory(realLockFactory)
+                                                                                  .eventBus(eventBus)
+                                                                                  .build();
+        subjectWithRealLocks.markDeleted(aggregate.getIdentifier());
+
+        // Act: loadOrCreate on a "deleted" aggregate — throws a subclass of AggregateNotFoundException
+        UnitOfWork<?> uow = startAndGetUnitOfWork();
+        assertThrows(AggregateNotFoundException.class,
+                     () -> subjectWithRealLocks.loadOrCreate(aggregate.getIdentifier(), StubAggregate::new));
+        uow.rollback();
+
+        // Assert: the lock must be released — another thread must be able to acquire it
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Boolean> acquirable = executor.submit(() -> {
+            try {
+                Lock l = realLockFactory.obtainLock(aggregate.getIdentifier());
+                l.release();
+                return true;
+            } catch (LockAcquisitionFailedException e) {
+                return false;
+            }
+        });
+        assertTrue(acquirable.get(5, TimeUnit.SECONDS),
+                   "lock must be released after loadOrCreate fails with an AggregateNotFoundException subclass");
+        executor.shutdownNow();
+    }
+
     @Test
     void loadAndStoreAggregate() throws Exception {
         startAndGetUnitOfWork();
@@ -270,12 +324,20 @@ class LockingRepositoryTest {
         return DefaultUnitOfWork.startAndGet(MESSAGE);
     }
 
+    private static class DeletedAggregateException extends AggregateNotFoundException {
+
+        DeletedAggregateException(String aggregateIdentifier) {
+            super(aggregateIdentifier, "Aggregate was deleted");
+        }
+    }
+
     private static class InMemoryLockingRepository extends LockingRepository<StubAggregate, Aggregate<StubAggregate>> {
 
         private final EventBus eventBus;
         private final AggregateModel<StubAggregate> aggregateModel;
 
         private final Map<Object, Aggregate<StubAggregate>> store;
+        private final Set<String> deletedAggregates;
         private int saveCount;
 
         private InMemoryLockingRepository(Builder builder) {
@@ -284,7 +346,13 @@ class LockingRepositoryTest {
             this.aggregateModel = builder.buildAggregateModel();
 
             store = new HashMap<>();
+            deletedAggregates = new HashSet<>();
             this.saveCount = 0;
+        }
+
+        void markDeleted(String aggregateIdentifier) {
+            store.remove(aggregateIdentifier);
+            deletedAggregates.add(aggregateIdentifier);
         }
 
         public static Builder builder() {
@@ -305,9 +373,11 @@ class LockingRepositoryTest {
 
         @Override
         protected Aggregate<StubAggregate> doLoadWithLock(String aggregateIdentifier, Long expectedVersion) {
+            if (deletedAggregates.contains(aggregateIdentifier)) {
+                throw new DeletedAggregateException(aggregateIdentifier);
+            }
             if (!store.containsKey(aggregateIdentifier)) {
-                throw new AggregateNotFoundException(aggregateIdentifier,
-                                                     "Aggregate not found");
+                throw new AggregateNotFoundException(aggregateIdentifier, "Aggregate not found");
             }
             return store.get(aggregateIdentifier);
         }


### PR DESCRIPTION
This pull request moves the catch-all `catch(Exception)` to be an outer try-catch instead of being part of the single try-catch.
In doing so, we ascertain that the exception rethrown when `isExactAggregateNotFound(Class<? extends AggregateNotFoundException>)` is false is caught, resulting in the lock to be released.
If we do not, we can accidentally keep a lock for an aggregate that's been marked deleted, but is hit with a quick subsequent create-if-missing invocation.

In doing the above, this PR resolves #4659.