### PR TITLE
Disable sonar for builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         include:
           - java-version: 21
-            sonar-enabled: true
+            # disable sonar for now
+            sonar-enabled: false
             deploy-enabled: true
           - java-version: 25
             sonar-enabled: false

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         include:
           - java-version: 21
-            sonar-enabled: true
+            # disable sonar for now
+            sonar-enabled: false
           - java-version: 25
             sonar-enabled: false
 


### PR DESCRIPTION
Currently builds are failing due to missing sonar configuration and our current sonar plan also has some limitations that make the analysis provide less value. We also discussed (without conclusion) switching to other tools for code analysis some time ago due to that pain. 

To avoid constant build failures, this PR aims to disable the sonar analysis for now until we decided how and if we continue use sonar for code analysis or if we switch to a different tool.

