### PR TITLE
[#4640] Document Axon Framework 4 snapshot reuse limitation

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -69,6 +69,12 @@ However, this version also expects that the Axon Server instances have migrated 
 If you have not performed this migration yet, but do want to upgrade to Axon Framework 5, you should use the `AggregateBasedAxonServerEventStorageEngine` instead.
 This engine uses Axon Server's previous aggregate-oriented APIs, which organize events by aggregate identifier and sequence number.
 
+[NOTE]
+====
+Switching a context to DCB also affects existing snapshots: Axon Framework 4 snapshots cannot be reused afterwards, and affected entities rebuild from their event streams.
+See xref:migration:paths/snapshotting.adoc#existing_snapshot_data[Reusing existing Axon Framework 4 snapshots] for the reasoning and what to expect.
+====
+
 To configure the `AggregateBasedAxonServerEventStorageEngine`, please regard the following samples:
 
 [tabs]

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -72,7 +72,7 @@ This engine uses Axon Server's previous aggregate-oriented APIs, which organize 
 [NOTE]
 ====
 Switching a context to DCB also affects existing snapshots: Axon Framework 4 snapshots cannot be reused afterwards, and affected entities rebuild from their event streams.
-See xref:migration:paths/snapshotting.adoc#existing_snapshot_data[Reusing existing Axon Framework 4 snapshots] for the reasoning and what to expect.
+See xref:migration:paths/snapshotting.adoc#reusing_existing_snapshots[Reusing existing Axon Framework 4 snapshots] for the reasoning and what to expect.
 ====
 
 To configure the `AggregateBasedAxonServerEventStorageEngine`, please regard the following samples:

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -158,7 +158,7 @@ The stores above only begin writing snapshots once your application runs on Axon
 The snapshots you already hold from Axon Framework 4 cannot be carried over, because the two versions locate a snapshot in the event stream with incompatible numbering:
 
 * *Aggregate-based storage* (the Axon Framework 4 model, and the aggregate-based storage engines in Axon Framework 5) numbers events per entity, each entity starting at 0.
-* *Dynamic Consistency Boundary (DCB) storage* numbers events store-wide, as a single global index shared by every event.
+* *Dynamic Consistency Boundary (DCB) storage* numbers events context-wide, as a single global index shared by every event.
 
 An Axon Framework 4 snapshot is positioned only by its aggregate sequence number and carries no global index, so a DCB store has no way to know where in the global stream to resume.
 

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -150,3 +150,23 @@ Use `AxonServerSnapshotStore` when you want persistent snapshot storage backed b
 When migrating from Axon Framework 4, make sure your application no longer assumes snapshot persistence is part of the event store implementation itself.
 Snapshot storage is now an explicit dependency of the entity module.
 ====
+
+[#existing_snapshot_data]
+== Reusing existing Axon Framework 4 snapshots
+
+The stores above only begin writing snapshots once your application runs on Axon Framework 5.
+The snapshots you already hold from Axon Framework 4 cannot be carried over, because the two versions locate a snapshot in the event stream with incompatible numbering:
+
+* *Aggregate-based storage* (the Axon Framework 4 model, and the aggregate-based storage engines in Axon Framework 5) numbers events per entity, each entity starting at 0.
+* *Dynamic Consistency Boundary (DCB) storage* numbers events store-wide, as a single global index shared by every event.
+
+An Axon Framework 4 snapshot is positioned only by its aggregate sequence number and carries no global index, so a DCB store has no way to know where in the global stream to resume.
+
+[IMPORTANT]
+====
+Existing Axon Framework 4 snapshots are therefore not reusable in Axon Framework 5, nor migratable to a DCB context.
+Once a context is switched to DCB they are ignored entirely: affected entities rebuild from a full event replay, and fresh snapshots are written from then on.
+====
+
+Accepting this is safe: a snapshot is only an optional performance cache, always rebuildable from the event stream, so losing it costs replay time, not correctness.
+For the storage engine choices that decide whether a context runs in aggregate-based or DCB mode, see the xref:migration:paths/event-store.adoc[Event Store migration].

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -151,7 +151,7 @@ When migrating from Axon Framework 4, make sure your application no longer assum
 Snapshot storage is now an explicit dependency of the entity module.
 ====
 
-[#existing_snapshot_data]
+[#reusing_existing_snapshots]
 == Reusing existing Axon Framework 4 snapshots
 
 The stores above only begin writing snapshots once your application runs on Axon Framework 5.
@@ -164,7 +164,7 @@ An Axon Framework 4 snapshot is positioned only by its aggregate sequence number
 
 [IMPORTANT]
 ====
-Existing Axon Framework 4 snapshots are therefore not reusable in Axon Framework 5, nor migratable to a DCB context.
+Existing Axon Framework 4 snapshots are therefore neither reusable in Axon Framework 5 nor migratable to a DCB context.
 Once a context is switched to DCB they are ignored entirely: affected entities rebuild from a full event replay, and fresh snapshots are written from then on.
 ====
 

--- a/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/snapshotting.adoc
@@ -168,5 +168,9 @@ Existing Axon Framework 4 snapshots are therefore neither reusable in Axon Frame
 Once a context is switched to DCB they are ignored entirely: affected entities rebuild from a full event replay, and fresh snapshots are written from then on.
 ====
 
-Accepting this is safe: a snapshot is only an optional performance cache, always rebuildable from the event stream, so losing it costs replay time, not correctness.
+This is not a correctness problem: a snapshot is only an optional cache, and every entity can be rebuilt from its event stream.
+It is a performance one, and the cost depends on your domain.
+Until fresh snapshots accumulate, each affected entity is sourced from its full history, so the first load after migration is slower.
+For short streams this is negligible, but an entity with a long stream, hundreds of thousands or millions of events, can suffer a significant response-time hit.
+There is no single answer here: assess the impact against your longest-lived entities and plan for the initial replay accordingly.
 For the storage engine choices that decide whether a context runs in aggregate-based or DCB mode, see the xref:migration:paths/event-store.adoc[Event Store migration].


### PR DESCRIPTION
Resolves #4640.

Documents that existing Axon Framework 4 snapshots cannot be reused in Axon Framework 5 and are not migratable to a DCB context, following the documentation-only approach chosen for this issue.

- `migration/paths/snapshotting.adoc`: new "Reusing existing Axon Framework 4 snapshots" section explaining why the two snapshot position models are incompatible (aggregate-local sequence number vs store-wide global index, with an Axon Framework 4 snapshot carrying no global index at all), that affected entities fall back to full event replay, and that snapshots are an optional cache so this is a performance cost, not a correctness problem.
- `migration/paths/event-store.adoc`: short cross-reference note in the (ungated) Axon Server DCB migration section, so open-source readers are pointed to the snapshotting page at the moment the DCB switch is discussed.