### PR TITLE
Adjust generics of registerIfNotPresent to match register

### DIFF
--- a/common/src/main/java/org/axonframework/common/configuration/ComponentRegistry.java
+++ b/common/src/main/java/org/axonframework/common/configuration/ComponentRegistry.java
@@ -52,7 +52,7 @@ public interface ComponentRegistry extends DescribableComponent {
      *                                    with the same type is already defined.
      */
     default <C> ComponentRegistry registerComponent(Class<C> type,
-                                                    ComponentBuilder<C> builder) {
+                                                    ComponentBuilder<? extends C> builder) {
         return registerComponent(ComponentDefinition.ofType(type)
                                                     .withBuilder(builder));
     }
@@ -234,7 +234,7 @@ public interface ComponentRegistry extends DescribableComponent {
      * @return The current instance of the {@code Configurer} for a fluent API.
      */
     default <C> ComponentRegistry registerIfNotPresent(Class<C> type,
-                                                       ComponentBuilder<C> builder) {
+                                                       ComponentBuilder<? extends C> builder) {
         return registerIfNotPresent(type, null, builder);
     }
 
@@ -258,7 +258,7 @@ public interface ComponentRegistry extends DescribableComponent {
      * @return The current instance of the {@code Configurer} for a fluent API.
      */
     default <C> ComponentRegistry registerIfNotPresent(Class<C> type,
-                                                       ComponentBuilder<C> builder,
+                                                       ComponentBuilder<? extends C> builder,
                                                        SearchScope searchScope) {
         return registerIfNotPresent(type, null, builder, searchScope);
     }
@@ -280,7 +280,7 @@ public interface ComponentRegistry extends DescribableComponent {
      */
     default <C> ComponentRegistry registerIfNotPresent(Class<C> type,
                                                        @Nullable String name,
-                                                       ComponentBuilder<C> builder) {
+                                                       ComponentBuilder<? extends C> builder) {
         return registerIfNotPresent(ComponentDefinition.ofTypeAndName(type, name).withBuilder(builder));
     }
 
@@ -308,7 +308,7 @@ public interface ComponentRegistry extends DescribableComponent {
      */
     default <C> ComponentRegistry registerIfNotPresent(Class<C> type,
                                                        @Nullable String name,
-                                                       ComponentBuilder<C> builder,
+                                                       ComponentBuilder<? extends C> builder,
                                                        SearchScope searchScope) {
         return registerIfNotPresent(ComponentDefinition.ofTypeAndName(type, name).withBuilder(builder), searchScope);
     }


### PR DESCRIPTION
Adjusting the generics to take subtypes would allow this pattern without generic errors:

```
        AtomicReference<PostgresqlEventStorageEngine> instance = new AtomicReference<>();
        ComponentBuilder<PostgresqlEventStorageEngine> shared = configuration ->
                instance.updateAndGet(e -> e != null ? e : new PostgresqlEventStorageEngine(
                        configuration.getComponent(DataSource.class),
                        configuration.getComponent(EventConverter.class)
                ));

        registry.registerIfNotPresent(EventStorageEngine.class, shared, SearchScope.ALL);
        registry.registerIfNotPresent(SnapshotStore.class, shared, SearchScope.ALL);
```

This would then allow me to simplify the code in the PG enhancer