### PR TITLE
[#4705] Skip interceptor members when applying @SequencingPolicy

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/HandlerAttributes.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/HandlerAttributes.java
@@ -76,6 +76,12 @@ public interface HandlerAttributes {
     String COMMAND_NAME_PATTERN = "CommandHandlerInterceptor.commandNamePattern";
 
     /**
+     * Attribute key referencing the message type handled by a
+     * {@link org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor}.
+     */
+    String INTERCEPTOR_MESSAGE_TYPE = "MessageHandlerInterceptor.messageType";
+
+    /**
      * Attribute key referencing whether the handler forces the creation of a new saga instance.
      */
     String FORCE_NEW_SAGA = "StartSaga.forceNew";

--- a/messaging/src/main/java/org/axonframework/messaging/core/interception/annotation/MessageHandlerInterceptorDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/interception/annotation/MessageHandlerInterceptorDefinition.java
@@ -50,9 +50,7 @@ public class MessageHandlerInterceptorDefinition implements HandlerEnhancerDefin
 
     @Override
     public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
-        String messageHandlerInterceptorMessageTypeAttributeKey =
-                MessageHandlerInterceptor.class.getSimpleName() + ".messageType";
-        if (original.attribute(messageHandlerInterceptorMessageTypeAttributeKey).isPresent()) {
+        if (original.attribute(HandlerAttributes.INTERCEPTOR_MESSAGE_TYPE).isPresent()) {
             Optional<Class<?>> resultType = original.attribute(HandlerAttributes.RESULT_TYPE);
             return resultType.isPresent()
                     ? new ResultHandlingInterceptorMember<>(original, resultType.get())

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinition.java
@@ -23,7 +23,6 @@ import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.SequencingPolicy;
 import org.axonframework.messaging.core.annotation.UnsupportedHandlerException;
 import org.axonframework.messaging.core.annotation.WrappedMessageHandlingMember;
-import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor;
 import org.axonframework.messaging.eventhandling.EventMessage;
 
 import java.lang.reflect.Constructor;
@@ -46,9 +45,6 @@ import java.util.Optional;
  */
 public class MethodSequencingPolicyEventHandlerDefinition implements HandlerEnhancerDefinition {
 
-    private static final String INTERCEPTOR_MESSAGE_TYPE_ATTRIBUTE =
-            MessageHandlerInterceptor.class.getSimpleName() + ".messageType";
-
     @Override
     public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
         // Only wrap event handlers - check the message type to work through any existing wrappers
@@ -59,7 +55,7 @@ public class MethodSequencingPolicyEventHandlerDefinition implements HandlerEnha
         // Interceptor members (e.g. @ExceptionHandler methods) never participate in sequencing, and their
         // payload type may not be an event payload (e.g. an exception type), so building the policy against
         // it could fail
-        if (original.attribute(INTERCEPTOR_MESSAGE_TYPE_ATTRIBUTE).isPresent()) {
+        if (original.attribute(HandlerAttributes.INTERCEPTOR_MESSAGE_TYPE).isPresent()) {
             return original;
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinition.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.SequencingPolicy;
 import org.axonframework.messaging.core.annotation.UnsupportedHandlerException;
 import org.axonframework.messaging.core.annotation.WrappedMessageHandlingMember;
+import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor;
 import org.axonframework.messaging.eventhandling.EventMessage;
 
 import java.lang.reflect.Constructor;
@@ -45,10 +46,20 @@ import java.util.Optional;
  */
 public class MethodSequencingPolicyEventHandlerDefinition implements HandlerEnhancerDefinition {
 
+    private static final String INTERCEPTOR_MESSAGE_TYPE_ATTRIBUTE =
+            MessageHandlerInterceptor.class.getSimpleName() + ".messageType";
+
     @Override
     public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
         // Only wrap event handlers - check the message type to work through any existing wrappers
         if (!original.canHandleMessageType(EventMessage.class)) {
+            return original;
+        }
+
+        // Interceptor members (e.g. @ExceptionHandler methods) never participate in sequencing, and their
+        // payload type may not be an event payload (e.g. an exception type), so building the policy against
+        // it could fail
+        if (original.attribute(INTERCEPTOR_MESSAGE_TYPE_ATTRIBUTE).isPresent()) {
             return original;
         }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinitionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/MethodSequencingPolicyEventHandlerDefinitionTest.java
@@ -20,12 +20,14 @@ import org.axonframework.common.ObjectUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
 import org.axonframework.messaging.core.annotation.AnnotatedMessageHandlingMemberDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.UnsupportedHandlerException;
 import org.axonframework.messaging.core.annotation.WrappedMessageHandlingMember;
+import org.axonframework.messaging.core.interception.annotation.ExceptionHandler;
 import org.axonframework.messaging.core.sequencing.MetadataSequencingPolicy;
 import org.axonframework.messaging.core.sequencing.PropertySequencingPolicy;
 import org.axonframework.messaging.core.sequencing.SequencingPolicy;
@@ -236,6 +238,28 @@ class MethodSequencingPolicyEventHandlerDefinitionTest {
     }
 
     @Nested
+    class ExceptionHandlerNotWrapped {
+
+        @Test
+        void exceptionHandlerWithClassLevelPolicyNotWrapped() {
+            MessageHandlingMember<EventHandlerWithExceptionHandler> handler = createHandler(
+                    EventHandlerWithExceptionHandler.class, "onError", IllegalStateException.class
+            );
+            MessageHandlingMember<EventHandlerWithExceptionHandler> wrappedHandler = testSubject.wrapHandler(handler);
+
+            // ExceptionHandler methods should NOT be wrapped, as the class-level policy only applies to
+            // event payload handlers and cannot be constructed against the exception type
+            assertSame(handler, wrappedHandler);
+        }
+
+        @Test
+        void inspectionOfClassWithPropertyPolicyAndExceptionHandlerSucceeds() {
+            // Reproduces issue #4705: inspection failed with "Failed to create SequencingPolicy instance: null"
+            assertDoesNotThrow(() -> AnnotatedHandlerInspector.inspectType(EventHandlerWithExceptionHandler.class));
+        }
+    }
+
+    @Nested
     class MetaAnnotationSupport {
 
         @Test
@@ -402,6 +426,30 @@ class MethodSequencingPolicyEventHandlerDefinitionTest {
         @ResetHandler
         @org.axonframework.messaging.core.annotation.SequencingPolicy(type = SequentialPolicy.class)
         void onReset() {
+        }
+    }
+
+    // Test event record with a property for the class-level PropertySequencingPolicy
+    public record SomethingHappened(String key) {
+
+    }
+
+    // Test class with class-level property-based SequencingPolicy and an ExceptionHandler - the ExceptionHandler
+    // should NOT be wrapped, as the exception type does not carry the sequencing property (issue #4705)
+    @org.axonframework.messaging.core.annotation.SequencingPolicy(
+            type = PropertySequencingPolicy.class,
+            parameters = {"key"}
+    )
+    static class EventHandlerWithExceptionHandler {
+
+        @SuppressWarnings("unused")
+        @EventHandler
+        void handle(SomethingHappened event) {
+        }
+
+        @SuppressWarnings("unused")
+        @ExceptionHandler(resultType = IllegalStateException.class)
+        void onError(IllegalStateException exception) {
         }
     }
 


### PR DESCRIPTION
Resolves #4705.

A class-level `@SequencingPolicy` was applied to any member able to handle `EventMessage`s, which includes `@ExceptionHandler` and other interceptor members. The declared policy was then eagerly constructed against the member's payload type, which for an exception handler is the exception type. Property-based policies fail construction against that type, aborting component inspection and application startup for any projection combining a property-based class-level `@SequencingPolicy` with an `@ExceptionHandler`.

Interceptor members never participate in sequencing (`AnnotatedEventHandlingComponent` only consults the sequencing wrapper for subscribed event handlers), so `MethodSequencingPolicyEventHandlerDefinition` now excludes them by checking for the `MessageHandlerInterceptor.messageType` attribute. Every interceptor member carries this attribute through annotation scanning, since `@ExceptionHandler` is meta-annotated with `@MessageHandlerInterceptor` and `@ResultHandler` only exists as a meta-annotation. This makes the check independent of the order in which handler enhancers wrap the member.

Includes an enhancer-level regression test asserting the exception handler member stays unwrapped, and the issue's `AnnotatedHandlerInspector.inspectType` reproducer. Both fail without the fix.