### PR TITLE
add error message in jackson serializer

### DIFF
--- a/messaging/src/main/java/org/axonframework/serialization/jackson3/Jackson3Serializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/jackson3/Jackson3Serializer.java
@@ -184,7 +184,7 @@ public class Jackson3Serializer implements Serializer {
             return new SimpleSerializedObject<>(serializedContent, expectedRepresentation,
                                                 typeForClass(ObjectUtils.nullSafeTypeOf(object)));
         } catch (JacksonException e) {
-            throw new SerializationException("Unable to serialize object", e);
+            throw new SerializationException("Unable to serialize object, details: " + e.getMessage(), e);
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
+++ b/messaging/src/main/java/org/axonframework/serialization/json/JacksonSerializer.java
@@ -151,7 +151,7 @@ public class JacksonSerializer implements Serializer {
             return new SimpleSerializedObject<>(serializedContent, expectedRepresentation,
                                                 typeForClass(ObjectUtils.nullSafeTypeOf(object)));
         } catch (JsonProcessingException e) {
-            throw new SerializationException("Unable to serialize object", e);
+            throw new SerializationException("Unable to serialize object, details: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
before the change user gets this:
`An attempt to create and store a snapshot resulted in an exception. Exception summary: An event for aggregate [e4c3008e-4120-4a4c-8d2c-e89a13bf4e72] at sequence [126] was already inserted. Original message: [Unable to serialize object]`

after:
`An attempt to create and store a snapshot resulted in an exception. Exception summary: An event for aggregate [e4c3008e-4120-4a4c-8d2c-e89a13bf4e72] at sequence [126] was already inserted. Original message: [Unable to serialize object, details: lateinit property orderIdFromPlatform has not been initialized
 at [No location information] ...`