### PR TITLE
EventStorageEngine#source and SnapshotStore methods - add ProcessingContext parameter

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -111,7 +111,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
                         : ac.orCriteria(condition.criteria())
         );
 
-        MessageStream<EventMessage> source = eventStorageEngine.source(condition);
+        MessageStream<EventMessage> source = eventStorageEngine.source(condition, processingContext);
         AtomicReference<ConsistencyMarker> markerReference = new AtomicReference<>(appendCondition.consistencyMarker());
 
         return source.onNext(entry -> {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -116,7 +116,25 @@ public interface EventStorageEngine extends DescribableComponent {
      * @return A <b>finite</b> {@link MessageStream} of {@link EventMessage events} matching the given
      * {@code condition}.
      */
-    MessageStream<EventMessage> source(SourcingCondition condition);
+    default MessageStream<EventMessage> source(SourcingCondition condition) {
+        return source(condition, null);
+    }
+
+    /**
+     * Creates a <b>finite</b> {@link MessageStream} of {@link EventMessage events} matching the given
+     * {@code condition}, carrying along the active {@link ProcessingContext}.
+     * <p>
+     * Behaves identically to {@link #source(SourcingCondition)}; the {@code context} is passed to decorators (for
+     * example snapshot-loading and tracing decorators) that need to correlate the sourcing operation with the
+     * surrounding unit of work.
+     *
+     * @param condition The {@link SourcingCondition} dictating the {@link MessageStream stream} of
+     *                  {@link EventMessage events} to source.
+     * @param context   The {@link ProcessingContext} active while sourcing; may be {@code null}.
+     * @return A <b>finite</b> {@link MessageStream} of {@link EventMessage events} matching the given
+     * {@code condition}.
+     */
+    MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context);
 
     /**
      * Creates an <b>infinite</b> {@link MessageStream} of {@link EventMessage events} matching the given

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -128,11 +128,11 @@ public interface EventStorageEngine extends DescribableComponent {
      * example snapshot-loading and tracing decorators) that need to correlate the sourcing operation with the
      * surrounding unit of work.
      *
-     * @param condition The {@link SourcingCondition} dictating the {@link MessageStream stream} of
-     *                  {@link EventMessage events} to source.
-     * @param context   The {@link ProcessingContext} active while sourcing; may be {@code null}.
-     * @return A <b>finite</b> {@link MessageStream} of {@link EventMessage events} matching the given
-     * {@code condition}.
+     * @param condition the {@link SourcingCondition} dictating the {@link MessageStream stream} of
+     *                  {@link EventMessage events} to source
+     * @param context   the {@link ProcessingContext} active while sourcing; may be {@code null}
+     * @return a <b>finite</b> {@link MessageStream} of {@link EventMessage events} matching the given
+     * {@code condition}
      */
     MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context);
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
@@ -78,41 +78,43 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
     }
 
     @Override
-    public MessageStream<EventMessage> source(SourcingCondition condition) {
+    public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
         if (condition.strategy() instanceof SourcingStrategy.Snapshot s) {
             return DelayedMessageStream.create(
-                snapshotStore.load(s.qualifiedName(), s.identifier())
-                    .thenApply(snapshot -> buildStream(snapshot, condition, s.maximumPosition()))
+                snapshotStore.load(s.qualifiedName(), s.identifier(), context)
+                    .thenApply(snapshot -> buildStream(snapshot, condition, s.maximumPosition(), context))
                     .exceptionally(e -> {
                         LOGGER.warn("Snapshot loading failed, falling back to full reconstruction for: {} ({})", s.qualifiedName(), s.identifier(), e);
 
-                        return source(Position.START, condition.criteria());
+                        return source(Position.START, condition.criteria(), context);
                     })
             );
         }
 
-        return delegate.source(condition);
+        return delegate.source(condition, context);
     }
 
     private MessageStream<EventMessage> buildStream(
         @Nullable Snapshot snapshot,
         SourcingCondition condition,
-        @Nullable Position maximumPosition
+        @Nullable Position maximumPosition,
+        @Nullable ProcessingContext context
     ) {
         if (snapshot == null || isAfter(snapshot.position(), maximumPosition)) {
-            return source(Position.START, condition.criteria());
+            return source(Position.START, condition.criteria(), context);
         }
 
         return MessageStream.<EventMessage>just(new SnapshotEventMessage(snapshot))
-            .concatWith(source(snapshot.position(), condition.criteria()));
+            .concatWith(source(snapshot.position(), condition.criteria(), context));
     }
 
     private static boolean isAfter(Position position, @Nullable Position maximumPosition) {
         return maximumPosition != null && !position.min(maximumPosition).equals(position);
     }
 
