### PR TITLE
[#4721] Allow `EventProcessorDefinitions` to supply an event source for a subscribing processor

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventProcessorPropertiesAndDefinitionInteractionIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventProcessorPropertiesAndDefinitionInteractionIT.java
@@ -17,6 +17,7 @@
 package org.axonframework.extension.springboot.autoconfig;
 
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.Registration;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.extension.spring.config.EventProcessorDefinition;
@@ -28,7 +29,12 @@ import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageHandlerInterceptor;
 import org.axonframework.messaging.core.MessageHandlerInterceptorChain;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventTestUtils;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
@@ -36,6 +42,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorConfiguration;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
@@ -55,11 +62,17 @@ import org.springframework.test.context.ContextConfiguration;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -123,6 +136,64 @@ class EventProcessorPropertiesAndDefinitionInteractionIT {
             return EventProcessorDefinition.pooledStreaming(KEY2)
                                       .assigningHandlers(p -> true)
                                       .notCustomized();
+        }
+    }
+
+    @org.springframework.context.annotation.Configuration
+    public static class DefinitionSuppliedEventSourceContext {
+
+        @Bean
+        public StubSubscribableEventSource definitionSuppliedSource() {
+            return new StubSubscribableEventSource();
+        }
+
+        @Bean
+        public RecordingEventHandler recordingEventHandler() {
+            return new RecordingEventHandler();
+        }
+
+        @Bean
+        public EventProcessorDefinition definitionSourcedProcessorDefinition(
+                StubSubscribableEventSource definitionSuppliedSource
+        ) {
+            return EventProcessorDefinition.subscribing("definition-sourced-processor")
+                                           .assigningHandlers(p -> p.beanType().equals(RecordingEventHandler.class))
+                                           .customized(c -> c.eventSource(definitionSuppliedSource));
+        }
+    }
+
+    /**
+     * A source that, unlike the {@link SimpleEventBus}, only implements {@link SubscribableEventSource}, like a
+     * persistent stream backed source does. This keeps type-level lookups of other components, like the
+     * {@link org.axonframework.messaging.eventhandling.EventSink}, unambiguous.
+     */
+    public static class StubSubscribableEventSource implements SubscribableEventSource {
+
+        private final SimpleEventBus delegate = new SimpleEventBus();
+
+        @Override
+        public Registration subscribe(
+                BiFunction<List<? extends EventMessage>, @Nullable ProcessingContext, CompletableFuture<?>> eventsBatchConsumer
+        ) {
+            return delegate.subscribe(eventsBatchConsumer);
+        }
+
+        public void publish(EventMessage event) {
+            delegate.publish(null, event);
+        }
+    }
+
+    public static class RecordingEventHandler {
+
+        private final List<String> handledEvents = new CopyOnWriteArrayList<>();
+
+        @EventHandler
+        public void handle(String event) {
+            handledEvents.add(event);
+        }
+
+        public List<String> handledEvents() {
+            return handledEvents;
         }
     }
 
@@ -368,6 +439,53 @@ class EventProcessorPropertiesAndDefinitionInteractionIT {
                     // we should not see the custom interceptor here
                     config -> assertThatCollection(config.interceptors()).anyMatch(StubInterceptor.class::isInstance)
             );
