### PR TITLE
[#4171] Add convenience overloads for declarative entity builders

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
@@ -104,7 +104,8 @@ class AnnotatedEventSourcedEntityModule<I, E>
                                     + "higher-level annotation on an enclosing class, package, or module."
                     ));
             SnapshotPolicy policy = buildSnapshotPolicy(entityType, resolved);
-            phase.snapshotPolicy(c -> policy);
+            ComponentBuilder<SnapshotPolicy> builder = c -> policy;
+            phase.snapshotPolicy(builder);
         }
 
         componentRegistry(cr -> cr.registerModule(phase.build()));

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcedEntityModule.java
@@ -32,7 +32,11 @@ import org.axonframework.modelling.configuration.EntityMetamodelConfigurationBui
 import org.axonframework.modelling.configuration.EntityModule;
 import org.axonframework.modelling.entity.EntityCommandHandlingComponent;
 import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.repository.Repository;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * An expansion of the {@link EntityModule}, specifically for event-sourced entities. When constructed, either
@@ -129,6 +133,22 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
          * @return The {@link EntityFactoryPhase} phase of this builder, for a fluent API.
          */
         EntityFactoryPhase<ID, E> messagingModel(EntityMetamodelConfigurationBuilder<E> metamodelFactory);
+
+        /**
+         * Registers a messaging metamodel factory that does not require the {@link org.axonframework.common.configuration.Configuration}.
+         * <p>
+         * Convenience overload for callers that only need the {@link EntityMetamodelBuilder}.
+         *
+         * @param metamodelFactory a factory constructing the {@link EntityMetamodel} from the
+         *                         {@link EntityMetamodelBuilder}
+         * @return the {@link EntityFactoryPhase} phase of this builder, for a fluent API
+         */
+        default EntityFactoryPhase<ID, E> messagingModel(
+                Function<EntityMetamodelBuilder<E>, EntityMetamodel<E>> metamodelFactory
+        ) {
+            Objects.requireNonNull(metamodelFactory, "The metamodelFactory cannot be null.");
+            return messagingModel((configuration, builder) -> metamodelFactory.apply(builder));
+        }
     }
 
     /**
@@ -155,6 +175,21 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
         CriteriaResolverPhase<ID, E> entityFactory(
                 ComponentBuilder<EventSourcedEntityFactory<ID, E>> entityFactory
         );
+
+        /**
+         * Registers the given {@link EventSourcedEntityFactory} as the factory for the event-sourced entity being
+         * built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the factory.
+         *
+         * @param entityFactory the {@link EventSourcedEntityFactory} for the event-sourced entity
+         * @return the {@link CriteriaResolverPhase} phase of this builder, for a fluent API
+         */
+        default CriteriaResolverPhase<ID, E> entityFactory(EventSourcedEntityFactory<ID, E> entityFactory) {
+            Objects.requireNonNull(entityFactory, "The entity factory cannot be null.");
+            return entityFactory(configuration -> entityFactory);
+        }
     }
 
     /**
@@ -183,6 +218,20 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
          * @return The {@link OptionalPhase} phase of this builder, for a fluent API.
          */
         OptionalPhase<ID, E> criteriaResolver(ComponentBuilder<CriteriaResolver<ID>> criteriaResolver);