-    private MessageStream<EventMessage> source(Position position, EventCriteria criteria) {
-        return delegate.source(SourcingCondition.conditionFor(position, criteria));
+    private MessageStream<EventMessage> source(Position position, EventCriteria criteria,
+                                               @Nullable ProcessingContext context) {
+        return delegate.source(SourcingCondition.conditionFor(position, criteria), context);
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -180,7 +180,7 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
     }
 
     @Override
-    public MessageStream<EventMessage> source(SourcingCondition condition) {
+    public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
         if (logger.isDebugEnabled()) {
             logger.debug("Start sourcing events with condition [{}].", condition);
         }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -257,7 +257,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     }
 
     @Override
-    public MessageStream<EventMessage> source(SourcingCondition condition) {
+    public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
         CompletableFuture<Void> endOfStreams = new CompletableFuture<>();
         List<AggregateSource> aggregateSources = condition.criteria()
                                                           .flatten()

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -187,10 +187,10 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
             });
     }
 
-    private void storeSnapshot(I identifier, E entity, Position position, ProcessingContext pc) {
+    private void storeSnapshot(I identifier, E entity, Position position, ProcessingContext context) {
         Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, ClockUtils.instant(), Map.of());
 
-        snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot, pc)
+        snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot, context)
             .whenComplete((voidResult, ex) -> {
                 if (ex != null) {
                     logger.warn("Snapshotting failed for {} with identifier {}", messageType, identifier, ex);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -179,7 +179,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
 
                     // Snapshot is made when specifically triggered by an event, or based on the statistics:
                     if (snapshotTriggered.get() || snapshotPolicy.shouldSnapshot(new EvolutionResult(evolutionCount.get(), sourcingTime))) {
-                        storeSnapshot(identifier, entity, positionRef.get());
+                        storeSnapshot(identifier, entity, positionRef.get(), pc);
                     }
                 }
 
@@ -187,10 +187,10 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
             });
     }
 
