### PR TITLE
[#4579] Invoke the subtype handler over a shadowed supertype handler

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -262,8 +262,9 @@ public class AnnotatedHandlerInspector<T> {
     }
 
     /**
-     * Returns a list of detected members of given {@code type}, that can handle messages of {@code messageType}. The
-     * list is further filtered to exclude any duplicate members that resolve to the same {@link Executable}.
+     * Returns a list of detected members of given {@code type}, that can handle messages of {@code messageType}. When
+     * several members resolve to the same method signature - for example a supertype handler that is overridden or
+     * shadowed by a subtype - only the member declared by the most specific type is retained.
      *
      * @param type a type of inspected entity
      * @param messageType a message type the returned handlers must be able to handle
@@ -271,17 +272,24 @@ public class AnnotatedHandlerInspector<T> {
      */
     public List<MessageHandlingMember<? super T>> getUniqueHandlers(Class<?> type, Class<? extends Message> messageType) {
         SortedSet<MessageHandlingMember<? super T>> set = handlers.getOrDefault(type, emptySortedSet());
-        Set<ExecutableSignature> seenMethods = new HashSet<>();
 
-        // Note: this is a stateful stream, do not change the order of the filter conditions as otherwise
-        // a method that belongs to a different message type may filter out methods that belong to the correct
-        // message type.
-        return set.stream()
+        // When several handlers resolve to the same method signature - because a supertype method is
+        // overridden or shadowed in a subtype - only the one declared by the most specific type is kept.
+        // Otherwise an inherited handler may take precedence over the subtype's own handler; for private
+        // methods, which are bound statically rather than virtually dispatched, this even causes the
+        // supertype's implementation to be invoked instead of the subtype's.
+        // Note: the messageType is filtered first on purpose, so a member handling a different message type
+        // cannot displace the member that actually handles the requested messageType.
+        Map<ExecutableSignature, MessageHandlingMember<? super T>> uniqueBySignature = set.stream()
             .filter(member -> member.canHandleMessageType(messageType))
-            .filter(member -> seenMethods.add(
-                member.unwrap(Executable.class).map(ExecutableSignature::of).orElseThrow()  // there is always an executable
-            ))
-            .toList();
+            .collect(Collectors.toMap(
+                member -> member.unwrap(Executable.class).map(ExecutableSignature::of).orElseThrow(),  // there is always an executable
+                member -> member,
+                (existing, replacement) ->
+                    existing.declaringClass().isAssignableFrom(replacement.declaringClass()) ? replacement : existing,
+                LinkedHashMap::new
+            ));
+        return List.copyOf(uniqueBySignature.values());
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
@@ -818,6 +818,40 @@ class AnnotatedEventHandlingComponentTest {
         }
     }
 
+    @Nested
+    class GivenPrivateHandlersInATypeHierarchy {
+
+        @Test
+        void invokesSubtypeHandlerInsteadOfShadowedPrivateSupertypeHandler() {
+            // given
+            // The supertype sorts lexically before the subtype, so the ordering used to select the
+            // supertype's private handler. Private methods are bound statically, so its body would run.
+            BaseWithPrivateHandler target = new SubWithPrivateHandler();
+            AnnotatedEventHandlingComponent<?> component = annotatedEventHandlingComponent(target);
+            EventMessage event = eventMessage(0);
+
+            // when
+            component.handle(event, messageProcessingContext(event));
+
+            // then
+            assertThat(target.handledBy).isEqualTo("sub");
+        }
+
+        @Test
+        void invokesPrivateSupertypeHandlerWhenSubtypeDoesNotDeclareItsOwn() {
+            // given
+            BaseWithPrivateHandler target = new SubWithoutOwnHandler();
+            AnnotatedEventHandlingComponent<?> component = annotatedEventHandlingComponent(target);
+            EventMessage event = eventMessage(0);
+
+            // when
+            component.handle(event, messageProcessingContext(event));
+
+            // then
+            assertThat(target.handledBy).isEqualTo("base");
+        }
+    }
+
     private void assertCalledOnlyOnce(Object handlerInstance) {
         AnnotatedEventHandlingComponent<?> annotatedEventHandlingComponent = annotatedEventHandlingComponent(
                 handlerInstance);
@@ -871,6 +905,30 @@ class AnnotatedEventHandlingComponentTest {
         void handleNotNamed() {
             handledNotNamed++;
         }
+    }
+
+    @SuppressWarnings("unused")
+    private static class BaseWithPrivateHandler {
+
+        String handledBy = "none";
+
+        @EventHandler
+        private void handle(Integer event) {
+            this.handledBy = "base";
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class SubWithPrivateHandler extends BaseWithPrivateHandler {
+
+        @EventHandler
+        private void handle(Integer event) {
+            this.handledBy = "sub";
+        }
+    }
+
+    private static class SubWithoutOwnHandler extends BaseWithPrivateHandler {
+
     }
 
         private @NonNull static AnnotatedEventHandlingComponent<?> annotatedEventHandlingComponent(Object eventHandler) {


### PR DESCRIPTION
## Issue

Closes #4579.

Annotated message handling components could invoke a **private** handler declared in a supertype instead of the matching handler declared in the actual (inspected) type.

## Root cause

`AnnotatedHandlerInspector#getUniqueHandlers` returned, per method signature, the first member in `HandlerComparator` order. The comparator's final tiebreaker is `Executable#toGenericString()`, which orders by the declaring class name. When a supertype and the inspected subtype declare a handler with the same signature (same priority, payload type and parameters), the supertype was selected whenever its class name sorts first lexically.

For public/protected methods this is invisible, because reflective invocation is virtually dispatched to the subtype's override. For **private** methods there is no virtual dispatch, so the supertype's implementation was actually executed.

## Fix

`getUniqueHandlers` now keeps, per method signature, the member declared by the most specific type. The subtype's own handler wins over a shadowed supertype handler, while an inherited handler that is *not* shadowed by the subtype is still used — so a private handler declared only in a base class keeps working for subtype instances.

## Tests

Added two behavioural tests to `AnnotatedEventHandlingComponentTest`:
- a supertype and a subtype both declaring a private `@EventHandler` → the subtype's handler is invoked (fails before the fix);
- a subtype without its own handler → the private supertype handler is still invoked (guards against over-filtering).

`./mvnw -pl messaging,modelling test` passes.

## Note

This change was prepared with AI assistance; I have reviewed and verified the analysis, fix and tests locally.
