### PR TITLE
Include connection-security documentation on the Spring Boot integration page

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/spring-boot-integration.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/spring-boot-integration.adoc
@@ -87,6 +87,10 @@ Other extensions can provide additional implementations:
 * PostgreSQL event store (via the PostgreSQL extension)
 * Reactive gateways for commands, events, and queries (via the xref:modules.adoc#axon-reactor[Reactor extension])
 
+ifdef::advanced-framework[]
+include::connector:partial$connection-security.adoc[]
+endif::[]
+
 == Component detection
 
 The Spring Boot Starter automatically detects Axon components in your application:


### PR DESCRIPTION
Surfaces the new TLS / mutual TLS configuration documentation (`connection-security.adoc` from the Axoniq Framework connector module) on the Spring Boot integration page, guarded by `ifdef::advanced-framework[]` like the other connector partials.

Covers `axon.axonserver.ssl-enabled`, `cert-file`, and the new `client-cert-file` / `client-key-file` properties.

> [!WARNING]
> Merge after AxonIQ/axoniq-framework#256, which adds the included partial — the Antora build fails on a missing include otherwise.

Open question for reviewers: should connection security also get its own entry in the master `nav.adoc`, or is inline on the Spring Boot integration page sufficient?