+
+        /**
+         * Registers the given {@link CriteriaResolver} for the event-sourced entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the resolver.
+         *
+         * @param criteriaResolver the {@link CriteriaResolver} for the event-sourced entity
+         * @return the {@link OptionalPhase} phase of this builder, for a fluent API
+         */
+        default OptionalPhase<ID, E> criteriaResolver(CriteriaResolver<ID> criteriaResolver) {
+            Objects.requireNonNull(criteriaResolver, "The criteria resolver cannot be null.");
+            return criteriaResolver(configuration -> criteriaResolver);
+        }
     }
 
     /**
@@ -208,6 +257,20 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
         OptionalPhase<ID, E> entityIdResolver(ComponentBuilder<EntityIdResolver<ID>> entityIdResolver);
 
         /**
+         * Registers an optional {@link EntityIdResolver} for the event-sourced entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the resolver.
+         *
+         * @param entityIdResolver the {@link EntityIdResolver} for the event-sourced entity
+         * @return the {@link OptionalPhase} phase of this builder, for a fluent API
+         */
+        default OptionalPhase<ID, E> entityIdResolver(EntityIdResolver<ID> entityIdResolver) {
+            Objects.requireNonNull(entityIdResolver, "The entity ID resolver cannot be null.");
+            return entityIdResolver(configuration -> entityIdResolver);
+        }
+
+        /**
          * Registers an optional {@link ComponentBuilder} of a {@link SnapshotPolicy} for the
          * event-sourced entity being built. The snapshot policy determines under which conditions
          * the entity state should be snapshotted during sourcing.
@@ -217,5 +280,20 @@ public interface EventSourcedEntityModule<ID, E> extends EntityModule<ID, E> {
          * @return The {@link OptionalPhase} phase of this builder, for a fluent API.
          */
         OptionalPhase<ID, E> snapshotPolicy(ComponentBuilder<SnapshotPolicy> snapshotPolicy);
+
+        /**
+         * Registers an optional {@link SnapshotPolicy} for the event-sourced entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the policy.
+         *
+         * @param snapshotPolicy the {@link SnapshotPolicy} for the event-sourced entity
+         * @return the {@link OptionalPhase} phase of this builder, for a fluent API
+         */
+        default OptionalPhase<ID, E> snapshotPolicy(SnapshotPolicy snapshotPolicy) {
+            Objects.requireNonNull(snapshotPolicy, "The snapshotPolicy cannot be null.");
+            ComponentBuilder<SnapshotPolicy> builder = configuration -> snapshotPolicy;
+            return snapshotPolicy(builder);
+        }
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/SnapshottingEntityLifecycleHandlerTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/SnapshottingEntityLifecycleHandlerTestSuite.java
@@ -112,7 +112,7 @@ public abstract class SnapshottingEntityLifecycleHandlerTestSuite {
                         return new Account(ac.id, ac.name, 0);
                     })
                     .criteriaResolver(c -> (id, ctx) -> EventCriteria.havingTags(Tag.of("account", id)))
-                    .snapshotPolicy(c -> snapshotPolicy)
+                    .snapshotPolicy(snapshotPolicy)
                     .build()
             )
             .build();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModuleTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.configuration;
 
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.common.lifecycle.LifecycleHandlerInvocationException;
 import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
@@ -35,16 +36,19 @@ import org.axonframework.messaging.core.sequencing.SequencingPolicy;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
+import org.axonframework.modelling.configuration.EntityMetamodelConfigurationBuilder;
 import org.axonframework.modelling.entity.EntityCommandHandlingComponent;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.repository.Repository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -88,6 +92,11 @@ class SimpleEventSourcedEntityModuleTest {
                                          .build();
         testSnapshotPolicy = SnapshotPolicy.afterEvents(5);
 
+        ComponentBuilder<SnapshotPolicy> snapshotPolicyBuilder = c -> {
+            constructedSnapshotPolicy.set(true);
+            return testSnapshotPolicy;
+        };
+
         testSubject = EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                               .messagingModel((c, b) -> {
                                                   constructedEntityModel.set(true);
@@ -105,10 +114,7 @@ class SimpleEventSourcedEntityModuleTest {
                                                   constructedEntityIdResolver.set(true);
                                                   return testEntityIdResolver;
                                               })
-                                              .snapshotPolicy(c -> {
-                                                  constructedSnapshotPolicy.set(true);
-                                                  return testSnapshotPolicy;
-                                              })
+                                              .snapshotPolicy(snapshotPolicyBuilder)
                                               .build();
     }
 
@@ -129,7 +135,7 @@ class SimpleEventSourcedEntityModuleTest {
         //noinspection DataFlowIssue
         assertThrows(NullPointerException.class,
                      () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
-                                                   .messagingModel(null));
+                                                   .messagingModel((EntityMetamodelConfigurationBuilder<Course>) null));
     }
 
     @Test
