### PR TITLE
[#3594] fix(messaging): EventAppender/CommandDispatcher#forContext must not cache a context-bound wrapper

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/InjectedCommandDispatcherBatchCausationInMemoryIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/InjectedCommandDispatcherBatchCausationInMemoryIT.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.student;
+
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.integrationtests.testsuite.infrastructure.InMemoryTestInfrastructure;
+import org.axonframework.integrationtests.testsuite.infrastructure.TestInfrastructure;
+import org.axonframework.integrationtests.testsuite.student.events.StudentEnrolledEvent;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.commandhandling.gateway.CommandDispatcher;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.Metadata;
+import org.axonframework.messaging.core.annotation.MetadataValue;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.EventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Regression test for the {@code forContext} batch-sharing defect (issue #3594).
+ * <p>
+ * A streaming (pooled) event processor creates ONE {@link UnitOfWork} — and therefore one root
+ * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext} — per BATCH, not per event. Each event in the
+ * batch is handled against a thin branch of that root. When
+ * {@link CommandDispatcher#forContext(org.axonframework.messaging.core.unitofwork.ProcessingContext) forContext} cached
+ * its wrapper on the shared root, the FIRST event's injected {@link CommandDispatcher} was handed back to every later
+ * event in the same batch — so their dispatched commands ran against event #1's context branch and inherited event #1's
+ * correlation/causation metadata (a corrupted causation chain), tracing on or not.
+ * <p>
+ * This test drives exactly that shape: two events in a single batch, an automation that dispatches a command per event
+ * through the <em>injected</em> {@link CommandDispatcher}. Each dispatched command must carry the {@code causationId}
+ * (and {@code correlationId}) of its OWN triggering event.
+ * <ul>
+ *     <li>With the buggy caching {@code forContext}: event #2's command carries event #1's ids → the two commands share
+ *     one {@code causationId} → this test fails.</li>
+ *     <li>With the fresh-per-call {@code forContext}: each command carries its own event's ids → this test passes.</li>
+ * </ul>
+ *
+ * @author Mateusz Nowak
+ */
+class InjectedCommandDispatcherBatchCausationInMemoryIT extends AbstractStudentIT {
+
+    private static final TestInfrastructure INFRASTRUCTURE = new InMemoryTestInfrastructure();
+    private static final String PROCESSOR_NAME = "when-student-enrolled-then-notify";
+
+    private final List<DispatchedCommand> dispatchedCommands = new CopyOnWriteArrayList<>();
+
+    @Override
+    protected TestInfrastructure testInfrastructure() {
+        return INFRASTRUCTURE;
+    }
+
+    @Test
+    void bothEventsInOneBatchDispatchCommandsCarryingTheirOwnCausationId() {
+        // given
+        startApp();
+        var studentId = UUID.randomUUID().toString();
+
+        // seed two events and let the initial (live) delivery settle — this advances the token past both events
+        var eventIdByCourse = storeTwoEnrollmentsInOneBatch(studentId, "course-1", "course-2");
+        await().atMost(10, TimeUnit.SECONDS)
+               .untilAsserted(() -> assertEquals(2, dispatchedCommands.size(),
+                                                 "both enrollment events should have dispatched a command"));
+
+        // when — replay the (now already-processed) events. A replay reads them as a backlog, which the pooled
+        // processor groups into a SINGLE batch (batchSize 2, one segment) sharing one root ProcessingContext —
+        // the shape that triggers the defect. (Live tailing delivers one event per batch, so it cannot reproduce
+        // it; and resetTokens only replays up to the current token, hence the initial live pass above.)
+        replayAlreadyProcessedEvents();
+
+        // then
+        await().atMost(10, TimeUnit.SECONDS)
+               .untilAsserted(() -> assertEquals(2, dispatchedCommands.size(),
+                                                 "the replayed batch should have dispatched a command per event"));
+
+        var byCourse = dispatchedCommands.stream()
+                                         .collect(Collectors.toMap(DispatchedCommand::courseId, Function.identity()));
+        var command1 = byCourse.get("course-1");
+        var command2 = byCourse.get("course-2");
+
+        // each command must be caused by its OWN triggering event, not by the first event of the batch
+        assertEquals(eventIdByCourse.get("course-1"), command1.causationId(),
+                     "command for event #1 must carry event #1's causationId");
+        assertEquals(eventIdByCourse.get("course-2"), command2.causationId(),
+                     "command for event #2 must carry event #2's causationId, not event #1's "
+                             + "(forContext must return a fresh CommandDispatcher per call)");
+
+        // ... and therefore the causation/correlation of the two commands differ
+        assertNotEquals(command1.causationId(), command2.causationId(),
+                        "the two commands must not share a causationId");
+        assertNotEquals(command1.correlationId(), command2.correlationId(),
+                        "the two commands must not share a correlationId");
+    }
+
+    private Map<String, String> storeTwoEnrollmentsInOneBatch(String studentId, String course1, String course2) {
+        var message1 = new GenericEventMessage(new MessageType(StudentEnrolledEvent.class),
+                                               new StudentEnrolledEvent(studentId, course1),
+                                               Metadata.emptyInstance());
+        var message2 = new GenericEventMessage(new MessageType(StudentEnrolledEvent.class),
+                                               new StudentEnrolledEvent(studentId, course2),
+                                               Metadata.emptyInstance());
+        UnitOfWork uow = unitOfWorkFactory.create();
+        // Publish BOTH events in a single call => one atomic append => the pooled processor reads them
+        // in ONE batch (sharing a single root ProcessingContext), which is what triggers the defect.
+        uow.runOnInvocation(context -> context.component(EventSink.class).publish(context, message1, message2));
+        uow.execute().join();
+        return Map.of(course1, message1.identifier(), course2, message2.identifier());
+    }
+
+    private void replayAlreadyProcessedEvents() {
+        PooledStreamingEventProcessor processor =
+                (PooledStreamingEventProcessor) startedConfiguration.getComponents(EventProcessor.class)
+                                                                    .get(PROCESSOR_NAME);
+        processor.shutdown()
+                 .thenCompose(ignored -> processor.resetTokens())
+                 .join();
+        dispatchedCommands.clear();
+        processor.start().join();
+    }
+
+    @Override
+    protected EventSourcingConfigurer testSuiteConfigurer(EventSourcingConfigurer configurer) {
+        CommandHandlingModule commandHandler = CommandHandlingModule
+                .named("notify-student-command-handler")
+                .commandHandlers()
+                .autodetectedCommandHandlingComponent(cfg -> new NotifyStudentCommandHandler(dispatchedCommands))
+                .build();
+        configurer.registerCommandHandlingModule(commandHandler);
+
+        var automationProcessor = EventProcessorModule
+                .pooledStreaming(PROCESSOR_NAME)
+                .eventHandlingComponents(components -> components.autodetected(
+                        "notifyAutomation",
+                        cfg -> new NotifyOnEnrollmentAutomation()
+                ))
+                // one segment + batch of two => both events are consumed in a single batch/UnitOfWork
+                .customized((cfg, c) -> c.initialSegmentCount(1).batchSize(2));
+
+        return configurer.messaging(
+                messaging -> messaging.eventProcessing(
+                        ep -> ep.pooledStreaming(ps -> ps.processor(automationProcessor))
+                )
+        );
+    }
+
+    record NotifyStudentCommand(String studentId, String courseId) {
+
+    }
+
+    record DispatchedCommand(String courseId, String causationId, String correlationId) {
+
+    }
+
+    /**
+     * Reacts to every {@link StudentEnrolledEvent} by dispatching a command through the <em>injected</em>
+     * {@link CommandDispatcher} — i.e. resolved via {@code forContext(context)} on each invocation. This is the path
+     * that carried the batch-sharing defect.
+     */
+    static class NotifyOnEnrollmentAutomation {
+
+        @EventHandler
+        MessageStream.Empty<?> react(StudentEnrolledEvent event, CommandDispatcher commandDispatcher) {
+            return MessageStream.fromFuture(
+                    commandDispatcher.send(new NotifyStudentCommand(event.studentId(), event.courseId())).getResultMessage()
+            ).ignoreEntries();
+        }
+    }
+
+    /**
+     * Captures the correlation/causation metadata each dispatched command actually arrived with.
+     */
+    static class NotifyStudentCommandHandler {
+
+        private final List<DispatchedCommand> captured;
+
+        NotifyStudentCommandHandler(List<DispatchedCommand> captured) {
+            this.captured = captured;
+        }
+
+        @CommandHandler
+        MessageStream.Single<?> handle(NotifyStudentCommand command,
+                                       @MetadataValue("causationId") String causationId,
+                                       @MetadataValue("correlationId") String correlationId) {
+            captured.add(new DispatchedCommand(command.courseId(), causationId, correlationId));
+            return MessageStream.just(SUCCESSFUL_COMMAND_RESULT);
+        }
+    }
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/InjectedCommandDispatcherBatchCausationInMemoryIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/student/InjectedCommandDispatcherBatchCausationInMemoryIT.java
@@ -49,24 +49,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
- * Regression test for the {@code forContext} batch-sharing defect (issue #3594).
- * <p>
- * A streaming (pooled) event processor creates ONE {@link UnitOfWork} — and therefore one root
- * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext} — per BATCH, not per event. Each event in the
- * batch is handled against a thin branch of that root. When
- * {@link CommandDispatcher#forContext(org.axonframework.messaging.core.unitofwork.ProcessingContext) forContext} cached
- * its wrapper on the shared root, the FIRST event's injected {@link CommandDispatcher} was handed back to every later
- * event in the same batch — so their dispatched commands ran against event #1's context branch and inherited event #1's
- * correlation/causation metadata (a corrupted causation chain), tracing on or not.
- * <p>
- * This test drives exactly that shape: two events in a single batch, an automation that dispatches a command per event
- * through the <em>injected</em> {@link CommandDispatcher}. Each dispatched command must carry the {@code causationId}
- * (and {@code correlationId}) of its OWN triggering event.
- * <ul>
- *     <li>With the buggy caching {@code forContext}: event #2's command carries event #1's ids → the two commands share
- *     one {@code causationId} → this test fails.</li>
- *     <li>With the fresh-per-call {@code forContext}: each command carries its own event's ids → this test passes.</li>
- * </ul>
+ * Verifies that when a {@link PooledStreamingEventProcessor} handles multiple events within a single batch, an
+ * automation reacting to each event resolves its own {@link CommandDispatcher} via
+ * {@link CommandDispatcher#forContext(org.axonframework.messaging.core.unitofwork.ProcessingContext) forContext}, and
+ * every command it dispatches carries the {@code causationId} and {@code correlationId} of its own triggering event.
  *
  * @author Mateusz Nowak
  */
@@ -95,9 +81,9 @@ class InjectedCommandDispatcherBatchCausationInMemoryIT extends AbstractStudentI
                                                  "both enrollment events should have dispatched a command"));
 
         // when — replay the (now already-processed) events. A replay reads them as a backlog, which the pooled
-        // processor groups into a SINGLE batch (batchSize 2, one segment) sharing one root ProcessingContext —
-        // the shape that triggers the defect. (Live tailing delivers one event per batch, so it cannot reproduce
-        // it; and resetTokens only replays up to the current token, hence the initial live pass above.)
+        // processor groups into a SINGLE batch (batchSize 2, one segment) sharing one root ProcessingContext, so
+        // both events are handled within it. (Live tailing delivers one event per batch; resetTokens only replays
+        // up to the current token, hence the initial live pass above.)
         replayAlreadyProcessedEvents();
 
         // then
@@ -110,12 +96,11 @@ class InjectedCommandDispatcherBatchCausationInMemoryIT extends AbstractStudentI
         var command1 = byCourse.get("course-1");
         var command2 = byCourse.get("course-2");
 
-        // each command must be caused by its OWN triggering event, not by the first event of the batch
+        // each command must be caused by its own triggering event
         assertEquals(eventIdByCourse.get("course-1"), command1.causationId(),
                      "command for event #1 must carry event #1's causationId");
         assertEquals(eventIdByCourse.get("course-2"), command2.causationId(),
-                     "command for event #2 must carry event #2's causationId, not event #1's "
-                             + "(forContext must return a fresh CommandDispatcher per call)");
+                     "command for event #2 must carry event #2's causationId, not event #1's");
 
         // ... and therefore the causation/correlation of the two commands differ
         assertNotEquals(command1.causationId(), command2.causationId(),
@@ -133,7 +118,7 @@ class InjectedCommandDispatcherBatchCausationInMemoryIT extends AbstractStudentI
                                                Metadata.emptyInstance());
         UnitOfWork uow = unitOfWorkFactory.create();
         // Publish BOTH events in a single call => one atomic append => the pooled processor reads them
-        // in ONE batch (sharing a single root ProcessingContext), which is what triggers the defect.
+        // in ONE batch (sharing a single root ProcessingContext).
         uow.runOnInvocation(context -> context.component(EventSink.class).publish(context, message1, message2));
         uow.execute().join();
         return Map.of(course1, message1.identifier(), course2, message2.identifier());
@@ -185,8 +170,7 @@ class InjectedCommandDispatcherBatchCausationInMemoryIT extends AbstractStudentI
 
     /**
      * Reacts to every {@link StudentEnrolledEvent} by dispatching a command through the <em>injected</em>
-     * {@link CommandDispatcher} — i.e. resolved via {@code forContext(context)} on each invocation. This is the path
-     * that carried the batch-sharing defect.
+     * {@link CommandDispatcher} - i.e. resolved via {@code forContext(context)} on each invocation.
      */
     static class NotifyOnEnrollmentAutomation {
 

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
@@ -49,12 +49,11 @@ public interface CommandDispatcher extends DescribableComponent {
     /**
      * Creates a dispatcher for the given {@link ProcessingContext}.
      * <p>
-     * You can use this dispatcher <b>only</b> for the context it was created for. Every invocation returns a fresh
-     * instance bound to the given {@code context} - it is never cached or shared with another call, even for the
-     * same {@code context}. This matters when {@code context} overrides one or more resources on top of a shared
-     * parent (e.g. one such override per event in a streaming processor's batch): each context with its own
-     * overridden resources must resolve its own dispatcher rather than risk one context's dispatcher leaking into
-     * another's.
+     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
+     * with another call, even for the same {@code context}. Use the returned dispatcher only for operations
+     * belonging to that {@code context}: if {@code context} is a branch created via
+     * {@link ProcessingContext#withResource} (e.g. one such branch per event in a streaming processor's batch), each
+     * branch must resolve its own dispatcher rather than risk one branch's dispatcher leaking into another's.
      *
      * @param context The {@link ProcessingContext} to create the dispatcher for.
      * @return A fresh command dispatcher specific for the given {@code context}.

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
@@ -21,7 +21,6 @@ import org.axonframework.common.configuration.Configuration;
 import org.axonframework.messaging.commandhandling.CommandBus;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.annotation.CommandDispatcherParameterResolverFactory;
-import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.annotation.MessageHandler;
@@ -48,24 +47,20 @@ import java.util.concurrent.CompletableFuture;
 public interface CommandDispatcher extends DescribableComponent {
 
     /**
-     * The {@link Context.ResourceKey} used to store the {@link CommandDispatcher} in the {@link ProcessingContext}.
-     */
-    Context.ResourceKey<ContextAwareCommandDispatcher> RESOURCE_KEY = Context.ResourceKey.withLabel("CommandDispatcher");
-
-    /**
      * Creates a dispatcher for the given {@link ProcessingContext}.
      * <p>
-     * You can use this dispatcher <b>only</b> for the context it was created for. There is no harm in using this method
-     * more than once with the same {@code context}, as the same dispatcher will be returned.
+     * You can use this dispatcher <b>only</b> for the context it was created for. Every invocation returns a fresh
+     * instance bound to the given {@code context} - it is never cached or shared with another call, even for the
+     * same {@code context}. This matters when {@code context} overrides one or more resources on top of a shared
+     * parent (e.g. one such override per event in a streaming processor's batch): each context with its own
+     * overridden resources must resolve its own dispatcher rather than risk one context's dispatcher leaking into
+     * another's.
      *
      * @param context The {@link ProcessingContext} to create the dispatcher for.
-     * @return The command dispatcher specific for the given {@code context}.
+     * @return A fresh command dispatcher specific for the given {@code context}.
      */
     static CommandDispatcher forContext(ProcessingContext context) {
-        return context.computeResourceIfAbsent(
-                RESOURCE_KEY,
-                () -> new ContextAwareCommandDispatcher(context.component(CommandGateway.class), context)
-        );
+        return new ContextAwareCommandDispatcher(context.component(CommandGateway.class), context);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
@@ -53,11 +53,9 @@ public interface CommandDispatcher extends DescribableComponent {
      * of dispatching directly through a {@link CommandGateway}: the dispatcher returned here is bound to that
      * {@code context}, so every command it sends is dispatched with that context's resources correctly applied.
      * <p>
-     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
-     * with another call, even for the same {@code context}. Use the returned dispatcher only for operations
-     * belonging to that {@code context}: if {@code context} is a branch created via
-     * {@link ProcessingContext#withResource} (e.g. one such branch per event in a streaming processor's batch), each
-     * branch must resolve its own dispatcher rather than risk one branch's dispatcher leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may
+     * override resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an
+     * instance across such branches would risk it silently operating against the wrong one.
      *
      * @param context The {@link ProcessingContext} to create the dispatcher for.
      * @return A fresh command dispatcher specific for the given {@code context}.

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
@@ -49,6 +49,11 @@ public interface CommandDispatcher extends DescribableComponent {
     /**
      * Creates a dispatcher for the given {@link ProcessingContext}.
      * <p>
+     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
+     * of dispatching directly through a {@link CommandGateway}: the dispatcher returned here is bound to that
+     * {@code context}, so every command it sends correctly carries the correlation/causation of whatever is
+     * currently being handled.
+     * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned dispatcher only for operations
      * belonging to that {@code context}: if {@code context} is a branch created via

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandDispatcher.java
@@ -51,8 +51,7 @@ public interface CommandDispatcher extends DescribableComponent {
      * <p>
      * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
      * of dispatching directly through a {@link CommandGateway}: the dispatcher returned here is bound to that
-     * {@code context}, so every command it sends correctly carries the correlation/causation of whatever is
-     * currently being handled.
+     * {@code context}, so every command it sends is dispatched with that context's resources correctly applied.
      * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned dispatcher only for operations

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
@@ -116,7 +116,7 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      * parent. Such a branch only intercepts {@code computeResourceIfAbsent} for its own overridden key; every other
      * key falls through to the shared parent, ultimately the root context. If the supplied instance holds onto
      * {@code context}, and {@code context} may be one of several sibling branches of a shared parent (for example,
-     * one branch per event in a streaming processor's batch), the first branch to call this method gets its
+     * one branch per message being handled within a shared batch), the first branch to call this method gets its
      * instance cached on the shared root, and every sibling branch that calls afterward receives that <em>same</em>
      * stale instance back - silently operating against the wrong branch. For example, this is unsafe:
      * <pre>{@code
@@ -125,9 +125,9 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      *     return context.computeResourceIfAbsent(RESOURCE_KEY, () -> new MyContextAwareGateway(context));
      * }
      * }</pre>
-     * If {@code context} is a per-event branch of a batch, the second event to call {@code forContext} receives the
-     * first event's gateway back, closed over the first event's branch. Supply a fresh instance directly instead,
-     * bypassing this resource store entirely:
+     * If {@code context} is a per-message branch of a batch, the second message to call {@code forContext} receives
+     * the first message's gateway back, closed over the first message's branch. Supply a fresh instance directly
+     * instead, bypassing this resource store entirely:
      * <pre>{@code
      * // SAFE: always supplies a fresh instance bound to whichever context is passed in.
      * static MyContextAwareGateway forContext(ProcessingContext context) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
@@ -107,6 +107,37 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      * "Recursive update"). This matters when stacking decorators that each cache their wrapped instance per
      * {@code ProcessingContext}: resolve the dependency on the delegate <em>before</em> entering the supplier, rather
      * than from within it.
+     * <p>
+     * <b>Never cache a resource whose construction closes over (holds a reference to) this {@code ProcessingContext}
+     * itself</b>, unless {@code key} is guaranteed to be one of the resources every possible branch of this context
+     * overrides. A {@link ResourceOverridingProcessingContext} - the result of {@link #withResource(ResourceKey,
+     * Object)} - only intercepts {@code computeResourceIfAbsent} for its own overridden key; every other key falls
+     * through to the shared delegate, ultimately the root context. If the supplied instance holds onto
+     * {@code context}, and {@code context} may be one of several sibling branches of a shared parent (for example,
+     * one branch per event in a streaming processor's batch), the first branch to call this method gets its
+     * instance cached on the shared root, and every sibling branch that calls afterward receives that <em>same</em>
+     * stale instance back - silently operating against the wrong branch. For example, this is unsafe:
+     * <pre>{@code
+     * // UNSAFE: MyContextAwareGateway's constructor stores a reference to "context".
+     * static MyContextAwareGateway forContext(ProcessingContext context) {
+     *     return context.computeResourceIfAbsent(RESOURCE_KEY, () -> new MyContextAwareGateway(context));
+     * }
+     * }</pre>
+     * If {@code context} is a per-event branch of a batch, the second event to call {@code forContext} receives the
+     * first event's gateway back, closed over the first event's branch. Construct a fresh instance on every call
+     * instead - see {@link org.axonframework.messaging.commandhandling.gateway.CommandDispatcher#forContext(ProcessingContext)},
+     * {@link org.axonframework.messaging.eventhandling.gateway.EventAppender#forContext(ProcessingContext)}, and
+     * {@link org.axonframework.messaging.queryhandling.QueryUpdateEmitter#forContext(ProcessingContext)}, all of
+     * which were fixed for exactly this reason.
+     * <p>
+     * This method remains the correct choice when the cached value does <em>not</em> reference {@code context} and
+     * is genuinely meant to be shared for the whole processing session, regardless of how many branches exist. For
+     * example:
+     * <pre>{@code
+     * // SAFE: the cached ConcurrentHashMap never references "context", and is meant to be
+     * // shared across every branch of the same processing session.
+     * var managedEntities = context.computeResourceIfAbsent(managedEntitiesKey, ConcurrentHashMap::new);
+     * }</pre>
      *
      * @param key              The key to register the resource for.
      * @param resourceSupplier The function to supply the resource to register. Must not call back into the resource

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
@@ -108,10 +108,10 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      * {@code ProcessingContext}: resolve the dependency on the delegate <em>before</em> entering the supplier, rather
      * than from within it.
      * <p>
-     * <b>Warning:</b> never cache a resource whose construction closes over (holds a reference to) this
-     * {@code ProcessingContext} itself - supply a fresh instance on every call instead - unless {@code key} is
-     * guaranteed to be one of the resources every possible branch of this context overrides. A "branch" here is any
-     * {@code ProcessingContext} returned by {@link #withResource(ResourceKey, Object)}: a
+     * <b>Warning:</b> never use this method for a resource whose construction closes over (holds a reference to)
+     * this {@code ProcessingContext} itself - construct a fresh instance directly on every call instead - unless
+     * {@code key} is guaranteed to be one of the resources every possible branch of this context overrides. A
+     * "branch" here is any {@code ProcessingContext} returned by {@link #withResource(ResourceKey, Object)}: a
      * {@link ResourceOverridingProcessingContext} that overrides one specific resource key on top of a shared
      * parent. Such a branch only intercepts {@code computeResourceIfAbsent} for its own overridden key; every other
      * key falls through to the shared parent, ultimately the root context. If the supplied instance holds onto

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
@@ -134,10 +134,6 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      *     return new MyContextAwareGateway(context);
      * }
      * }</pre>
-     * See {@link org.axonframework.messaging.commandhandling.gateway.CommandDispatcher#forContext(ProcessingContext)},
-     * {@link org.axonframework.messaging.eventhandling.gateway.EventAppender#forContext(ProcessingContext)}, and
-     * {@link org.axonframework.messaging.queryhandling.QueryUpdateEmitter#forContext(ProcessingContext)}, all of
-     * which were fixed for exactly this reason.
      * <p>
      * This method remains the correct choice when the cached value does <em>not</em> reference {@code context} and
      * is genuinely meant to be shared for the whole processing session, regardless of how many branches exist. For

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingContext.java
@@ -108,11 +108,13 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      * {@code ProcessingContext}: resolve the dependency on the delegate <em>before</em> entering the supplier, rather
      * than from within it.
      * <p>
-     * <b>Never cache a resource whose construction closes over (holds a reference to) this {@code ProcessingContext}
-     * itself</b>, unless {@code key} is guaranteed to be one of the resources every possible branch of this context
-     * overrides. A {@link ResourceOverridingProcessingContext} - the result of {@link #withResource(ResourceKey,
-     * Object)} - only intercepts {@code computeResourceIfAbsent} for its own overridden key; every other key falls
-     * through to the shared delegate, ultimately the root context. If the supplied instance holds onto
+     * <b>Warning:</b> never cache a resource whose construction closes over (holds a reference to) this
+     * {@code ProcessingContext} itself - supply a fresh instance on every call instead - unless {@code key} is
+     * guaranteed to be one of the resources every possible branch of this context overrides. A "branch" here is any
+     * {@code ProcessingContext} returned by {@link #withResource(ResourceKey, Object)}: a
+     * {@link ResourceOverridingProcessingContext} that overrides one specific resource key on top of a shared
+     * parent. Such a branch only intercepts {@code computeResourceIfAbsent} for its own overridden key; every other
+     * key falls through to the shared parent, ultimately the root context. If the supplied instance holds onto
      * {@code context}, and {@code context} may be one of several sibling branches of a shared parent (for example,
      * one branch per event in a streaming processor's batch), the first branch to call this method gets its
      * instance cached on the shared root, and every sibling branch that calls afterward receives that <em>same</em>
@@ -124,8 +126,15 @@ public interface ProcessingContext extends ProcessingLifecycle, ApplicationConte
      * }
      * }</pre>
      * If {@code context} is a per-event branch of a batch, the second event to call {@code forContext} receives the
-     * first event's gateway back, closed over the first event's branch. Construct a fresh instance on every call
-     * instead - see {@link org.axonframework.messaging.commandhandling.gateway.CommandDispatcher#forContext(ProcessingContext)},
+     * first event's gateway back, closed over the first event's branch. Supply a fresh instance directly instead,
+     * bypassing this resource store entirely:
+     * <pre>{@code
+     * // SAFE: always supplies a fresh instance bound to whichever context is passed in.
+     * static MyContextAwareGateway forContext(ProcessingContext context) {
+     *     return new MyContextAwareGateway(context);
+     * }
+     * }</pre>
+     * See {@link org.axonframework.messaging.commandhandling.gateway.CommandDispatcher#forContext(ProcessingContext)},
      * {@link org.axonframework.messaging.eventhandling.gateway.EventAppender#forContext(ProcessingContext)}, and
      * {@link org.axonframework.messaging.queryhandling.QueryUpdateEmitter#forContext(ProcessingContext)}, all of
      * which were fixed for exactly this reason.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
@@ -52,8 +52,8 @@ public interface EventAppender extends DescribableComponent {
      * Creates an appender for the given {@link ProcessingContext}.
      * <p>
      * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
-     * of appending directly through an {@link EventSink}: the appender returned here is bound to that {@code context},
-     * so every event it appends correctly carries the correlation/causation of whatever is currently being handled.
+     * of appending directly through an {@link EventSink}: the appender returned here is bound to that
+     * {@code context}, so every event it appends is published with that context's resources correctly applied.
      * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
@@ -72,8 +72,8 @@ public interface EventAppender extends DescribableComponent {
      * Creates an appender for the given {@link ProcessingContext} and {@link EventSink}.
      * <p>
      * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
-     * of appending directly through an {@link EventSink}: the appender returned here is bound to that {@code context},
-     * so every event it appends correctly carries the correlation/causation of whatever is currently being handled.
+     * of appending directly through an {@link EventSink}: the appender returned here is bound to that
+     * {@code context}, so every event it appends is published with that context's resources correctly applied.
      * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned appender only for operations belonging

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
@@ -51,11 +51,11 @@ public interface EventAppender extends DescribableComponent {
     /**
      * Creates an appender for the given {@link ProcessingContext}.
      * <p>
-     * You can use this appender only for the context it was created for. Every invocation returns a fresh instance
-     * bound to the given {@code context} - it is never cached or shared with another call, even for the same
-     * {@code context}. This matters when {@code context} overrides one or more resources on top of a shared parent
-     * (e.g. one such override per event in a streaming processor's batch): each context with its own overridden
-     * resources must resolve its own appender rather than risk one context's appender leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
+     * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
+     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
+     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own appender
+     * rather than risk one branch's appender leaking into another's.
      *
      * @param context The {@link ProcessingContext} to create the appender for.
      * @return A fresh appender specific for the given {@code context}.
@@ -67,11 +67,11 @@ public interface EventAppender extends DescribableComponent {
     /**
      * Creates an appender for the given {@link ProcessingContext} and {@link EventSink}.
      * <p>
-     * You can use this appender only for the context it was created for. Every invocation returns a fresh instance
-     * bound to the given {@code context} - it is never cached or shared with another call, even for the same
-     * {@code context}. This matters when {@code context} overrides one or more resources on top of a shared parent
-     * (e.g. one such override per event in a streaming processor's batch): each context with its own overridden
-     * resources must resolve its own appender rather than risk one context's appender leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
+     * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
+     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
+     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own appender
+     * rather than risk one branch's appender leaking into another's.
      *
      * @param context             The {@link ProcessingContext} to create the appender for.
      * @param eventSink           The {@link EventSink} to use for the appender.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
@@ -20,7 +20,6 @@ import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.messaging.eventhandling.EventSink;
 import org.axonframework.messaging.eventhandling.annotation.EventAppenderParameterResolverFactory;
-import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.annotation.MessageHandler;
@@ -50,32 +49,34 @@ import java.util.Objects;
 public interface EventAppender extends DescribableComponent {
 
     /**
-     * The {@link Context.ResourceKey} used to store the {@link EventAppender} in the {@link ProcessingContext}.
-     */
-    Context.ResourceKey<ProcessingContextEventAppender> RESOURCE_KEY = Context.ResourceKey.withLabel("EventAppender");
-
-    /**
      * Creates an appender for the given {@link ProcessingContext}.
      * <p>
-     * You can use this appender only for the context it was created for. There is no harm in using this method more
-     * than once, as the same appender will be returned.
+     * You can use this appender only for the context it was created for. Every invocation returns a fresh instance
+     * bound to the given {@code context} - it is never cached or shared with another call, even for the same
+     * {@code context}. This matters when {@code context} overrides one or more resources on top of a shared parent
+     * (e.g. one such override per event in a streaming processor's batch): each context with its own overridden
+     * resources must resolve its own appender rather than risk one context's appender leaking into another's.
      *
      * @param context The {@link ProcessingContext} to create the appender for.
-     * @return The created appender.
+     * @return A fresh appender specific for the given {@code context}.
      */
     static EventAppender forContext(ProcessingContext context) {
         return forContext(context, context.component(EventSink.class), context.component(MessageTypeResolver.class));
     }
 
     /**
-     * Creates an appender for the given {@link ProcessingContext} and {@link EventSink}. You can use this appender only
-     * for the context it was created for. There is no harm in using this method more than once, as the same appender
-     * will be returned.
+     * Creates an appender for the given {@link ProcessingContext} and {@link EventSink}.
+     * <p>
+     * You can use this appender only for the context it was created for. Every invocation returns a fresh instance
+     * bound to the given {@code context} - it is never cached or shared with another call, even for the same
+     * {@code context}. This matters when {@code context} overrides one or more resources on top of a shared parent
+     * (e.g. one such override per event in a streaming processor's batch): each context with its own overridden
+     * resources must resolve its own appender rather than risk one context's appender leaking into another's.
      *
      * @param context             The {@link ProcessingContext} to create the appender for.
      * @param eventSink           The {@link EventSink} to use for the appender.
      * @param messageTypeResolver The {@link MessageTypeResolver} to use for the appender.
-     * @return The created appender.
+     * @return A fresh appender specific for the given {@code context}.
      */
     static EventAppender forContext(
             ProcessingContext context,
@@ -83,10 +84,7 @@ public interface EventAppender extends DescribableComponent {
             MessageTypeResolver messageTypeResolver
     ) {
         Objects.requireNonNull(context, "ProcessingContext may not be null");
-        return context.computeResourceIfAbsent(
-                RESOURCE_KEY,
-                () -> new ProcessingContextEventAppender(context, eventSink, messageTypeResolver)
-        );
+        return new ProcessingContextEventAppender(context, eventSink, messageTypeResolver);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
@@ -51,6 +51,10 @@ public interface EventAppender extends DescribableComponent {
     /**
      * Creates an appender for the given {@link ProcessingContext}.
      * <p>
+     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
+     * of appending directly through an {@link EventSink}: the appender returned here is bound to that {@code context},
+     * so every event it appends correctly carries the correlation/causation of whatever is currently being handled.
+     * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
      * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
@@ -66,6 +70,10 @@ public interface EventAppender extends DescribableComponent {
 
     /**
      * Creates an appender for the given {@link ProcessingContext} and {@link EventSink}.
+     * <p>
+     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
+     * of appending directly through an {@link EventSink}: the appender returned here is bound to that {@code context},
+     * so every event it appends correctly carries the correlation/causation of whatever is currently being handled.
      * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned appender only for operations belonging

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/gateway/EventAppender.java
@@ -55,11 +55,9 @@ public interface EventAppender extends DescribableComponent {
      * of appending directly through an {@link EventSink}: the appender returned here is bound to that
      * {@code context}, so every event it appends is published with that context's resources correctly applied.
      * <p>
-     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
-     * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
-     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
-     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own appender
-     * rather than risk one branch's appender leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may
+     * override resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an
+     * instance across such branches would risk it silently operating against the wrong one.
      *
      * @param context The {@link ProcessingContext} to create the appender for.
      * @return A fresh appender specific for the given {@code context}.
@@ -75,11 +73,9 @@ public interface EventAppender extends DescribableComponent {
      * of appending directly through an {@link EventSink}: the appender returned here is bound to that
      * {@code context}, so every event it appends is published with that context's resources correctly applied.
      * <p>
-     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
-     * with another call, even for the same {@code context}. Use the returned appender only for operations belonging
-     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
-     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own appender
-     * rather than risk one branch's appender leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may
+     * override resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an
+     * instance across such branches would risk it silently operating against the wrong one.
      *
      * @param context             The {@link ProcessingContext} to create the appender for.
      * @param eventSink           The {@link EventSink} to use for the appender.

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -18,7 +18,6 @@ package org.axonframework.messaging.queryhandling;
 
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.conversion.ConversionException;
-import org.axonframework.messaging.core.Context.ResourceKey;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeNotResolvedException;
 import org.axonframework.messaging.core.MessageTypeResolver;
@@ -48,28 +47,25 @@ import java.util.function.Supplier;
 public interface QueryUpdateEmitter extends DescribableComponent {
 
     /**
-     * The {@link ResourceKey} used to store the {@link QueryUpdateEmitter} in the {@link ProcessingContext}.
-     */
-    ResourceKey<QueryUpdateEmitter> RESOURCE_KEY = ResourceKey.withLabel("QueryUpdateEmitter");
-
-    /**
      * Creates a query update emitter for the given {@link ProcessingContext}.
      * <p>
-     * You can use this emitter <b>only</b> for the context it was created for. There is no harm in using this method
-     * more than once with the same {@code context}, as the same emitter will be returned.
+     * You can use this emitter <b>only</b> for the context it was created for. Every invocation returns a fresh
+     * instance bound to the given {@code context} - it is never cached or shared with another call, even for the
+     * same {@code context}. This matters when {@code context} overrides one or more resources on top of a shared
+     * parent (e.g. one such override per event in a streaming processor's batch): each context with its own
+     * overridden resources must resolve its own emitter rather than risk one context's emitter leaking into
+     * another's. See {@link ProcessingContext#computeResourceIfAbsent} for why this method deliberately does not
+     * cache its result.
      *
      * @param context The {@link ProcessingContext} to create the emitter for.
-     * @return The emitter specific for the given {@code context}.
+     * @return A fresh emitter specific for the given {@code context}.
      */
     static QueryUpdateEmitter forContext(ProcessingContext context) {
-        return context.computeResourceIfAbsent(
-                RESOURCE_KEY,
-                () -> new SimpleQueryUpdateEmitter(
-                        context.component(QueryBus.class),
-                        context.component(MessageTypeResolver.class),
-                        context.component(MessageConverter.class),
-                        context
-                )
+        return new SimpleQueryUpdateEmitter(
+                context.component(QueryBus.class),
+                context.component(MessageTypeResolver.class),
+                context.component(MessageConverter.class),
+                context
         );
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -54,11 +54,9 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * ensuring updates are emitted in the correct order relative to the lifecycle of whatever is currently being
      * handled.
      * <p>
-     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
-     * with another call, even for the same {@code context}. Use the returned emitter only for operations belonging
-     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
-     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own emitter
-     * rather than risk one branch's emitter leaking into another's.
+     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may
+     * override resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an
+     * instance across such branches would risk it silently operating against the wrong one.
      *
      * @param context The {@link ProcessingContext} to create the emitter for.
      * @return A fresh emitter specific for the given {@code context}.

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -49,13 +49,12 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Creates a query update emitter for the given {@link ProcessingContext}.
      * <p>
-     * You can use this emitter <b>only</b> for the context it was created for. Every invocation returns a fresh
-     * instance bound to the given {@code context} - it is never cached or shared with another call, even for the
-     * same {@code context}. This matters when {@code context} overrides one or more resources on top of a shared
-     * parent (e.g. one such override per event in a streaming processor's batch): each context with its own
-     * overridden resources must resolve its own emitter rather than risk one context's emitter leaking into
-     * another's. See {@link ProcessingContext#computeResourceIfAbsent} for why this method deliberately does not
-     * cache its result.
+     * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
+     * with another call, even for the same {@code context}. Use the returned emitter only for operations belonging
+     * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
+     * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own emitter
+     * rather than risk one branch's emitter leaking into another's. See
+     * {@link ProcessingContext#computeResourceIfAbsent} for why this method deliberately does not cache its result.
      *
      * @param context The {@link ProcessingContext} to create the emitter for.
      * @return A fresh emitter specific for the given {@code context}.

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -49,6 +49,11 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Creates a query update emitter for the given {@link ProcessingContext}.
      * <p>
+     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
+     * of emitting directly through a {@link QueryBus}: the emitter returned here is bound to that {@code context},
+     * ensuring updates are emitted in the correct order relative to the lifecycle of whatever is currently being
+     * handled.
+     * <p>
      * Every invocation returns a fresh instance bound to the given {@code context} - it is never cached or shared
      * with another call, even for the same {@code context}. Use the returned emitter only for operations belonging
      * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -58,8 +58,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * with another call, even for the same {@code context}. Use the returned emitter only for operations belonging
      * to that {@code context}: if {@code context} is a branch created via {@link ProcessingContext#withResource}
      * (e.g. one such branch per event in a streaming processor's batch), each branch must resolve its own emitter
-     * rather than risk one branch's emitter leaking into another's. See
-     * {@link ProcessingContext#computeResourceIfAbsent} for why this method deliberately does not cache its result.
+     * rather than risk one branch's emitter leaking into another's.
      *
      * @param context The {@link ProcessingContext} to create the emitter for.
      * @return A fresh emitter specific for the given {@code context}.

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -23,6 +23,9 @@ import org.axonframework.common.util.MockException;
 import org.axonframework.conversion.DelegatingGeneralConverter;
 import org.axonframework.conversion.GeneralConverter;
 import org.axonframework.conversion.TestConverter;
+import org.axonframework.messaging.commandhandling.gateway.CommandDispatcher;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.commandhandling.gateway.CommandResult;
 import org.axonframework.messaging.core.ApplicationContext;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
@@ -66,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -119,6 +123,7 @@ class PooledStreamingEventProcessorTest {
     private SimpleEventHandlingComponent simpleEhc;
     private RecordingEventHandlingComponent defaultEventHandlingComponent;
     private GeneralConverter converter;
+    private CommandGateway commandGateway;
 
     @BeforeEach
     void setUp() {
@@ -133,6 +138,7 @@ class PooledStreamingEventProcessorTest {
         simpleEhc.subscribe(new QualifiedName(Integer.class), (event, ctx) -> MessageStream.empty());
         defaultEventHandlingComponent = spy(new RecordingEventHandlingComponent(simpleEhc));
         converter = new DelegatingGeneralConverter(TestConverter.JACKSON.getConverter());
+        commandGateway = mock(CommandGateway.class);
         withTestSubject(List.of()); // default always applied
     }
 
@@ -156,6 +162,7 @@ class PooledStreamingEventProcessorTest {
 
         TestApplicationContext testApplicationContext = new TestApplicationContext();
         testApplicationContext.addComponent(GeneralConverter.class, null, converter);
+        testApplicationContext.addComponent(CommandGateway.class, null, commandGateway);
         EventProcessorConfiguration baseConfig = new EventProcessorConfiguration(PROCESSOR_NAME, null);
         var testDefaultConfiguration = new PooledStreamingEventProcessorConfiguration(baseConfig)
                 .eventSource(stubMessageSource)
@@ -480,6 +487,70 @@ class PooledStreamingEventProcessorTest {
 
             // then
             assertTrue(countDownLatch.await(5, TimeUnit.SECONDS));
+        }
+
+        @Test
+        void forContextDispatchesUsingEachEventsOwnPerEventResourceWithinABatch() {
+            // Within a single batch, ProcessorEventHandlingComponents.handle(entries, context) branches the shared
+            // batch context once per event, overriding TrackingToken.RESOURCE_KEY with that event's own token (see
+            // WorkPackage#processBatch). CommandDispatcher.forContext(ctx) caches its wrapper under a DIFFERENT key
+            // (CommandDispatcher.RESOURCE_KEY) via computeResourceIfAbsent: if that cache write is not scoped to the
+            // event's own branch, the wrapper created for the first event handled in a batch leaks into every later
+            // event of that SAME batch, which then dispatches in the first event's branch instead of its own.
+            //
+            // For each event this records the TrackingToken the handler itself observed (always correct - read
+            // directly off its own branch) plus a batch identity key (the branch's toString omits the per-event
+            // override, so two events share this key iff they were branched from the same batch root). It also
+            // records the TrackingToken the CommandGateway actually saw when CommandDispatcher.forContext(ctx)
+            // dispatched. Within any batch shared by 2+ events, every event's dispatched token must equal its own
+            // handler-observed token - not another event's from the same batch.
+            Map<Object, TrackingToken> tokenSeenByHandler = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<Object, String> batchKeyOfEvent = Collections.synchronizedMap(new HashMap<>());
+            Map<Object, TrackingToken> tokenSeenAtDispatch = Collections.synchronizedMap(new HashMap<>());
+
+            when(commandGateway.send(any(), any(ProcessingContext.class))).thenAnswer(invocation -> {
+                Object payload = invocation.getArgument(0);
+                ProcessingContext dispatchContext = invocation.getArgument(1);
+                TrackingToken.fromContext(dispatchContext).ifPresent(token -> tokenSeenAtDispatch.put(payload, token));
+                return mock(CommandResult.class);
+            });
+
+            var ehc = SimpleEventHandlingComponent.create("test");
+            ehc.subscribe(new QualifiedName(String.class), (event, ctx) -> {
+                Object payload = event.payload();
+                TrackingToken.fromContext(ctx).ifPresent(token -> tokenSeenByHandler.put(payload, token));
+                batchKeyOfEvent.put(payload, ctx.toString());
+                return MessageStream.fromFuture(CommandDispatcher.forContext(ctx).send(payload).getResultMessage()).ignoreEntries().cast();
+            });
+            stubMessageSource = new AsyncInMemoryStreamableEventSource(false, false);
+            withTestSubject(List.of(ehc), c -> c.initialSegmentCount(1).batchSize(5));
+
+            // when - publish 3 events before starting; the WorkPackage groups whichever of them arrive together
+            // into the same batch
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            stubMessageSource.publishMessage(event1);
+            stubMessageSource.publishMessage(event2);
+            stubMessageSource.publishMessage(event3);
+            startEventProcessor();
+
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(tokenSeenAtDispatch.keySet())
+                           .containsExactlyInAnyOrder("event-1", "event-2", "event-3"));
+
+            // sanity precondition - this only proves anything if at least one batch actually contained 2+ events
+            Map<String, List<Object>> eventsByBatch = batchKeyOfEvent.entrySet().stream()
+                    .collect(Collectors.groupingBy(Map.Entry::getValue,
+                                                    Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
+            assertThat(eventsByBatch.values())
+                    .as("expected at least one batch with 2+ events, so the cross-event forContext cache can be observed")
+                    .anyMatch(eventsInBatch -> eventsInBatch.size() >= 2);
+
+            // then - each event's dispatch must have used ITS OWN per-event token, matching what its handler saw.
+            // With the caching bug, an event sharing a batch with an earlier one dispatches using that earlier
+            // event's token instead of its own.
+            assertThat(tokenSeenAtDispatch).isEqualTo(tokenSeenByHandler);
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -501,21 +501,18 @@ class PooledStreamingEventProcessorTest {
             assertTrue(countDownLatch.await(5, TimeUnit.SECONDS));
         }
 
+        /**
+         * Verifies that when a batch contains multiple events, each event's {@code @EventHandler} resolves a
+         * {@link CommandDispatcher} bound to its <em>own</em> per-event {@link ProcessingContext} branch, so that
+         * every dispatched command carries that event's own per-event resource - not another event's from the same
+         * batch.
+         */
         @Test
         void forContextDispatchesUsingEachEventsOwnPerEventResourceWithinABatch() {
-            // Within a single batch, ProcessorEventHandlingComponents.handle(entries, context) branches the shared
-            // batch context once per event, overriding TrackingToken.RESOURCE_KEY with that event's own token (see
-            // WorkPackage#processBatch). This test guards CommandDispatcher.forContext(ctx) returning a fresh
-            // dispatcher bound to that event's OWN branch every time: if it were cached under some other resource
-            // key instead, the wrapper created for the first event handled in a batch would leak into every later
-            // event of that SAME batch, which would then dispatch in the first event's branch instead of its own.
-            //
-            // For each event this records the TrackingToken the handler itself observed (always correct - read
-            // directly off its own branch) plus a batch identity key (the branch's toString omits the per-event
-            // override, so two events share this key iff they were branched from the same batch root). It also
-            // records the TrackingToken the CommandGateway actually saw when CommandDispatcher.forContext(ctx)
-            // dispatched. Within any batch shared by 2+ events, every event's dispatched token must equal its own
-            // handler-observed token - not another event's from the same batch.
+            // For each event, records the TrackingToken the handler itself observed (read directly off its own
+            // branch) plus a batch identity key (the branch's toString omits the per-event override, so two events
+            // share this key iff they were branched from the same batch root). Also records the TrackingToken the
+            // CommandGateway actually saw when CommandDispatcher.forContext(ctx) dispatched.
             Map<Object, TrackingToken> tokenSeenByHandler = Collections.synchronizedMap(new LinkedHashMap<>());
             Map<Object, String> batchKeyOfEvent = Collections.synchronizedMap(new HashMap<>());
             Map<Object, TrackingToken> tokenSeenAtDispatch = Collections.synchronizedMap(new HashMap<>());
@@ -556,31 +553,25 @@ class PooledStreamingEventProcessorTest {
                     .collect(Collectors.groupingBy(Map.Entry::getValue,
                                                     Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
             assertThat(eventsByBatch.values())
-                    .as("expected at least one batch with 2+ events, so the cross-event forContext cache can be observed")
+                    .as("expected at least one batch with 2+ events, so each event's own branch resolution can be observed")
                     .anyMatch(eventsInBatch -> eventsInBatch.size() >= 2);
 
-            // then - each event's dispatch must have used ITS OWN per-event token, matching what its handler saw.
-            // With the caching bug, an event sharing a batch with an earlier one dispatches using that earlier
-            // event's token instead of its own.
+            // then - each event's dispatch must have used its own per-event token, matching what its handler saw
             assertThat(tokenSeenAtDispatch).isEqualTo(tokenSeenByHandler);
         }
 
+        /**
+         * Verifies that when a batch contains multiple events, each event's {@code @EventHandler} resolves a
+         * {@link QueryUpdateEmitter} bound to its <em>own</em> per-event {@link ProcessingContext} branch, so that
+         * every emitted update carries that event's own per-event resource - not another event's from the same
+         * batch.
+         */
         @Test
         void forContextEmitsUsingEachEventsOwnPerEventResourceWithinABatch() {
-            // Same defect shape as CommandDispatcher.forContext (see the test above), but for
-            // QueryUpdateEmitter.forContext: within a single batch, each event is handled against its own thin
-            // branch of the shared batch context, overriding TrackingToken.RESOURCE_KEY with that event's own
-            // token. This guards QueryUpdateEmitter.forContext(ctx) returning a fresh emitter bound to that event's
-            // OWN branch every time: if it were cached under some other resource key instead, the wrapper created
-            // for the first event handled in a batch would leak into every later event of that SAME batch, which
-            // would then emit in the first event's branch instead of its own.
-            //
-            // For each event this records the TrackingToken the handler itself observed (always correct - read
-            // directly off its own branch) plus a batch identity key (the branch's toString omits the per-event
-            // override, so two events share this key iff they were branched from the same batch root). It also
-            // records the TrackingToken the QueryBus actually saw when QueryUpdateEmitter.forContext(ctx) emitted.
-            // Within any batch shared by 2+ events, every event's emitted token must equal its own handler-observed
-            // token - not another event's from the same batch.
+            // For each event, records the TrackingToken the handler itself observed (read directly off its own
+            // branch) plus a batch identity key (the branch's toString omits the per-event override, so two events
+            // share this key iff they were branched from the same batch root). Also records the TrackingToken the
+            // QueryBus actually saw when QueryUpdateEmitter.forContext(ctx) emitted.
             Map<Object, TrackingToken> tokenSeenByHandler = Collections.synchronizedMap(new LinkedHashMap<>());
             Map<Object, String> batchKeyOfEvent = Collections.synchronizedMap(new HashMap<>());
             Map<Object, TrackingToken> tokenSeenAtEmit = Collections.synchronizedMap(new HashMap<>());
@@ -623,12 +614,10 @@ class PooledStreamingEventProcessorTest {
                     .collect(Collectors.groupingBy(Map.Entry::getValue,
                                                     Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
             assertThat(eventsByBatch.values())
-                    .as("expected at least one batch with 2+ events, so the cross-event forContext cache can be observed")
+                    .as("expected at least one batch with 2+ events, so each event's own branch resolution can be observed")
                     .anyMatch(eventsInBatch -> eventsInBatch.size() >= 2);
 
-            // then - each event's emit must have used ITS OWN per-event token, matching what its handler saw.
-            // With the caching bug, an event sharing a batch with an earlier one emits using that earlier
-            // event's token instead of its own.
+            // then - each event's emit must have used its own per-event token, matching what its handler saw
             assertThat(tokenSeenAtEmit).isEqualTo(tokenSeenByHandler);
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -493,10 +493,10 @@ class PooledStreamingEventProcessorTest {
         void forContextDispatchesUsingEachEventsOwnPerEventResourceWithinABatch() {
             // Within a single batch, ProcessorEventHandlingComponents.handle(entries, context) branches the shared
             // batch context once per event, overriding TrackingToken.RESOURCE_KEY with that event's own token (see
-            // WorkPackage#processBatch). CommandDispatcher.forContext(ctx) caches its wrapper under a DIFFERENT key
-            // (CommandDispatcher.RESOURCE_KEY) via computeResourceIfAbsent: if that cache write is not scoped to the
-            // event's own branch, the wrapper created for the first event handled in a batch leaks into every later
-            // event of that SAME batch, which then dispatches in the first event's branch instead of its own.
+            // WorkPackage#processBatch). This test guards CommandDispatcher.forContext(ctx) returning a fresh
+            // dispatcher bound to that event's OWN branch every time: if it were cached under some other resource
+            // key instead, the wrapper created for the first event handled in a batch would leak into every later
+            // event of that SAME batch, which would then dispatch in the first event's branch instead of its own.
             //
             // For each event this records the TrackingToken the handler itself observed (always correct - read
             // directly off its own branch) plus a batch identity key (the branch's toString omits the per-event

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -27,10 +27,13 @@ import org.axonframework.messaging.commandhandling.gateway.CommandDispatcher;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.commandhandling.gateway.CommandResult;
 import org.axonframework.messaging.core.ApplicationContext;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
@@ -56,6 +59,9 @@ import org.axonframework.messaging.eventhandling.replay.ReplayStatus;
 import org.axonframework.messaging.eventhandling.replay.ReplayStatusChangedHandler;
 import org.axonframework.messaging.eventhandling.replay.ResetHandler;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.queryhandling.QueryBus;
+import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
+import org.axonframework.messaging.queryhandling.SubscriptionQueryUpdateMessage;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
@@ -83,6 +89,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -124,6 +131,7 @@ class PooledStreamingEventProcessorTest {
     private RecordingEventHandlingComponent defaultEventHandlingComponent;
     private GeneralConverter converter;
     private CommandGateway commandGateway;
+    private QueryBus queryBus;
 
     @BeforeEach
     void setUp() {
@@ -139,6 +147,7 @@ class PooledStreamingEventProcessorTest {
         defaultEventHandlingComponent = spy(new RecordingEventHandlingComponent(simpleEhc));
         converter = new DelegatingGeneralConverter(TestConverter.JACKSON.getConverter());
         commandGateway = mock(CommandGateway.class);
+        queryBus = mock(QueryBus.class);
         withTestSubject(List.of()); // default always applied
     }
 
@@ -163,6 +172,9 @@ class PooledStreamingEventProcessorTest {
         TestApplicationContext testApplicationContext = new TestApplicationContext();
         testApplicationContext.addComponent(GeneralConverter.class, null, converter);
         testApplicationContext.addComponent(CommandGateway.class, null, commandGateway);
+        testApplicationContext.addComponent(QueryBus.class, null, queryBus);
+        testApplicationContext.addComponent(MessageTypeResolver.class, null, new ClassBasedMessageTypeResolver());
+        testApplicationContext.addComponent(MessageConverter.class, null, mock(MessageConverter.class));
         EventProcessorConfiguration baseConfig = new EventProcessorConfiguration(PROCESSOR_NAME, null);
         var testDefaultConfiguration = new PooledStreamingEventProcessorConfiguration(baseConfig)
                 .eventSource(stubMessageSource)
@@ -551,6 +563,73 @@ class PooledStreamingEventProcessorTest {
             // With the caching bug, an event sharing a batch with an earlier one dispatches using that earlier
             // event's token instead of its own.
             assertThat(tokenSeenAtDispatch).isEqualTo(tokenSeenByHandler);
+        }
+
+        @Test
+        void forContextEmitsUsingEachEventsOwnPerEventResourceWithinABatch() {
+            // Same defect shape as CommandDispatcher.forContext (see the test above), but for
+            // QueryUpdateEmitter.forContext: within a single batch, each event is handled against its own thin
+            // branch of the shared batch context, overriding TrackingToken.RESOURCE_KEY with that event's own
+            // token. This guards QueryUpdateEmitter.forContext(ctx) returning a fresh emitter bound to that event's
+            // OWN branch every time: if it were cached under some other resource key instead, the wrapper created
+            // for the first event handled in a batch would leak into every later event of that SAME batch, which
+            // would then emit in the first event's branch instead of its own.
+            //
+            // For each event this records the TrackingToken the handler itself observed (always correct - read
+            // directly off its own branch) plus a batch identity key (the branch's toString omits the per-event
+            // override, so two events share this key iff they were branched from the same batch root). It also
+            // records the TrackingToken the QueryBus actually saw when QueryUpdateEmitter.forContext(ctx) emitted.
+            // Within any batch shared by 2+ events, every event's emitted token must equal its own handler-observed
+            // token - not another event's from the same batch.
+            Map<Object, TrackingToken> tokenSeenByHandler = Collections.synchronizedMap(new LinkedHashMap<>());
+            Map<Object, String> batchKeyOfEvent = Collections.synchronizedMap(new HashMap<>());
+            Map<Object, TrackingToken> tokenSeenAtEmit = Collections.synchronizedMap(new HashMap<>());
+
+            when(queryBus.emitUpdate(any(), any(), any())).thenAnswer(invocation -> {
+                Supplier<SubscriptionQueryUpdateMessage> updateSupplier = invocation.getArgument(1);
+                ProcessingContext emitContext = invocation.getArgument(2);
+                Object payload = updateSupplier.get().payload();
+                TrackingToken.fromContext(emitContext).ifPresent(token -> tokenSeenAtEmit.put(payload, token));
+                return CompletableFuture.completedFuture(null);
+            });
+
+            var ehc = SimpleEventHandlingComponent.create("test");
+            ehc.subscribe(new QualifiedName(String.class), (event, ctx) -> {
+                Object payload = event.payload();
+                TrackingToken.fromContext(ctx).ifPresent(token -> tokenSeenByHandler.put(payload, token));
+                batchKeyOfEvent.put(payload, ctx.toString());
+                QueryUpdateEmitter.forContext(ctx).emit(String.class, q -> true, payload);
+                return MessageStream.empty();
+            });
+            stubMessageSource = new AsyncInMemoryStreamableEventSource(false, false);
+            withTestSubject(List.of(ehc), c -> c.initialSegmentCount(1).batchSize(5));
+
+            // when - publish 3 events before starting; the WorkPackage groups whichever of them arrive together
+            // into the same batch
+            EventMessage event1 = EventTestUtils.asEventMessage("event-1");
+            EventMessage event2 = EventTestUtils.asEventMessage("event-2");
+            EventMessage event3 = EventTestUtils.asEventMessage("event-3");
+            stubMessageSource.publishMessage(event1);
+            stubMessageSource.publishMessage(event2);
+            stubMessageSource.publishMessage(event3);
+            startEventProcessor();
+
+            await().atMost(2, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(tokenSeenAtEmit.keySet())
+                           .containsExactlyInAnyOrder("event-1", "event-2", "event-3"));
+
+            // sanity precondition - this only proves anything if at least one batch actually contained 2+ events
+            Map<String, List<Object>> eventsByBatch = batchKeyOfEvent.entrySet().stream()
+                    .collect(Collectors.groupingBy(Map.Entry::getValue,
+                                                    Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
+            assertThat(eventsByBatch.values())
+                    .as("expected at least one batch with 2+ events, so the cross-event forContext cache can be observed")
+                    .anyMatch(eventsInBatch -> eventsInBatch.size() >= 2);
+
+            // then - each event's emit must have used ITS OWN per-event token, matching what its handler saw.
+            // With the caching bug, an event sharing a batch with an earlier one emits using that earlier
+            // event's token instead of its own.
+            assertThat(tokenSeenAtEmit).isEqualTo(tokenSeenByHandler);
         }
     }
 


### PR DESCRIPTION
## The problem

A streaming (pooled) event processor creates **one `UnitOfWork` — and therefore one root `ProcessingContext` — per batch, not per event** (`WorkPackage#processEvents`: one `unitOfWorkFactory.create()`, one `onInvocation` action for the whole event batch). Each event in the batch is handled against a thin, immutable branch of that root (`ProcessorEventHandlingComponents#withEntryResources` → `ResourceOverridingProcessingContext`), which overrides *only* the entry's own keys (tracking token, aggregate identifiers). Every other resource key falls through the branch to the shared root map.

`CommandDispatcher.forContext(context)` and `EventAppender.forContext(context)` cached their wrapper via:

```java
context.computeResourceIfAbsent(RESOURCE_KEY, () -> new ContextAwareCommandDispatcher(gateway, context));
```

`RESOURCE_KEY` is **not** one of the keys a per-event branch overrides, so the cache write falls through and lands on the shared root. The first event's parameter resolution stores a wrapper whose closure captured the *first event's* context branch — and every later event in the same batch gets that same stale wrapper back. From that point on, every `send()`/`append()` for events 2..N in the batch silently runs against event 1's branch instead of its own.

```mermaid
flowchart TB
    Root["Root ProcessingContext<br/>(one UnitOfWork per batch)"]

    Root -->|"interceptOnHandle:<br/>bind CORRELATION_DATA<br/>causationId = event1.id"| Branch1["ProcessingContext for Event 1<br/>overridden resources: CORRELATION_DATA<br/>causationId = event1.id<br/>(everything else falls through to Root)"]
    Root -->|"interceptOnHandle:<br/>bind CORRELATION_DATA<br/>causationId = event2.id"| Branch2["ProcessingContext for Event 2<br/>overridden resources: CORRELATION_DATA<br/>causationId = event2.id<br/>(everything else falls through to Root)"]

    Branch1 -->|"forContext(branch1)<br/>MISS -&gt; create + cache on Root"| DispatcherForEvent1["Dispatcher created for Event 1<br/>(ContextAwareCommandDispatcher)<br/>commandGateway: CommandGateway<br/>context: Branch1 (Event 1)"]

    Branch2 -.->|"BUG: forContext(branch2)<br/>RESOURCE_KEY isn't an overridden<br/>resource -&gt; falls through to Root -&gt;<br/>HIT -&gt; returns the dispatcher<br/>already created for Event 1"| DispatcherForEvent1
    Branch2 ==>|"FIX: forContext(branch2)<br/>always constructs fresh"| DispatcherForEvent2["Dispatcher created for Event 2<br/>(ContextAwareCommandDispatcher)<br/>commandGateway: CommandGateway<br/>context: Branch2 (Event 2)"]

    DispatcherForEvent1 -->|"send(cmd) -&gt; commandGateway.send(cmd, context)<br/>stamps causationId from context"| Result1["cmd carries causationId = event1.id<br/>(correct for Event 1, WRONG if this is Event 2's dispatcher)"]
    DispatcherForEvent2 -->|"send(cmd) -&gt; commandGateway.send(cmd, context)<br/>stamps causationId from context"| Result2["cmd carries causationId = event2.id<br/>(correct for Event 2)"]

    style DispatcherForEvent2 fill:#e6ffe6,stroke:#2e7d32
    style Result2 fill:#e6ffe6,stroke:#2e7d32
    style DispatcherForEvent1 fill:#fff3e0,stroke:#e65100
```

Each `ContextAwareCommandDispatcher` is just two fields — `commandGateway` and the `context` it closes over — so whichever `context` it was built with is the one every `send()` call dispatches through, forever. The dashed edge above is the bug: because `RESOURCE_KEY` was never one of the resources a branch overrides, Event 2's `forContext(branch2)` call fell through to the shared root, found `RESOURCE_KEY` already populated by Event 1, and got Event 1's dispatcher back — closed over Event 1's context, not its own. As a result, event 2's command carries event 1's `causationId` instead of its own. The solid double edge is the fix: no cache to fall through to, so Event 2 always gets its own dispatcher closed over `branch2`, and its command correctly carries `causationId = event2.id`.

This is a real defect, not a theoretical one, because two default-on consumers read that captured context:

**1. Correlation metadata.** `CorrelationDataInterceptor` (registered by default via `MessagingConfigurationDefaults` with `MessageOriginProvider`) binds `CORRELATION_DATA` per handled message onto a context branch (`interceptOnHandle`), and stamps every dispatched command's/appended event's metadata from the context passed to dispatch (`interceptOnDispatch`). Through the cached wrapper, event 2's commands — and transitively the events they produce — carry event 1's `correlationId`/`causationId`: a corrupted causation chain in persisted business metadata, whether or not tracing is enabled.

**2. Trace parenting.** `TracingCommandBus` resolves the dispatch span's parent from the context passed to dispatch. The captured branch carries event 1's method-span scope under `SpanScope.RESOURCE_KEY`, so event 2's dispatch span — and, via the metadata that span injects, its entire command-handling subtree — renders under event 1's trace instead of its own:

```
EventProcessor.process BookingRequested           (event 1's trace)
`- DualDispatchProjection.on(BookingRequested,..) event 1's method span
   |- CommandBus.dispatchCommand ConfirmBooking   event 1's dispatch  OK
   `- CommandBus.dispatchCommand ConfirmBooking   event 2's dispatch  WRONG TREE
      `- CommandBus.handleCommand ...             event 2's whole command subtree

EventProcessor.process BookingConfirmed           (event 2's trace)
`- DualDispatchProjection.on(BookingConfirmed,..) childless -- looks like
                                                  a handler that did nothing
```

This distributed tracing support (`TracingCommandBus`, `SpanScope`, issue #3594) is not yet part of a released version — it's still under active development. In fact, this batch-sharing defect was only *discovered* because of that in-progress work: inspecting traces during tracing development surfaced the wrong-parent span tree above, which is what led back to this `forContext` caching bug in the first place.

**Not affected:** `TrackingToken` and the other entry-overridden resources — no production code reads them off a dispatched command's context today, so they were wrong on the captured branch but unconsumed.

The bug was masked in most existing tests because the first user of each gateway type was also its only user in that batch — first-writer-wins hides the defect whenever only one event per batch ever calls `forContext`.

## The general principle behind the fix

The real problem isn't "caching is slow" — both `ContextAwareCommandDispatcher` and `ProcessingContextEventAppender` are stateless beyond the components/context they close over, so caching bought nothing but a documented same-instance convenience.

The actual problem is **what** was being cached: a wrapper whose closure captures the *specific* `ProcessingContext` it was built for. Caching a resource like that under a resource key is only safe if that key is itself branched in lockstep with every context that might request it. Since `forContext`'s entire contract is "give me something bound to *this* context," and contexts branch per event/entry in a batch, no single non-branched key can safely cache it — whichever branch asks first "poisons" the cache for every sibling branch that asks after it.

## Considered solutions

### Implemented: remove the cache entirely

`forContext` now unconditionally constructs a fresh `ContextAwareCommandDispatcher` / `ProcessingContextEventAppender` on every call, closing over whatever `context` was actually passed in. The `RESOURCE_KEY` constants are removed from both interfaces (not deprecated — deleted, since nothing meaningfully used them other than this now-removed cache write, and no other production code reads them).

### Rejected: `computeResourceIfAbsent` taking a `Function<ProcessingContext, T>`

@smcvb proposed keeping the caching machinery, but changing `computeResourceIfAbsent` to accept a `Function<ProcessingContext, T>` instead of a `Supplier<T>`, so the factory could be handed "the current context" rather than one closed over at first-cache time.

This does not fix the defect. The factory function is only ever invoked on a cache **miss**. The failure mode here is a cache **hit** — a later event's branch finding `RESOURCE_KEY` already populated by an earlier, unrelated branch on the shared root — so the function would simply never run for that later event, and the exact same stale cached instance would still be returned regardless of what the function could have done with a fresher context. The bug is the cache itself, not the shape of what populates it on a miss.

### Explored further and abandoned: a real per-branch cache, and a lazy "context supplier"

Two follow-up ideas were explored in more depth (see the linked discussion) before settling on the fix in this PR:

- **A new `ProcessingContext` method giving `ResourceOverridingProcessingContext` a genuine per-branch cache** (a lazily-created local map, distinct from the existing shared-root `computeResourceIfAbsent`), so `forContext` could go back to returning the "same instance per call" the old Javadoc promised, this time correctly scoped per branch. Set aside because: the practical win is thin — a fresh instance is needed per event in a batch anyway in the common case, since each event gets its own branch; the only real saving is avoiding redundant construction when a *single* event is handled by multiple independently-registered `EventHandlingComponent`s that each call `forContext` for that same event (a real but narrow scenario) — and no name we found for such a method avoided leaking `ResourceOverridingProcessingContext`'s internal branching concept into the public `ProcessingContext` API.
- **Resolving the context lazily via a supplier instead of a fixed reference**, so a cached wrapper wouldn't need to close over one specific branch at construction time. This doesn't work: a resource's binding to *some* `ProcessingContext` is fixed the moment it's constructed, regardless of whether that reference arrives as a plain value or via an indirection like a supplier — "the old context is still there" either way. The deeper reason we can't just mutate/reuse one context object in place across calls either: different event handlers may legitimately need different resources at the same time within one `UnitOfWork`.

### Implemented (final): remove the cache entirely, everywhere it existed

Removing the cache is the simplest fix that's actually correct, so it's the one this PR ships — applied consistently to `CommandDispatcher`, `EventAppender`, **and `QueryUpdateEmitter`** (which had the identical bug, flagged in review: it followed the same `forContext` + `computeResourceIfAbsent(RESOURCE_KEY, ...)` pattern, and `SimpleQueryUpdateEmitter` closes over its `ProcessingContext` in its constructor exactly like the other two wrappers did).

This does trade away the "same instance every call" convenience the old Javadoc promised on all three interfaces. We're open to a better answer if one exists (e.g. genuinely branch-aware caching, if `ProcessingContext` ever grows a cheap way to distinguish "which branch am I") — flagging this explicitly rather than treating "just don't cache" as the final word.

To stop this exact mistake from recurring at some future call site, the general rule is now documented directly on `ProcessingContext#computeResourceIfAbsent`'s Javadoc: never cache a resource whose construction closes over the `ProcessingContext` itself, unless the cache key is guaranteed to be branched in lockstep with every context that might request it — with a concrete unsafe example (a wrapper closing over `context`, cached under a plain key) and a concrete safe contrast (a plain `ConcurrentHashMap`, which never references the context and is legitimately meant to be shared for the whole processing session, as `SimpleRepository`'s `managedEntitiesKey` usage already relies on). This was chosen over an ADR or a contribution-skill update — both considered and set aside as more ceremony than the fix warrants — since the Javadoc lives right next to the method every future caller will read before making the same mistake.

## What this PR contains

- `messaging/.../commandhandling/gateway/CommandDispatcher.java` — remove `RESOURCE_KEY`, `forContext` now always constructs fresh.
- `messaging/.../eventhandling/gateway/EventAppender.java` — remove `RESOURCE_KEY`, both `forContext` overloads now always construct fresh.
- `messaging/.../queryhandling/QueryUpdateEmitter.java` — remove `RESOURCE_KEY`, `forContext` now always constructs fresh (same fix, same bug shape, flagged in review).
- `messaging/.../core/unitofwork/ProcessingContext.java` — new Javadoc paragraph on `computeResourceIfAbsent` documenting the general rule, with unsafe/safe examples.
- `PooledStreamingEventProcessorTest.ProcessingContextResourcesTest#forContextDispatchesUsingEachEventsOwnPerEventResourceWithinABatch` — exercises the defect through the real `PooledStreamingEventProcessor` batch pipeline. A mocked `CommandGateway` is registered on the processor's `ApplicationContext`; the event handler calls `CommandDispatcher.forContext(ctx).send(...)` per event and separately records the `TrackingToken` it observes directly off its own branch (always correct). The test compares that against the `TrackingToken` the `CommandGateway` actually saw at dispatch time, deriving which events shared a batch from `ProcessingContext` identity (batch-grouping timing isn't fixed by the framework).
- `PooledStreamingEventProcessorTest.ProcessingContextResourcesTest#forContextEmitsUsingEachEventsOwnPerEventResourceWithinABatch` — the same test shape, for `QueryUpdateEmitter`: a mocked `QueryBus` is registered, the event handler calls `QueryUpdateEmitter.forContext(ctx).emit(...)` per event, and the emitted update's `TrackingToken` is compared against what the handler observed on its own branch.
- `InjectedCommandDispatcherBatchCausationInMemoryIT` — end-to-end integration test: two `StudentEnrolledEvent`s are appended atomically so a processor replay groups them into a single batch (`batchSize=2`, one segment). Each event's `@EventHandler` dispatches a command through the *injected* `CommandDispatcher`. Asserts each dispatched command carries the `causationId`/`correlationId` of its *own* triggering event, not event 1's.

All tests failed deterministically against the old caching `forContext` implementations and now pass with the fix. (No new end-to-end IT was added for `EventAppender` or `QueryUpdateEmitter` specifically — the `PooledStreamingEventProcessorTest`-level regressions plus the existing `CommandDispatcher` IT were judged sufficient proof of the general defect shape, since it's the identical root cause in all three.)

## Test plan

- [x] `./mvnw test -pl messaging -Dtest='PooledStreamingEventProcessorTest$ProcessingContextResourcesTest#forContextDispatchesUsingEachEventsOwnPerEventResourceWithinABatch'` — now passes
- [x] `./mvnw test -pl messaging -Dtest='PooledStreamingEventProcessorTest$ProcessingContextResourcesTest#forContextEmitsUsingEachEventsOwnPerEventResourceWithinABatch'` — now passes
- [x] `./mvnw -Pintegration-test test -pl integrationtests -Dtest=InjectedCommandDispatcherBatchCausationInMemoryIT` — now passes
- [x] Full `messaging` module suite: 4121 tests, 0 failures
- [x] Full `integrationtests` module (`mvn -Pintegration-test verify -pl integrationtests`): BUILD SUCCESS, 0 failures




