### PR TITLE
[#4643] Ensure Event Processing results in token progress when no events match the `EventCriteria`

### DIFF
--- a/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
+++ b/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
@@ -78,5 +78,5 @@ public interface TransactionalExecutor<T> {
      *     the provided function, never {@code null}.
      * @throws NullPointerException When {@code function} is {@code null}.
      */
-    <R> CompletableFuture<@Nullable R> apply(ThrowingFunction<T, R, Exception> function);
+    <R> CompletableFuture<R> apply(ThrowingFunction<T, R, Exception> function);
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -535,7 +535,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         }
     }
 
-    private TransactionalExecutor<EntityManager> entityManagerExecutor(ProcessingContext processingContext) {
+    private TransactionalExecutor<EntityManager> entityManagerExecutor(@Nullable ProcessingContext processingContext) {
         return transactionalExecutorProvider.getTransactionalExecutor(processingContext);
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -40,6 +40,7 @@ import org.axonframework.eventsourcing.eventstore.SourcingStrategy;
 import org.axonframework.eventsourcing.eventstore.StreamSpliterator;
 import org.axonframework.eventsourcing.eventstore.TaggedEventMessage;
 import org.axonframework.eventsourcing.eventstore.TerminalEventMessage;
+import org.axonframework.messaging.eventstreaming.TokenProgressMessage;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.MessageStream;
@@ -347,7 +348,10 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
         return new ContinuousMessageStream<>(
                 () -> queryTokensAndEventsBy(cursorRef, condition),
-                tae -> new SimpleEntry<>(convertToEventMessage(tae.event), buildTrackedContext(tae)),
+                tae -> tae.event() != null
+                        ? new SimpleEntry<>(convertToEventMessage(tae.event()), buildTrackedContext(tae))
+                        : new SimpleEntry<>(TokenProgressMessage.INSTANCE,
+                                            Context.with(TrackingToken.RESOURCE_KEY, tae.token())),
                 (ms, r) -> {
                     streamCallbacks.put(ms, r);
                     return () -> streamCallbacks.remove(ms) != null;
@@ -358,27 +362,45 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private List<TokenAndEvent> queryTokensAndEventsBy(AtomicReference<GapAwareTrackingToken> cursorRef, StreamingCondition condition) {
         return entityManagerExecutor(null).apply(em -> {
             List<TokenAndEvent> result = new ArrayList<>();
-            GapAwareTrackingToken cleanedToken = cleanedToken(em, cursorRef.get());
-            List<AggregateEventEntry> events = queryEventsBy(em, cleanedToken);
-
-            GapAwareTrackingToken token = cleanedToken;
-
+            GapAwareTrackingToken token = cleanedToken(em, cursorRef.get());
             Instant gapTimeoutThreshold = tokenOperations.gapTimeoutThreshold();
-            for (AggregateEventEntry event : events) {
-                String type = event.aggregateType();
-                String identifier = event.aggregateIdentifier();
+            boolean anyEventsScanned = false;
 
-                // A null type or identifier is allowed, but those cannot form a valid tag:
-                Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
+            do {
+                List<AggregateEventEntry> events = queryEventsBy(em, token);
 
-                // Always advance the cursor to track the furthest scanned position, regardless of match:
-                token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
-                cursorRef.set(token);
+                for (AggregateEventEntry event : events) {
+                    String type = event.aggregateType();
+                    String identifier = event.aggregateIdentifier();
 
-                if (condition.matches(new QualifiedName(event.type()), tags)) {
-                    result.add(new TokenAndEvent(token, event));
+                    // A null type or identifier is allowed, but those cannot form a valid tag:
+                    Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
+
+                    // Always advance the cursor to track the furthest scanned position, regardless of match:
+                    token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
+                    cursorRef.set(token);
+                    anyEventsScanned = true;
+
+                    if (condition.matches(new QualifiedName(event.type()), tags)) {
+                        result.add(new TokenAndEvent(token, event));
+                    }
                 }
+
+                if (finalBatchPredicate.test(events)) {
+                    break;  // Reached the tail of the event store; stop scanning
+                }
+
+                // Prevent the JPA first-level cache from accumulating all skipped entries across
+                // iterations: after a fully-filtered batch the entities are no longer needed.
+                em.clear();
+            } while (result.isEmpty());
+
+            // When the entire scanned range contains no matching events, emit a token-advancement sentinel (null event)
+            // so consumers can advance their tokens to the furthest scanned position.
+            if (result.isEmpty() && anyEventsScanned) {
+                result.add(new TokenAndEvent(token, null));
             }
+
             return result;
         }).join();
     }
@@ -529,7 +551,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     }
 
-    private record TokenAndEvent(GapAwareTrackingToken token, AggregateEventEntry event) {
+    private record TokenAndEvent(GapAwareTrackingToken token, @Nullable AggregateEventEntry event) {
 
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -454,6 +455,131 @@ class AggregateBasedJpaEventStorageEngineIT
             // then — the stream must eventually surface the matching test event despite the
             // non-matching batch preceding it
             await().untilAsserted(() -> assertThat(stream.peek()).isNotEmpty());
+        }
+
+        /**
+         * This test validates that fix introduced for #4643 works as expected.
+         */
+        @Test
+        void streamLoopsThroughEventStreamUntilConditionMatchingEntryIsFound() {
+            // given — 9 non-matching events followed by 1 matching event, with batchSize=1 so
+            // queryTokensAndEventsBy must iterate through exactly 9 single-event batches before
+            // finding the match
+            AggregateBasedJpaEventStorageEngine testEngine = new AggregateBasedJpaEventStorageEngine(
+                    new JpaTransactionalExecutorProvider(entityManagerFactory),
+                    converter,
+                    config -> config
+                            .batchSize(1)
+                            .eventCoordinator(new JpaPollingEventCoordinator(
+                                    new FactoryBasedEntityManagerProvider(entityManagerFactory),
+                                    Duration.ofMillis(500)
+                            ))
+                            .persistenceExceptionResolver(new PersistenceExceptionResolver() {
+                                @Override
+                                public boolean isDuplicateKeyViolation(@NonNull Exception exception) {
+                                    return causeIsEntityExistsException(exception);
+                                }
+
+                                private boolean causeIsEntityExistsException(Throwable exception) {
+                                    return exception instanceof java.sql.SQLIntegrityConstraintViolationException
+                                            || (exception.getCause() != null
+                                            && causeIsEntityExistsException(exception.getCause()));
+                                }
+                            })
+            );
+
+            try {
+                for (int i = 1; i <= 9; i++) {
+                    appendCommitAndWait(testEngine, AppendCondition.none(),
+                                        taggedEventMessage("other-" + i, OTHER_AGGREGATE_TAGS));
+                }
+                appendCommitAndWait(testEngine, AppendCondition.none(),
+                                    taggedEventMessage("test-1", TEST_AGGREGATE_TAGS));
+                // Validate 10 events have actually been inserted by checking the latest token
+                CompletableFuture<TrackingToken> latestToken = testEngine.latestToken();
+                assertThat(latestToken).isCompleted();
+                OptionalLong latestPosition = latestToken.join().position();
+                assertThat(latestPosition).isPresent();
+                assertThat(latestPosition.getAsLong()).isEqualTo(10);
+
+                // when — stream filtered to TEST_AGGREGATE_CRITERIA; batchSize is 1, so each of the
+                // 9 preceding events forms its own batch that must be skipped in the loop
+                MessageStream<EventMessage> stream = testEngine.stream(
+                        StreamingCondition.conditionFor(trackingTokenAt(0), TEST_AGGREGATE_CRITERIA)
+                );
+
+                // then — a single peek() must return the matching event without any retry loop:
+                // queryTokensAndEventsBy loops through all 9 non-matching batches in one invocation,
+                // so the very first peek() surfaces the 10th event directly
+                Optional<MessageStream.Entry<EventMessage>> peek = stream.peek();
+                assertThat(peek).isNotEmpty();
+                assertThat(peek.get().message().payloadAs(String.class)).isEqualTo("test-1");
+            } finally {
+                testEngine.close();
+            }
+        }
+
+        /**
+         * This test validates the token-progress aspect of the fix introduced for #4643: when the
+         * entire event store contains no matching events, the stream must still deliver one entry
+         * (the last scanned event as a cursor-advancement marker) so that the WorkPackage can
+         * advance and store its tracking token.  Without this, a stop/restart would force the PSEP
+         * to re-scan the entire filtered gap from the beginning every time.
+         */
+        @Test
+        void streamReturnsLastScannedEntryAsTokenAdvancementMarker_whenNoMatchingEventsExist() {
+            // given — 10 events, none of which match TEST_AGGREGATE_CRITERIA; batchSize=1 forces
+            // the loop to iterate through all 10 single-event batches
+            AggregateBasedJpaEventStorageEngine testEngine = new AggregateBasedJpaEventStorageEngine(
+                    new JpaTransactionalExecutorProvider(entityManagerFactory),
+                    converter,
+                    config -> config
+                            .batchSize(1)
+                            .eventCoordinator(new JpaPollingEventCoordinator(
+                                    new FactoryBasedEntityManagerProvider(entityManagerFactory),
+                                    Duration.ofMillis(500)
+                            ))
+                            .persistenceExceptionResolver(new PersistenceExceptionResolver() {
+                                @Override
+                                public boolean isDuplicateKeyViolation(@NonNull Exception exception) {
+                                    return causeIsEntityExistsException(exception);
+                                }
+
+                                private boolean causeIsEntityExistsException(Throwable exception) {
+                                    return exception instanceof java.sql.SQLIntegrityConstraintViolationException
+                                            || (exception.getCause() != null
+                                            && causeIsEntityExistsException(exception.getCause()));
+                                }
+                            })
+            );
+            try {
+                // Use emptySet() tags (no aggregate identifier) so each event gets a null
+                // aggregate sequence number — avoiding unique-constraint conflicts on
+                // (aggregateIdentifier, aggregateSequenceNumber) across separate transactions.
+                for (int i = 1; i <= 10; i++) {
+                    appendCommitAndWait(testEngine, AppendCondition.none(),
+                                        taggedEventMessage("other-" + i, emptySet()));
+                }
+
+                // when — stream filtered to TEST_AGGREGATE_CRITERIA; none of the events match
+                MessageStream<EventMessage> stream = testEngine.stream(
+                        StreamingCondition.conditionFor(trackingTokenAt(0), TEST_AGGREGATE_CRITERIA)
+                );
+
+                // then — despite zero matching events, a single peek() must return a marker whose
+                // token equals the latest token in the store: the loop consumed all batches and
+                // reported the furthest scanned position so the WorkPackage can advance its token
+                TrackingToken latestToken = testEngine.latestToken().join();
+                assertThat(latestToken.position()).isPresent();
+
+                Optional<MessageStream.Entry<EventMessage>> peek = stream.peek();
+                assertThat(peek).isNotEmpty();
+                Optional<TrackingToken> markerToken = peek.flatMap(TrackingToken::fromContext);
+                assertThat(markerToken).isPresent();
+                assertThat(markerToken.get().position()).isEqualTo(latestToken.position());
+            } finally {
+                testEngine.close();
+            }
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -16,14 +16,13 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
-import org.axonframework.common.ProcessUtils;
 import org.axonframework.common.ClockUtils;
+import org.axonframework.common.ProcessUtils;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentChangeListener;
@@ -36,6 +35,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.axonframework.messaging.eventstreaming.TokenProgressMessage;
 import org.axonframework.messaging.eventstreaming.TrackingTokenSource;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -1300,6 +1300,15 @@ class Coordinator {
                         }
                     }
                     offerEventsToWorkPackages(eventEntries);
+                } else if (eventEntry.message() instanceof TokenProgressMessage) {
+                    // Not a real event: advance each work package's token to reflect progress through
+                    // a fully-filtered batch, without dispatching anything to event handlers.
+                    TrackingToken token =
+                            TrackingToken.fromContext(eventEntry)
+                                         .orElseThrow(() -> new IllegalArgumentException(
+                                                 "Receiving a TokenProgressMessage without a TrackingToken in the context"
+                                         ));
+                    workPackages.values().forEach(wp -> wp.advanceTokenTo(token));
                 } else {
                     offerEventToWorkPackages(eventEntry);
                 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -18,7 +18,6 @@ package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.Assert;
 import org.axonframework.common.ClockUtils;
-import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.LegacyResources;
@@ -30,7 +29,6 @@ import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.EventHandlingComponent;
 import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -43,12 +41,12 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
-import java.util.concurrent.CompletionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -536,6 +534,27 @@ class WorkPackage {
     }
 
     /**
+     * Advances this {@code WorkPackage}'s position to the given {@code token} without delivering an event to any
+     * handler. The token-advancement entry is queued like a normal event, so {@code lastConsumedToken} advances and the
+     * stored token is updated once the claim-extension threshold is met.
+     * <p>
+     * Use this when the event source has consumed a batch but filtered every event: no real event should be dispatched,
+     * yet the processor token must move forward so restarts do not re-scan the same gap.
+     * <p>
+     * <b>Threading note:</b> This method is and should only be called by the {@link Coordinator} thread.
+     *
+     * @param token the furthest scanned position to advance this work package's token to
+     */
+    public void advanceTokenTo(TrackingToken token) {
+        if (lastDeliveredToken.covers(token)) {
+            return;
+        }
+        processingQueue.add(new TokenOnlyEntry(token));
+        lastDeliveredToken = token;
+        scheduleWorker();
+    }
+
+    /**
      * Lambda to be invoked whenever the event batch of this package's {@code segment} processed.
      *
      * @param batchProcessedCallback lambda to be invoked whenever the event batch of this package's {@code segment}
@@ -843,6 +862,26 @@ class WorkPackage {
             if (canHandle) {
                 eventBatch.add(eventEntry.withResource(TrackingToken.RESOURCE_KEY, wrappedToken));
             }
+        }
+    }
+
+    /**
+     * A {@link ProcessingEntry} that carries only a {@link TrackingToken}.
+     * <p>
+     * Used when {@link #advanceTokenTo(TrackingToken)} is invoked, which is typically invoked when event consumption
+     * filtered out all events. This entry ensures we still progress the token.
+     */
+    private record TokenOnlyEntry(TrackingToken token) implements ProcessingEntry {
+
+        @Override
+        public TrackingToken trackingToken() {
+            return token;
+        }
+
+        @Override
+        public void addToBatch(List<MessageStream.Entry<? extends EventMessage>> eventBatch,
+                               TrackingToken wrappedToken) {
+            // no-op: position markers never add to the event batch
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventstreaming/TokenProgressMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventstreaming/TokenProgressMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.eventstreaming;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+
+/**
+ * Empty {@link GenericEventMessage} implementation without any {@link EventMessage#payload() payload}, used as a
+ * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken} progress marker for the
+ * {@link org.axonframework.messaging.core.MessageStream} in absence of any events that matched the
+ * {@link StreamingCondition}.
+ * <p>
+ * Required to be paired with {@link org.axonframework.messaging.core.Context} containing the {@code TrackingToken} to
+ * signal the actual progress that's been made.
+ * <p>
+ * Emitting this marker into the stream allows event consumers to progress the stored token to the furthest scanned
+ * position even when no events matched the criteria. This prevents consumers from remaining frozen at an earlier
+ * position when large gaps of non-matching events exist, and avoids re-scanning the same gap from scratch on processor
+ * restart.
+ *
+ * @author Steven van Beelen
+ * @since 5.1.2
+ */
+@Internal
+public class TokenProgressMessage extends GenericEventMessage {
+
+    /**
+     * The sole instance of the {@link TokenProgressMessage}.
+     */
+    public static final TokenProgressMessage INSTANCE = new TokenProgressMessage();
+
+    private TokenProgressMessage() {
+        super(new MessageType(TokenProgressMessage.class), null);
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -16,27 +16,6 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.UnaryOperator;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.ProcessRetriesExhaustedException;
 import org.axonframework.common.ReflectionUtils;
@@ -58,10 +37,32 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.axonframework.messaging.eventstreaming.TokenProgressMessage;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 import org.mockito.stubbing.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link Coordinator}.
@@ -773,6 +774,110 @@ class CoordinatorTest {
 
             // then - the failure is swallowed by the exceptionally handler and a retry is still scheduled
             verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        }
+    }
+
+    /**
+     * Tests for the {@link TokenProgressMessage} routing path in {@code coordinateWorkPackages()}, verifying that a
+     * progress marker in the event stream is forwarded to {@link WorkPackage#advanceTokenTo} without going through
+     * {@link WorkPackage#scheduleEvent}.
+     */
+    @Nested
+    class TokenProgressMessageRoutingTest {
+
+        @Test
+        void tokenProgressMessageCallsAdvanceTokenToOnAllWorkPackagesWithoutSchedulingAnEvent() {
+            // given — a stream that contains a single TokenProgressMessage carrying an advanced position
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(0L);
+            GlobalSequenceTrackingToken advanceToken = new GlobalSequenceTrackingToken(5L);
+
+            MessageStream<EventMessage> testStream = MessageStream.fromIterable(
+                    List.of(TokenProgressMessage.INSTANCE),
+                    ignored -> trackingTokenContext(advanceToken)
+            );
+
+            when(workPackage.hasRemainingCapacity()).thenReturn(true);
+            when(workPackage.isAbortTriggered()).thenReturn(false);
+
+            when(executorService.submit(any(Runnable.class))).thenAnswer(runTaskAsync());
+            doAnswer(invocation -> { ((Runnable) invocation.getArgument(0)).run(); return null; })
+                    .doAnswer(invocation -> null)
+                    .when(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+            when(tokenStore.fetchSegments(eq(PROCESSOR_NAME), any())).thenReturn(completedFuture(SEGMENTS));
+            when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
+                    .thenReturn(completedFuture(Collections.singletonList(SEGMENT_ONE)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ONE), any()))
+                    .thenReturn(completedFuture(storedToken));
+            when(messageSource.open(any(StreamingCondition.class), isNull())).thenReturn(testStream);
+
+            // when
+            awaitStart(testSubject);
+
+            // then — advanceTokenTo is called on the work package with the marker's token;
+            //        scheduleEvent must never be called since the entry carries no real event
+            await().atMost(500, TimeUnit.MILLISECONDS)
+                   .untilAsserted(() -> verify(workPackage).advanceTokenTo(advanceToken));
+            verify(workPackage, never()).scheduleEvent(any());
+        }
+
+        @Test
+        void tokenProgressMessageInMiddleOfStreamDoesNotDisruptSchedulingOfSurroundingEvents() {
+            // given — four real events separated by a single TokenProgressMessage in the middle
+            GlobalSequenceTrackingToken storedToken = new GlobalSequenceTrackingToken(0L);
+            GlobalSequenceTrackingToken token1 = new GlobalSequenceTrackingToken(1L);
+            GlobalSequenceTrackingToken token2 = new GlobalSequenceTrackingToken(2L);
+            GlobalSequenceTrackingToken advanceToken = new GlobalSequenceTrackingToken(3L);
+            GlobalSequenceTrackingToken token3 = new GlobalSequenceTrackingToken(4L);
+            GlobalSequenceTrackingToken token4 = new GlobalSequenceTrackingToken(5L);
+
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            EventMessage event4 = EventTestUtils.asEventMessage("event-4");
+
+            // each entry is identified by reference so the context supplier can assign individual tokens
+            Map<EventMessage, TrackingToken> tokenPerEntry = Map.of(
+                    event1, token1,
+                    event2, token2,
+                    TokenProgressMessage.INSTANCE, advanceToken,
+                    event3, token3,
+                    event4, token4
+            );
+
+            MessageStream<EventMessage> testStream = MessageStream.fromIterable(
+                    List.of(event1, event2, TokenProgressMessage.INSTANCE, event3, event4),
+                    e -> trackingTokenContext(tokenPerEntry.get(e))
+            );
+
+            when(workPackage.hasRemainingCapacity()).thenReturn(true);
+            when(workPackage.isAbortTriggered()).thenReturn(false);
+            when(workPackage.scheduleEvent(any())).thenReturn(true);
+
+            when(executorService.submit(any(Runnable.class))).thenAnswer(runTaskAsync());
+            doAnswer(invocation -> { ((Runnable) invocation.getArgument(0)).run(); return null; })
+                    .doAnswer(invocation -> null)
+                    .when(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+            when(tokenStore.fetchSegments(eq(PROCESSOR_NAME), any())).thenReturn(completedFuture(SEGMENTS));
+            when(tokenStore.fetchAvailableSegments(eq(PROCESSOR_NAME), any()))
+                    .thenReturn(completedFuture(Collections.singletonList(SEGMENT_ONE)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ONE), any()))
+                    .thenReturn(completedFuture(storedToken));
+            when(messageSource.open(any(StreamingCondition.class), isNull())).thenReturn(testStream);
+
+            // when
+            awaitStart(testSubject);
+
+            // then — all four real events reach scheduleEvent; the marker is routed to advanceTokenTo instead
+            await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+                verify(workPackage, times(4)).scheduleEvent(any());
+                verify(workPackage).advanceTokenTo(advanceToken);
+            });
+            // the marker must never appear as an argument to scheduleEvent
+            verify(workPackage, never()).scheduleEvent(
+                    argThat(entry -> entry.message() instanceof TokenProgressMessage)
+            );
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -778,6 +778,85 @@ class WorkPackageTest {
         }
     }
 
+    @Nested
+    class AdvanceTokenToTest {
+
+        @Test
+        void advanceTokenToStoresTokenWithoutDispatchingAnyEvent() {
+            // given — extremely short threshold to force the empty-batch storeToken path on the first worker run
+            WorkPackage subject = testSubjectBuilder.claimExtensionThreshold(1).build();
+            TrackingToken advanceToken = new GlobalSequenceTrackingToken(5L);
+
+            // when — only a token-only advancement, no real event is scheduled
+            subject.advanceTokenTo(advanceToken);
+
+            // then — the token must be stored at the advanced position; nothing must reach the batch processor
+            ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+            await().atMost(TIMEOUT).untilAsserted(() -> {
+                subject.scheduleWorker();  // re-trigger in case the claim threshold had not yet elapsed
+                verify(tokenStore, atLeastOnce()).storeToken(
+                        tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any()
+                );
+            });
+            assertThat(tokenCaptor.getValue()).isEqualTo(advanceToken);
+            assertThat(batchProcessor.getProcessedEvents()).isEmpty();
+        }
+
+        @Test
+        void advanceTokenToDoesNotInterfereWithTrailingScheduledEvents() {
+            // given — a token advancement immediately followed by a real event
+            TrackingToken advanceToken = new GlobalSequenceTrackingToken(5L);
+            TrackingToken eventToken = new GlobalSequenceTrackingToken(10L);
+            var trailingEntry = new SimpleEntry<>(EventTestUtils.asEventMessage("trailing"),
+                                                  trackingTokenContext(eventToken));
+
+            // when — token-only advancement drains alongside the trailing event in the same processEvents() run
+            testSubject.advanceTokenTo(advanceToken);
+            testSubject.scheduleEvent(trailingEntry);
+
+            // then — the trailing event IS dispatched and its token is stored; the marker adds no extra entry
+            await().atMost(TIMEOUT).untilAsserted(() -> {
+                ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+                verify(tokenStore).storeToken(
+                        tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any()
+                );
+                assertThat(tokenCaptor.getValue()).isEqualTo(eventToken);
+            });
+            assertThat(batchProcessor.getProcessedEvents()).hasSize(1);
+        }
+
+        @Test
+        void advanceTokenToBetweenTwoEventsProcessesOnlyTheRealEvents() {
+            // given — a real event, a token-only advancement, then another real event
+            TrackingToken firstToken = new GlobalSequenceTrackingToken(3L);
+            TrackingToken advanceToken = new GlobalSequenceTrackingToken(7L);
+            TrackingToken secondToken = new GlobalSequenceTrackingToken(10L);
+            var firstEntry = new SimpleEntry<>(EventTestUtils.asEventMessage("first"),
+                                               trackingTokenContext(firstToken));
+            var secondEntry = new SimpleEntry<>(EventTestUtils.asEventMessage("second"),
+                                                trackingTokenContext(secondToken));
+
+            // when — the token-only entry sits between the two real events in the processing queue
+            testSubject.scheduleEvent(firstEntry);
+            testSubject.advanceTokenTo(advanceToken);
+            testSubject.scheduleEvent(secondEntry);
+
+            // then — exactly the two real events are dispatched; the marker contributes no entry to any batch
+            await().atMost(TIMEOUT).untilAsserted(
+                    () -> assertThat(batchProcessor.getProcessedEvents()).hasSize(2)
+            );
+
+            // and the final stored token reflects the second event's position (advancing through the marker first)
+            await().atMost(TIMEOUT).untilAsserted(() -> {
+                ArgumentCaptor<TrackingToken> tokenCaptor = ArgumentCaptor.forClass(TrackingToken.class);
+                verify(tokenStore, atLeastOnce()).storeToken(
+                        tokenCaptor.capture(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any()
+                );
+                assertThat(tokenCaptor.getAllValues()).contains(secondToken);
+            });
+        }
+    }
+
     private static Context globalTrackingTokenContext(long globalIndex) {
         return trackingTokenContext(new GlobalSequenceTrackingToken(globalIndex));
     }


### PR DESCRIPTION
This pull ensures that `TrackingTokens` keep progressing when streaming events, even if the retrieved event batches carry no events of interest for the consumer. 
This PR introduces roughly two changes to support this, being:

1. The engine should progress in the `EventStorageEngine#stream(StreamingCondition)`, until it hits an event that matches the given `StreamingCondition`. 
2. The engine should return a marker `EventMessage` when there are no events matching the `StreamingCondition` at all. 

The former will cover the majority of the scenarios wherein a batch of retrieved events results in no outcome.
This solution is currently maintained solely in the `AggregateBasedJpaEventStorageEngine`. 
It will require adjustments to the Axon Server ans PosgreSQL `EventStorageEngine` as well.

The latter is typically reserved for relatively large event stores and event processors with very little to no event handlers matching events in the store.
To that end, this PR introduces the (internal) `TokenProgressMessage`, which should be returned by an `EventStorageEngine` when there are no events matching the `StreamingCondition` for several iterations of event retrieval.
As the `TokenProgressMessage` is a special case, consumers need to deal with it accordingly. For now, that's reserved for the `PooledStreamingEventProcessor` only.
Per requirement, the `Coordinator` of the PSEP reacts on the `TokenProgressMessage`, noting it should simply update all it's `WorkPackages` their last seen `TrackingToken`.
To be able to perform this update **without** passing an event, the `WorkPackage` has a new method to advance the token.
Just as with the previous fix, this switch requires changes in the Axon Server ans PosgreSQL `EventStorageEngine` as well, to ensure they return a `TokenProgressMessage`.

Tests have been introduced for the `AggregateBasedJpaEventStorageEngine`, the `Coordinator`, and the `WorkPackage` to validate the behavior.

Appended a small clean-up to this PR as well: the removal of an incorrectly placed `@Nullable` annotation.

By doing the above, this PR works towards resolving #4643.
A port to `axon-5.1.x` is still required, though.