-    private void storeSnapshot(I identifier, E entity, Position position) {
+    private void storeSnapshot(I identifier, E entity, Position position, ProcessingContext pc) {
         Snapshot newSnapshot = new Snapshot(position, messageType.version(), entity, ClockUtils.instant(), Map.of());
 
-        snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot)
+        snapshotStore.store(messageType.qualifiedName(), identifier, newSnapshot, pc)
             .whenComplete((voidResult, ex) -> {
                 if (ex != null) {
                     logger.warn("Snapshotting failed for {} with identifier {}", messageType, identifier, ex);

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/inmemory/InMemorySnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/inmemory/InMemorySnapshotStore.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.snapshot.inmemory;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
@@ -44,7 +45,8 @@ public class InMemorySnapshotStore implements SnapshotStore {
     private final Map<QualifiedName, Map<Object, Snapshot>> entitiesByIdentifierByName = new ConcurrentHashMap<>();
 
     @Override
-    public CompletableFuture<Void> store(QualifiedName qualifiedName, Object identifier, Snapshot snapshot) {
+    public CompletableFuture<Void> store(QualifiedName qualifiedName, Object identifier, Snapshot snapshot,
+                                         @Nullable ProcessingContext context) {
         Objects.requireNonNull(qualifiedName, "The qualifiedName parameter must not be null.");
         Objects.requireNonNull(identifier, "The identifier parameter must not be null.");
         Objects.requireNonNull(snapshot, "The snapshot parameter must not be null.");
@@ -57,7 +59,8 @@ public class InMemorySnapshotStore implements SnapshotStore {
     }
 
     @Override
-    public CompletableFuture<@Nullable Snapshot> load(QualifiedName qualifiedName, Object identifier) {
+    public CompletableFuture<@Nullable Snapshot> load(QualifiedName qualifiedName, Object identifier,
+                                                      @Nullable ProcessingContext context) {
         Objects.requireNonNull(qualifiedName, "The qualifiedName parameter must not be null.");
         Objects.requireNonNull(identifier, "The identifier parameter must not be null.");
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.snapshot.store;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
@@ -48,10 +49,13 @@ public interface SnapshotStore {
      * @param qualifiedName the name of the snapshot to persist, cannot be {@code null}
      * @param identifier the identifier of the snapshot to persist, cannot be {@code null}
      * @param snapshot the snapshot to persist, cannot be {@code null}
+     * @param context the {@link ProcessingContext} active while storing, used by decorators (e.g. tracing) to correlate
+     *                the operation with the surrounding unit of work; may be {@code null}
      * @return a {@link CompletableFuture} that completes when the snapshot has been stored
-     * @throws NullPointerException if any argument is {@code null}
+     * @throws NullPointerException if any non-nullable argument is {@code null}
      */
-    CompletableFuture<Void> store(QualifiedName qualifiedName, Object identifier, Snapshot snapshot);
+    CompletableFuture<Void> store(QualifiedName qualifiedName, Object identifier, Snapshot snapshot,
+                                  @Nullable ProcessingContext context);
 
     /**
      * Loads the latest snapshot for a given name and identifier.
@@ -65,8 +69,11 @@ public interface SnapshotStore {
      *
      * @param qualifiedName the name of the snapshot, cannot be {@code null}
      * @param identifier the identifier of the snapshot, cannot be {@code null}
+     * @param context the {@link ProcessingContext} active while loading, used by decorators (e.g. tracing) to correlate
+     *                the operation with the surrounding unit of work; may be {@code null}
      * @return a {@link CompletableFuture} containing the snapshot, or containing {@code null} if no matching snapshot exists
-     * @throws NullPointerException if any argument is {@code null}
+     * @throws NullPointerException if any non-nullable argument is {@code null}
      */
-    CompletableFuture<@Nullable Snapshot> load(QualifiedName qualifiedName, Object identifier);
+    CompletableFuture<@Nullable Snapshot> load(QualifiedName qualifiedName, Object identifier,
+                                               @Nullable ProcessingContext context);
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/SnapshottingEntityLifecycleHandlerTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/SnapshottingEntityLifecycleHandlerTestSuite.java
@@ -161,7 +161,7 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
 
         // snapshot might be written async, so we need to await the snapshot to be present
         await().atMost(Duration.ofSeconds(2))
-               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID)
+               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID, null)
                                                             .get(1, TimeUnit.SECONDS)).isNotNull());
 
         {
@@ -219,7 +219,7 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
 
         // snapshot might be written async, so we need to await the snapshot to be present
         await().atMost(Duration.ofSeconds(2))
-               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID)
+               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID, null)
                                                             .get(1, TimeUnit.SECONDS)).isNotNull());
 
         {
@@ -250,7 +250,8 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
                 new Account(ACCOUNT_ID, "My Account", 262144),
                 Instant.now(),
                 Map.of()
-            )
+            ),
+            null
         ).join();
 
         appender.clear();
@@ -286,7 +287,7 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
 
         // snapshot might be written async, so we need to await the snapshot to be present
         await().atMost(Duration.ofSeconds(2))
-               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID)
+               .untilAsserted(() -> assertThat(snapshotStore.load(new QualifiedName(Account.class), ACCOUNT_ID, null)
                                                             .get(1, TimeUnit.SECONDS)).isNotNull());
 
         {   // New snapshot (overwriting the bad one) should be available now
@@ -317,7 +318,8 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
                 "Junk",  // incorrect data, which leads to deserialization error
                 Instant.now(),
                 Map.of()
-            )
+            ),
+            null
         ).join();
 
         appender.clear();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
