### PR TITLE
[#4643] `AggregateBasedJpaEventStorageEngine#stream` loops until `StreamingCondition` matching events are retrieved

### DIFF
--- a/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
+++ b/common/src/main/java/org/axonframework/common/tx/TransactionalExecutor.java
@@ -78,5 +78,5 @@ public interface TransactionalExecutor<T> {
      *     the provided function, never {@code null}.
      * @throws NullPointerException When {@code function} is {@code null}.
      */
-    <R> CompletableFuture<@Nullable R> apply(ThrowingFunction<T, R, Exception> function);
+    <R> CompletableFuture<R> apply(ThrowingFunction<T, R, Exception> function);
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -357,14 +357,12 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     private List<TokenAndEvent> queryTokensAndEventsBy(AtomicReference<GapAwareTrackingToken> cursorRef,
                                                         StreamingCondition condition) {
-        while (true) {
-            TokenAndEventBatch result = queryBatch(cursorRef, condition);
-            if (!result.events().isEmpty() || result.exhausted()) {
-                return result.events();
-            }
-            // A full batch of non-condition-matching events was scanned and the cursor advanced.
-            // Loop back to scan the next batch right away.
-        }
+        TokenAndEventBatch result;
+        do {
+            result = queryBatch(cursorRef, condition);
+            // fetch as long as there are no events and the stream did not arrive at it's head
+        } while (result.events.isEmpty() && !result.exhausted);
+        return result.events;
     }
 
     private TokenAndEventBatch queryBatch(AtomicReference<GapAwareTrackingToken> cursorRef,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -355,15 +355,28 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         );
     }
 
-    private List<TokenAndEvent> queryTokensAndEventsBy(AtomicReference<GapAwareTrackingToken> cursorRef, StreamingCondition condition) {
+    private List<TokenAndEvent> queryTokensAndEventsBy(AtomicReference<GapAwareTrackingToken> cursorRef,
+                                                        StreamingCondition condition) {
+        while (true) {
+            TokenAndEventBatch result = queryBatch(cursorRef, condition);
+            if (!result.events().isEmpty() || result.exhausted()) {
+                return result.events();
+            }
+            // A full batch of non-condition-matching events was scanned and the cursor advanced.
+            // Loop back to scan the next batch right away.
+        }
+    }
+
+    private TokenAndEventBatch queryBatch(AtomicReference<GapAwareTrackingToken> cursorRef,
+                                          StreamingCondition condition) {
         return entityManagerExecutor(null).apply(em -> {
-            List<TokenAndEvent> result = new ArrayList<>();
+            List<TokenAndEvent> matches = new ArrayList<>();
             GapAwareTrackingToken cleanedToken = cleanedToken(em, cursorRef.get());
             List<AggregateEventEntry> events = queryEventsBy(em, cleanedToken);
 
             GapAwareTrackingToken token = cleanedToken;
-
             Instant gapTimeoutThreshold = tokenOperations.gapTimeoutThreshold();
+
             for (AggregateEventEntry event : events) {
                 String type = event.aggregateType();
                 String identifier = event.aggregateIdentifier();
@@ -371,15 +384,16 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                 // A null type or identifier is allowed, but those cannot form a valid tag:
                 Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
 
-                // Always advance the cursor to track the furthest scanned position, regardless of match:
+                // Always advance the cursor past every scanned event, regardless of match:
                 token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
                 cursorRef.set(token);
 
                 if (condition.matches(new QualifiedName(event.type()), tags)) {
-                    result.add(new TokenAndEvent(token, event));
+                    matches.add(new TokenAndEvent(token, event));
                 }
             }
-            return result;
+            // A partial batch means we've reached the end of the currently known event store.
+            return new TokenAndEventBatch(matches, events.size() < batchSize);
         }).join();
     }
 
@@ -526,6 +540,10 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
             AtomicReference<AggregateBasedConsistencyMarker> markerReference,
             MessageStream<EventMessage> source
     ) {
+
+    }
+
+    private record TokenAndEventBatch(List<TokenAndEvent> events, boolean exhausted) {
 
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -527,7 +527,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         }
     }
 
-    private TransactionalExecutor<EntityManager> entityManagerExecutor(ProcessingContext processingContext) {
+    private TransactionalExecutor<EntityManager> entityManagerExecutor(@Nullable ProcessingContext processingContext) {
         return transactionalExecutorProvider.getTransactionalExecutor(processingContext);
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStoreTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStoreTestSuite.java
@@ -592,6 +592,41 @@ public abstract class StorageEngineBackedEventStoreTestSuite<E extends EventStor
     }
 
     @Nested
+    protected class GivenNonMatchingEventsPrecedingMatchingOnes {
+
+        /**
+         * Regression test for issue #4643.
+         * <p>
+         * When streaming with a condition that matches only a subset of event types or entities, the engine must
+         * advance past batches of non-matching events without waiting for new appends. Previously, a full batch of
+         * non-matching events caused the stream to stall for some storage engines until an external signal (e.g. new
+         * append) arrived.
+         * <p>
+         * The 105 non-matching events ensure at least one full batch of non-matching events is scanned before the
+         * matching event is reached, which is the configuration that triggered the original bug with the default JPA
+         * batch size of 100.
+         */
+        @Test
+        protected void streamShouldAdvancePastNonMatchingBatchesWithoutWaitingForNewAppends() {
+            // given - 105 events for TAG2 (non-matching), then 1 event for TAG1 (matching)
+            List<EventMessage> nonMatchingEvents = new ArrayList<>();
+            for (int i = 0; i < 105; i++) {
+                nonMatchingEvents.add(message(new CourseUpdated(TAG2.value(), "non-match-" + i)));
+            }
+            unitOfWork().executeWithResult(pc -> eventStore.publish(pc, nonMatchingEvents)).join();
+
+            EventMessage matchingEvent = message(new CourseUpdated(TAG1.value(), "match-1"));
+            unitOfWork().executeWithResult(pc -> eventStore.publish(pc, matchingEvent)).join();
+
+            // when - streaming from baseToken for TAG1 only (no new events will be appended)
+            // then - the matching event is found by scanning past the non-matching batches
+            assertThat(stream(StreamingCondition.conditionFor(baseToken, EventCriteria.havingTags(TAG1)), 1))
+                .usingComparatorForType(EVENT_COMPARATOR, GenericEventMessage.class)
+                .containsExactly(matchingEvent);
+        }
+    }
+
+    @Nested
     protected class OverrideAppendCondition {
 
         /**


### PR DESCRIPTION
This pull request adjusts the `AggregateBasedJpaEventStorageEngine#streaming` method, to keep querying batches of events until some match the given `StreamingCondition`. 
If we don't do this, there's a chance that the batch is empty, stalling the `ContinuousMessageStream` until it's nudged (e.g. when a new event is appended). 
Thus, the old approach essentially blocks a consumer like the `PooledStreamingEventProcessor`, potentially indefinitely.

This PR is a second try to resolve issue #4643, with the original PR being #4681.
This PR differs from #4681 as it's an `AggregateBasedJpaEventStorageEngine` only solution.
This is by design, as Axon Server and our PostgreSQL `EventStorageEngine` implementations ensure the same: they loop through the event store until a `StreamingCondition` match is found.
As all `EventStorageEngines` support this, and should support this, a test has been added to the `StorageEngineBackedEventStoreTestSuite` to validate the behavior that an `EventStorageEngine#stream` operation will progress until a first `StreamingCondition` match has been found.

By doing the above, this PR works towards resolving #4643.
A port to `axon-5.1.x` is still required, though.