+        }
+    }
+
+    @Nested
+    @SpringBootTest(
+            classes = {EventProcessorPropertiesAndDefinitionInteractionIT.MyCustomContext.class,
+                    DefinitionSuppliedEventSourceContext.class},
+            properties = {
+                    "axon.eventstorage.jpa.polling-interval=0"
+            },
+            webEnvironment = SpringBootTest.WebEnvironment.NONE
+    )
+    class DefinitionSuppliedEventSourceTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Autowired
+        private StubSubscribableEventSource definitionSuppliedSource;
+
+        @Autowired
+        private RecordingEventHandler recordingEventHandler;
+
+        @Test
+        void processorUsesTheDefinitionSuppliedEventSourceWhenNoSourceSettingIsPresent() {
+            // given - no unique type-level SubscribableEventSource is resolvable (the event store and the
+            // definition-supplied source are both candidates), so only the EventProcessorDefinition can
+            // supply the source for the processor
+            assertThat(context.getBeanProvider(SubscribableEventSource.class).getIfUnique()).isNull();
+
+            AxonConfiguration axonApplication = context.getBean(AxonConfiguration.class);
+            Configuration processorConfig = axonApplication.getModuleConfiguration(
+                    "EventProcessor[definition-sourced-processor]").orElseThrow();
+            assertThat(processorConfig.getOptionalComponent(EventProcessor.class, "definition-sourced-processor"))
+                    .isPresent();
+            assertThat(processorConfig.getOptionalComponent(SubscribingEventProcessorConfiguration.class))
+                    .hasValueSatisfying(
+                            config -> assertThat(config.eventSource()).isSameAs(definitionSuppliedSource)
+                    );
+
+            // when
+            definitionSuppliedSource.publish(EventTestUtils.asEventMessage("definition-sourced-event"));
+
+            // then
+            await().atMost(Duration.ofSeconds(2))
+                   .untilAsserted(() -> assertThat(recordingEventHandler.handledEvents())
+                           .contains("definition-sourced-event"));
         }
     }
 

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
@@ -18,6 +18,7 @@ package org.axonframework.extension.spring.config;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
+import org.axonframework.common.StringUtils;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
@@ -70,6 +71,14 @@ interface SpringCustomizations {
 
     /**
      * Customization executed based on the {@link EventProcessorSettings.SubscribingEventProcessorSettings}.
+     * <p>
+     * The {@link SubscribableEventSource} is only mandatory when the
+     * {@link EventProcessorSettings#source() source setting} is explicitly set. When it is unset (or empty), this
+     * customization falls back to resolving the unique, type-level {@code SubscribableEventSource} (typically the
+     * {@link org.axonframework.messaging.eventhandling.EventBus}) and only sets a source when one is found. Otherwise,
+     * it leaves the source untouched, allowing customizations applied after this one, like an
+     * {@code EventProcessorDefinition}, to supply it. A still-missing source is reported when the resulting
+     * {@link SubscribingEventProcessorConfiguration} is validated.
      */
     class SpringSubscribingEventProcessingModuleCustomization implements SubscribingEventProcessorModule.Customization {
 
@@ -86,21 +95,18 @@ interface SpringCustomizations {
         @Override
         public SubscribingEventProcessorConfiguration apply(Configuration configuration,
                                                             SubscribingEventProcessorConfiguration subscribingEventProcessorConfiguration) {
-            var messageSource = getComponent(configuration,
-                                             SubscribableEventSource.class,
-                                             settings.source(),
-                                             null
-            );
-            require(messageSource != null, "Could not find a mandatory Source with name '" + settings.source()
-                    + "' for event processor '" + name + "'.");
-
             var unitOfWorkFactory = getComponent(configuration, UnitOfWorkFactory.class, null, null);
             require(unitOfWorkFactory != null,
                     "Could not find a mandatory UnitOfWorkFactory for event processor '" + name + "'.");
+            var result = subscribingEventProcessorConfiguration.unitOfWorkFactory(unitOfWorkFactory);
 
-            return subscribingEventProcessorConfiguration
-                    .eventSource(messageSource)
-                    .unitOfWorkFactory(unitOfWorkFactory);
+            String sourceName = StringUtils.nonEmptyOrNull(settings.source()) ? settings.source() : null;
+            var messageSource = getComponent(configuration, SubscribableEventSource.class, sourceName, null);
+            if (sourceName != null) {
+                require(messageSource != null, "Could not find a mandatory Source with name '" + settings.source()
+                        + "' for event processor '" + name + "'.");
+            }
+            return messageSource != null ? result.eventSource(messageSource) : result;
         }
     }
 

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.spring.config;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.messaging.core.SubscribableEventSource;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.eventhandling.EventBus;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.axonframework.messaging.eventhandling.configuration.EventBusConfigurationDefaults;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorConfiguration;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test class validating how the {@link SpringCustomizations.SpringSubscribingEventProcessingModuleCustomization}
+ * resolves the {@link SubscribableEventSource} from the
+ * {@link EventProcessorSettings.SubscribingEventProcessorSettings#source() source setting}.
+ *
+ * @author Jakob Hatzl
+ */
+class SpringCustomizationsTest {
+
+    private static final String PROCESSOR_NAME = "test-processor";
+
+    @Nested
+    class ExplicitlyConfiguredSource {
+
+        @Test
+        void appliesTheSourceRegisteredUnderTheConfiguredName() {
+            // given
+            SimpleEventBus namedSource = new SimpleEventBus();
+            var configuration = configuration(
+                    cr -> cr.registerComponent(SubscribableEventSource.class, "my-source", cfg -> namedSource)
+            );
+
+            // when
+            var result = customize(configuration, "my-source");
+
+            // then
+            assertThat(result.eventSource()).isSameAs(namedSource);
+            assertThat(result.unitOfWorkFactory()).isSameAs(configuration.getComponent(UnitOfWorkFactory.class));
+        }
+
+        @Test
+        void failsWhenTheConfiguredSourceCannotBeResolved() {
+            // given - the type-level default EventBus must not satisfy an explicitly configured source name
+            var configuration = configuration(cr -> {
+            });
+
+            // when / then
+            assertThatThrownBy(() -> customize(configuration, "unknown-source"))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("'unknown-source'")
+                    .hasMessageContaining(PROCESSOR_NAME);
+        }
+    }
+
+    @Nested
+    class UnsetSource {
+
+        @Test
+        void appliesTheUniqueTypeLevelDefaultWhenTheSourceIsUnset() {
+            // given
+            var configuration = configuration(cr -> {
+            });
+
+            // when
+            var result = customize(configuration, null);
+
+            // then - the default EventBus is the unique type-level SubscribableEventSource
+            assertThat(result.eventSource()).isSameAs(configuration.getComponent(EventBus.class));
+        }
+
+        @Test
+        void leavesTheSourceUnsetWhenNoTypeLevelDefaultIsPresent() {
+            // given - only a named source is registered, which an unset source setting must not resolve to
+            var configuration = configurationWithoutTypeLevelSource(
+                    cr -> cr.registerComponent(SubscribableEventSource.class,
+                                               "named-source",
+                                               cfg -> new SimpleEventBus())
+            );
+
+            // when
+            var result = customize(configuration, null);
+
+            // then - a customization applied after this one, like an EventProcessorDefinition, may supply the source
+            assertThat(result.eventSource()).isNull();
+        }
+
+        @Test
+        void keepsAnAlreadyAssignedSourceWhenNoTypeLevelDefaultIsPresent() {
+            // given
+            SimpleEventBus assignedSource = new SimpleEventBus();
+            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            });
+            var processorConfiguration = processorConfiguration().eventSource(assignedSource);
+
+            // when
+            var result = SpringCustomizations
+                    .subscribingCustomizations(PROCESSOR_NAME, new TestSubscribingSettings(null))
+                    .apply(configuration, processorConfiguration);
+
+            // then
+            assertThat(result.eventSource()).isSameAs(assignedSource);
+        }
+
+        @Test
+        void allowsASubsequentCustomizationToSupplyTheSourceWhenTheSettingIsUnset() {
+            // given
+            SimpleEventBus definitionSource = new SimpleEventBus();
+            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            });
+            // mirrors how settings customizations are chained before definition customizations
+            var chained = SpringCustomizations
+                    .subscribingCustomizations(PROCESSOR_NAME, new TestSubscribingSettings(null))
+                    .andThen((cfg, processorConfig) -> processorConfig.eventSource(definitionSource));
+
+            // when
+            var result = chained.apply(configuration, processorConfiguration());
+
+            // then
+            assertThat(result.eventSource()).isSameAs(definitionSource);
+        }
+    }
+
+    @Nested
+    class EmptySourceName {
+
+        @Test
+        void appliesTheUniqueTypeLevelDefaultWhenTheSourceIsEmpty() {
+            // given
+            var configuration = configuration(cr -> {
+            });
+
+            // when
+            var result = customize(configuration, "");
+
+            // then
+            assertThat(result.eventSource()).isSameAs(configuration.getComponent(EventBus.class));
+        }
+
+        @Test
+        void leavesTheSourceUnsetWhenTheSourceIsEmptyAndNoTypeLevelDefaultIsPresent() {
+            // given
+            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            });
+
+            // when
+            var result = customize(configuration, "");
+
+            // then
+            assertThat(result.eventSource()).isNull();
+        }
+    }
+
+    private static AxonConfiguration configuration(Consumer<ComponentRegistry> components) {
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        // classpath enhancers, like the event sourcing defaults, would register additional event sources
+        configurer.componentRegistry(ComponentRegistry::disableEnhancerScanning);
+        configurer.componentRegistry(components);
+        return configurer.build();
+    }
+
+    private static AxonConfiguration configurationWithoutTypeLevelSource(Consumer<ComponentRegistry> components) {
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        // without the default EventBus and classpath enhancers no type-level SubscribableEventSource is present
+        configurer.componentRegistry(cr -> cr.disableEnhancerScanning()
+                                             .disableEnhancer(EventBusConfigurationDefaults.class));
+        configurer.componentRegistry(components);
+        return configurer.build();
+    }
+
+    private static SubscribingEventProcessorConfiguration customize(Configuration configuration,
+                                                                    @Nullable String source) {
+        return SpringCustomizations
+                .subscribingCustomizations(PROCESSOR_NAME, new TestSubscribingSettings(source))
+                .apply(configuration, processorConfiguration());
+    }
+
+    private static SubscribingEventProcessorConfiguration processorConfiguration() {
+        return new SubscribingEventProcessorConfiguration(new EventProcessorConfiguration(PROCESSOR_NAME, null));
+    }
+
+    private record TestSubscribingSettings(@Nullable String source)
+            implements EventProcessorSettings.SubscribingEventProcessorSettings {
+
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorConfiguration.java
@@ -147,7 +147,9 @@ public class SubscribingEventProcessorConfiguration extends EventProcessorConfig
     @Override
     protected void validate() throws AxonConfigurationException {
         super.validate();
-        assertNonNull(eventSource, "The SubscribableMessageSource is a hard requirement and should be provided");
+        assertNonNull(eventSource,
+                      "The SubscribableEventSource is a hard requirement for event processor '" + processorName
+                              + "' and should be provided. Set it through this configuration's eventSource method.");
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.processing.subscribing;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.DefaultComponentRegistry;
@@ -49,6 +50,7 @@ import org.axonframework.messaging.eventhandling.processing.errorhandling.Propag
 import org.junit.jupiter.api.*;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 /**
@@ -607,6 +610,27 @@ class SubscribingEventProcessorModuleTest {
             // then
             var messageSource = configuration.getOptionalComponent(ErrorHandler.class);
             assertThat(messageSource).isNotPresent();
+        }
+    }
+
+    @Nested
+    class MissingEventSourceValidationTest {
+
+        @Test
+        void constructingProcessorWithoutEventSourceReportsProcessorNameAndRemedies() {
+            // given
+            String processorName = "no-source-processor";
+            var configurationWithoutSource = new SubscribingEventProcessorConfiguration(
+                    new EventProcessorConfiguration(processorName, null)
+            );
+
+            // when / then
+            assertThatThrownBy(() -> new SubscribingEventProcessor(processorName,
+                                                                   List.of(),
+                                                                   configurationWithoutSource))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("event processor '" + processorName + "'")
+                    .hasMessageContaining("SubscribableEventSource");
         }
     }
 


### PR DESCRIPTION
This PR adjusts the SpringCustomizations.SpringSubscribingEventProcessingModuleCustomization to allow subsequent customizations to supply a `SubscribableEventSource` by making the source only mandatory if a name is explicitly set via the `EventProcessorSettings#source()`.

Now, if the `EventProcessorSettings#source()` is not set or empty, the message source is only applied if resolvable from the config (i.e. if a type level source like the `EventBus` is configured), but no exception is thrown as before.

If the `EventProcessorSettings#source()` is explicitly set, the behaviour stays as before that a `SubscribablEventSource` with that exact name must be resolvable from the configuration, otherwise an exception is thrown. 

Resolves #4721 