@@ -138,7 +144,7 @@ class SimpleEventSourcedEntityModuleTest {
         assertThrows(NullPointerException.class,
                      () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                                    .messagingModel((c, b) -> testEntityModel)
-                                                   .entityFactory(null));
+                                                   .entityFactory((ComponentBuilder<EventSourcedEntityFactory<CourseId, Course>>) null));
     }
 
     @Test
@@ -148,7 +154,7 @@ class SimpleEventSourcedEntityModuleTest {
                      () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
                                                    .messagingModel((c, m) -> testEntityModel)
                                                    .entityFactory(c -> testEntityFactory)
-                                                   .criteriaResolver(null));
+                                                   .criteriaResolver((ComponentBuilder<CriteriaResolver<CourseId>>) null));
     }
 
     @Test
@@ -159,7 +165,7 @@ class SimpleEventSourcedEntityModuleTest {
                                                    .messagingModel((c, b) -> testEntityModel)
                                                    .entityFactory(c -> testEntityFactory)
                                                    .criteriaResolver(c -> testCriteriaResolver)
-                                                   .entityIdResolver(null));
+                                                   .entityIdResolver((ComponentBuilder<EntityIdResolver<CourseId>>) null));
     }
 
     @Test
@@ -169,7 +175,7 @@ class SimpleEventSourcedEntityModuleTest {
                                           .messagingModel((c, b) -> testEntityModel)
                                           .entityFactory(c -> testEntityFactory)
                                           .criteriaResolver(c -> testCriteriaResolver)
-                                          .snapshotPolicy(null)
+                                          .snapshotPolicy((ComponentBuilder<SnapshotPolicy>) null)
         );
     }
 
