### PR TITLE
Wrap ESE when it is not the same instance providing SnapshotStore

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
@@ -37,7 +37,6 @@ import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventhandling.configuration.EventBusConfigurationDefaults;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * A {@link ConfigurationEnhancer} registering the default components of the {@link EventSourcingConfigurer}.
@@ -54,12 +53,15 @@ import java.util.Optional;
  * Furthermore, this enhancer will decorate the:
  * <ul>
  *     <li>The {@link EventStorageEngine} in a {@link SnapshotCapableEventStorageEngine} <b>if</b> a
- *     {@link SnapshotStore} is present and the engine does not already implement snapshot support.</li>
+ *     {@link SnapshotStore} is present and it is not the same instance as the engine. When the engine and the
+ *     snapshot store are the same instance, the engine handles snapshots natively (potentially in a single
+ *     round-trip) and wrapping it would degrade performance.</li>
  *     <li>The {@link EventStore} in a {@link InterceptingEventStore} <b>if</b> there are any
  *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry}.</li>
  * </ul>
  *
  * @author Steven van Beelen
+ * @author John Hendrikx
  * @since 5.0.0
  */
 public class EventSourcingConfigurationDefaults implements ConfigurationEnhancer {
@@ -87,10 +89,10 @@ public class EventSourcingConfigurationDefaults implements ConfigurationEnhancer
                 EventStorageEngine.class,
                 SnapshotCapableEventStorageEngine.DECORATION_ORDER,
                 (config, name, engine) -> {
-                    Optional<SnapshotStore> snapshotStore = config.getOptionalComponent(SnapshotStore.class);
-                    return snapshotStore.isEmpty() || engine instanceof SnapshotStore
+                    SnapshotStore snapshotStore = config.getOptionalComponent(SnapshotStore.class).orElse(null);
+                    return snapshotStore == null || snapshotStore == engine
                             ? engine
-                            : new SnapshotCapableEventStorageEngine(engine, snapshotStore.orElseThrow());
+                            : new SnapshotCapableEventStorageEngine(engine, snapshotStore);
                 }
         );
         registry.registerDecorator(

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -51,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Test class validating the {@link EventSourcingConfigurationDefaults}.
  *
  * @author Steven van Beelen
+ * @author John Hendrikx
  */
 @ExtendWith(MockitoExtension.class)
 class EventSourcingConfigurationDefaultsTest {
@@ -147,15 +148,32 @@ class EventSourcingConfigurationDefaultsTest {
     }
 
     @Test
-    void doesNotDecorateEventStorageEngineWhenItAlreadyImplementsSnapshotStore(
-            @Mock(extraInterfaces = SnapshotStore.class) InMemoryEventStorageEngine snapshotAwareEngine) {
+    void doesNotDecorateEventStorageEngineWhenSnapshotStoreIsSameInstance(
+            @Mock(extraInterfaces = SnapshotStore.class) InMemoryEventStorageEngine snapshotAwareEngine
+    ) {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        configurer.componentRegistry(cr -> cr.registerComponent(EventStorageEngine.class, c -> snapshotAwareEngine)
+                                             .registerComponent(SnapshotStore.class,
+                                                                c -> (SnapshotStore) snapshotAwareEngine));
+        Configuration resultConfig = configurer.build();
+
+        // wrapping would prevent the engine's single-round-trip optimisation
+        assertThat(resultConfig.getComponent(EventStorageEngine.class))
+                .isNotInstanceOf(SnapshotCapableEventStorageEngine.class);
+    }
+
+    @Test
+    void decoratesEventStorageEngineWhenSnapshotStoreIsDifferentInstance_evenIfEngineImplementsSnapshotStore(
+            @Mock(extraInterfaces = SnapshotStore.class) InMemoryEventStorageEngine snapshotAwareEngine
+    ) {
         ApplicationConfigurer configurer = EventSourcingConfigurer.create();
         configurer.componentRegistry(cr -> cr.registerComponent(EventStorageEngine.class, c -> snapshotAwareEngine)
                                              .registerComponent(SnapshotStore.class, c -> new InMemorySnapshotStore()));
         Configuration resultConfig = configurer.build();
 
+        // snapshot reads must be routed to the registered SnapshotStore, not the engine itself
         assertThat(resultConfig.getComponent(EventStorageEngine.class))
-                .isNotInstanceOf(SnapshotCapableEventStorageEngine.class);
+                .isInstanceOf(SnapshotCapableEventStorageEngine.class);
     }
 
     @Test


### PR DESCRIPTION
When an ESE is a `SnapshotStore`, but the registered `SnapshotStore` is NOT the same instance, then the `SnapshotCapableEventStorageEngine` wrapper must still be applied.