### PR TITLE
fix(messaging): preserve enhancers in UnitOfWorkConfiguration#forcedSameThreadInvocation

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
@@ -57,7 +57,7 @@ public record UnitOfWorkConfiguration(Executor workScheduler, boolean allowAsync
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
         public UnitOfWorkConfiguration forcedSameThreadInvocation() {
-        return new UnitOfWorkConfiguration(Runnable::run, false, List.of());
+        return new UnitOfWorkConfiguration(Runnable::run, false, processingLifecycleEnhancers);
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
@@ -65,4 +65,15 @@ class UnitOfWorkConfigurationTest {
             .isInstanceOf(UnsupportedOperationException.class);
     }
 
+    @Test
+    void forcedSameThreadInvocationShouldRetainRegisteredEnhancers() {
+        Consumer<ProcessingLifecycle> consumer = pc -> {};
+        UnitOfWorkConfiguration config = defaultConfig.registerProcessingLifecycleEnhancer(consumer);
+
+        UnitOfWorkConfiguration newConfig = config.forcedSameThreadInvocation();
+
+        assertThat(newConfig.allowAsyncProcessing()).isFalse();
+        assertThat(newConfig.processingLifecycleEnhancers()).containsExactly(consumer);
+    }
+
 }


### PR DESCRIPTION
## Summary
- `forcedSameThreadInvocation()` built a new `UnitOfWorkConfiguration` with a hardcoded empty enhancer list instead of carrying over `processingLifecycleEnhancers`, silently dropping any enhancers registered before switching to same-thread invocation (e.g. via `TransactionalUnitOfWorkFactory` when the transaction manager requires same-thread invocations).
- Fixed it to preserve `processingLifecycleEnhancers` from the current instance.
- Added a regression test (`forcedSameThreadInvocationShouldRetainRegisteredEnhancers`) verifying enhancers survive the switch to same-thread invocation.