@@ -239,6 +245,84 @@ class SimpleEventSourcedEntityModuleTest {
         assertInstanceOf(EntityCommandHandlingComponent.class, component);
         assertTrue(component.supportedCommands().contains(new QualifiedName("instance")));
         assertTrue(component.supportedCommands().contains(new QualifiedName("creational")));
+    }
+
+    @Nested
+    class ConvenienceOverloads {
+
+        @Test
+        void acceptsDirectComponentInstancesWithoutConfigurationLambdas() {
+            // given / when
+            EventSourcedEntityModule<CourseId, Course> module =
+                    EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                            .messagingModel(builder -> testEntityModel)
+                                            .entityFactory(testEntityFactory)
+                                            .criteriaResolver(testCriteriaResolver)
+                                            .entityIdResolver(testEntityIdResolver)
+                                            .snapshotPolicy(testSnapshotPolicy)
+                                            .build();
+
+            AxonConfiguration configuration = EventSourcingConfigurer.create()
+                    .componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> mock(SnapshotStore.class)))
+                    .componentRegistry(cr -> cr.registerModule(module))
+                    .start();
+
+            // then
+            Repository<CourseId, Course> result = configuration.getComponent(StateManager.class)
+                                                               .repository(Course.class, CourseId.class);
+            assertThat(result).isInstanceOf(EventSourcingRepository.class);
+            assertThat(module.entityName()).isEqualTo(Course.class.getName() + "#" + CourseId.class.getName());
+        }
+
+        @Test
+        void convenienceMessagingModelThrowsNullPointerExceptionForNullFactory() {
+            //noinspection DataFlowIssue,rawtypes,unchecked
+            assertThrows(NullPointerException.class,
+                         () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                                       .messagingModel(
+                                                               (java.util.function.Function<org.axonframework.modelling.entity.EntityMetamodelBuilder<Course>, EntityMetamodel<Course>>) null));
+        }
+
+        @Test
+        void convenienceEntityFactoryThrowsNullPointerExceptionForNullFactory() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                                       .messagingModel(builder -> testEntityModel)
+                                                       .entityFactory((EventSourcedEntityFactory<CourseId, Course>) null));
+        }
+
+        @Test
+        void convenienceCriteriaResolverThrowsNullPointerExceptionForNullResolver() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                                       .messagingModel(builder -> testEntityModel)
+                                                       .entityFactory(testEntityFactory)
+                                                       .criteriaResolver((CriteriaResolver<CourseId>) null));
+        }
+
+        @Test
+        void convenienceEntityIdResolverThrowsNullPointerExceptionForNullResolver() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                                       .messagingModel(builder -> testEntityModel)
+                                                       .entityFactory(testEntityFactory)
+                                                       .criteriaResolver(testCriteriaResolver)
+                                                       .entityIdResolver((EntityIdResolver<CourseId>) null));
+        }
+
+        @Test
+        void convenienceSnapshotPolicyThrowsNullPointerExceptionForNullPolicy() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> EventSourcedEntityModule.declarative(CourseId.class, Course.class)
+                                                       .messagingModel(builder -> testEntityModel)
+                                                       .entityFactory(testEntityFactory)
+                                                       .criteriaResolver(testCriteriaResolver)
+                                                       .snapshotPolicy((SnapshotPolicy) null));
+        }
     }
 
     record CourseId() {

--- a/modelling/src/main/java/org/axonframework/modelling/configuration/StateBasedEntityModule.java
+++ b/modelling/src/main/java/org/axonframework/modelling/configuration/StateBasedEntityModule.java
@@ -21,9 +21,14 @@ import org.axonframework.common.configuration.ModuleBuilder;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.modelling.EntityIdResolver;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.repository.SimpleRepositoryEntityLoader;
 import org.axonframework.modelling.repository.SimpleRepositoryEntityPersister;
 import org.axonframework.modelling.repository.Repository;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * An expansion on the {@link EntityModule}, specifically for state-based entities.
@@ -81,12 +86,40 @@ public interface StateBasedEntityModule<ID, E> extends EntityModule<ID, E> {
         PersisterPhase<ID, E> loader(ComponentBuilder<SimpleRepositoryEntityLoader<ID, E>> loader);
 
         /**
+         * Registers the given {@code loader} for the state-based entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the loader.
+         *
+         * @param loader the {@link SimpleRepositoryEntityLoader} for the state-based entity
+         * @return the "persister" phase of this builder, for a fluent API
+         */
+        default PersisterPhase<ID, E> loader(SimpleRepositoryEntityLoader<ID, E> loader) {
+            Objects.requireNonNull(loader, "The loader cannot be null.");
+            return loader(configuration -> loader);
+        }
+
+        /**
          * Registers the given {@code repository} as a factory method for the state-based entity being built.
          *
          * @param repository A factory method constructing a {@link Repository}.
          * @return The parent {@link StateBasedEntityModule}, signaling the end of configuring a state-based entity.
          */
         MessagingMetamodelPhase<ID, E> repository(ComponentBuilder<Repository<ID, E>> repository);
+
+        /**
+         * Registers the given {@code repository} for the state-based entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the repository.
+         *
+         * @param repository the {@link Repository} for the state-based entity
+         * @return the messaging metamodel phase of this builder, for a fluent API
+         */
+        default MessagingMetamodelPhase<ID, E> repository(Repository<ID, E> repository) {
+            Objects.requireNonNull(repository, "The repository cannot be null.");
+            return repository(configuration -> repository);
+        }
     }
 
     /**
@@ -108,6 +141,20 @@ public interface StateBasedEntityModule<ID, E> extends EntityModule<ID, E> {
         MessagingMetamodelPhase<ID, E> persister(
                 ComponentBuilder<SimpleRepositoryEntityPersister<ID, E>> persister
         );
+
+        /**
+         * Registers the given {@code persister} for the state-based entity being built.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the persister.
+         *
+         * @param persister the {@link SimpleRepositoryEntityPersister} for the state-based entity
+         * @return the messaging metamodel phase of this builder, for a fluent API
+         */
+        default MessagingMetamodelPhase<ID, E> persister(SimpleRepositoryEntityPersister<ID, E> persister) {
+            Objects.requireNonNull(persister, "The persister cannot be null.");
+            return persister(configuration -> persister);
+        }
     }
 
     /**
@@ -134,6 +181,23 @@ public interface StateBasedEntityModule<ID, E> extends EntityModule<ID, E> {
         EntityIdResolverPhase<ID, E> messagingModel(
                 EntityMetamodelConfigurationBuilder<E> metamodelFactory
         );
+
+        /**
+         * Registers a messaging metamodel factory that does not require the
+         * {@link org.axonframework.common.configuration.Configuration}.
+         * <p>
+         * Convenience overload for callers that only need the {@link EntityMetamodelBuilder}.
+         *
+         * @param metamodelFactory a factory constructing the {@link EntityMetamodel} from the
+         *                         {@link EntityMetamodelBuilder}
+         * @return the next phase of this builder, allowing for configuring the entity's ID resolver
+         */
+        default EntityIdResolverPhase<ID, E> messagingModel(
+                Function<EntityMetamodelBuilder<E>, EntityMetamodel<E>> metamodelFactory
+        ) {
+            Objects.requireNonNull(metamodelFactory, "The metamodelFactory cannot be null.");
+            return messagingModel((configuration, builder) -> metamodelFactory.apply(builder));
+        }
     }
 
     /**
@@ -159,5 +223,19 @@ public interface StateBasedEntityModule<ID, E> extends EntityModule<ID, E> {
         StateBasedEntityModule<ID, E> entityIdResolver(
                 ComponentBuilder<EntityIdResolver<ID>> entityIdResolver
         );
+
+        /**
+         * Registers the given {@code entityIdResolver} for resolving entity identifiers from a given {@link Message}.
+         * <p>
+         * Convenience overload for callers that do not need the {@link org.axonframework.common.configuration.Configuration}
+         * to construct the resolver.
+         *
+         * @param entityIdResolver the {@link EntityIdResolver} for the state-based entity
+         * @return the {@link StateBasedEntityModule}, signaling the end of this builder
+         */
+        default StateBasedEntityModule<ID, E> entityIdResolver(EntityIdResolver<ID> entityIdResolver) {
+            Objects.requireNonNull(entityIdResolver, "The entity ID resolver cannot be null.");
+            return entityIdResolver(configuration -> entityIdResolver);
+        }
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/configuration/StateBasedEntityModuleTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/configuration/StateBasedEntityModuleTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.modelling.configuration;
 
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.commandhandling.CommandHandlingComponent;
 import org.axonframework.messaging.core.MessageStream;