@@ -175,7 +175,7 @@ class SimpleEventStoreTest {
             GlobalIndexConsistencyMarker markerAfterCommit = new GlobalIndexConsistencyMarker(42);
 
             UnitOfWork unitOfWork = aUnitOfWork();
-            when(mockStorageEngine.source(any())).thenReturn(messageStreamOf(10));
+            when(mockStorageEngine.source(any(), any())).thenReturn(messageStreamOf(10));
             when(mockStorageEngine.appendEvents(any(), any(ProcessingContext.class), anyList())).thenReturn(completedFuture(mockAppendTransaction));
             when(mockAppendTransaction.commit()).thenReturn(completedFuture(null));
             when(mockAppendTransaction.afterCommit(any())).thenReturn(completedFuture(markerAfterCommit));
@@ -212,9 +212,9 @@ class SimpleEventStoreTest {
             GlobalIndexConsistencyMarker markerAfterCommit = new GlobalIndexConsistencyMarker(101);
 
             UnitOfWork unitOfWork = aUnitOfWork();
-            when(mockStorageEngine.source(any())).thenReturn(messageStreamOf(size1))
-                                                 .thenReturn(messageStreamOf(size2))
-                                                 .thenReturn(messageStreamOf(size3));
+            when(mockStorageEngine.source(any(), any())).thenReturn(messageStreamOf(size1))
+                                                        .thenReturn(messageStreamOf(size2))
+                                                        .thenReturn(messageStreamOf(size3));
             when(mockStorageEngine.appendEvents(any(), any(ProcessingContext.class), anyList())).thenReturn(completedFuture(mockAppendTransaction));
             when(mockAppendTransaction.commit()).thenReturn(completedFuture(null));
             when(mockAppendTransaction.afterCommit(any())).thenReturn(completedFuture(markerAfterCommit));

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
@@ -23,6 +23,7 @@ import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
@@ -151,7 +152,8 @@ class SnapshotCapableEventStorageEngineTest {
         snapshotStore.store(
             SNAPSHOT_TYPE,
             AGGREGATE_ID,
-            new Snapshot(position, "1.0", payload, Instant.now(), Map.of())
+            new Snapshot(position, "1.0", payload, Instant.now(), Map.of()),
+            null
         ).join();
     }
 
@@ -167,12 +169,13 @@ class SnapshotCapableEventStorageEngineTest {
     private static SnapshotStore failingSnapshotStore() {
         return new SnapshotStore() {
             @Override
-            public CompletableFuture<Void> store(QualifiedName qn, Object id, Snapshot s) {
+            public CompletableFuture<Void> store(QualifiedName qn, Object id, Snapshot s,
+                                                 ProcessingContext context) {
                 throw new UnsupportedOperationException();
             }
 
             @Override
-            public CompletableFuture<Snapshot> load(QualifiedName qn, Object id) {
+            public CompletableFuture<Snapshot> load(QualifiedName qn, Object id, ProcessingContext context) {
                 return CompletableFuture.failedFuture(new RuntimeException("snapshot store failure"));
             }
         };

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -246,7 +246,7 @@ class SnapshottingEntityLifecycleHandlerTest {
 
             source();
 
-            Snapshot snapshot = snapshotStore.load(ACCOUNT_TYPE.qualifiedName(), ACCOUNT_ID).join();
+            Snapshot snapshot = snapshotStore.load(ACCOUNT_TYPE.qualifiedName(), ACCOUNT_ID, null).join();
 
             assertThat(snapshot).isNotNull();
             assertThat(snapshot.payload()).isEqualTo(new Account(ACCOUNT_ID, "Alice", 300));
@@ -265,7 +265,7 @@ class SnapshottingEntityLifecycleHandlerTest {
 
             source(matchHandler);
 
-            assertThat(snapshotStore.load(ACCOUNT_TYPE.qualifiedName(), ACCOUNT_ID).join()).isNotNull();
+            assertThat(snapshotStore.load(ACCOUNT_TYPE.qualifiedName(), ACCOUNT_ID, null).join()).isNotNull();
         }
 
         @Test
@@ -335,7 +335,8 @@ class SnapshottingEntityLifecycleHandlerTest {
         snapshotStore.store(
             ACCOUNT_TYPE.qualifiedName(),
             ACCOUNT_ID,
-            new Snapshot(position, version, payload, Instant.now(), Map.of())
+            new Snapshot(position, version, payload, Instant.now(), Map.of()),
+            null
         ).join();
     }
 


### PR DESCRIPTION
Widen SnapshotStore#store/#load and add a ProcessingContext overload to EventStorageEngine#source so the active ProcessingContext reaches the snapshot store on both the store and load paths.

It's an enabler for Tracing context propagation via ProcessingContext. 