### PR TITLE
[#4618] replace joinAndUnwrap in subscribing processor

### DIFF
--- a/docs/reference-guide/modules/events/pages/event-processors/subscribing.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/subscribing.adoc
@@ -19,6 +19,11 @@ When using a simple bus solution like the `EventBus` as the event source, the Su
 Operations like xref:event-processors/streaming.adoc#replaying-events[replaying] are, therefore, not an option for any Subscribing Processor.
 Furthermore, when the `EventBus` is used as the event source, the event publishing thread is the same one that handles the event in the Subscribing Processor.
 
+[NOTE]
+====
+As a result, publication through the `EventBus` completes only after every subscribed handler has finished, and a failing handler propagates its failure back to the publisher, failing the event publication.
+====
+
 Although this coupled approach deserves a spot within the framework, most scenarios require further decoupling of components by separating the threads as well.
 When, for example, an application requires event processing parallelization to get a higher performance, this can be a blocker.
 This predicament is why the `SubscribingEventProcessor` is not the default in Axon Framework.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
@@ -16,13 +16,13 @@
 
 package org.axonframework.messaging.eventhandling;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +36,9 @@ import java.util.function.BiFunction;
  * This event bus supports two publication modes depending on whether a {@link ProcessingContext} is provided:
  * <ul>
  *     <li><b>Immediate publication (context is {@code null}):</b> Events are published directly to all subscribers
- *     without any queueing or lifecycle management. This mode is useful for fire-and-forget event publication
- *     outside of any transactional boundary.</li>
+ *     without any queueing or lifecycle management, outside any transactional boundary. The returned
+ *     {@link CompletableFuture} completes once all subscribers have finished handling the events, and completes
+ *     exceptionally when a subscriber fails.</li>
  *     <li><b>Deferred publication (context is provided):</b> Events are queued and published during the
  *     {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}
  *     phase of the processing lifecycle. This ensures that events are only published if the processing context
@@ -106,9 +107,8 @@ public class SimpleEventBus implements EventBus {
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context, List<? extends EventMessage> events) {
         if (context == null) {
-            // No processing context, publish immediately
-            eventSubscribers.notifySubscribers(events, context);
-            return FutureUtils.emptyCompletedFuture();
+            // No processing context, publish immediately and propagate subscriber completion to the publisher.
+            return eventSubscribers.notifySubscribers(events, context);
         }
 
         registerEventPublishingHooks(context, events);

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
@@ -21,10 +21,10 @@ import org.axonframework.common.FutureUtils;
 import org.axonframework.common.Registration;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.lifecycle.Phase;
+import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.SimpleEntry;
-import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -114,10 +114,9 @@ public class SubscribingEventProcessor implements EventProcessor {
             // This event processor has already been started
             return FutureUtils.emptyCompletedFuture();
         }
-        eventBusRegistration = eventSource.subscribe((events, context) -> {
-            this.process(events.stream().map(it -> (EventMessage) it).toList(), context);
-            return CompletableFuture.completedFuture(null);
-        });
+        eventBusRegistration = eventSource.subscribe(
+                (events, context) -> this.process(events.stream().map(EventMessage.class::cast).toList(), context)
+        );
         return FutureUtils.emptyCompletedFuture();
     }
 
@@ -133,28 +132,41 @@ public class SubscribingEventProcessor implements EventProcessor {
     }
 
     /**
-     * Process the given messages. A Unit of Work must be created for this processing.
+     * Process the given messages, returning a {@link CompletableFuture} that completes when processing is done.
      * <p>
-     * This implementation creates a Batching unit of work for the given batch of {@code eventMessages}.
+     * When a {@code context} is provided, the events are processed within that context. Otherwise, a new
+     * {@link UnitOfWork} is created for the given batch of {@code eventMessages}.
+     * <p>
+     * The returned future completes when processing finishes, or completes exceptionally when processing fails,
+     * allowing the publisher to observe failures through the publication future.
      *
      * @param eventMessages the messages to process
-     * @param context the {@link ProcessingContext} to use
+     * @param context       the {@link ProcessingContext} to use, or {@code null} to create a new {@link UnitOfWork}
+     * @return a {@link CompletableFuture} that completes when processing of the {@code eventMessages} is done
      */
-    protected void process(List<EventMessage> eventMessages, @Nullable ProcessingContext context) {
+    protected CompletableFuture<Void> process(List<EventMessage> eventMessages, @Nullable ProcessingContext context) {
         try {
-            if (context != null) { // if ProcessingContext is provided from the outside, the events will be processed in that context
-                FutureUtils.joinAndUnwrap(processWithErrorHandling(eventMessages, context).asCompletableFuture());
-            } else { // otherwise new UnitOfWork is created
-                UnitOfWork unitOfWork = this.configuration.unitOfWorkFactory().create();
-                unitOfWork.onInvocation(processingContext -> processWithErrorHandling(eventMessages,
-                                                                                      processingContext).asCompletableFuture());
-                FutureUtils.joinAndUnwrap(unitOfWork.execute());
-            }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new EventProcessingException("Exception occurred while processing events", e);
+            return context != null
+                    ? processInContext(eventMessages, context)
+                    : processInNewUnitOfWork(eventMessages);
+        } catch (RuntimeException runtimeFailure) {
+            // a failure while synchronously building the processing pipeline is reported through the returned
+            // future, so it never breaks the publishing thread; failures during handling are carried by the future
+            return CompletableFuture.failedFuture(runtimeFailure);
         }
+    }
+
+    private CompletableFuture<Void> processInContext(List<EventMessage> eventMessages, ProcessingContext context) {
+        // the events are processed in the ProcessingContext provided from the outside
+        return processWithErrorHandling(eventMessages, context).asCompletableFuture()
+                                                               .thenAccept(ignored -> {});
+    }
+
+    private CompletableFuture<Void> processInNewUnitOfWork(List<EventMessage> eventMessages) {
+        UnitOfWork unitOfWork = this.configuration.unitOfWorkFactory().create();
+        unitOfWork.onInvocation(processingContext -> processWithErrorHandling(eventMessages,
+                                                                              processingContext).asCompletableFuture());
+        return unitOfWork.execute();
     }
 
     private MessageStream.Empty<Message> processWithErrorHandling(List<EventMessage> events,

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
@@ -115,7 +115,7 @@ public class SubscribingEventProcessor implements EventProcessor {
             return FutureUtils.emptyCompletedFuture();
         }
         eventBusRegistration = eventSource.subscribe(
-                (events, context) -> this.process(events.stream().map(EventMessage.class::cast).toList(), context)
+                (events, context) -> this.processAsync(events.stream().map(EventMessage.class::cast).toList(), context)
         );
         return FutureUtils.emptyCompletedFuture();
     }
@@ -144,19 +144,44 @@ public class SubscribingEventProcessor implements EventProcessor {
      * @param context       the {@link ProcessingContext} to use, or {@code null} to create a new {@link UnitOfWork}
      * @return a {@link CompletableFuture} that completes when processing of the {@code eventMessages} is done
      */
-    protected CompletableFuture<Void> process(List<EventMessage> eventMessages, @Nullable ProcessingContext context) {
+    protected CompletableFuture<Void> processAsync(List<EventMessage> eventMessages,
+                                                   @Nullable ProcessingContext context) {
         try {
             return context != null
-                    ? processInContext(eventMessages, context)
+                    ? processInGivenContext(eventMessages, context)
                     : processInNewUnitOfWork(eventMessages);
         } catch (RuntimeException e) {
             // a failure while synchronously building the processing pipeline is reported through the returned
             // future, so it never breaks the publishing thread; failures during handling are carried by the future
-            return CompletableFuture.failedFuture(runtimeFailure);
+            return CompletableFuture.failedFuture(e);
         }
     }
 
-    private CompletableFuture<Void> processInContext(List<EventMessage> eventMessages, ProcessingContext context) {
+    /**
+     * Process the given messages, blocking the calling thread until processing is done.
+     * <p>
+     * When a {@code context} is provided, the events are processed within that context. Otherwise, a new
+     * {@link UnitOfWork} is created for the given batch of {@code eventMessages}.
+     *
+     * @param eventMessages the messages to process
+     * @param context       the {@link ProcessingContext} to use, or {@code null} to create a new {@link UnitOfWork}
+     * @throws EventProcessingException if a checked exception occurs while processing the events
+     * @deprecated in favor of {@link #processAsync(List, ProcessingContext)}, which reports completion and failures
+     * through the returned {@link CompletableFuture} rather than blocking the calling thread. This method is retained
+     * for backward compatibility and blocks until processing finishes.
+     */
+    @Deprecated(since = "5.2.0", forRemoval = true)
+    protected void process(List<EventMessage> eventMessages, @Nullable ProcessingContext context) {
+        try {
+            FutureUtils.joinAndUnwrap(processAsync(eventMessages, context));
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new EventProcessingException("Exception occurred while processing events", e);
+        }
+    }
+
+    private CompletableFuture<Void> processInGivenContext(List<EventMessage> eventMessages, ProcessingContext context) {
         return processWithErrorHandling(eventMessages, context).asCompletableFuture()
                                                                .thenAccept(ignored -> {});
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
@@ -149,7 +149,7 @@ public class SubscribingEventProcessor implements EventProcessor {
             return context != null
                     ? processInContext(eventMessages, context)
                     : processInNewUnitOfWork(eventMessages);
-        } catch (RuntimeException runtimeFailure) {
+        } catch (RuntimeException e) {
             // a failure while synchronously building the processing pipeline is reported through the returned
             // future, so it never breaks the publishing thread; failures during handling are carried by the future
             return CompletableFuture.failedFuture(runtimeFailure);

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessor.java
@@ -157,7 +157,6 @@ public class SubscribingEventProcessor implements EventProcessor {
     }
 
     private CompletableFuture<Void> processInContext(List<EventMessage> eventMessages, ProcessingContext context) {
-        // the events are processed in the ProcessingContext provided from the outside
         return processWithErrorHandling(eventMessages, context).asCompletableFuture()
                                                                .thenAccept(ignored -> {});
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
@@ -28,6 +28,7 @@ import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.junit.jupiter.api.*;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -180,6 +181,54 @@ class SimpleEventBusTest {
         void publishingWithoutSubscribersDoesNotFail() {
             // when / then - no exception should be thrown
             testSubject.publish(null, List.of(newEvent("event1")));
+        }
+
+        @Test
+        void publishFutureOnlyCompletesWhenSubscribersComplete() {
+            // given
+            CompletableFuture<Void> subscriberResult = new CompletableFuture<>();
+            testSubject.subscribe((events, context) -> subscriberResult);
+
+            // when
+            CompletableFuture<Void> publishResult = testSubject.publish(null, List.of(newEvent("event1")));
+
+            // then - the publish future tracks the subscriber and does not complete before it does
+            assertThat(publishResult).isNotDone();
+            subscriberResult.complete(null);
+            assertThat(publishResult).isCompleted();
+        }
+
+        @Test
+        void publishFutureCompletesExceptionallyWhenSubscriberFails() {
+            // given
+            RuntimeException failure = new RuntimeException("subscriber failed");
+            testSubject.subscribe((events, context) -> CompletableFuture.failedFuture(failure));
+
+            // when
+            CompletableFuture<Void> publishResult = testSubject.publish(null, List.of(newEvent("event1")));
+
+            // then
+            assertThat(publishResult)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .havingCause()
+                    .isEqualTo(failure);
+        }
+
+        @Test
+        void everySubscriberIsNotifiedEvenWhenAnEarlierOneFails() {
+            // given
+            testSubject.subscribe((events, context) -> CompletableFuture.failedFuture(new RuntimeException("boom")));
+            RecordingEventListener laterListener = new RecordingEventListener();
+            testSubject.subscribe(laterListener);
+
+            // when
+            CompletableFuture<Void> publishResult = testSubject.publish(null, List.of(newEvent("event1")));
+
+            // then - the earlier failure does not prevent the later subscriber from receiving the event,
+            // and the failure is still reported to the publisher
+            assertThat(laterListener.getReceivedEvents()).hasSize(1);
+            assertThat(publishResult).isCompletedExceptionally();
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.*;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,7 +83,8 @@ class SubscribingEventProcessorModuleTest {
             SubscribingEventProcessorModule module = EventProcessorModule
                     .subscribing(processorName)
                     .eventHandlingComponents(components -> components.declarative("component",
-                            cfg -> SimpleEventHandlingComponent.create("test")
+                                                                                  cfg -> SimpleEventHandlingComponent.create(
+                                                                                          "test")
                     ))
                     .customized((cfg, c) -> c);
 
@@ -161,9 +163,12 @@ class SubscribingEventProcessorModuleTest {
                     ep -> ep.subscribing(
                             sp -> sp.defaults(d -> d.eventSource(eventBus))
                                     .defaultProcessor("test-processor",
-                                                      components -> components.declarative("component1", cfg -> component1)
-                                                                              .declarative("component2", cfg -> component2)
-                                                                              .autodetected("component3", cfg -> component3)
+                                                      components -> components.declarative("component1",
+                                                                                           cfg -> component1)
+                                                                              .declarative("component2",
+                                                                                           cfg -> component2)
+                                                                              .autodetected("component3",
+                                                                                            cfg -> component3)
                                     )
                     )
             );
@@ -205,9 +210,12 @@ class SubscribingEventProcessorModuleTest {
                     ep -> ep.subscribing(
                             sp -> sp.defaults(d -> d.eventSource(eventBus))
                                     .defaultProcessor("test-processor",
-                                                      components -> components.declarative("component1", cfg -> component1)
-                                                                              .declarative("component2", cfg -> component2)
-                                                                              .autodetected("component3", cfg -> component3)
+                                                      components -> components.declarative("component1",
+                                                                                           cfg -> component1)
+                                                                              .declarative("component2",
+                                                                                           cfg -> component2)
+                                                                              .autodetected("component3",
+                                                                                            cfg -> component3)
                                     )
                     )
             );
@@ -229,6 +237,83 @@ class SubscribingEventProcessorModuleTest {
                    .untilAsserted(() -> assertThat(component2.handled(sampleEvent)).isTrue());
             await().atMost(Duration.ofMillis(500))
                    .untilAsserted(() -> assertThat(component3HandledPayload.get()).isEqualTo(sampleEvent.payload()));
+
+            // cleanup
+            configuration.shutdown();
+        }
+
+        @Test
+        void handlerFailurePropagatesToPublisherWhenPublishProcessingContextIsNull() {
+            // given
+            SimpleEventBus eventBus = new SimpleEventBus();
+            RuntimeException handlerFailure = new RuntimeException("handler failed");
+            var failingComponent = new Object() {
+                @EventHandler
+                public void handle(String event) {
+                    throw handlerFailure;
+                }
+            };
+            var configurer = MessagingConfigurer.create();
+            configurer.eventProcessing(
+                    processingConfigurer -> processingConfigurer.subscribing(
+                            subscribingEventProcessorsConfigurer ->
+                                    subscribingEventProcessorsConfigurer
+                                            .defaults(subscribingEventProcessorCfg -> subscribingEventProcessorCfg.eventSource(
+                                                    eventBus))
+                                            .defaultProcessor("test-processor",
+                                                              components -> components.autodetected("failing",
+                                                                                                    cfg -> failingComponent)
+                                            )
+                    )
+            );
+            var configuration = configurer.build();
+            configuration.start();
+
+            // when
+            EventMessage sampleEvent = EventTestUtils.asEventMessage("test-event");
+            CompletableFuture<Void> publishResult = eventBus.publish(null, sampleEvent);
+
+            // then - the publisher observes the handler failure through the publication future
+            assertThatThrownBy(() -> FutureUtils.joinAndUnwrap(publishResult)).isSameAs(handlerFailure);
+
+            // cleanup
+            configuration.shutdown();
+        }
+
+        @Test
+        void handlerFailureFailsThePublishingUnitOfWorkWhenPublishProcessingContextIsNotNull() {
+            // given
+            SimpleEventBus eventBus = new SimpleEventBus();
+            RuntimeException handlerFailure = new RuntimeException("handler failed");
+            var failingComponent = new Object() {
+                @EventHandler
+                public void handle(String event) {
+                    throw handlerFailure;
+                }
+            };
+            var configurer = MessagingConfigurer.create();
+            configurer.eventProcessing(
+                    eventProcessingConfigurer -> eventProcessingConfigurer.subscribing(
+                            subscribingEventProcessorsConfigurer ->
+                                    subscribingEventProcessorsConfigurer
+                                            .defaults(subscribingEventProcessorCfg -> subscribingEventProcessorCfg.eventSource(eventBus))
+                                            .defaultProcessor("test-processor",
+                                                              components -> components.autodetected("failing",
+                                                                                                    cfg -> failingComponent)
+                                            )
+                    )
+            );
+            var configuration = configurer.build();
+            configuration.start();
+
+            // when
+            EventMessage sampleEvent = EventTestUtils.asEventMessage("test-event");
+            CompletableFuture<Void> publishResult = aUnitOfWorkFactory()
+                    .create()
+                    .executeWithResult(ctx -> eventBus.publish(ctx, sampleEvent));
+
+            // then - the failure surfaces to the publisher when the publishing unit of work commits
+            assertThatThrownBy(() -> FutureUtils.joinAndUnwrap(publishResult)).isSameAs(handlerFailure);
 
             // cleanup
             configuration.shutdown();
@@ -269,7 +354,8 @@ class SubscribingEventProcessorModuleTest {
             SubscribingEventProcessorModule sepModuleOne =
                     EventProcessorModule.subscribing("processor-one")
                                         .eventHandlingComponents(
-                                                components -> components.declarative("componentOne", cfg -> componentOne)
+                                                components -> components.declarative("componentOne",
+                                                                                     cfg -> componentOne)
                                         )
                                         .customized((config, psepConfig) -> psepConfig.withInterceptor(
                                                 specificInterceptorOne
@@ -278,7 +364,8 @@ class SubscribingEventProcessorModuleTest {
             SubscribingEventProcessorModule sepModuleTwo =
                     EventProcessorModule.subscribing("processor-two")
                                         .eventHandlingComponents(
-                                                components -> components.declarative("componentTwo", cfg -> componentTwo)
+                                                components -> components.declarative("componentTwo",
+                                                                                     cfg -> componentTwo)
                                         )
                                         .customized((config, psepConfig) -> psepConfig.withInterceptor(
                                                 specificInterceptorTwo
@@ -667,7 +754,8 @@ class SubscribingEventProcessorModuleTest {
                                                          .orElse(new SimpleEventBus())));
     }
 
-        private @NonNull static Function<EventHandlingComponentsConfigurer.RequiredComponentPhase, EventHandlingComponentsConfigurer.CompletePhase> singleTestEventHandlingComponent() {
+    private @NonNull
+    static Function<EventHandlingComponentsConfigurer.RequiredComponentPhase, EventHandlingComponentsConfigurer.CompletePhase> singleTestEventHandlingComponent() {
         var eventHandlingComponent = SimpleEventHandlingComponent.create("test");
         eventHandlingComponent.subscribe(new QualifiedName(String.class), (event, context) -> MessageStream.empty());
         return components -> components.declarative("eventHandlingComponent", cfg -> eventHandlingComponent);
@@ -685,11 +773,12 @@ class SubscribingEventProcessorModuleTest {
                                               processorName).ifPresent(p -> assertThat(p.isRunning()).isTrue()));
     }
 
-        private @NonNull static Optional<SubscribingEventProcessor> processor(
+    private @NonNull
+    static Optional<SubscribingEventProcessor> processor(
             AxonConfiguration configuration,
             String processorName
     ) {
-            return configuration.getModuleConfiguration("EventProcessor[" + processorName + "]")
+        return configuration.getModuleConfiguration("EventProcessor[" + processorName + "]")
                             .flatMap(m -> m.getOptionalComponent(EventProcessor.class, processorName))
                             .filter(SubscribingEventProcessor.class::isInstance)
                             .map(SubscribingEventProcessor.class::cast);


### PR DESCRIPTION

Removes both `FutureUtils#joinAndUnwrap` calls from the `SubscribingEventProcessor`, making event handling non-blocking (as done in #3773 for the `PooledStreamingEventProcessor`).

Fixes #4618

- `process` now returns `CompletableFuture<Void>` and `start()` returns it, so handling failures reach the publisher.
- `SimpleEventBus#publish(null, ...)` now returns the subscriber-completion future instead of an always-completed one, so a failing handler fails the publication. With multiple subscribers all are notified and the first failure is reported (`allOf`).