@@ -26,8 +27,11 @@ import org.axonframework.messaging.core.correlation.CorrelationDataProviderRegis
 import org.axonframework.messaging.core.correlation.DefaultCorrelationDataProviderRegistry;
 import org.axonframework.messaging.core.sequencing.NoOpSequencingPolicy;
 import org.axonframework.messaging.core.sequencing.SequencingPolicy;
+import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.entity.EntityCommandHandlingComponent;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.repository.Repository;
 import org.axonframework.modelling.repository.SimpleRepository;
 import org.axonframework.modelling.repository.SimpleRepositoryEntityLoader;
@@ -37,7 +41,9 @@ import org.mockito.*;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -82,7 +88,7 @@ class StateBasedEntityModuleTest {
         //noinspection DataFlowIssue
         assertThrows(NullPointerException.class,
                      () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
-                                                 .repository(null));
+                                                 .repository((ComponentBuilder<Repository<CourseId, Course>>) null));
     }
 
     @Test
@@ -90,7 +96,7 @@ class StateBasedEntityModuleTest {
         //noinspection DataFlowIssue
         assertThrows(NullPointerException.class,
                      () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
-                                                 .loader(null));
+                                                 .loader((ComponentBuilder<SimpleRepositoryEntityLoader<CourseId, Course>>) null));
     }
 
     @Test
@@ -99,7 +105,7 @@ class StateBasedEntityModuleTest {
         assertThrows(NullPointerException.class,
                      () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
                                                  .loader(c -> testLoader)
-                                                 .persister(null));
+                                                 .persister((ComponentBuilder<SimpleRepositoryEntityPersister<CourseId, Course>>) null));
     }
 
     @Test
