### PR TITLE
[#206] Initial setup multi tenancy demo

### DIFF
--- a/docs/reference-guide/modules/ROOT/partials/nav.adoc
+++ b/docs/reference-guide/modules/ROOT/partials/nav.adoc
@@ -20,6 +20,10 @@ ifdef::data-protection[]
 include::data-protection:partial$nav.adoc[]
 endif::[]
 
+ifdef::advanced-framework[]
+include::multi-tenancy:partial$nav.adoc[]
+endif::[]
+
 include::tuning:partial$nav.adoc[]
 
 include::monitoring:partial$nav.adoc[]

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -56,6 +56,7 @@
         <module>university-java-springboot-4</module>
         <module>university-demo-kotlin</module>
         <module>university-message-transformation</module>
+        <module>university-multi-tenancy</module>
     </modules>
 
     <build>

--- a/examples/university-multi-tenancy/.gitignore
+++ b/examples/university-multi-tenancy/.gitignore
@@ -1,0 +1,3 @@
+# Never commit license files
+axon-server.license
+*.license

--- a/examples/university-multi-tenancy/README.md
+++ b/examples/university-multi-tenancy/README.md
@@ -1,17 +1,17 @@
-# Axon Framework 5 - Multi-Tenancy Demo
+# Axoniq Framework Multi-Tenancy Demo
 
 Tenant-aware components in Axoniq Framework 5.3.
 
-A SaaS platform hosts several universities. Each is its own tenant, and their data must never
-mix. The feature this demo teaches lets you register a tenant-scoped component once and have the
-framework hand each message handler the instance belonging to the tenant of the message it is
-handling. A handler never resolves a tenant itself.
+A platform hosts several universities. Each is its own tenant, and their data must never mix. The
+feature this demo teaches lets you register a tenant-scoped component once and have the framework
+hand each message handler the instance belonging to the tenant of the message it is handling. A
+handler never resolves a tenant itself.
 
 ## The idea
 
 A tenant-aware component is described by two types you write: the component itself, and a
 `TenantComponentFactory` saying how to build it for one tenant. You register a
-`TenantComponentProvider` per component type. This demo registers two, to show that several
+`TenantComponentProvider` per component type. This demo registers two to show that several
 tenant-scoped types coexist and are each matched to a handler parameter by its own type:
 
 * `CourseStatsRepository`, a per-tenant read model of enrolment counts.
@@ -33,18 +33,35 @@ feature.
 
 ## How the demo is built
 
+Start with `MultiTenancyApplication`: its `runLifecycle` reads top to bottom as the story the demo
+tells. The `university` package is the feature being multi-tenanted.
+
+Everything in `scaffolding` is exactly that: scaffolding. Like the temporary structure builders put
+up around a building, it is not the thing being built. It is the supporting machinery that runs and
+shows the demo (providing the tenants, publishing enrolments, rendering each tenant's view, reading
+the toggle, capturing the outcome), kept out of the way so `MultiTenancyApplication` and `university`
+stay the focus of this demo.
+
 ```
 org.axonframework.examples.demo.multitenancy
-+- MultiTenancyApplication          bootstrap that publishes events and prints each tenant's view
-+- DemoTenantProvider               supplies the tenants (in memory, standing in for Axon Server)
-+- university
-   +- UniversityModuleConfiguration registers the providers and the projection
-   +- events                        StudentEnrolledInCourse
-   +- audit                         AuditLog + InMemoryAuditLog (a second per-tenant component)
-   +- read/coursestats              the read side
-      +- CourseStatsRepository      the per-tenant component (AutoCloseable)
-      +- InMemoryCourseStatsRepository
-      +- CourseStatsProjection      the @EventHandler that gets both components injected
++- MultiTenancyApplication          the lesson: walks the tenant lifecycle top to bottom
++- university                       the feature being multi-tenanted
+|  +- UniversityModuleConfiguration registers the providers and the projection
+|  +- events                        StudentEnrolledInCourse
+|  +- audit                         AuditLog + InMemoryAuditLog (a second per-tenant component)
+|  +- read/coursestats              the read side
+|     +- CourseStatsRepository      the per-tenant component (AutoCloseable)
+|     +- InMemoryCourseStatsRepository
+|     +- CourseStatsProjection      the @EventHandler that gets both components injected
++- scaffolding                      demo plumbing, not the lesson
+   +- TenantProvisioning            how a run provisions tenants: the only difference between the two runs
+   +- DemoTenantProvider            supplies the tenants in memory (the default run)
+   +- AxonServerTenantContexts      creates and deletes tenant contexts (the Axon Server run)
+   +- Enrolments                    publishes enrolment events and reads them back
+   +- TenantView                    renders one tenant's isolated view
+   +- ProviderAmbiguityGuardrail    the configuration-time guardrail
+   +- ConfigurationProperties       reads the axon.server.enabled toggle
+   +- DemoOutcome                   what a run observed, asserted by the smoke test
 ```
 
 `MultiTenancyApplication` enrols students by publishing `StudentEnrolledInCourse` events that carry their
@@ -59,7 +76,8 @@ From this module's directory:
 mvn compile exec:java
 ```
 
-Or run `MultiTenancyApplication#main` from your IDE.
+Or run `MultiTenancyApplication#main` from your IDE. By default, this runs the in-memory version. See
+[Against Axon Server](#against-axon-server) to run the same lifecycle against Axon Server.
 
 ## What to look for
 
@@ -72,7 +90,7 @@ The run walks the whole tenant lifecycle and both guardrails, and the log shows 
 * **Runtime tenants.** Ogdenville is added while running and its instances appear on its first event.
 * **Unknown tenant rejected.** An enrolment for a tenant the application does not know fails with a
   `TenantNotResolvedException`, so no instance is ever built for it.
-* **Ambiguity rejected.** Registering two providers for one component type is refused, because the
+* **Ambiguity rejected.** Registering two providers for one component type is refused because the
   framework cannot know which instance a parameter of that type should receive.
 * **Cleanup.** Removing a tenant closes its instances, and shutting down closes the rest. The
   `logback.xml` raises `io.axoniq.framework.messaging.multitenancy` to `DEBUG`, so the subscription
@@ -80,6 +98,41 @@ The run walks the whole tenant lifecycle and both guardrails, and the log shows 
 
 ## Against Axon Server
 
-In production each tenant is a real Axon Server context that the `AxonServerTenantProvider`
-discovers, and enrolments arrive as routed messages instead of being published directly. That path
-builds on per-tenant message routing and lands as this branch grows.
+1. Place a licensed Axon Server's license file next to this README as `axon-server.license`
+   (see [Requirements](#requirements) below). The `docker-compose.yaml` already mounts it.
+2. `docker compose up -d` in this module's directory.
+3. Flip `axon.server.enabled` to `true` in `src/main/resources/application.properties`.
+4. Re-run `MultiTenancyApplication#main` (or run `runWithAxonServer` directly).
+
+Each tenant is then a real Axon Server context that the `AxonServerTenantProvider` sources, rather
+than an entry in the in-memory `DemoTenantProvider`. The dashboard at <http://localhost:8024> shows
+the tenant contexts appear and disappear as the run adds and removes them.
+
+The feature this demonstrates is where the tenants come from: the `AxonServerTenantProvider` treats
+each configured context as a tenant, and the framework injects each context's per-tenant components
+into the projection. Enrolments still flow through the same `SimpleEventBus` carrying their tenant in
+metadata, so isolation, replay, the guardrails, and cleanup all behave exactly as in the in-memory
+run. Per-tenant routing of the events themselves through Axon Server lands with later work on this
+feature.
+
+What the run does differently:
+
+* **Predefined tenants.** `springfield` and `shelbyville` are passed to the provider as predefined
+  contexts and created in Axon Server before it starts.
+* **Runtime tenant.** `ogdenville` is added by creating its context through the Admin API and
+  registering it on the provider, so its instances appear on its first event.
+* **Tenant removal.** Removing `shelbyville` deregisters it and deletes its context.
+
+### Requirements
+
+Each tenant is its own context, and multiple contexts are an Enterprise Edition feature that needs a
+licensed Axon Server. The `docker-compose.yaml` here uses the Enterprise Edition image, which without
+a license runs a trial in standalone mode. That trial lets the server run, but it cannot create the
+per-tenant contexts this run provisions (it rejects them with `AXONIQ-1700 Maximum number of contexts
+reached`).
+
+To run this path, provide a license: place your license file next to this README as
+`axon-server.license` (it is git-ignored). The `docker-compose.yaml` mounts that file into the
+container, so `docker compose up -d` fails if it is missing.
+
+Without a license, the demo still runs fully in memory, which is the default.

--- a/examples/university-multi-tenancy/README.md
+++ b/examples/university-multi-tenancy/README.md
@@ -1,0 +1,85 @@
+# Axon Framework 5 - Multi-Tenancy Demo
+
+Tenant-aware components in Axoniq Framework 5.3.
+
+A SaaS platform hosts several universities. Each is its own tenant, and their data must never
+mix. The feature this demo teaches lets you register a tenant-scoped component once and have the
+framework hand each message handler the instance belonging to the tenant of the message it is
+handling. A handler never resolves a tenant itself.
+
+## The idea
+
+A tenant-aware component is described by two types you write: the component itself, and a
+`TenantComponentFactory` saying how to build it for one tenant. You register a
+`TenantComponentProvider` per component type. This demo registers two, to show that several
+tenant-scoped types coexist and are each matched to a handler parameter by its own type:
+
+* `CourseStatsRepository`, a per-tenant read model of enrolment counts.
+* `AuditLog`, a per-tenant audit trail.
+
+A handler simply declares the types it needs, and each is injected for the message's tenant:
+
+```java
+@EventHandler
+public void on(StudentEnrolledInCourse event, CourseStatsRepository statistics, AuditLog auditLog) {
+    statistics.recordEnrolment(event.courseId());       // the current tenant's repository
+    auditLog.record("enrolled " + event.studentId());   // the current tenant's audit log
+}
+```
+
+`UniversityModuleConfiguration` does the wiring: it registers one provider per type and the
+projection as an ordinary subscribing event handler. That is the entire configuration for the
+feature.
+
+## How the demo is built
+
+```
+org.axonframework.examples.demo.multitenancy
++- MultiTenancyApplication          bootstrap that publishes events and prints each tenant's view
++- DemoTenantProvider               supplies the tenants (in memory, standing in for Axon Server)
++- university
+   +- UniversityModuleConfiguration registers the providers and the projection
+   +- events                        StudentEnrolledInCourse
+   +- audit                         AuditLog + InMemoryAuditLog (a second per-tenant component)
+   +- read/coursestats              the read side
+      +- CourseStatsRepository      the per-tenant component (AutoCloseable)
+      +- InMemoryCourseStatsRepository
+      +- CourseStatsProjection      the @EventHandler that gets both components injected
+```
+
+`MultiTenancyApplication` enrols students by publishing `StudentEnrolledInCourse` events that carry their
+tenant. The framework routes each event to the projection with the right tenant's instances
+injected, exactly as it would in production.
+
+## Running
+
+From this module's directory:
+
+```
+mvn compile exec:java
+```
+
+Or run `MultiTenancyApplication#main` from your IDE.
+
+## What to look for
+
+The run walks the whole tenant lifecycle and both guardrails, and the log shows each step:
+
+* **Multiple component types.** Every tenant view prints both an enrolment count and an audit-entry
+  count, so both providers are injected, each matched by type.
+* **Isolation.** Springfield, Shelbyville, and Ogdenville each see only their own enrolments.
+* **Replay on startup.** The provider already knows the tenants before the first event.
+* **Runtime tenants.** Ogdenville is added while running and its instances appear on its first event.
+* **Unknown tenant rejected.** An enrolment for a tenant the application does not know fails with a
+  `TenantNotResolvedException`, so no instance is ever built for it.
+* **Ambiguity rejected.** Registering two providers for one component type is refused, because the
+  framework cannot know which instance a parameter of that type should receive.
+* **Cleanup.** Removing a tenant closes its instances, and shutting down closes the rest. The
+  `logback.xml` raises `io.axoniq.framework.messaging.multitenancy` to `DEBUG`, so the subscription
+  and per-tenant creation and destruction are visible.
+
+## Against Axon Server
+
+In production each tenant is a real Axon Server context that the `AxonServerTenantProvider`
+discovers, and enrolments arrive as routed messages instead of being published directly. That path
+builds on per-tenant message routing and lands as this branch grows.

--- a/examples/university-multi-tenancy/docker-compose.yaml
+++ b/examples/university-multi-tenancy/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  axon-server:
+    # Enterprise Edition image: one context per tenant is an Enterprise Edition feature. It needs a
+    # license (see the README): without one, the server runs a trial that cannot create extra contexts.
+    image: docker.axoniq.io/axoniq/axonserver:2026.0.0
+    hostname: axon-server
+    ports:
+      - "8024:8024"
+      - "8124:8124"
+    environment:
+      AXONIQ_AXONSERVER_HOSTNAME: axon-server
+      AXONIQ_AXONSERVER_DEVMODE_ENABLED: true
+      # Auto-create the built-in _admin and default (DCB) contexts on the first boot, so no manual cluster
+      # initialization is needed. Creating the per-tenant contexts still requires the license below.
+      AXONIQ_AXONSERVER_STANDALONE_DCB: true
+    volumes:
+      - data:/axonserver/data
+      - events:/axonserver/events
+      # Provide a license in the file `axon-server.license` to create the per-tenant contexts: drop your license file in the same directory as this file
+      - ./axon-server.license:/axonserver/config/axoniq.license:ro
+
+volumes:
+  data:
+    driver: local
+  events:
+    driver: local

--- a/examples/university-multi-tenancy/pom.xml
+++ b/examples/university-multi-tenancy/pom.xml
@@ -85,12 +85,10 @@
             <artifactId>axon-server-connector</artifactId>
         </dependency>
 
-        <!-- The feature under demonstration. Pinned explicitly, as it is not yet managed by the
-             axoniq-framework BOM. Drop the version once the BOM manages it. -->
+        <!-- The feature under demonstration, managed by the axoniq-framework BOM imported above. -->
         <dependency>
             <groupId>io.axoniq.framework</groupId>
             <artifactId>axoniq-multi-tenancy</artifactId>
-            <version>${axoniq-framework.version}</version>
         </dependency>
 
         <!-- Logging Dependencies -->

--- a/examples/university-multi-tenancy/pom.xml
+++ b/examples/university-multi-tenancy/pom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.axonframework.examples</groupId>
+        <artifactId>axon-framework-examples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>university-multi-tenancy</artifactId>
+    <name>Axon Example - Java - University Multi-Tenancy</name>
+    <description>
+        Demonstrates the Axoniq Framework 5.3 tenant-aware components feature: a per-tenant
+        component is registered once and the correct tenant's instance is provided to message
+        handling, with the full tenant lifecycle of replay, runtime add, remove, and cleanup.
+    </description>
+
+    <properties>
+        <!--
+        Tenant-aware components (TenantComponentProvider) ship in the 5.3.0 line, which is not
+        released yet, so this demo resolves against 5.3.0-SNAPSHOT rather than the released BOM
+        the examples parent manages.
+        -->
+        <axoniq-framework.version>5.3.0-SNAPSHOT</axoniq-framework.version>
+
+        <!-- Runtime libraries -->
+        <awaitility.version>4.3.0</awaitility.version>
+        <logback.version>1.5.38</logback.version>
+
+        <!-- Test libraries -->
+        <assertj.version>3.27.7</assertj.version>
+        <junit.version>6.1.1</junit.version>
+
+        <!-- Build plugins -->
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Align every Axon module on ${axoniq-framework.version}, overriding the older line
+                 managed by the examples parent. -->
+            <dependency>
+                <groupId>io.axoniq.framework</groupId>
+                <artifactId>axoniq-framework-bom</artifactId>
+                <version>${axoniq-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Axon Framework Dependencies -->
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-eventsourcing</artifactId>
+        </dependency>
+
+        <!-- Axon Server connector, the backing TenantProvider discovers one context per tenant. -->
+        <dependency>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axon-server-connector</artifactId>
+        </dependency>
+
+        <!-- The feature under demonstration. Pinned explicitly, as it is not yet managed by the
+             axoniq-framework BOM. Drop the version once the BOM manages it. -->
+        <dependency>
+            <groupId>io.axoniq.framework</groupId>
+            <artifactId>axoniq-multi-tenancy</artifactId>
+            <version>${axoniq-framework.version}</version>
+        </dependency>
+
+        <!-- Logging Dependencies -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Used by the bootstrap to await tenant lifecycle transitions before printing. -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Daxon.axonserver.suppressDownloadMessage=true</argLine>
+                </configuration>
+            </plugin>
+            <!-- Lets users boot the demo with `mvn exec:java` without naming the main class. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <configuration>
+                    <mainClass>org.axonframework.examples.demo.multitenancy.MultiTenancyApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/ConfigurationProperties.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/ConfigurationProperties.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Runtime configuration toggles for the demo, loaded from {@code application.properties}.
+ *
+ * @param axonServerEnabled whether the demo should drive tenants from Axon Server contexts rather
+ *                          than the bundled in-memory tenant provider
+ */
+public record ConfigurationProperties(boolean axonServerEnabled) {
+
+    /**
+     * Loads the properties from the {@code application.properties} classpath resource, defaulting to
+     * the in-memory setup when the resource or a property is absent.
+     *
+     * @return the loaded configuration properties
+     */
+    public static ConfigurationProperties load() {
+        Properties properties = new Properties();
+        try (InputStream stream = ConfigurationProperties.class.getResourceAsStream("/application.properties")) {
+            if (stream != null) {
+                properties.load(stream);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not load application.properties", e);
+        }
+        return new ConfigurationProperties(
+                Boolean.parseBoolean(properties.getProperty("axon.server.enabled", "false"))
+        );
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/DemoTenantProvider.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/DemoTenantProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import io.axoniq.framework.messaging.multitenancy.api.MultiTenantAwareComponent;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import org.axonframework.common.Registration;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+
+/**
+ * In-memory {@link TenantProvider} for the demo, standing in for the Axon Server backed provider
+ * that discovers one context per tenant.
+ * <p>
+ * It mirrors the subscribe-and-replay semantics of the real provider: tenants known at subscription
+ * time are replayed to a newly subscribed component, and tenants added or removed afterward reach
+ * every subscribed component through its registration hooks. Cancelling a subscription cancels every
+ * tenant registration made on the component's behalf, releasing that component's per-tenant resources.
+ */
+public class DemoTenantProvider implements TenantProvider {
+
+    private final List<TenantDescriptor> tenantDescriptors = new CopyOnWriteArrayList<>();
+    private final List<MultiTenantAwareComponent> subscribedComponents = new CopyOnWriteArrayList<>();
+    // One entry per tenant-component pair, so cancellation can select by either dimension.
+    private final List<TenantRegistration> registrations = new CopyOnWriteArrayList<>();
+
+    /**
+     * Constructs a provider knowing the given {@code initialTenants} from the start.
+     *
+     * @param initialTenants the tenants known before any component subscribes
+     */
+    public DemoTenantProvider(TenantDescriptor... initialTenants) {
+        this.tenantDescriptors.addAll(List.of(initialTenants));
+    }
+
+    @Override
+    public synchronized Registration subscribe(MultiTenantAwareComponent component) {
+        subscribedComponents.add(component);
+        tenantDescriptors.forEach(tenant -> registrations.add(new TenantRegistration(
+                tenant, component, component.registerTenant(tenant)
+        )));
+        return () -> {
+            subscribedComponents.remove(component);
+            cancelRegistrationsMatching(registration -> registration.component() == component);
+            return true;
+        };
+    }
+
+    @Override
+    public List<TenantDescriptor> tenants() {
+        return List.copyOf(tenantDescriptors);
+    }
+
+    /**
+     * Adds a tenant at runtime, registering and starting it on every subscribed component.
+     *
+     * @param tenant the tenant to add
+     */
+    public synchronized void addTenant(TenantDescriptor tenant) {
+        if (tenantDescriptors.contains(tenant)) {
+            return;
+        }
+        tenantDescriptors.add(tenant);
+        subscribedComponents.forEach(component -> registrations.add(new TenantRegistration(
+                tenant, component, component.registerAndStartTenant(tenant)
+        )));
+    }
+
+    /**
+     * Removes a tenant, cancelling its registration on every subscribed component so their
+     * per-tenant instances are destroyed.
+     *
+     * @param tenant the tenant to remove
+     */
+    public synchronized void removeTenant(TenantDescriptor tenant) {
+        if (tenantDescriptors.remove(tenant)) {
+            cancelRegistrationsMatching(registration -> registration.tenant().equals(tenant));
+        }
+    }
+
+    private synchronized void cancelRegistrationsMatching(Predicate<TenantRegistration> criterion) {
+        List<TenantRegistration> matching = registrations.stream().filter(criterion).toList();
+        registrations.removeAll(matching);
+        matching.reversed().forEach(registration -> registration.registration().cancel());
+    }
+
+    private record TenantRegistration(TenantDescriptor tenant,
+                                      MultiTenantAwareComponent component,
+                                      Registration registration) {
+
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
@@ -16,51 +16,60 @@
 
 package org.axonframework.examples.demo.multitenancy;
 
-import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
-import io.axoniq.framework.messaging.multitenancy.api.MetadataBasedTenantResolver;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
-import io.axoniq.framework.messaging.multitenancy.api.TenantNotResolvedException;
-import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
 import org.awaitility.Awaitility;
-import org.axonframework.common.AxonConfigurationException;
+import org.awaitility.core.ConditionTimeoutException;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.scaffolding.ConfigurationProperties;
+import org.axonframework.examples.demo.multitenancy.scaffolding.DemoOutcome;
+import org.axonframework.examples.demo.multitenancy.scaffolding.DemoTenantProvider;
+import org.axonframework.examples.demo.multitenancy.scaffolding.Enrolments;
+import org.axonframework.examples.demo.multitenancy.scaffolding.ProviderAmbiguityGuardrail;
+import org.axonframework.examples.demo.multitenancy.scaffolding.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.scaffolding.TenantView;
 import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
-import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
-import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatistics;
 import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
-import org.axonframework.messaging.core.MessageType;
-import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.configuration.MessagingConfigurer;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.EventSink;
 import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 
 /**
  * Bootstraps the multi-tenancy demo.
  * <p>
- * A SaaS platform hosts several universities, each an isolated tenant. Two per-tenant components
- * are registered once (a {@link CourseStatsRepository} and an {@link AuditLog}), and enrolments are
- * published as events. The framework routes each event to the {@link CourseStatsProjection} with
- * both of the event's tenant instances injected, each matched by type, so no handler ever resolves
- * a tenant itself. This bootstrap walks the whole tenant lifecycle in one run and also shows the
- * two guardrails: an unknown tenant is rejected, and registering two providers for one type is
- * rejected at configuration time.
+ * A platform hosts several universities, each an isolated tenant. The feature this demonstrates
+ * is that a per-tenant component is registered once and the framework hands each message handler the
+ * instance belonging to the tenant of the message it is handling, so no handler ever resolves a tenant
+ * itself. Here two such parts are registered (a {@link CourseStatsRepository} and an
+ * {@link AuditLog}), enrolments are published as events carrying their tenant in metadata, and the
+ * framework routes each event to the {@link CourseStatsProjection} with both of that tenant's instances
+ * injected, matched by type.
  * <p>
- * The demo runs entirely in memory. The Axon Server backed path, where each tenant is a real
- * context and enrolments arrive as routed messages, arrives with the command routing this demo
- * will grow into.
+ * {@link #runLifecycle} reads top to bottom as the story the demo tells: tenants known at startup,
+ * a tenant added at runtime, an unknown tenant rejected, a tenant removed, and shutdown. The
+ * supporting cast lives in small classes next to this one, so this file stays the lesson:
+ * <ul>
+ *     <li>{@link TenantProvisioning} is where the tenants come from, and the only thing that differs between
+ *     the two runs.</li>
+ *     <li>{@link Enrolments} publishes the enrolment events and reads them back.</li>
+ *     <li>{@link TenantView} renders one tenant's isolated view.</li>
+ *     <li>{@link ProviderAmbiguityGuardrail} demonstrates the configuration-time guardrail.</li>
+ * </ul>
+ * <p>
+ * The same lifecycle runs two ways, selected by the {@code axon.server.enabled} toggle: in memory by
+ * default (tenants from a {@link DemoTenantProvider}), or against Axon Server (tenants are real
+ * contexts the {@link AxonServerTenantProvider} sources). Either way the enrolments flow through the
+ * same {@link SimpleEventBus}, so only the {@link TenantProvisioning} changes.
  */
 public class MultiTenancyApplication {
 
@@ -71,65 +80,125 @@ public class MultiTenancyApplication {
     private static final TenantDescriptor OGDENVILLE = TenantDescriptor.tenantWithId("ogdenville");
     private static final TenantDescriptor UNKNOWN = TenantDescriptor.tenantWithId("atlantis");
 
+    // The tenants known before the application starts.
+    private static final List<TenantDescriptor> KNOWN_TENANTS = List.of(SPRINGFIELD, SHELBYVILLE);
+    // On the Axon Server run these are the predefined context names the AxonServerTenantProvider uses.
+    private static final String PREDEFINED_CONTEXTS = String.join(",", SPRINGFIELD.tenantId(), SHELBYVILLE.tenantId());
+
     private static final String COURSE_CS_101 = "cs-101";
     private static final String COURSE_LAW_200 = "law-200";
 
     /**
-     * Entry point running the in-memory demo end to end.
+     * Entry point running the demo end to end, in memory by default or against Axon Server when the
+     * {@code axon.server.enabled} property is set.
      *
      * @param args ignored
      */
     public static void main(String[] args) {
-        ConfigurationProperties props = ConfigurationProperties.load();
-        if (props.axonServerEnabled()) {
-            logger.info("Axon Server mode is not wired on this branch yet. Running the in-memory demo instead.");
-        }
-        new MultiTenancyApplication().run();
+        ConfigurationProperties properties = ConfigurationProperties.load();
+        MultiTenancyApplication demo = new MultiTenancyApplication();
+        DemoOutcome outcome = properties.axonServerEnabled() ? demo.runWithAxonServer() : demo.run();
+        logger.info("Demo finished. Outcome: {}", outcome);
     }
 
     /**
-     * Runs the in-memory demo end to end and returns what it observed, so callers (and the smoke
-     * test) can assert the outcome through the same path a user runs. Reads as the sequence of steps
-     * the demo performs; each step is a method below.
+     * Runs the in-memory demo end to end, with the tenants supplied by an in-memory
+     * {@link DemoTenantProvider}, and returns what it observed so the smoke test can assert the outcome
+     * through the same entry point a user runs.
      *
      * @return the observed outcome of the demo run
      */
     public DemoOutcome run() {
-        boolean ambiguousProvidersRejected = demonstrateAmbiguousProvidersRejected();
-
         SimpleEventBus eventBus = new SimpleEventBus();
         DemoTenantProvider tenantProvider = new DemoTenantProvider(SPRINGFIELD, SHELBYVILLE);
         TenantComponentProvider<CourseStatsRepository> statsProvider = UniversityModuleConfiguration.courseStatsProvider();
         TenantComponentProvider<AuditLog> auditProvider = UniversityModuleConfiguration.auditLogProvider();
-        AxonConfiguration configuration = startConfiguration(eventBus, tenantProvider, statsProvider, auditProvider);
+
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        UniversityModuleConfiguration.configure(configurer, eventBus, tenantProvider, statsProvider, auditProvider);
+        AxonConfiguration configuration = configurer.build();
+
+        return runLifecycle(eventBus, configuration, statsProvider, auditProvider,
+                            config -> TenantProvisioning.inMemory(tenantProvider));
+    }
+
+    /**
+     * Runs the demo end to end against Axon Server, sourcing the tenants from Axon Server contexts
+     * rather than from an in-memory provider. The lifecycle is identical to {@link #run()}. Only the
+     * {@link TenantProvisioning} differs. This path needs a running multi-context (Enterprise Edition) Axon
+     * Server, reachable on its default {@code localhost} address.
+     *
+     * @return the observed outcome of the demo run
+     */
+    public DemoOutcome runWithAxonServer() {
+        SimpleEventBus eventBus = new SimpleEventBus();
+        TenantComponentProvider<CourseStatsRepository> statsProvider = UniversityModuleConfiguration.courseStatsProvider();
+        TenantComponentProvider<AuditLog> auditProvider = UniversityModuleConfiguration.auditLogProvider();
+
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        UniversityModuleConfiguration.configureForAxonServer(configurer, eventBus, PREDEFINED_CONTEXTS,
+                                                             statsProvider, auditProvider);
+        AxonConfiguration configuration = configurer.build();
+
+        return runLifecycle(eventBus, configuration, statsProvider, auditProvider,
+                            config -> TenantProvisioning.axonServer(config, KNOWN_TENANTS));
+    }
+
+    /**
+     * Starts the given {@code configuration} and walks the whole tenant lifecycle, returning what it
+     * observed. This is the story both runs share. Only the {@code provisioning} differs. The per-tenant
+     * components it reads are {@link AutoCloseable}, but the framework closes them on tenant removal and
+     * shutdown, so this only reads their state.
+     *
+     * @param eventSink      the sink enrolments are published on
+     * @param configuration  the built, not-yet-started configuration to run
+     * @param statsProvider  the provider of the per-tenant course-statistics repositories
+     * @param auditProvider  the provider of the per-tenant audit logs
+     * @param provisioningFactory builds the tenant provisioning for this run once the configuration is
+     *                       started (the Axon Server provisioning resolves its components from it)
+     * @return the observed outcome of the demo run
+     */
+    private DemoOutcome runLifecycle(EventSink eventSink,
+                                     AxonConfiguration configuration,
+                                     TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                     TenantComponentProvider<AuditLog> auditProvider,
+                                     Function<AxonConfiguration, TenantProvisioning> provisioningFactory) {
+        // Guardrail, shown up front and independent of the run: two providers for one component type
+        // are rejected at configuration time.
+        boolean ambiguousProvidersRejected = ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType();
+
+        configuration.start();
+        TenantProvisioning provisioning = provisioningFactory.apply(configuration);
 
         boolean shutDown = false;
         try {
-            logReplayedTenants(statsProvider);
+            provisioning.prepareKnownTenants();
+            logger.info("Providers subscribed at startup. Known tenants: {}", tenantIds(statsProvider));
 
-            enrolStudents(eventBus, statsProvider);
-            printTenantView("Springfield University", statsProvider, auditProvider, SPRINGFIELD);
-            printTenantView("Shelbyville University", statsProvider, auditProvider, SHELBYVILLE);
+            // 1. Enrol students in the tenants known at startup and show each tenant sees only its own.
+            enrolStudents(eventSink, statsProvider);
+            logTenantView("Springfield University", statsProvider, auditProvider, SPRINGFIELD);
+            logTenantView("Shelbyville University", statsProvider, auditProvider, SHELBYVILLE);
 
-            enrolInTenantAddedAtRuntime(eventBus, tenantProvider, statsProvider);
-            printTenantView("Ogdenville University (added at runtime)", statsProvider, auditProvider, OGDENVILLE);
+            // 2. Add a tenant at runtime. Its instances materialize on its first event, no config change.
+            provisioning.addTenant(OGDENVILLE);
+            Enrolments.enrol(eventSink, OGDENVILLE, COURSE_CS_101, "dan");
+            Enrolments.awaitEnrolments(statsProvider, OGDENVILLE, 1);
+            logTenantView("Ogdenville University (added at runtime)", statsProvider, auditProvider, OGDENVILLE);
 
-            boolean unknownTenantRejected = unknownTenantIsRejected(eventBus);
+            // 3. An enrolment for a tenant the application does not know is rejected.
+            boolean unknownTenantRejected = unknownTenantIsRejected(eventSink);
+
+            // 4. Removing a tenant closes its per-tenant instances.
             boolean shelbyvilleClosedOnRemoval =
-                    removingTenantClosesItsInstances(tenantProvider, statsProvider, auditProvider, SHELBYVILLE);
+                    removingTenantClosesItsInstances(provisioning, statsProvider, auditProvider);
 
-            int springfieldEnrolments = totalEnrolments(statsProvider.componentFor(SPRINGFIELD));
-            int springfieldAuditEntries = auditProvider.componentFor(SPRINGFIELD).entries().size();
-            boolean allClosedOnShutdown =
-                    shutdownClosesRemainingInstances(configuration, statsProvider, SPRINGFIELD, OGDENVILLE);
+            // 5. Shutting down closes every remaining tenant's instances. Capture the outcome and stop.
+            DemoOutcome outcome = shutDownAndBuildOutcome(configuration, statsProvider, auditProvider,
+                                                          unknownTenantRejected, ambiguousProvidersRejected,
+                                                          shelbyvilleClosedOnRemoval);
             shutDown = true;
-
-            return new DemoOutcome(springfieldEnrolments,
-                                   springfieldAuditEntries,
-                                   unknownTenantRejected,
-                                   ambiguousProvidersRejected,
-                                   shelbyvilleClosedOnRemoval,
-                                   allClosedOnShutdown);
+            return outcome;
         } finally {
             if (!shutDown) {
                 configuration.shutdown();
@@ -137,219 +206,120 @@ public class MultiTenancyApplication {
         }
     }
 
-    private static AxonConfiguration startConfiguration(SimpleEventBus eventBus,
-                                                        DemoTenantProvider tenantProvider,
-                                                        TenantComponentProvider<CourseStatsRepository> statsProvider,
-                                                        TenantComponentProvider<AuditLog> auditProvider) {
-        MessagingConfigurer configurer = MessagingConfigurer.create();
-        UniversityModuleConfiguration.configure(configurer, eventBus, tenantProvider, statsProvider, auditProvider);
-        AxonConfiguration configuration = configurer.build();
-        configuration.start();
-        return configuration;
-    }
-
-    private static void logReplayedTenants(TenantComponentProvider<CourseStatsRepository> statsProvider) {
-        logger.info("Providers subscribed at startup. Tenants replayed to the provider: {}",
-                    tenantIds(statsProvider.tenants()));
-    }
-
     /**
-     * Enrols students in the tenants known at startup. Each event is routed to the projection with
-     * both the tenant's {@link CourseStatsRepository} and its {@link AuditLog} injected, matched by
-     * parameter type.
+     * Enrols students in the tenants known at startup. Each event is routed to the projection with both
+     * the tenant's {@link CourseStatsRepository} and its {@link AuditLog} injected, matched by type.
      */
-    private static void enrolStudents(SimpleEventBus eventBus,
+    private static void enrolStudents(EventSink eventSink,
                                       TenantComponentProvider<CourseStatsRepository> statsProvider) {
-        enrol(eventBus, SPRINGFIELD, COURSE_CS_101, "alice");
-        enrol(eventBus, SPRINGFIELD, COURSE_CS_101, "bob");
-        enrol(eventBus, SHELBYVILLE, COURSE_LAW_200, "carol");
-        awaitEnrolments(statsProvider, SPRINGFIELD, 2);
-        awaitEnrolments(statsProvider, SHELBYVILLE, 1);
+        Enrolments.enrol(eventSink, SPRINGFIELD, COURSE_CS_101, "alice");
+        Enrolments.enrol(eventSink, SPRINGFIELD, COURSE_CS_101, "bob");
+        Enrolments.enrol(eventSink, SHELBYVILLE, COURSE_LAW_200, "carol");
+        Enrolments.awaitEnrolments(statsProvider, SPRINGFIELD, 2);
+        Enrolments.awaitEnrolments(statsProvider, SHELBYVILLE, 1);
     }
 
     /**
-     * Adds a tenant at runtime and enrols a student in it, showing that its instances materialize on
-     * the first event without any configuration change.
+     * Logs the given tenant's isolated view. Guarded on the log level, so the view (which walks the
+     * tenant's components) is only rendered when info logging is on.
      */
-    private static void enrolInTenantAddedAtRuntime(SimpleEventBus eventBus,
-                                                    DemoTenantProvider tenantProvider,
-                                                    TenantComponentProvider<CourseStatsRepository> statsProvider) {
-        tenantProvider.addTenant(OGDENVILLE);
-        enrol(eventBus, OGDENVILLE, COURSE_CS_101, "dan");
-        awaitEnrolments(statsProvider, OGDENVILLE, 1);
+    private static void logTenantView(String label,
+                                      TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                      TenantComponentProvider<AuditLog> auditProvider,
+                                      TenantDescriptor tenant) {
+        if (logger.isInfoEnabled()) {
+            logger.info("{}", TenantView.render(label, statsProvider, auditProvider, tenant));
+        }
     }
 
     /**
-     * Publishes an enrolment for a tenant the application does not know, and confirms it is rejected
-     * with a {@link TenantNotResolvedException} so that no instance is ever built for it.
+     * Publishes an enrolment for a tenant the application does not know and confirms it is rejected, so
+     * that no instance is ever built for it.
      */
-    private static boolean unknownTenantIsRejected(SimpleEventBus eventBus) {
-        boolean rejected = enrolExpectingRejection(eventBus, UNKNOWN, COURSE_CS_101, "eve");
-        logger.info("Enrolment for an unknown tenant rejected with TenantNotResolvedException: {}", rejected);
+    private static boolean unknownTenantIsRejected(EventSink eventSink) {
+        boolean rejected;
+        try {
+            Enrolments.enrol(eventSink, UNKNOWN, COURSE_CS_101, "eve");
+            rejected = false;
+        } catch (RuntimeException e) {
+            rejected = Enrolments.causedByTenantNotResolved(e);
+        }
+        logger.info("Enrolment for an unknown tenant rejected: {}", rejected);
         return rejected;
     }
 
     /**
-     * Removes a tenant and confirms both of its {@link AutoCloseable} instances were closed.
+     * Removes Shelbyville through the {@code provisioning} and confirms both of its instances were closed.
+     * The per-tenant components are {@link AutoCloseable} and closed by the framework on removal, so
+     * this reads their state before and after removing the tenant.
      */
-    private static boolean removingTenantClosesItsInstances(DemoTenantProvider tenantProvider,
+    // Holds the components to check isClosed() after removal. The framework, not this method, closes them.
+    private static boolean removingTenantClosesItsInstances(TenantProvisioning provisioning,
                                                             TenantComponentProvider<CourseStatsRepository> statsProvider,
-                                                            TenantComponentProvider<AuditLog> auditProvider,
-                                                            TenantDescriptor tenant) {
-        CourseStatsRepository statistics = statsProvider.componentFor(tenant);
-        AuditLog auditLog = auditProvider.componentFor(tenant);
-        tenantProvider.removeTenant(tenant);
+                                                            TenantComponentProvider<AuditLog> auditProvider) {
+        CourseStatsRepository statistics = statsProvider.componentFor(SHELBYVILLE);
+        AuditLog auditLog = auditProvider.componentFor(SHELBYVILLE);
+        provisioning.removeTenant(SHELBYVILLE);
         boolean closed = statistics.isClosed() && auditLog.isClosed();
-        logger.info("Tenant [{}] removed. Its instances are closed: {}", tenant.tenantId(), closed);
+        logger.info("Tenant [{}] removed. Its instances are closed: {}", SHELBYVILLE.tenantId(), closed);
         return closed;
     }
 
     /**
-     * Shuts the configuration down and confirms every still-registered tenant's instance was closed,
-     * as the cancelled provider subscriptions destroy them.
+     * Shuts the configuration down and gathers what the run observed into a {@link DemoOutcome}, reading
+     * Springfield's totals and confirming shutdown closed every still-registered tenant's instances (the
+     * canceled provider subscriptions destroy them).
      */
-    private static boolean shutdownClosesRemainingInstances(AxonConfiguration configuration,
-                                                            TenantComponentProvider<CourseStatsRepository> statsProvider,
-                                                            TenantDescriptor... tenants) {
-        List<CourseStatsRepository> repositories = Arrays.stream(tenants).map(statsProvider::componentFor).toList();
+    // Holds the components to check isClosed() after shutdown. The framework, not this method, closes them.
+    @SuppressWarnings("resource")
+    private static DemoOutcome shutDownAndBuildOutcome(AxonConfiguration configuration,
+                                                       TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                                       TenantComponentProvider<AuditLog> auditProvider,
+                                                       boolean unknownTenantRejected,
+                                                       boolean ambiguousProvidersRejected,
+                                                       boolean shelbyvilleClosedOnRemoval) {
+        int springfieldEnrolments = Enrolments.totalEnrolments(statsProvider.componentFor(SPRINGFIELD));
+        int springfieldAuditEntries = auditProvider.componentFor(SPRINGFIELD).entries().size();
+        int ogdenvilleEnrolments = Enrolments.totalEnrolments(statsProvider.componentFor(OGDENVILLE));
+
+        // Both components of every still-registered tenant should be closed once shutdown cancels the
+        // provider subscriptions.
+        List<CourseStatsRepository> repositories =
+                List.of(statsProvider.componentFor(SPRINGFIELD), statsProvider.componentFor(OGDENVILLE));
+        List<AuditLog> auditLogs =
+                List.of(auditProvider.componentFor(SPRINGFIELD), auditProvider.componentFor(OGDENVILLE));
         configuration.shutdown();
-        Awaitility.await("shutdown cleanup")
-                  .atMost(Duration.ofSeconds(5))
-                  .until(() -> repositories.stream().allMatch(CourseStatsRepository::isClosed));
-        boolean allClosed = repositories.stream().allMatch(CourseStatsRepository::isClosed);
-        logger.info("Shutdown complete. All remaining tenant instances closed: {}", allClosed);
-        return allClosed;
+        boolean allClosedOnShutdown = awaitClosed(() ->
+                repositories.stream().allMatch(CourseStatsRepository::isClosed)
+                        && auditLogs.stream().allMatch(AuditLog::isClosed));
+        logger.info("Shutdown complete. All remaining tenant instances closed: {}", allClosedOnShutdown);
+
+        return new DemoOutcome(springfieldEnrolments,
+                               springfieldAuditEntries,
+                               ogdenvilleEnrolments,
+                               unknownTenantRejected,
+                               ambiguousProvidersRejected,
+                               shelbyvilleClosedOnRemoval,
+                               allClosedOnShutdown);
     }
 
     /**
-     * Builds a throwaway configuration that registers two providers for the same component type and
-     * checks that resolving a handler parameter of that type is rejected, since the framework cannot
-     * know which instance to inject.
-     *
-     * @return {@code true} if the ambiguity was rejected with an {@link AxonConfigurationException}
+     * Waits until the given {@code closed} condition holds, returning whether it did within the timeout.
+     * Unlike a bare {@code await(...).until(...)}, this returns {@code false} on timeout rather than
+     * throwing, so the demo can report the cleanup outcome instead of failing opaquely.
      */
-    private boolean demonstrateAmbiguousProvidersRejected() {
-        DemoTenantProvider tenantProvider = new DemoTenantProvider(SPRINGFIELD);
-        MessagingConfigurer configurer = MessagingConfigurer.create();
-        configurer.componentRegistry(registry -> registry
-                .disableEnhancer(AxonServerConfigurationEnhancer.class)
-                .registerComponent(TenantProvider.class, config -> tenantProvider)
-                // Two providers for CourseStatsRepository make that handler parameter ambiguous.
-                .registerComponent(TenantComponentProvider.class, "courseStatsA",
-                                   config -> UniversityModuleConfiguration.courseStatsProvider())
-                .registerComponent(TenantComponentProvider.class, "courseStatsB",
-                                   config -> UniversityModuleConfiguration.courseStatsProvider()));
-        AxonConfiguration configuration = configurer.build();
-        configuration.start();
+    private static boolean awaitClosed(BooleanSupplier closed) {
         try {
-            // Ask the parameter resolver to match the CourseStatsRepository parameter, exactly as
-            // handler inspection does. With two providers of that type, it cannot choose one.
-            ParameterResolverFactory resolverFactory = configuration.getComponent(ParameterResolverFactory.class);
-            Method handler = CourseStatsProjection.class.getDeclaredMethod(
-                    "on", StudentEnrolledInCourse.class, CourseStatsRepository.class, AuditLog.class);
-            resolverFactory.createInstance(handler, handler.getParameters(), 1);
-            logger.warn("Expected ambiguous providers to be rejected, but resolution succeeded.");
-            return false;
-        } catch (AxonConfigurationException e) {
-            logger.info("Two providers for one component type rejected: {}", e.getMessage());
+            Awaitility.await("shutdown cleanup")
+                      .atMost(Duration.ofSeconds(5))
+                      .until(closed::getAsBoolean);
             return true;
-        } catch (NoSuchMethodException e) {
-            throw new IllegalStateException("Demo projection handler method not found.", e);
-        } finally {
-            configuration.shutdown();
-        }
-    }
-
-    private static void enrol(SimpleEventBus eventBus, TenantDescriptor tenant, String courseId, String studentId) {
-        // No active ProcessingContext: the event is published standalone, not from within a handler.
-        eventBus.publish(null, enrolmentEvent(tenant, courseId, studentId))
-                .orTimeout(5, TimeUnit.SECONDS)
-                .join();
-    }
-
-    private static boolean enrolExpectingRejection(SimpleEventBus eventBus,
-                                                   TenantDescriptor tenant,
-                                                   String courseId,
-                                                   String studentId) {
-        try {
-            // No active ProcessingContext: the event is published standalone, not from within a handler.
-            eventBus.publish(null, enrolmentEvent(tenant, courseId, studentId))
-                    .orTimeout(5, TimeUnit.SECONDS)
-                    .join();
+        } catch (ConditionTimeoutException e) {
             return false;
-        } catch (RuntimeException e) {
-            return causedByTenantNotResolved(e);
         }
     }
 
-    private static EventMessage enrolmentEvent(TenantDescriptor tenant, String courseId, String studentId) {
-        return new GenericEventMessage(new MessageType(StudentEnrolledInCourse.class),
-                                       new StudentEnrolledInCourse(courseId, studentId))
-                .andMetadata(Map.of(MetadataBasedTenantResolver.DEFAULT_TENANT_KEY, tenant.tenantId()));
-    }
-
-    private static void awaitEnrolments(TenantComponentProvider<CourseStatsRepository> provider,
-                                        TenantDescriptor tenant,
-                                        int expected) {
-        Awaitility.await("enrolments for " + tenant.tenantId())
-                  .atMost(Duration.ofSeconds(5))
-                  .until(() -> totalEnrolments(provider.componentFor(tenant)) >= expected);
-    }
-
-    /**
-     * What a demo run observed, used to assert the outcome from the demo's own entry point.
-     *
-     * @param springfieldEnrolments      the enrolments recorded in Springfield's course-statistics repository
-     * @param springfieldAuditEntries    the entries recorded in Springfield's audit log
-     * @param unknownTenantRejected      whether an event for an unknown tenant was rejected
-     * @param ambiguousProvidersRejected whether two providers for one type were rejected at configuration time
-     * @param shelbyvilleClosedOnRemoval whether Shelbyville's instances were closed when its tenant was removed
-     * @param allClosedOnShutdown        whether every remaining tenant's instances were closed on shutdown
-     */
-    public record DemoOutcome(int springfieldEnrolments,
-                              int springfieldAuditEntries,
-                              boolean unknownTenantRejected,
-                              boolean ambiguousProvidersRejected,
-                              boolean shelbyvilleClosedOnRemoval,
-                              boolean allClosedOnShutdown) {
-
-    }
-
-    private static void printTenantView(String label,
-                                        TenantComponentProvider<CourseStatsRepository> statsProvider,
-                                        TenantComponentProvider<AuditLog> auditProvider,
-                                        TenantDescriptor tenant) {
-        CourseStatsRepository statistics = statsProvider.componentFor(tenant);
-        AuditLog auditLog = auditProvider.componentFor(tenant);
-        StringBuilder report = new StringBuilder("\n").append(label).append(":\n");
-        List<CourseStatistics> statisticsPerCourse = statistics.statistics();
-        if (statisticsPerCourse.isEmpty()) {
-            report.append("  (no enrolments)\n");
-        } else {
-            statisticsPerCourse.forEach(statistic -> report.append("  - ")
-                                                           .append(statistic.courseId())
-                                                           .append(": ")
-                                                           .append(statistic.enrolments())
-                                                           .append(" enrolments\n"));
-        }
-        report.append("  audit entries: ").append(auditLog.entries().size()).append('\n');
-        logger.info("{}", report);
-    }
-
-    private static List<String> tenantIds(List<TenantDescriptor> tenants) {
-        return tenants.stream().map(TenantDescriptor::tenantId).toList();
-    }
-
-    private static int totalEnrolments(CourseStatsRepository repository) {
-        return repository.statistics().stream().mapToInt(CourseStatistics::enrolments).sum();
-    }
-
-    private static boolean causedByTenantNotResolved(Throwable throwable) {
-        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
-            if (cause instanceof TenantNotResolvedException) {
-                return true;
-            }
-        }
-        return false;
+    private static List<String> tenantIds(TenantComponentProvider<CourseStatsRepository> statsProvider) {
+        return statsProvider.tenants().stream().map(TenantDescriptor::tenantId).toList();
     }
 }

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
+import io.axoniq.framework.messaging.multitenancy.api.MetadataBasedTenantResolver;
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.api.TenantNotResolvedException;
+import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import org.awaitility.Awaitility;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
+import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatistics;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsProjection;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Bootstraps the multi-tenancy demo.
+ * <p>
+ * A SaaS platform hosts several universities, each an isolated tenant. Two per-tenant components
+ * are registered once (a {@link CourseStatsRepository} and an {@link AuditLog}), and enrolments are
+ * published as events. The framework routes each event to the {@link CourseStatsProjection} with
+ * both of the event's tenant instances injected, each matched by type, so no handler ever resolves
+ * a tenant itself. This bootstrap walks the whole tenant lifecycle in one run and also shows the
+ * two guardrails: an unknown tenant is rejected, and registering two providers for one type is
+ * rejected at configuration time.
+ * <p>
+ * The demo runs entirely in memory. The Axon Server backed path, where each tenant is a real
+ * context and enrolments arrive as routed messages, arrives with the command routing this demo
+ * will grow into.
+ */
+public class MultiTenancyApplication {
+
+    private static final Logger logger = LoggerFactory.getLogger(MultiTenancyApplication.class);
+
+    private static final TenantDescriptor SPRINGFIELD = TenantDescriptor.tenantWithId("springfield");
+    private static final TenantDescriptor SHELBYVILLE = TenantDescriptor.tenantWithId("shelbyville");
+    private static final TenantDescriptor OGDENVILLE = TenantDescriptor.tenantWithId("ogdenville");
+    private static final TenantDescriptor UNKNOWN = TenantDescriptor.tenantWithId("atlantis");
+
+    private static final String COURSE_CS_101 = "cs-101";
+    private static final String COURSE_LAW_200 = "law-200";
+
+    /**
+     * Entry point running the in-memory demo end to end.
+     *
+     * @param args ignored
+     */
+    public static void main(String[] args) {
+        ConfigurationProperties props = ConfigurationProperties.load();
+        if (props.axonServerEnabled()) {
+            logger.info("Axon Server mode is not wired on this branch yet. Running the in-memory demo instead.");
+        }
+        new MultiTenancyApplication().run();
+    }
+
+    /**
+     * Runs the in-memory demo end to end and returns what it observed, so callers (and the smoke
+     * test) can assert the outcome through the same path a user runs. Reads as the sequence of steps
+     * the demo performs; each step is a method below.
+     *
+     * @return the observed outcome of the demo run
+     */
+    public DemoOutcome run() {
+        boolean ambiguousProvidersRejected = demonstrateAmbiguousProvidersRejected();
+
+        SimpleEventBus eventBus = new SimpleEventBus();
+        DemoTenantProvider tenantProvider = new DemoTenantProvider(SPRINGFIELD, SHELBYVILLE);
+        TenantComponentProvider<CourseStatsRepository> statsProvider = UniversityModuleConfiguration.courseStatsProvider();
+        TenantComponentProvider<AuditLog> auditProvider = UniversityModuleConfiguration.auditLogProvider();
+        AxonConfiguration configuration = startConfiguration(eventBus, tenantProvider, statsProvider, auditProvider);
+
+        boolean shutDown = false;
+        try {
+            logReplayedTenants(statsProvider);
+
+            enrolStudents(eventBus, statsProvider);
+            printTenantView("Springfield University", statsProvider, auditProvider, SPRINGFIELD);
+            printTenantView("Shelbyville University", statsProvider, auditProvider, SHELBYVILLE);
+
+            enrolInTenantAddedAtRuntime(eventBus, tenantProvider, statsProvider);
+            printTenantView("Ogdenville University (added at runtime)", statsProvider, auditProvider, OGDENVILLE);
+
+            boolean unknownTenantRejected = unknownTenantIsRejected(eventBus);
+            boolean shelbyvilleClosedOnRemoval =
+                    removingTenantClosesItsInstances(tenantProvider, statsProvider, auditProvider, SHELBYVILLE);
+
+            int springfieldEnrolments = totalEnrolments(statsProvider.componentFor(SPRINGFIELD));
+            int springfieldAuditEntries = auditProvider.componentFor(SPRINGFIELD).entries().size();
+            boolean allClosedOnShutdown =
+                    shutdownClosesRemainingInstances(configuration, statsProvider, SPRINGFIELD, OGDENVILLE);
+            shutDown = true;
+
+            return new DemoOutcome(springfieldEnrolments,
+                                   springfieldAuditEntries,
+                                   unknownTenantRejected,
+                                   ambiguousProvidersRejected,
+                                   shelbyvilleClosedOnRemoval,
+                                   allClosedOnShutdown);
+        } finally {
+            if (!shutDown) {
+                configuration.shutdown();
+            }
+        }
+    }
+
+    private static AxonConfiguration startConfiguration(SimpleEventBus eventBus,
+                                                        DemoTenantProvider tenantProvider,
+                                                        TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                                        TenantComponentProvider<AuditLog> auditProvider) {
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        UniversityModuleConfiguration.configure(configurer, eventBus, tenantProvider, statsProvider, auditProvider);
+        AxonConfiguration configuration = configurer.build();
+        configuration.start();
+        return configuration;
+    }
+
+    private static void logReplayedTenants(TenantComponentProvider<CourseStatsRepository> statsProvider) {
+        logger.info("Providers subscribed at startup. Tenants replayed to the provider: {}",
+                    tenantIds(statsProvider.tenants()));
+    }
+
+    /**
+     * Enrols students in the tenants known at startup. Each event is routed to the projection with
+     * both the tenant's {@link CourseStatsRepository} and its {@link AuditLog} injected, matched by
+     * parameter type.
+     */
+    private static void enrolStudents(SimpleEventBus eventBus,
+                                      TenantComponentProvider<CourseStatsRepository> statsProvider) {
+        enrol(eventBus, SPRINGFIELD, COURSE_CS_101, "alice");
+        enrol(eventBus, SPRINGFIELD, COURSE_CS_101, "bob");
+        enrol(eventBus, SHELBYVILLE, COURSE_LAW_200, "carol");
+        awaitEnrolments(statsProvider, SPRINGFIELD, 2);
+        awaitEnrolments(statsProvider, SHELBYVILLE, 1);
+    }
+
+    /**
+     * Adds a tenant at runtime and enrols a student in it, showing that its instances materialize on
+     * the first event without any configuration change.
+     */
+    private static void enrolInTenantAddedAtRuntime(SimpleEventBus eventBus,
+                                                    DemoTenantProvider tenantProvider,
+                                                    TenantComponentProvider<CourseStatsRepository> statsProvider) {
+        tenantProvider.addTenant(OGDENVILLE);
+        enrol(eventBus, OGDENVILLE, COURSE_CS_101, "dan");
+        awaitEnrolments(statsProvider, OGDENVILLE, 1);
+    }
+
+    /**
+     * Publishes an enrolment for a tenant the application does not know, and confirms it is rejected
+     * with a {@link TenantNotResolvedException} so that no instance is ever built for it.
+     */
+    private static boolean unknownTenantIsRejected(SimpleEventBus eventBus) {
+        boolean rejected = enrolExpectingRejection(eventBus, UNKNOWN, COURSE_CS_101, "eve");
+        logger.info("Enrolment for an unknown tenant rejected with TenantNotResolvedException: {}", rejected);
+        return rejected;
+    }
+
+    /**
+     * Removes a tenant and confirms both of its {@link AutoCloseable} instances were closed.
+     */
+    private static boolean removingTenantClosesItsInstances(DemoTenantProvider tenantProvider,
+                                                            TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                                            TenantComponentProvider<AuditLog> auditProvider,
+                                                            TenantDescriptor tenant) {
+        CourseStatsRepository statistics = statsProvider.componentFor(tenant);
+        AuditLog auditLog = auditProvider.componentFor(tenant);
+        tenantProvider.removeTenant(tenant);
+        boolean closed = statistics.isClosed() && auditLog.isClosed();
+        logger.info("Tenant [{}] removed. Its instances are closed: {}", tenant.tenantId(), closed);
+        return closed;
+    }
+
+    /**
+     * Shuts the configuration down and confirms every still-registered tenant's instance was closed,
+     * as the cancelled provider subscriptions destroy them.
+     */
+    private static boolean shutdownClosesRemainingInstances(AxonConfiguration configuration,
+                                                            TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                                            TenantDescriptor... tenants) {
+        List<CourseStatsRepository> repositories = Arrays.stream(tenants).map(statsProvider::componentFor).toList();
+        configuration.shutdown();
+        Awaitility.await("shutdown cleanup")
+                  .atMost(Duration.ofSeconds(5))
+                  .until(() -> repositories.stream().allMatch(CourseStatsRepository::isClosed));
+        boolean allClosed = repositories.stream().allMatch(CourseStatsRepository::isClosed);
+        logger.info("Shutdown complete. All remaining tenant instances closed: {}", allClosed);
+        return allClosed;
+    }
+
+    /**
+     * Builds a throwaway configuration that registers two providers for the same component type and
+     * checks that resolving a handler parameter of that type is rejected, since the framework cannot
+     * know which instance to inject.
+     *
+     * @return {@code true} if the ambiguity was rejected with an {@link AxonConfigurationException}
+     */
+    private boolean demonstrateAmbiguousProvidersRejected() {
+        DemoTenantProvider tenantProvider = new DemoTenantProvider(SPRINGFIELD);
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        configurer.componentRegistry(registry -> registry
+                .disableEnhancer(AxonServerConfigurationEnhancer.class)
+                .registerComponent(TenantProvider.class, config -> tenantProvider)
+                // Two providers for CourseStatsRepository make that handler parameter ambiguous.
+                .registerComponent(TenantComponentProvider.class, "courseStatsA",
+                                   config -> UniversityModuleConfiguration.courseStatsProvider())
+                .registerComponent(TenantComponentProvider.class, "courseStatsB",
+                                   config -> UniversityModuleConfiguration.courseStatsProvider()));
+        AxonConfiguration configuration = configurer.build();
+        configuration.start();
+        try {
+            // Ask the parameter resolver to match the CourseStatsRepository parameter, exactly as
+            // handler inspection does. With two providers of that type, it cannot choose one.
+            ParameterResolverFactory resolverFactory = configuration.getComponent(ParameterResolverFactory.class);
+            Method handler = CourseStatsProjection.class.getDeclaredMethod(
+                    "on", StudentEnrolledInCourse.class, CourseStatsRepository.class, AuditLog.class);
+            resolverFactory.createInstance(handler, handler.getParameters(), 1);
+            logger.warn("Expected ambiguous providers to be rejected, but resolution succeeded.");
+            return false;
+        } catch (AxonConfigurationException e) {
+            logger.info("Two providers for one component type rejected: {}", e.getMessage());
+            return true;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Demo projection handler method not found.", e);
+        } finally {
+            configuration.shutdown();
+        }
+    }
+
+    private static void enrol(SimpleEventBus eventBus, TenantDescriptor tenant, String courseId, String studentId) {
+        // No active ProcessingContext: the event is published standalone, not from within a handler.
+        eventBus.publish(null, enrolmentEvent(tenant, courseId, studentId))
+                .orTimeout(5, TimeUnit.SECONDS)
+                .join();
+    }
+
+    private static boolean enrolExpectingRejection(SimpleEventBus eventBus,
+                                                   TenantDescriptor tenant,
+                                                   String courseId,
+                                                   String studentId) {
+        try {
+            // No active ProcessingContext: the event is published standalone, not from within a handler.
+            eventBus.publish(null, enrolmentEvent(tenant, courseId, studentId))
+                    .orTimeout(5, TimeUnit.SECONDS)
+                    .join();
+            return false;
+        } catch (RuntimeException e) {
+            return causedByTenantNotResolved(e);
+        }
+    }
+
+    private static EventMessage enrolmentEvent(TenantDescriptor tenant, String courseId, String studentId) {
+        return new GenericEventMessage(new MessageType(StudentEnrolledInCourse.class),
+                                       new StudentEnrolledInCourse(courseId, studentId))
+                .andMetadata(Map.of(MetadataBasedTenantResolver.DEFAULT_TENANT_KEY, tenant.tenantId()));
+    }
+
+    private static void awaitEnrolments(TenantComponentProvider<CourseStatsRepository> provider,
+                                        TenantDescriptor tenant,
+                                        int expected) {
+        Awaitility.await("enrolments for " + tenant.tenantId())
+                  .atMost(Duration.ofSeconds(5))
+                  .until(() -> totalEnrolments(provider.componentFor(tenant)) >= expected);
+    }
+
+    /**
+     * What a demo run observed, used to assert the outcome from the demo's own entry point.
+     *
+     * @param springfieldEnrolments      the enrolments recorded in Springfield's course-statistics repository
+     * @param springfieldAuditEntries    the entries recorded in Springfield's audit log
+     * @param unknownTenantRejected      whether an event for an unknown tenant was rejected
+     * @param ambiguousProvidersRejected whether two providers for one type were rejected at configuration time
+     * @param shelbyvilleClosedOnRemoval whether Shelbyville's instances were closed when its tenant was removed
+     * @param allClosedOnShutdown        whether every remaining tenant's instances were closed on shutdown
+     */
+    public record DemoOutcome(int springfieldEnrolments,
+                              int springfieldAuditEntries,
+                              boolean unknownTenantRejected,
+                              boolean ambiguousProvidersRejected,
+                              boolean shelbyvilleClosedOnRemoval,
+                              boolean allClosedOnShutdown) {
+
+    }
+
+    private static void printTenantView(String label,
+                                        TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                        TenantComponentProvider<AuditLog> auditProvider,
+                                        TenantDescriptor tenant) {
+        CourseStatsRepository statistics = statsProvider.componentFor(tenant);
+        AuditLog auditLog = auditProvider.componentFor(tenant);
+        StringBuilder report = new StringBuilder("\n").append(label).append(":\n");
+        List<CourseStatistics> statisticsPerCourse = statistics.statistics();
+        if (statisticsPerCourse.isEmpty()) {
+            report.append("  (no enrolments)\n");
+        } else {
+            statisticsPerCourse.forEach(statistic -> report.append("  - ")
+                                                           .append(statistic.courseId())
+                                                           .append(": ")
+                                                           .append(statistic.enrolments())
+                                                           .append(" enrolments\n"));
+        }
+        report.append("  audit entries: ").append(auditLog.entries().size()).append('\n');
+        logger.info("{}", report);
+    }
+
+    private static List<String> tenantIds(List<TenantDescriptor> tenants) {
+        return tenants.stream().map(TenantDescriptor::tenantId).toList();
+    }
+
+    private static int totalEnrolments(CourseStatsRepository repository) {
+        return repository.statistics().stream().mapToInt(CourseStatistics::enrolments).sum();
+    }
+
+    private static boolean causedByTenantNotResolved(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof TenantNotResolvedException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Bootstrap and demo infrastructure for the multi-tenancy example: the runnable application, its
+ * configuration toggles, and the in-memory tenant provider that stands in for Axon Server.
+ */
+@NullMarked
+package org.axonframework.examples.demo.multitenancy;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/AxonServerTenantContexts.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/AxonServerTenantContexts.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+import io.axoniq.axonserver.connector.admin.AdminChannel;
+import io.axoniq.axonserver.grpc.admin.ContextOverview;
+import io.axoniq.axonserver.grpc.admin.CreateContextRequest;
+import io.axoniq.axonserver.grpc.admin.DeleteContextRequest;
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static io.axoniq.framework.axonserver.connector.api.AxonServerConfiguration.ADMIN_CONTEXT;
+import static io.axoniq.framework.axonserver.connector.api.AxonServerConfiguration.DEFAULT_REPLICATION_GROUP;
+
+/**
+ * Creates and deletes Axon Server contexts through the Admin API, so the demo can provision one
+ * context per tenant and add or remove tenants at runtime.
+ * <p>
+ * Each tenant of the Axon Server-backed run is a real Axon Server context. This helper wraps the
+ * {@link AxonServerConnectionManager}'s {@link AdminChannel admin channel} to keep that provisioning
+ * out of the application flow. Managing contexts requires a multi-context (Enterprise Edition) Axon
+ * Server, so this helper is only used on the Axon Server-backed path.
+ */
+public final class AxonServerTenantContexts {
+
+    private static final Logger logger = LoggerFactory.getLogger(AxonServerTenantContexts.class);
+
+    private static final Duration ADMIN_TIMEOUT = Duration.ofSeconds(30);
+
+    private final AxonServerConnectionManager connectionManager;
+
+    /**
+     * Constructs a helper managing contexts through the given {@code connectionManager}.
+     *
+     * @param connectionManager the connection manager whose admin channel provisions the contexts
+     */
+    public AxonServerTenantContexts(AxonServerConnectionManager connectionManager) {
+        this.connectionManager = Objects.requireNonNull(connectionManager, "The connection manager must not be null");
+    }
+
+    /**
+     * Creates the given {@code context} as a tenant context when Axon Server does not know it yet, and
+     * waits until it is visible. A context that already exists is left untouched, so running the demo
+     * repeatedly is safe.
+     *
+     * @param context the name of the context to create
+     */
+    public void createContextIfAbsent(String context) {
+        if (contexts().contains(context)) {
+            logger.info("Context [{}] already exists, reusing it.", context);
+            return;
+        }
+        logger.info("Creating context [{}].", context);
+        adminChannel().createContext(CreateContextRequest.newBuilder()
+                                                         .setName(context)
+                                                         .setReplicationGroupName(DEFAULT_REPLICATION_GROUP)
+                                                         .setDcbContext(true)
+                                                         .build())
+                      .orTimeout(ADMIN_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
+                      .join();
+        Awaitility.await("context [" + context + "] created")
+                  .atMost(ADMIN_TIMEOUT)
+                  .until(() -> contexts().contains(context));
+    }
+
+    /**
+     * Deletes the given {@code context} and waits until it is gone. Deleting a tenant's context removes
+     * its Axon Server data, matching the demo's tenant-removal step.
+     *
+     * @param context the name of the context to delete
+     */
+    public void deleteContext(String context) {
+        logger.info("Deleting context [{}].", context);
+        adminChannel().deleteContext(DeleteContextRequest.newBuilder()
+                                                         .setName(context)
+                                                         .build())
+                      .orTimeout(ADMIN_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
+                      .join();
+        Awaitility.await("context [" + context + "] deleted")
+                  .atMost(ADMIN_TIMEOUT)
+                  .until(() -> !contexts().contains(context));
+    }
+
+    private List<String> contexts() {
+        return adminChannel().getAllContexts()
+                             .orTimeout(ADMIN_TIMEOUT.toSeconds(), TimeUnit.SECONDS)
+                             .join()
+                             .stream()
+                             .map(ContextOverview::getName)
+                             .toList();
+    }
+
+    private AdminChannel adminChannel() {
+        return connectionManager.getConnection(ADMIN_CONTEXT).adminChannel();
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/ConfigurationProperties.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/ConfigurationProperties.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.axonframework.examples.demo.multitenancy;
+package org.axonframework.examples.demo.multitenancy.scaffolding;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/DemoOutcome.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/DemoOutcome.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+/**
+ * What a demo run observed, returned by the run, so the smoke test can assert the outcome through the
+ * same entry point a user runs.
+ *
+ * @param springfieldEnrolments      the enrolments recorded in Springfield's course-statistics repository
+ * @param springfieldAuditEntries    the entries recorded in Springfield's audit log
+ * @param ogdenvilleEnrolments       the enrolments recorded in the runtime-added Ogdenville's repository
+ * @param unknownTenantRejected      whether an event for an unknown tenant was rejected
+ * @param ambiguousProvidersRejected whether two providers for one type were rejected at configuration time
+ * @param shelbyvilleClosedOnRemoval whether Shelbyville's instances were closed when its tenant was removed
+ * @param allClosedOnShutdown        whether every remaining tenant's instances were closed on shutdown
+ */
+public record DemoOutcome(int springfieldEnrolments,
+                          int springfieldAuditEntries,
+                          int ogdenvilleEnrolments,
+                          boolean unknownTenantRejected,
+                          boolean ambiguousProvidersRejected,
+                          boolean shelbyvilleClosedOnRemoval,
+                          boolean allClosedOnShutdown) {
+
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/DemoTenantProvider.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/DemoTenantProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.axonframework.examples.demo.multitenancy;
+package org.axonframework.examples.demo.multitenancy.scaffolding;
 
 import io.axoniq.framework.messaging.multitenancy.api.MultiTenantAwareComponent;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/Enrolments.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/Enrolments.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+import io.axoniq.framework.messaging.multitenancy.api.MetadataBasedTenantResolver;
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.api.TenantNotResolvedException;
+import org.awaitility.Awaitility;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatistics;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Publishes enrolments as events and reads them back, hiding the demo's event plumbing behind a few
+ * verbs. Each enrolment is a {@link StudentEnrolledInCourse} event carrying its tenant in metadata
+ * under {@link MetadataBasedTenantResolver#DEFAULT_TENANT_KEY}. That metadata is how the framework
+ * routes the event to the right tenant's components.
+ */
+public final class Enrolments {
+
+    private Enrolments() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Enrols a student by publishing an enrolment event for the given {@code tenant}, and blocks until
+     * the projection has handled it.
+     *
+     * @param eventSink the sink to publish on
+     * @param tenant    the tenant the enrolment belongs to
+     * @param courseId  the course enrolled in
+     * @param studentId the student enrolling
+     */
+    public static void enrol(EventSink eventSink, TenantDescriptor tenant, String courseId, String studentId) {
+        // No active ProcessingContext: the event is published standalone, not from within a handler.
+        eventSink.publish(null, enrolmentEvent(tenant, courseId, studentId))
+                .orTimeout(5, TimeUnit.SECONDS)
+                .join();
+    }
+
+    /**
+     * Waits until the given {@code tenant}'s repository has recorded at least {@code expected}
+     * enrolments, since events are handled asynchronously.
+     *
+     * @param provider the provider of the per-tenant course-statistics repositories
+     * @param tenant   the tenant whose enrolments to wait for
+     * @param expected the number of enrolments to wait for
+     */
+    // Reads the tenant's repository state. The framework, not this method, closes that repository.
+    public static void awaitEnrolments(TenantComponentProvider<CourseStatsRepository> provider,
+                                       TenantDescriptor tenant,
+                                       int expected) {
+        Awaitility.await("enrolments for " + tenant.tenantId())
+                  .atMost(Duration.ofSeconds(5))
+                  .until(() -> totalEnrolments(provider.componentFor(tenant)) >= expected);
+    }
+
+    /**
+     * Returns the total number of enrolments recorded across all courses in the given {@code repository}.
+     *
+     * @param repository the repository to total the enrolments of
+     * @return the total number of enrolments
+     */
+    public static int totalEnrolments(CourseStatsRepository repository) {
+        return repository.statistics().stream().mapToInt(CourseStatistics::enrolments).sum();
+    }
+
+    /**
+     * Returns {@code true} if the given {@code throwable} was caused by a
+     * {@link TenantNotResolvedException}, the failure the framework raises for an unknown tenant.
+     *
+     * @param throwable the throwable to inspect
+     * @return {@code true} if a {@link TenantNotResolvedException} is in its cause chain
+     */
+    public static boolean causedByTenantNotResolved(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof TenantNotResolvedException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static EventMessage enrolmentEvent(TenantDescriptor tenant, String courseId, String studentId) {
+        return new GenericEventMessage(new MessageType(StudentEnrolledInCourse.class),
+                                       new StudentEnrolledInCourse(courseId, studentId))
+                .andMetadata(Map.of(MetadataBasedTenantResolver.DEFAULT_TENANT_KEY, tenant.tenantId()));
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/ProviderAmbiguityGuardrail.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/ProviderAmbiguityGuardrail.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsProjection;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The demo's configuration-time guardrail: registering two {@link TenantComponentProvider}s for the
+ * same component type makes a handler parameter of that type ambiguous, so the framework refuses to
+ * resolve it. This is driven through the normal event-processing path, so it fails exactly where a
+ * real application would: registering the {@link CourseStatsProjection} and starting the configuration
+ * triggers handler inspection, which cannot decide which provider feeds the projection's
+ * {@code CourseStatsRepository} parameter.
+ */
+public final class ProviderAmbiguityGuardrail {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProviderAmbiguityGuardrail.class);
+
+    private ProviderAmbiguityGuardrail() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Builds a throwaway configuration that registers the {@link CourseStatsProjection} with two
+     * providers for its {@code CourseStatsRepository} parameter, and checks that starting it is rejected
+     * because the framework cannot know which provider to inject.
+     *
+     * @return {@code true} if the ambiguity was rejected with an {@link AxonConfigurationException}
+     */
+    public static boolean rejectsTwoProvidersForOneType() {
+        SimpleEventBus eventBus = new SimpleEventBus();
+        MessagingConfigurer configurer = MessagingConfigurer.create();
+        configurer.componentRegistry(registry -> {
+            // The parameter resolver that rejects the ambiguity is installed by the multi-tenancy
+            // enhancer, so it is enabled here too. This guardrail is about provider ambiguity, so it
+            // runs in memory regardless of whether the demo itself runs against Axon Server.
+            MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
+            registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
+                    .registerComponent(TenantProvider.class,
+                                       config -> new DemoTenantProvider(TenantDescriptor.tenantWithId("sample")))
+                    // Two providers for CourseStatsRepository make that handler parameter ambiguous.
+                    .registerComponent(TenantComponentProvider.class, "courseStatsA",
+                                       config -> UniversityModuleConfiguration.courseStatsProvider())
+                    .registerComponent(TenantComponentProvider.class, "courseStatsB",
+                                       config -> UniversityModuleConfiguration.courseStatsProvider());
+        });
+        // Register the projection through the normal event-processing path, so its handler inspection
+        // resolves the ambiguous parameter exactly as it would in a real application.
+        configurer.eventProcessing(eventProcessing -> eventProcessing.subscribing(
+                subscribing -> subscribing
+                        .defaults(defaults -> defaults.eventSource(eventBus))
+                        .defaultProcessor("ambiguity-check",
+                                          components -> components.autodetected(
+                                                  "course-stats", config -> new CourseStatsProjection()))));
+        AxonConfiguration configuration = configurer.build();
+        try {
+            configuration.start();
+            logger.warn("Expected ambiguous providers to be rejected, but startup succeeded.");
+            return false;
+        } catch (RuntimeException e) {
+            AxonConfigurationException ambiguity = ambiguityCause(e);
+            if (ambiguity != null) {
+                logger.info("Two providers for one component type rejected: {}", ambiguity.getMessage());
+                return true;
+            }
+            throw e;
+        } finally {
+            configuration.shutdown();
+        }
+    }
+
+    // The ambiguity surfaces as an AxonConfigurationException, wrapped in the lifecycle exception that
+    // startup throws, so the cause chain is scanned rather than the top-level type.
+    private static @Nullable AxonConfigurationException ambiguityCause(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof AxonConfigurationException axonConfigurationException) {
+                return axonConfigurationException;
+            }
+        }
+        return null;
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/TenantProvisioning.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/TenantProvisioning.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
+import org.axonframework.common.configuration.AxonConfiguration;
+
+import java.util.List;
+
+/**
+ * How this run provisions and removes its tenants, and the only thing that differs between the demo's
+ * two runs. The rest of the lifecycle is identical, so isolating these three operations captures the
+ * whole difference between the in-memory and Axon Server runs.
+ * <p>
+ * Get one through {@link #inMemory(DemoTenantProvider)} or {@link #axonServer(AxonConfiguration, List)}.
+ */
+public interface TenantProvisioning {
+
+    /**
+     * Ensures the tenants known before startup exist. In memory they already do, so this is a no-op.
+     * Against Axon Server it creates their contexts.
+     */
+    void prepareKnownTenants();
+
+    /**
+     * Registers a tenant discovered at runtime, so its per-tenant instances materialize on its first
+     * event. Against Axon Server this also creates the tenant's context.
+     *
+     * @param tenant the tenant to add
+     */
+    void addTenant(TenantDescriptor tenant);
+
+    /**
+     * Deregisters a tenant, releasing its per-tenant instances. Against Axon Server this also deletes
+     * the tenant's context.
+     *
+     * @param tenant the tenant to remove
+     */
+    void removeTenant(TenantDescriptor tenant);
+
+    /**
+     * Provisioning over an in-memory {@link DemoTenantProvider}: tenants are just entries in the
+     * provider, with no Axon Server contexts to manage.
+     *
+     * @param tenantProvider the in-memory provider supplying the tenants
+     * @return the in-memory tenant provisioning
+     */
+    static TenantProvisioning inMemory(DemoTenantProvider tenantProvider) {
+        return new TenantProvisioning() {
+            @Override
+            public void prepareKnownTenants() {
+                // The predefined tenants are already known to the in-memory provider.
+            }
+
+            @Override
+            public void addTenant(TenantDescriptor tenant) {
+                tenantProvider.addTenant(tenant);
+            }
+
+            @Override
+            public void removeTenant(TenantDescriptor tenant) {
+                tenantProvider.removeTenant(tenant);
+            }
+        };
+    }
+
+    /**
+     * Provisioning over Axon Server: each tenant is a real context. It creates the contexts of the
+     * tenants it registers and deletes the context of the tenant it removes, so the server reflects the
+     * tenant set the run walks through. The {@link AxonServerTenantProvider} and connection manager are
+     * resolved from the started {@code configuration}.
+     *
+     * @param configuration the started configuration to resolve the Axon Server components from
+     * @param knownTenants  the tenants known before startup, whose contexts are created up front
+     * @return the Axon Server tenant provisioning
+     */
+    static TenantProvisioning axonServer(AxonConfiguration configuration, List<TenantDescriptor> knownTenants) {
+        AxonServerTenantProvider tenantProvider =
+                (AxonServerTenantProvider) configuration.getComponent(TenantProvider.class);
+        AxonServerTenantContexts contexts =
+                new AxonServerTenantContexts(configuration.getComponent(AxonServerConnectionManager.class));
+        return new TenantProvisioning() {
+            @Override
+            public void prepareKnownTenants() {
+                knownTenants.forEach(tenant -> contexts.createContextIfAbsent(tenant.tenantId()));
+            }
+
+            @Override
+            public void addTenant(TenantDescriptor tenant) {
+                contexts.createContextIfAbsent(tenant.tenantId());
+                tenantProvider.addTenant(tenant);
+            }
+
+            @Override
+            public void removeTenant(TenantDescriptor tenant) {
+                tenantProvider.removeTenant(tenant);
+                contexts.deleteContext(tenant.tenantId());
+            }
+        };
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/TenantView.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/TenantView.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.scaffolding;
+
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatistics;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
+
+import java.util.List;
+
+/**
+ * Renders one tenant's isolated view: its per-course enrolment counts and its audit-entry count. The
+ * two parts come from their own providers but are always the given tenant's instances, which is
+ * what makes the isolation between tenants visible in the log.
+ */
+public final class TenantView {
+
+    private TenantView() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Renders the given {@code tenant}'s view as a multi-line, human-readable block.
+     * <p>
+     * The per-tenant components are {@link AutoCloseable}, but the framework closes them on tenant
+     * removal and shutdown, so this only reads their state and never closes them itself.
+     *
+     * @param label         the heading for the tenant's view
+     * @param statsProvider the provider of the per-tenant course-statistics repositories
+     * @param auditProvider the provider of the per-tenant audit logs
+     * @param tenant        the tenant whose view to render
+     * @return the rendered view
+     */
+    // The framework closes the per-tenant components on tenant removal and shutdown, so this only reads
+    // their state and never closes them itself.
+    @SuppressWarnings("resource")
+    public static String render(String label,
+                                TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                TenantComponentProvider<AuditLog> auditProvider,
+                                TenantDescriptor tenant) {
+        CourseStatsRepository statistics = statsProvider.componentFor(tenant);
+        AuditLog auditLog = auditProvider.componentFor(tenant);
+        StringBuilder view = new StringBuilder("\n").append(label).append(":\n");
+        List<CourseStatistics> statisticsPerCourse = statistics.statistics();
+        if (statisticsPerCourse.isEmpty()) {
+            view.append("  (no enrolments)\n");
+        } else {
+            statisticsPerCourse.forEach(statistic -> view.append("  - ")
+                                                         .append(statistic.courseId())
+                                                         .append(": ")
+                                                         .append(statistic.enrolments())
+                                                         .append(" enrolments\n"));
+        }
+        view.append("  audit entries: ").append(auditLog.entries().size()).append('\n');
+        return view.toString();
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/scaffolding/package-info.java
@@ -15,11 +15,12 @@
  */
 
 /**
- * Bootstrap and demo infrastructure for the multi-tenancy example: the runnable application, its
- * configuration toggles, the in-memory tenant provider used by default, and the helper that
- * provisions Axon Server contexts when the demo runs against Axon Server.
+ * Supporting classes for the multi-tenancy demo: the two tenant provisioning strategies (in-memory and
+ * Axon Server), the enrolment publishing and tenant-view rendering helpers, the configuration-time
+ * guardrail, and the run's toggle and outcome. The lesson itself lives one package up, in
+ * {@link org.axonframework.examples.demo.multitenancy.MultiTenancyApplication}.
  */
 @NullMarked
-package org.axonframework.examples.demo.multitenancy;
+package org.axonframework.examples.demo.multitenancy.scaffolding;
 
 import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university;
+
+import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationDefaults;
+import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.audit.InMemoryAuditLog;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsProjection;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
+import org.axonframework.examples.demo.multitenancy.university.read.coursestats.InMemoryCourseStatsRepository;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.axonframework.messaging.eventhandling.processing.errorhandling.PropagatingErrorHandler;
+
+/**
+ * Wires the university's tenant-aware components into a {@link MessagingConfigurer}.
+ * <p>
+ * This is the whole configuration a developer writes for the feature: register one
+ * {@link TenantComponentProvider} per tenant-scoped component type, and register the
+ * {@link CourseStatsProjection} as an ordinary event-handling component. From there the framework
+ * provides each event's handler the instances of that event's tenant, each matched by type.
+ */
+public final class UniversityModuleConfiguration {
+
+    private UniversityModuleConfiguration() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Creates the provider of per-tenant {@link CourseStatsRepository} instances, each built lazily
+     * on the tenant's first use.
+     *
+     * @return the tenant-scoped course-statistics provider
+     */
+    public static TenantComponentProvider<CourseStatsRepository> courseStatsProvider() {
+        return TenantComponentProvider.withFactory(
+                CourseStatsRepository.class,
+                tenant -> new InMemoryCourseStatsRepository(tenant.tenantId())
+        );
+    }
+
+    /**
+     * Creates the provider of per-tenant {@link AuditLog} instances, each built lazily on the
+     * tenant's first use.
+     *
+     * @return the tenant-scoped audit-log provider
+     */
+    public static TenantComponentProvider<AuditLog> auditLogProvider() {
+        return TenantComponentProvider.withFactory(
+                AuditLog.class,
+                tenant -> new InMemoryAuditLog(tenant.tenantId())
+        );
+    }
+
+    /**
+     * Registers the tenant-aware wiring on the given {@code configurer}: the {@link TenantProvider}
+     * supplying the tenants, one {@link TenantComponentProvider} per tenant-scoped component type,
+     * and the {@link CourseStatsProjection} subscribed to the given {@code eventSource}.
+     * <p>
+     * The {@link MultiTenancyConfigurationDefaults} enhancer, which installs the tenant parameter
+     * resolver and subscribes the providers, is discovered automatically. Only the Axon Server
+     * configuration enhancer is disabled, so the demo runs fully in memory. The processor uses a
+     * {@link PropagatingErrorHandler} so that a rejected tenant surfaces to the publisher rather
+     * than only being logged.
+     *
+     * @param configurer     the configurer to extend
+     * @param eventSource    the event source the projection processor subscribes to
+     * @param tenantProvider the provider of the application's tenants
+     * @param statsProvider  the provider of the per-tenant course-statistics repositories
+     * @param auditProvider  the provider of the per-tenant audit logs
+     */
+    public static void configure(MessagingConfigurer configurer,
+                                 SimpleEventBus eventSource,
+                                 TenantProvider tenantProvider,
+                                 TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                 TenantComponentProvider<AuditLog> auditProvider) {
+        configurer.componentRegistry(registry -> registry
+                // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
+                .disableEnhancer(AxonServerConfigurationEnhancer.class)
+                .registerComponent(TenantProvider.class, config -> tenantProvider)
+                // The names only keep the two registrations distinct in the registry. A handler
+                // parameter is still matched to a provider by the component type that provider
+                // produces. That is why one provider per component type is fine, while two
+                // providers for the same type make a parameter of that type ambiguous.
+                .registerComponent(TenantComponentProvider.class, "courseStats", config -> statsProvider)
+                .registerComponent(TenantComponentProvider.class, "auditLog", config -> auditProvider));
+        configurer.eventProcessing(eventProcessing -> eventProcessing.subscribing(
+                subscribing -> subscribing
+                        .defaults(defaults -> defaults.eventSource(eventSource)
+                                                      .errorHandler(PropagatingErrorHandler.instance()))
+                        .defaultProcessor(
+                                "course-stats-projection",
+                                components -> components.autodetected("course-stats",
+                                                                      config -> new CourseStatsProjection()))));
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
@@ -19,14 +19,18 @@ package org.axonframework.examples.demo.multitenancy.university;
 import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
+import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationDefaults;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.SearchScope;
 import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.audit.InMemoryAuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.coursestats.CourseStatsRepository;
 import org.axonframework.examples.demo.multitenancy.university.read.coursestats.InMemoryCourseStatsRepository;
+import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.configuration.MessagingConfigurer;
-import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.PropagatingErrorHandler;
 
 /**
@@ -70,13 +74,16 @@ public final class UniversityModuleConfiguration {
     }
 
     /**
-     * Registers the tenant-aware wiring on the given {@code configurer}: the {@link TenantProvider}
-     * supplying the tenants, one {@link TenantComponentProvider} per tenant-scoped component type,
-     * and the {@link CourseStatsProjection} subscribed to the given {@code eventSource}.
+     * Registers the in-memory tenant-aware wiring on the given {@code configurer}: the
+     * {@link TenantProvider} supplying the tenants, one {@link TenantComponentProvider} per
+     * tenant-scoped component type, and the {@link CourseStatsProjection} subscribed to the given
+     * {@code eventSource}.
      * <p>
      * The {@link MultiTenancyConfigurationDefaults} enhancer, which installs the tenant parameter
-     * resolver and subscribes the providers, is discovered automatically. Only the Axon Server
-     * configuration enhancer is disabled, so the demo runs fully in memory. The processor uses a
+     * resolver and subscribes the providers, only runs when multi-tenancy is enabled, so this method
+     * turns it on with {@link MultiTenancyEnabled#enableMultiTenancyEnhancer(ComponentRegistry)}. The
+     * Axon Server configuration enhancer is disabled and the {@code tenantProvider} is registered
+     * explicitly, so the demo runs fully in memory. The processor uses a
      * {@link PropagatingErrorHandler} so that a rejected tenant surfaces to the publisher rather
      * than only being logged.
      *
@@ -87,20 +94,85 @@ public final class UniversityModuleConfiguration {
      * @param auditProvider  the provider of the per-tenant audit logs
      */
     public static void configure(MessagingConfigurer configurer,
-                                 SimpleEventBus eventSource,
+                                 SubscribableEventSource eventSource,
                                  TenantProvider tenantProvider,
                                  TenantComponentProvider<CourseStatsRepository> statsProvider,
                                  TenantComponentProvider<AuditLog> auditProvider) {
-        configurer.componentRegistry(registry -> registry
-                // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
-                .disableEnhancer(AxonServerConfigurationEnhancer.class)
-                .registerComponent(TenantProvider.class, config -> tenantProvider)
-                // The names only keep the two registrations distinct in the registry. A handler
-                // parameter is still matched to a provider by the component type that provider
-                // produces. That is why one provider per component type is fine, while two
-                // providers for the same type make a parameter of that type ambiguous.
-                .registerComponent(TenantComponentProvider.class, "courseStats", config -> statsProvider)
-                .registerComponent(TenantComponentProvider.class, "auditLog", config -> auditProvider));
+        configurer.componentRegistry(registry -> {
+            MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
+            // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
+            registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
+                    .registerComponent(TenantProvider.class, config -> tenantProvider);
+            registerTenantComponents(registry, statsProvider, auditProvider);
+        });
+        registerProjection(configurer, eventSource);
+    }
+
+    /**
+     * Registers the Axon Server backed tenant-aware wiring on the given {@code configurer}: the
+     * {@link AxonServerTenantProvider} sourcing its tenants from the given {@code predefinedContexts},
+     * one {@link TenantComponentProvider} per tenant-scoped component type, and the
+     * {@link CourseStatsProjection} subscribed to the given {@code eventSource}.
+     * <p>
+     * The difference with {@link #configure(MessagingConfigurer, SubscribableEventSource, TenantProvider,
+     * TenantComponentProvider, TenantComponentProvider)} is the source of the tenants: the Axon Server
+     * configuration enhancer is left enabled, so an {@code AxonServerConnectionManager} is available,
+     * and the {@link AxonServerTenantProvider} treats each configured context as a tenant. Enrolments
+     * still flow through the given {@code eventSource} carrying their tenant in metadata, exactly as in
+     * the in-memory setup, so the framework injects each context's per-tenant components.
+     *
+     * @param configurer         the configurer to extend
+     * @param eventSource        the event source the projection processor subscribes to
+     * @param predefinedContexts a comma-separated list of Axon Server context names to treat as tenants
+     * @param statsProvider      the provider of the per-tenant course-statistics repositories
+     * @param auditProvider      the provider of the per-tenant audit logs
+     */
+    public static void configureForAxonServer(MessagingConfigurer configurer,
+                                              SubscribableEventSource eventSource,
+                                              String predefinedContexts,
+                                              TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                              TenantComponentProvider<AuditLog> auditProvider) {
+        configurer.componentRegistry(registry -> {
+            MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
+            // Keep the Axon Server enhancer so the AxonServerConnectionManager the tenant provider needs
+            // is available. Register the provider over predefined contexts, so it does not override the
+            // default (auto-discovering) one the multi-tenancy enhancer would otherwise register.
+            registry.registerIfNotPresent(
+                    MultiTenancyConfigurationDefaults.axonServerTenantProvider(predefinedContexts),
+                    SearchScope.ALL);
+            registerTenantComponents(registry, statsProvider, auditProvider);
+        });
+        registerProjection(configurer, eventSource);
+    }
+
+    /**
+     * Registers the two per-tenant component providers on the given {@code registry}.
+     * <p>
+     * The registration names only keep the two registrations distinct in the registry. A handler
+     * parameter is still matched to a provider by the component type that provider produces. That is
+     * why one provider per component type is fine, while two providers for the same type make a
+     * parameter of that type ambiguous.
+     *
+     * @param registry      the registry to register the providers on
+     * @param statsProvider the provider of the per-tenant course-statistics repositories
+     * @param auditProvider the provider of the per-tenant audit logs
+     */
+    private static void registerTenantComponents(ComponentRegistry registry,
+                                                 TenantComponentProvider<CourseStatsRepository> statsProvider,
+                                                 TenantComponentProvider<AuditLog> auditProvider) {
+        registry.registerComponent(TenantComponentProvider.class, "courseStats", config -> statsProvider)
+                .registerComponent(TenantComponentProvider.class, "auditLog", config -> auditProvider);
+    }
+
+    /**
+     * Registers the {@link CourseStatsProjection} as a subscribing event processor reading from the
+     * given {@code eventSource}, using a {@link PropagatingErrorHandler} so that a rejected tenant
+     * surfaces to the publisher rather than only being logged.
+     *
+     * @param configurer  the configurer to extend
+     * @param eventSource the event source the projection processor subscribes to
+     */
+    private static void registerProjection(MessagingConfigurer configurer, SubscribableEventSource eventSource) {
         configurer.eventProcessing(eventProcessing -> eventProcessing.subscribing(
                 subscribing -> subscribing
                         .defaults(defaults -> defaults.eventSource(eventSource)

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/AuditLog.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/AuditLog.java
@@ -43,6 +43,9 @@ public interface AuditLog extends AutoCloseable {
 
     /**
      * Returns whether this audit log has been closed, meaning its tenant was removed.
+     * <p>
+     * This is demo instrumentation for observing the framework-driven cleanup. A real tenant-aware
+     * component only needs its domain methods plus {@link AutoCloseable}; it would not expose this.
      *
      * @return {@code true} if this audit log was closed
      */

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/AuditLog.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/AuditLog.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.audit;
+
+import java.util.List;
+
+/**
+ * A tenant-scoped audit trail, the demo's second tenant-aware component type.
+ * <p>
+ * It exists alongside the course-statistics repository to show that several tenant-scoped types
+ * can be registered, each matched to a handler parameter by its own type. One instance exists per
+ * tenant, and being {@link AutoCloseable} it is closed when its tenant is removed.
+ */
+public interface AuditLog extends AutoCloseable {
+
+    /**
+     * Records the given audit {@code entry} for this tenant.
+     *
+     * @param entry the audit entry to record
+     */
+    void record(String entry);
+
+    /**
+     * Returns the audit entries recorded for this tenant.
+     *
+     * @return the audit entries recorded for this tenant
+     */
+    List<String> entries();
+
+    /**
+     * Returns whether this audit log has been closed, meaning its tenant was removed.
+     *
+     * @return {@code true} if this audit log was closed
+     */
+    boolean isClosed();
+
+    @Override
+    void close();
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/InMemoryAuditLog.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/InMemoryAuditLog.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.audit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * In-memory {@link AuditLog}, backing the demo without external infrastructure.
+ */
+public class InMemoryAuditLog implements AuditLog {
+
+    private static final Logger logger = LoggerFactory.getLogger(InMemoryAuditLog.class);
+
+    private final String tenantId;
+    private final List<String> entries = new CopyOnWriteArrayList<>();
+    private volatile boolean closed = false;
+
+    /**
+     * Constructs an audit log for the tenant with the given {@code tenantId}.
+     *
+     * @param tenantId the identifier of the tenant this audit log belongs to
+     */
+    public InMemoryAuditLog(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    @Override
+    public void record(String entry) {
+        entries.add(entry);
+    }
+
+    @Override
+    public List<String> entries() {
+        return List.copyOf(entries);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        logger.info("Closed audit log for tenant [{}].", tenantId);
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/InMemoryAuditLog.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/InMemoryAuditLog.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -39,7 +40,7 @@ public class InMemoryAuditLog implements AuditLog {
      * @param tenantId the identifier of the tenant this audit log belongs to
      */
     public InMemoryAuditLog(String tenantId) {
-        this.tenantId = tenantId;
+        this.tenantId = Objects.requireNonNull(tenantId, "The tenant id must not be null");
     }
 
     @Override

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/audit/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The per-tenant audit log, a second tenant-aware component type shown alongside the course
+ * statistics to demonstrate matching several component types by parameter type.
+ */
+@NullMarked
+package org.axonframework.examples.demo.multitenancy.university.audit;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/events/StudentEnrolledInCourse.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/events/StudentEnrolledInCourse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.events;
+
+/**
+ * Event stating that a student enrolled in a course within a tenant.
+ *
+ * @param courseId  the identifier of the course enrolled in
+ * @param studentId the identifier of the enrolling student
+ */
+public record StudentEnrolledInCourse(String courseId, String studentId) {
+
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/events/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/events/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The university domain events published by the demo.
+ */
+@NullMarked
+package org.axonframework.examples.demo.multitenancy.university.events;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The university-bounded context and its tenant-aware wiring.
+ */
+@NullMarked
+package org.axonframework.examples.demo.multitenancy.university;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatistics.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatistics.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.coursestats;
+
+/**
+ * The enrolment count for a single course within one tenant's read model.
+ *
+ * @param courseId   the identifier of the course
+ * @param enrolments the number of enrolments recorded for the course
+ */
+public record CourseStatistics(String courseId, int enrolments) {
+
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsProjection.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsProjection.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.coursestats;
+
+import org.axonframework.examples.demo.multitenancy.university.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+
+/**
+ * Projection maintaining per-tenant course statistics and an audit trail.
+ * <p>
+ * The handler declares a {@link CourseStatsRepository} and an {@link AuditLog} parameter and is
+ * handed the instances of the tenant of the event being handled, each matched by its own type, so
+ * it never resolves a tenant itself. This is the whole developer-facing surface of tenant-aware
+ * components.
+ */
+public class CourseStatsProjection {
+
+    /**
+     * Records the enrolment on the current tenant's course-statistics repository and audit log.
+     *
+     * @param event      the enrolment event being handled
+     * @param statistics the injected course-statistics repository of the event's tenant
+     * @param auditLog   the injected audit log of the event's tenant
+     */
+    @EventHandler
+    public void on(StudentEnrolledInCourse event, CourseStatsRepository statistics, AuditLog auditLog) {
+        statistics.recordEnrolment(event.courseId());
+        auditLog.record("Enrolled student [" + event.studentId() + "] in course [" + event.courseId() + "]");
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsRepository.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsRepository.java
@@ -43,6 +43,9 @@ public interface CourseStatsRepository extends AutoCloseable {
 
     /**
      * Returns whether this repository has been closed, meaning its tenant was removed.
+     * <p>
+     * This is demo instrumentation for observing the framework-driven cleanup. A real tenant-aware
+     * component only needs its domain methods plus {@link AutoCloseable}; it would not expose this.
      *
      * @return {@code true} if this repository was closed
      */

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsRepository.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/CourseStatsRepository.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.coursestats;
+
+import java.util.List;
+
+/**
+ * A tenant-scoped read model holding course enrolment statistics for a single tenant.
+ * <p>
+ * One instance exists per tenant. Message handlers never look a tenant up: they declare this type
+ * as a parameter, and the framework injects the instance belonging to the tenant of the message
+ * being handled. Being {@link AutoCloseable}, the instance is closed when its tenant is removed.
+ */
+public interface CourseStatsRepository extends AutoCloseable {
+
+    /**
+     * Records one enrolment for the given {@code courseId}.
+     *
+     * @param courseId the identifier of the course to record an enrolment for
+     */
+    void recordEnrolment(String courseId);
+
+    /**
+     * Returns the enrolment statistics per course held for this tenant.
+     *
+     * @return the enrolment statistics per course
+     */
+    List<CourseStatistics> statistics();
+
+    /**
+     * Returns whether this repository has been closed, meaning its tenant was removed.
+     *
+     * @return {@code true} if this repository was closed
+     */
+    boolean isClosed();
+
+    @Override
+    void close();
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/InMemoryCourseStatsRepository.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/InMemoryCourseStatsRepository.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.coursestats;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * In-memory {@link CourseStatsRepository}, backing the demo without external infrastructure.
+ * <p>
+ * A real application would back this with the tenant's own datasource. The tenant identifier is
+ * carried only so the closing of an instance is visible in the log when its tenant is removed.
+ */
+public class InMemoryCourseStatsRepository implements CourseStatsRepository {
+
+    private static final Logger logger = LoggerFactory.getLogger(InMemoryCourseStatsRepository.class);
+
+    private final String tenantId;
+    private final ConcurrentMap<String, AtomicInteger> enrolmentsByCourse = new ConcurrentHashMap<>();
+    private volatile boolean closed = false;
+
+    /**
+     * Constructs a repository for the tenant with the given {@code tenantId}.
+     *
+     * @param tenantId the identifier of the tenant this repository belongs to
+     */
+    public InMemoryCourseStatsRepository(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    @Override
+    public void recordEnrolment(String courseId) {
+        enrolmentsByCourse.computeIfAbsent(courseId, ignored -> new AtomicInteger()).incrementAndGet();
+    }
+
+    @Override
+    public List<CourseStatistics> statistics() {
+        return enrolmentsByCourse.entrySet()
+                                 .stream()
+                                 .map(entry -> new CourseStatistics(entry.getKey(), entry.getValue().get()))
+                                 .toList();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        logger.info("Closed course-stats repository for tenant [{}].", tenantId);
+    }
+}

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/InMemoryCourseStatsRepository.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/InMemoryCourseStatsRepository.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,7 +45,7 @@ public class InMemoryCourseStatsRepository implements CourseStatsRepository {
      * @param tenantId the identifier of the tenant this repository belongs to
      */
     public InMemoryCourseStatsRepository(String tenantId) {
-        this.tenantId = tenantId;
+        this.tenantId = Objects.requireNonNull(tenantId, "The tenant id must not be null");
     }
 
     @Override

--- a/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/package-info.java
+++ b/examples/university-multi-tenancy/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/coursestats/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The course-statistics read model: the per-tenant repository that is the tenant-aware component,
+ * and the projection that has it injected while handling events.
+ */
+@NullMarked
+package org.axonframework.examples.demo.multitenancy.university.read.coursestats;
+
+import org.jspecify.annotations.NullMarked;

--- a/examples/university-multi-tenancy/src/main/resources/application.properties
+++ b/examples/university-multi-tenancy/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+# Multi-tenancy demo configuration.
+#
+# The demo runs fully in memory by default, using a bundled TenantProvider with predefined
+# tenants. The Axon Server backed path, with one context per tenant, lands as this branch grows.
+# This toggle is the switch it will read.
+axon.server.enabled=false

--- a/examples/university-multi-tenancy/src/main/resources/application.properties
+++ b/examples/university-multi-tenancy/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # Multi-tenancy demo configuration.
 #
-# The demo runs fully in memory by default, using a bundled TenantProvider with predefined
-# tenants. The Axon Server backed path, with one context per tenant, lands as this branch grows.
-# This toggle is the switch it will read.
+# The demo runs fully in memory by default, using a bundled TenantProvider with predefined tenants.
+# Set this toggle to true to run against Axon Server instead, with one context per tenant sourced by
+# the AxonServerTenantProvider. That path needs a running multi-context (Enterprise Edition) Axon
+# Server on its default localhost address. See the README for how to run it.
 axon.server.enabled=false

--- a/examples/university-multi-tenancy/src/main/resources/logback.xml
+++ b/examples/university-multi-tenancy/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Surfaces the provider subscription and per-tenant component creation and destruction. -->
+    <logger name="io.axoniq.framework.messaging.multitenancy" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/examples/university-multi-tenancy/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import org.axonframework.examples.demo.multitenancy.MultiTenancyApplication.DemoOutcome;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test running the demo through its own entry point and asserting the observed outcome:
+ * per-tenant isolation across both component types, the unknown-tenant and ambiguity guardrails,
+ * destroy on tenant removal, and cleanup on shutdown.
+ */
+class MultiTenancyDemoTest {
+
+    @Test
+    void runsTheTenantLifecycleEndToEnd() {
+        // given the in-memory demo application
+        MultiTenancyApplication demo = new MultiTenancyApplication();
+
+        // when the demo runs end to end
+        DemoOutcome outcome = demo.run();
+
+        // then both of Springfield's components saw only its own two enrolments, matched by type
+        // and isolated from the other tenants
+        assertThat(outcome.springfieldEnrolments()).isEqualTo(2);
+        assertThat(outcome.springfieldAuditEntries()).isEqualTo(2);
+        // and an event for an unknown tenant was rejected
+        assertThat(outcome.unknownTenantRejected()).isTrue();
+        // and registering two providers for one component type was rejected at configuration time
+        assertThat(outcome.ambiguousProvidersRejected()).isTrue();
+        // and removing Shelbyville closed its instances
+        assertThat(outcome.shelbyvilleClosedOnRemoval()).isTrue();
+        // and shutting down closed every remaining tenant's instances
+        assertThat(outcome.allClosedOnShutdown()).isTrue();
+    }
+}

--- a/examples/university-multi-tenancy/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -16,7 +16,7 @@
 
 package org.axonframework.examples.demo.multitenancy;
 
-import org.axonframework.examples.demo.multitenancy.MultiTenancyApplication.DemoOutcome;
+import org.axonframework.examples.demo.multitenancy.scaffolding.DemoOutcome;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +40,8 @@ class MultiTenancyDemoTest {
         // and isolated from the other tenants
         assertThat(outcome.springfieldEnrolments()).isEqualTo(2);
         assertThat(outcome.springfieldAuditEntries()).isEqualTo(2);
+        // and the tenant added at runtime recorded its own enrolment in isolation
+        assertThat(outcome.ogdenvilleEnrolments()).isEqualTo(1);
         // and an event for an unknown tenant was rejected
         assertThat(outcome.unknownTenantRejected()).isTrue();
         // and registering two providers for one component type was rejected at configuration time


### PR DESCRIPTION
# Add university-multi-tenancy example

An initial setup for the demo of the [multi tenancy feature](https://github.com/AxonIQ/axoniq-framework/issues/176) taken into account the tenant aware components made in https://github.com/AxonIQ/axoniq-framework/pull/245. 

See the module
[README](examples/university-multi-tenancy/README.md) for the story, what it shows, the layout,
and how to run it.

Initial setup, opened against `feature/axoniq/176/multi-tenancy-demo` so it stays open and grows
as the rest of multi-tenancy lands. Part of [#176.](https://github.com/AxonIQ/axoniq-framework/issues/176)

## Notes for the reviewer

* **Builds on axoniq-framework#206.** Targets the `5.3.0-SNAPSHOT` line (not released yet), so the
  `axoniq-multi-tenancy` version is pinned explicitly until the BOM manages it. The module compiles
  once [#206](https://github.com/AxonIQ/axoniq-framework/pull/245/changes#diff-3948022472ed1f74f51675eefb7c31cd040b99444037369997000c6e6063d6c8)'s artifact is available.