@@ -167,6 +173,83 @@ class StateBasedEntityModuleTest {
         CommandHandlingComponent commandHandlingComponent = captor.getValue();
         assertInstanceOf(EntityCommandHandlingComponent.class, commandHandlingComponent);
         assertTrue(commandHandlingComponent.supportedCommands().contains(new QualifiedName("myQualifiedName")));
+    }
+
+    @Nested
+    class ConvenienceOverloads {
+
+        @Test
+        void acceptsDirectComponentInstancesWithoutConfigurationLambdas() {
+            // given / when
+            StateBasedEntityModule<CourseId, Course> module = StateBasedEntityModule
+                    .declarative(CourseId.class, Course.class)
+                    .loader(testLoader)
+                    .persister(testPersister)
+                    .messagingModel(builder -> builder
+                            .instanceCommandHandler(new QualifiedName("myQualifiedName"),
+                                                    (c1, command, ctx) -> MessageStream.empty().cast())
+                            .build())
+                    .entityIdResolver((message, context) -> new CourseId());
+
+            AxonConfiguration configuration = ModellingConfigurer
+                    .create()
+                    .componentRegistry(cr -> cr.registerModule(module))
+                    .start();
+
+            // then
+            Repository<CourseId, Course> result = configuration
+                    .getComponent(StateManager.class)
+                    .repository(Course.class, CourseId.class);
+            assertThat(result).isInstanceOf(SimpleRepository.class);
+            assertThat(module.entityName()).isEqualTo("Course#CourseId");
+        }
+
+        @Test
+        void convenienceLoaderThrowsNullPointerExceptionForNullLoader() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
+                                                     .loader((SimpleRepositoryEntityLoader<CourseId, Course>) null));
+        }
+
+        @Test
+        void conveniencePersisterThrowsNullPointerExceptionForNullPersister() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
+                                                     .loader(testLoader)
+                                                     .persister((SimpleRepositoryEntityPersister<CourseId, Course>) null));
+        }
+
+        @Test
+        void convenienceRepositoryThrowsNullPointerExceptionForNullRepository() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
+                                                     .repository((Repository<CourseId, Course>) null));
+        }
+
+        @Test
+        void convenienceMessagingModelThrowsNullPointerExceptionForNullFactory() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
+                                                     .loader(testLoader)
+                                                     .persister(testPersister)
+                                                     .messagingModel(
+                                                             (Function<EntityMetamodelBuilder<Course>, EntityMetamodel<Course>>) null));
+        }
+
+        @Test
+        void convenienceEntityIdResolverThrowsNullPointerExceptionForNullResolver() {
+            //noinspection DataFlowIssue
+            assertThrows(NullPointerException.class,
+                         () -> StateBasedEntityModule.declarative(CourseId.class, Course.class)
+                                                     .loader(testLoader)
+                                                     .persister(testPersister)
+                                                     .messagingModel(builder -> builder.build())
+                                                     .entityIdResolver((EntityIdResolver<CourseId>) null));
+        }
     }
 
     private StateBasedEntityModule<CourseId, Course> stateBasedModuleWithoutModel() {


### PR DESCRIPTION
## Summary
- Adds convenience overloads on `EventSourcedEntityModule` and `StateBasedEntityModule` so callers can register factories/resolvers/policies directly, without wrapping them in `Configuration` lambdas.
- Improves readability of declarative entity configuration (as requested in #4171), while keeping the existing `ComponentBuilder` APIs intact.
- Resolves `SnapshotPolicy` overload ambiguity by using an explicit `ComponentBuilder` where a same-arity functional interface would otherwise conflict.

## Changes
- `EventSourcedEntityModule`: `messagingModel(Function)`, `entityFactory(...)`, `criteriaResolver(...)`, `entityIdResolver(...)`, `snapshotPolicy(...)`
- `StateBasedEntityModule`: `loader(...)`, `persister(...)`, `repository(...)`, `messagingModel(Function)`, `entityIdResolver(...)`
- Unit tests covering the new overloads (including null-safety) in `SimpleEventSourcedEntityModuleTest` and `StateBasedEntityModuleTest`

## Example
```java
EventSourcedEntityModule.declarative(String.class, Account.class)
    .messagingModel(model -> model.entityEvolver(evolver()).build())
    .entityFactory(EventSourcedEntityFactory.fromIdentifier(Account::new))
    .criteriaResolver((id, ctx) -> EventCriteria.havingTags(Tag.of("account", id)))
    .build();
```

---

This PR will resolve #4171 