### PR TITLE
`UnitOfWork` now includes `ProcessingLifecycleInterceptor`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptor.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.core.unitofwork;
 
 import org.axonframework.common.FutureUtils;
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.Phase;
 import org.jspecify.annotations.Nullable;
 
@@ -25,49 +26,43 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
- * Vendor-neutral seam that is invoked <em>immediately around</em> every action executed by a {@link UnitOfWork} — on
- * the very thread that runs the action.
+ * Seam that is invoked <em>immediately around</em> every action executed by a {@link UnitOfWork}, on the very thread
+ * that runs the action.
  * <p>
- * Every registered phase action (INVOCATION, PREPARE_COMMIT, COMMIT, AFTER_COMMIT, …), as well as the completion- and
+ * Every registered phase action (INVOCATION, PREPARE_COMMIT, COMMIT, AFTER_COMMIT, ...), as well as the completion- and
  * error-handler dispatch sites, passes through this interceptor. This makes it the single choke point for bridging
- * thread-bound state — distributed tracing context, MDC, security context — into the segments that the framework
- * executes on its own {@link UnitOfWorkConfiguration#workScheduler() work scheduler} threads.
+ * thread-bound state, such as distributed tracing context, MDC, or security context, into the segments that the
+ * framework executes on its own {@link UnitOfWorkConfiguration#workScheduler() work scheduler} threads.
  * <p>
- * The three dispatch kinds are exposed as three separate, all-{@code abstract} methods —
- * {@link #interceptPhaseAction(ProcessingContext, Phase, Supplier)},
- * {@link #interceptCompletionHandler(ProcessingContext, Runnable)}, and
- * {@link #interceptErrorHandler(ProcessingContext, Phase, Throwable, Runnable)} — rather than a single method
- * discriminated by a nullable flag. The compiler therefore forces every implementation to consider all three sites,
- * removing the risk of an implementation that silently covers phase actions while missing the completion- or
- * error-handler dispatch. Implementations that want to apply the same behavior uniformly to all three kinds (the
- * common case for state-bridging infrastructure such as a tracing binding) should use {@link #uniform(UniformInterceptor)}
- * instead of implementing this interface directly.
+ * The three dispatch kinds are exposed as three separate, all-{@code abstract} methods,
+ * {@link #interceptPhase(ProcessingContext, Phase, Supplier)},
+ * {@link #interceptCompletion(ProcessingContext, Runnable)}, and
+ * {@link #interceptError(ProcessingContext, Phase, Throwable, Runnable)}, rather than a single method discriminated by
+ * a nullable flag. The compiler therefore forces every implementation to consider all three sites, removing the risk
+ * of an implementation that silently covers phase actions while missing the completion- or error-handler dispatch.
+ * Implementations that want to apply the same behavior uniformly to all three kinds (the common case for state-bridging
+ * infrastructure such as a tracing binding) should use {@link #intercept(UniformInterceptor)} instead of implementing
+ * this interface directly.
  * <p>
- * The interceptor is <b>dormant by default</b>: the {@link #PASS_THROUGH} instance simply invokes the action, adding no
- * behavior and no overhead. It is meant to be installed by infrastructure (for example a tracing binding) through
- * {@link UnitOfWorkConfiguration#interceptor(ProcessingLifecycleInterceptor)}, which composes contributors
+ * No interceptor is installed by default: {@link UnitOfWorkConfiguration#defaultValues()} leaves the interceptor
+ * {@code null}, and the {@link UnitOfWork} then runs actions directly, adding no behavior and no overhead. An
+ * interceptor is meant to be installed by infrastructure (for example a tracing binding) through
+ * {@link UnitOfWorkConfiguration#addLifecycleInterceptor(ProcessingLifecycleInterceptor)}, which composes contributors
  * via {@link #andThen(ProcessingLifecycleInterceptor)} so multiple installers never clobber one another.
  * <p>
  * Implementations run on the action's thread and MUST restore any thread-bound state they mutate before returning,
  * regardless of the action's outcome (typically via try-with-resources).
  * <p>
- * <b>Evolution policy:</b> this is a public SPI. Should a future minor release introduce another dispatch-kind
- * method, its default implementation MUST delegate to an existing method of this interface (safe-by-default), never
- * pass through the action unintercepted (skip-by-default). This preserves the guarantee that a wrap-everything
- * implementor (any implementation obtained through {@link #uniform(UniformInterceptor)}) keeps covering every
- * dispatch site across releases.
+ * <b>Evolution policy:</b> should a future minor release introduce another dispatch-kind method, its default
+ * implementation MUST delegate to an existing method of this interface (safe-by-default), never pass through the action
+ * unintercepted (skip-by-default). This preserves the guarantee that a wrap-everything implementor (any implementation
+ * obtained through {@link #intercept(UniformInterceptor)}) keeps covering every dispatch site across releases.
  *
  * @author Mateusz Nowak
  * @since 5.3.0
  */
+@Internal
 public interface ProcessingLifecycleInterceptor {
-
-    /**
-     * A no-op interceptor that invokes every action unchanged. This is the default installed by
-     * {@link UnitOfWorkConfiguration#defaultValues()}, guaranteeing zero behavioral change when no contributor is
-     * registered.
-     */
-    ProcessingLifecycleInterceptor PASS_THROUGH = uniform((context, action) -> action.get());
 
     /**
      * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
@@ -78,8 +73,8 @@ public interface ProcessingLifecycleInterceptor {
      * @param action  the action to execute, returning a {@link CompletableFuture} that completes when the action is done
      * @return the result of executing the {@code action}
      */
-    CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
-                                              Supplier<CompletableFuture<?>> action);
+    CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
+                                        Supplier<CompletableFuture<?>> action);
 
     /**
      * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
@@ -89,7 +84,7 @@ public interface ProcessingLifecycleInterceptor {
      * @param context the {@link ProcessingContext} of the {@link UnitOfWork} whose completion handler is dispatched
      * @param action  the completion-handler dispatch to execute
      */
-    void interceptCompletionHandler(ProcessingContext context, Runnable action);
+    void interceptCompletion(ProcessingContext context, Runnable action);
 
     /**
      * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
@@ -101,42 +96,42 @@ public interface ProcessingLifecycleInterceptor {
      * @param cause       the failure that moved the lifecycle into its error state
      * @param action      the error-handler dispatch to execute
      */
-    void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
-                               Runnable action);
+    void interceptError(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                        Runnable action);
 
     /**
-     * Creates a {@link ProcessingLifecycleInterceptor} that applies the given {@code around} interceptor
-     * uniformly to all three dispatch kinds — phase actions, completion-handler dispatch, and error-handler dispatch.
+     * Creates a {@link ProcessingLifecycleInterceptor} that applies the given {@code interceptor} uniformly to all
+     * three dispatch kinds: phase actions, completion-handler dispatch, and error-handler dispatch.
      * <p>
      * This is the shape most infrastructure contributors need: state-bridging behavior (restoring thread-locals,
-     * activating a live span, …) that does not depend on which kind of dispatch is being intercepted, expressed as a
+     * activating a live span, ...) that does not depend on which kind of dispatch is being intercepted, expressed as a
      * single lambda that can never under-cover a dispatch site.
      *
-     * @param around the kind-agnostic interceptor applied to every dispatch site
-     * @return a {@link ProcessingLifecycleInterceptor} delegating every dispatch kind to {@code around}
+     * @param interceptor the kind-agnostic interceptor applied to every dispatch site
+     * @return a {@link ProcessingLifecycleInterceptor} delegating every dispatch kind to {@code interceptor}
      */
-    static ProcessingLifecycleInterceptor uniform(UniformInterceptor around) {
-        Objects.requireNonNull(around, "around may not be null.");
+    static ProcessingLifecycleInterceptor intercept(UniformInterceptor interceptor) {
+        Objects.requireNonNull(interceptor, "interceptor may not be null.");
         return new ProcessingLifecycleInterceptor() {
 
             @Override
-            public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
-                                                              Supplier<CompletableFuture<?>> action) {
-                return around.intercept(context, action);
+            public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
+                                                       Supplier<CompletableFuture<?>> action) {
+                return interceptor.intercept(context, action);
             }
 
             @Override
-            public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
-                around.intercept(context, () -> {
+            public void interceptCompletion(ProcessingContext context, Runnable action) {
+                interceptor.intercept(context, () -> {
                     action.run();
                     return FutureUtils.emptyCompletedFuture();
                 });
             }
 
             @Override
-            public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
-                                              Runnable action) {
-                around.intercept(context, () -> {
+            public void interceptError(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                                       Runnable action) {
+                interceptor.intercept(context, () -> {
                     action.run();
                     return FutureUtils.emptyCompletedFuture();
                 });
@@ -145,40 +140,40 @@ public interface ProcessingLifecycleInterceptor {
     }
 
     /**
-     * Composes this interceptor with the {@code next} one, invoking {@code this} on the outside and {@code next} on
+     * Composes this interceptor with the {@code other} one, invoking {@code this} on the outside and {@code other} on
      * the inside (closest to the action), per dispatch kind. Composition ensures multiple contributors never clobber
      * each other.
      *
-     * @param next the interceptor to invoke inside this one
+     * @param other the interceptor to invoke inside this one
      * @return a composed {@link ProcessingLifecycleInterceptor}
      */
-    default ProcessingLifecycleInterceptor andThen(ProcessingLifecycleInterceptor next) {
-        Objects.requireNonNull(next, "next may not be null.");
+    default ProcessingLifecycleInterceptor andThen(ProcessingLifecycleInterceptor other) {
+        Objects.requireNonNull(other, "other may not be null.");
         ProcessingLifecycleInterceptor self = this;
         return new ProcessingLifecycleInterceptor() {
 
             @Override
-            public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
-                                                              Supplier<CompletableFuture<?>> action) {
-                return self.interceptPhaseAction(context, phase, () -> next.interceptPhaseAction(context, phase, action));
+            public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
+                                                       Supplier<CompletableFuture<?>> action) {
+                return self.interceptPhase(context, phase, () -> other.interceptPhase(context, phase, action));
             }
 
             @Override
-            public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
-                self.interceptCompletionHandler(context, () -> next.interceptCompletionHandler(context, action));
+            public void interceptCompletion(ProcessingContext context, Runnable action) {
+                self.interceptCompletion(context, () -> other.interceptCompletion(context, action));
             }
 
             @Override
-            public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
-                                              Runnable action) {
-                self.interceptErrorHandler(context, failedPhase, cause,
-                                           () -> next.interceptErrorHandler(context, failedPhase, cause, action));
+            public void interceptError(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                                       Runnable action) {
+                self.interceptError(context, failedPhase, cause,
+                                    () -> other.interceptError(context, failedPhase, cause, action));
             }
         };
     }
 
     /**
-     * Kind-agnostic interceptor applied uniformly to all dispatch sites by {@link #uniform(UniformInterceptor)}.
+     * Kind-agnostic interceptor applied uniformly to all dispatch sites by {@link #intercept(UniformInterceptor)}.
      */
     @FunctionalInterface
     interface UniformInterceptor {

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptor.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.unitofwork;
+
+import org.axonframework.common.FutureUtils;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.Phase;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * Vendor-neutral seam that is invoked <em>immediately around</em> every action executed by a {@link UnitOfWork} — on
+ * the very thread that runs the action.
+ * <p>
+ * Every registered phase action (INVOCATION, PREPARE_COMMIT, COMMIT, AFTER_COMMIT, …), as well as the completion- and
+ * error-handler dispatch sites, passes through this interceptor. This makes it the single choke point for bridging
+ * thread-bound state — distributed tracing context, MDC, security context — into the segments that the framework
+ * executes on its own {@link UnitOfWorkConfiguration#workScheduler() work scheduler} threads.
+ * <p>
+ * The three dispatch kinds are exposed as three separate, all-{@code abstract} methods —
+ * {@link #interceptPhaseAction(ProcessingContext, Phase, Supplier)},
+ * {@link #interceptCompletionHandler(ProcessingContext, Runnable)}, and
+ * {@link #interceptErrorHandler(ProcessingContext, Phase, Throwable, Runnable)} — rather than a single method
+ * discriminated by a nullable flag. The compiler therefore forces every implementation to consider all three sites,
+ * removing the risk of an implementation that silently covers phase actions while missing the completion- or
+ * error-handler dispatch. Implementations that want to apply the same behavior uniformly to all three kinds (the
+ * common case for state-bridging infrastructure such as a tracing binding) should use {@link #uniform(UniformInterceptor)}
+ * instead of implementing this interface directly.
+ * <p>
+ * The interceptor is <b>dormant by default</b>: the {@link #PASS_THROUGH} instance simply invokes the action, adding no
+ * behavior and no overhead. It is meant to be installed by infrastructure (for example a tracing binding) through
+ * {@link UnitOfWorkConfiguration#interceptor(ProcessingLifecycleInterceptor)}, which composes contributors
+ * via {@link #andThen(ProcessingLifecycleInterceptor)} so multiple installers never clobber one another.
+ * <p>
+ * Implementations run on the action's thread and MUST restore any thread-bound state they mutate before returning,
+ * regardless of the action's outcome (typically via try-with-resources).
+ * <p>
+ * <b>Evolution policy:</b> this is a public SPI. Should a future minor release introduce another dispatch-kind
+ * method, its default implementation MUST delegate to an existing method of this interface (safe-by-default), never
+ * pass through the action unintercepted (skip-by-default). This preserves the guarantee that a wrap-everything
+ * implementor (any implementation obtained through {@link #uniform(UniformInterceptor)}) keeps covering every
+ * dispatch site across releases.
+ *
+ * @author Mateusz Nowak
+ * @since 5.3.0
+ */
+public interface ProcessingLifecycleInterceptor {
+
+    /**
+     * A no-op interceptor that invokes every action unchanged. This is the default installed by
+     * {@link UnitOfWorkConfiguration#defaultValues()}, guaranteeing zero behavioral change when no contributor is
+     * registered.
+     */
+    ProcessingLifecycleInterceptor PASS_THROUGH = uniform((context, action) -> action.get());
+
+    /**
+     * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
+     * thread-bound state (tracing context, MDC, security) into phase actions registered in a lifecycle phase.
+     *
+     * @param context the {@link ProcessingContext} of the {@link UnitOfWork} executing the action
+     * @param phase   the {@link ProcessingLifecycle.Phase} the action executes in
+     * @param action  the action to execute, returning a {@link CompletableFuture} that completes when the action is done
+     * @return the result of executing the {@code action}
+     */
+    CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                              Supplier<CompletableFuture<?>> action);
+
+    /**
+     * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
+     * thread-bound state into a {@code whenComplete}-handler dispatch, running after the lifecycle completed
+     * successfully.
+     *
+     * @param context the {@link ProcessingContext} of the {@link UnitOfWork} whose completion handler is dispatched
+     * @param action  the completion-handler dispatch to execute
+     */
+    void interceptCompletionHandler(ProcessingContext context, Runnable action);
+
+    /**
+     * Invoked on the thread that executes the {@code action}, immediately around it. This is the seam for bridging
+     * thread-bound state into an {@code onError}-handler dispatch, running after the lifecycle failed.
+     *
+     * @param context     the {@link ProcessingContext} of the {@link UnitOfWork} whose error handler is dispatched
+     * @param failedPhase the {@link ProcessingLifecycle.Phase} whose action failed, or {@code null} when the failure
+     *                    preceded the first phase
+     * @param cause       the failure that moved the lifecycle into its error state
+     * @param action      the error-handler dispatch to execute
+     */
+    void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                               Runnable action);
+
+    /**
+     * Creates a {@link ProcessingLifecycleInterceptor} that applies the given {@code around} interceptor
+     * uniformly to all three dispatch kinds — phase actions, completion-handler dispatch, and error-handler dispatch.
+     * <p>
+     * This is the shape most infrastructure contributors need: state-bridging behavior (restoring thread-locals,
+     * activating a live span, …) that does not depend on which kind of dispatch is being intercepted, expressed as a
+     * single lambda that can never under-cover a dispatch site.
+     *
+     * @param around the kind-agnostic interceptor applied to every dispatch site
+     * @return a {@link ProcessingLifecycleInterceptor} delegating every dispatch kind to {@code around}
+     */
+    static ProcessingLifecycleInterceptor uniform(UniformInterceptor around) {
+        Objects.requireNonNull(around, "around may not be null.");
+        return new ProcessingLifecycleInterceptor() {
+
+            @Override
+            public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                              Supplier<CompletableFuture<?>> action) {
+                return around.intercept(context, action);
+            }
+
+            @Override
+            public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                around.intercept(context, () -> {
+                    action.run();
+                    return FutureUtils.emptyCompletedFuture();
+                });
+            }
+
+            @Override
+            public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                                              Runnable action) {
+                around.intercept(context, () -> {
+                    action.run();
+                    return FutureUtils.emptyCompletedFuture();
+                });
+            }
+        };
+    }
+
+    /**
+     * Composes this interceptor with the {@code next} one, invoking {@code this} on the outside and {@code next} on
+     * the inside (closest to the action), per dispatch kind. Composition ensures multiple contributors never clobber
+     * each other.
+     *
+     * @param next the interceptor to invoke inside this one
+     * @return a composed {@link ProcessingLifecycleInterceptor}
+     */
+    default ProcessingLifecycleInterceptor andThen(ProcessingLifecycleInterceptor next) {
+        Objects.requireNonNull(next, "next may not be null.");
+        ProcessingLifecycleInterceptor self = this;
+        return new ProcessingLifecycleInterceptor() {
+
+            @Override
+            public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                              Supplier<CompletableFuture<?>> action) {
+                return self.interceptPhaseAction(context, phase, () -> next.interceptPhaseAction(context, phase, action));
+            }
+
+            @Override
+            public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                self.interceptCompletionHandler(context, () -> next.interceptCompletionHandler(context, action));
+            }
+
+            @Override
+            public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase, Throwable cause,
+                                              Runnable action) {
+                self.interceptErrorHandler(context, failedPhase, cause,
+                                           () -> next.interceptErrorHandler(context, failedPhase, cause, action));
+            }
+        };
+    }
+
+    /**
+     * Kind-agnostic interceptor applied uniformly to all dispatch sites by {@link #uniform(UniformInterceptor)}.
+     */
+    @FunctionalInterface
+    interface UniformInterceptor {
+
+        /**
+         * Invoked on the thread that executes the {@code action}, immediately around it, regardless of which
+         * dispatch kind (phase action, completion handler, or error handler) is being intercepted.
+         *
+         * @param context the {@link ProcessingContext} of the {@link UnitOfWork} executing the action
+         * @param action  the action to execute, returning a {@link CompletableFuture} that completes when the action is done
+         * @return the result of executing the {@code action}
+         */
+        CompletableFuture<?> intercept(ProcessingContext context, Supplier<CompletableFuture<?>> action);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/SimpleUnitOfWorkFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/SimpleUnitOfWorkFactory.java
@@ -78,7 +78,7 @@ public class SimpleUnitOfWorkFactory implements UnitOfWorkFactory {
             configuration.workScheduler(),
             !configuration.allowAsyncProcessing(),
             applicationContext,
-            configuration.interceptor()
+            configuration.lifecycleInterceptor()
         );
 
         configuration.processingLifecycleEnhancers().forEach(enhancer -> enhancer.accept(uow));

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/SimpleUnitOfWorkFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/SimpleUnitOfWorkFactory.java
@@ -77,7 +77,8 @@ public class SimpleUnitOfWorkFactory implements UnitOfWorkFactory {
             identifier,
             configuration.workScheduler(),
             !configuration.allowAsyncProcessing(),
-            applicationContext
+            applicationContext,
+            configuration.interceptor()
         );
 
         configuration.processingLifecycleEnhancers().forEach(enhancer -> enhancer.accept(uow));

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
@@ -72,12 +72,11 @@ public class UnitOfWork implements ProcessingLifecycle {
     /**
      * Constructs a {@code UnitOfWork} with the given parameters.
      *
-     * @param identifier         The identifier of this Unit of Work.
-     * @param workScheduler      The {@link Executor} for processing unit of work actions.
-     * @param applicationContext The {@link ApplicationContext} for component resolution.
-     * @param interceptor        The {@link ProcessingLifecycleInterceptor} invoked immediately around every action
-     *                           and handler dispatch; {@link ProcessingLifecycleInterceptor#PASS_THROUGH} for the
-     *                           direct, zero-overhead path.
+     * @param identifier           The identifier of this Unit of Work.
+     * @param workScheduler        The {@link Executor} for processing unit of work actions.
+     * @param applicationContext   The {@link ApplicationContext} for component resolution.
+     * @param lifecycleInterceptor The {@link ProcessingLifecycleInterceptor} invoked immediately around every action
+     *                             and handler dispatch, or {@code null} for the direct, zero-overhead path.
      */
     @Internal
     UnitOfWork(
@@ -85,19 +84,18 @@ public class UnitOfWork implements ProcessingLifecycle {
             Executor workScheduler,
             boolean forceSyncProcessing,
             ApplicationContext applicationContext,
-            ProcessingLifecycleInterceptor interceptor
+            @Nullable ProcessingLifecycleInterceptor lifecycleInterceptor
     ) {
         Objects.requireNonNull(identifier, "identifier may not be null.");
         Objects.requireNonNull(workScheduler, "workScheduler may not be null.");
         Objects.requireNonNull(applicationContext, "applicationContext may not be null.");
-        Objects.requireNonNull(interceptor, "interceptor may not be null.");
         this.identifier = identifier;
         this.context = new UnitOfWorkProcessingContext(
                 identifier,
                 workScheduler,
                 forceSyncProcessing,
                 applicationContext,
-                interceptor
+                lifecycleInterceptor
         );
     }
 
@@ -221,24 +219,21 @@ public class UnitOfWork implements ProcessingLifecycle {
         private final ApplicationContext applicationContext;
         private final ConcurrentMap<ResourceKey<?>, Object> resources;
         private final boolean forceSyncProcessing;
-        private final ProcessingLifecycleInterceptor interceptor;
-        private final boolean intercepting;
+        private final @Nullable ProcessingLifecycleInterceptor lifecycleInterceptor;
 
         private UnitOfWorkProcessingContext(
                 String identifier,
                 Executor workScheduler,
                 boolean forceSyncProcessing,
                 ApplicationContext applicationContext,
-                ProcessingLifecycleInterceptor interceptor
+                @Nullable ProcessingLifecycleInterceptor lifecycleInterceptor
         ) {
             this.identifier = identifier;
             this.workScheduler = workScheduler;
             this.forceSyncProcessing = forceSyncProcessing;
             this.resources = new ConcurrentHashMap<>();
             this.applicationContext = applicationContext;
-            this.interceptor = interceptor;
-            // Determined once: the PASS_THROUGH default keeps the original direct execution path (zero overhead).
-            this.intercepting = interceptor != ProcessingLifecycleInterceptor.PASS_THROUGH;
+            this.lifecycleInterceptor = lifecycleInterceptor;
         }
 
         @Override
@@ -406,7 +401,7 @@ public class UnitOfWork implements ProcessingLifecycle {
             while (!completeHandlers.isEmpty()) {
                 Consumer<ProcessingContext> nextCompletionHandler = completeHandlers.poll();
                 if (nextCompletionHandler != null) {
-                    workScheduler.execute(() -> interceptedCompletionHandler(
+                    workScheduler.execute(() -> interceptCompletion(
                             () -> nextCompletionHandler.accept(this)
                     ));
                 }
@@ -422,7 +417,7 @@ public class UnitOfWork implements ProcessingLifecycle {
                 ErrorHandler nextErrorHandler = errorHandlers.poll();
                 if (nextErrorHandler != null) {
                     workScheduler.execute(
-                            () -> interceptedErrorHandler(
+                            () -> interceptError(
                                     recordedCause.phase(),
                                     recordedCause.cause(),
                                     () -> nextErrorHandler.handle(this, recordedCause.phase(), recordedCause.cause())
@@ -451,7 +446,7 @@ public class UnitOfWork implements ProcessingLifecycle {
 
             CompletableFuture<Void> phaseResult = actionQueue.stream()
                                                              .map(handler -> FutureUtils.emptyCompletedFuture()
-                                                                                        .thenComposeAsync(result -> intercepted(
+                                                                                        .thenComposeAsync(result -> intercept(
                                                                                                 current, handler), workScheduler)
                                                                                         .thenAccept(FutureUtils::ignoreResult))
                                                              .reduce(CompletableFuture::allOf)
@@ -469,36 +464,57 @@ public class UnitOfWork implements ProcessingLifecycle {
 
         /**
          * Runs the given phase {@code handler} through the {@link ProcessingLifecycleInterceptor}, or directly
-         * when no interceptor is installed (the {@link ProcessingLifecycleInterceptor#PASS_THROUGH} default),
-         * keeping the original zero-overhead execution path.
+         * when no interceptor is installed, keeping the original zero-overhead execution path.
          */
-        private CompletableFuture<?> intercepted(Phase phase, Function<ProcessingContext, CompletableFuture<?>> handler) {
-            return intercepting
-                    ? interceptor.interceptPhaseAction(this, phase, () -> handler.apply(this))
+        private CompletableFuture<?> intercept(Phase phase, Function<ProcessingContext, CompletableFuture<?>> handler) {
+            return lifecycleInterceptor != null
+                    ? lifecycleInterceptor.interceptPhase(this, phase, () -> handler.apply(this))
                     : handler.apply(this);
         }
 
         /**
-         * Runs the given completion-handler {@code action} through the {@link ProcessingLifecycleInterceptor},
-         * or directly when no interceptor is installed.
+         * Runs the given completion-handler {@code action} through the {@link ProcessingLifecycleInterceptor}, or
+         * directly when no interceptor is installed.
+         * <p>
+         * A misbehaving interceptor that throws is logged and swallowed here: this dispatch runs on a bare
+         * {@code workScheduler.execute(...)} worker thread, so an escaping exception would otherwise vanish silently
+         * and block every completion handler still queued behind it. A failing interceptor must not turn an otherwise
+         * successful completion into a failure.
          */
-        private void interceptedCompletionHandler(Runnable action) {
-            if (intercepting) {
-                interceptor.interceptCompletionHandler(this, action);
-            } else {
-                action.run();
+        private void interceptCompletion(Runnable action) {
+            try {
+                if (lifecycleInterceptor != null) {
+                    lifecycleInterceptor.interceptCompletion(this, action);
+                } else {
+                    action.run();
+                }
+            } catch (Exception e) {
+                logger.warn("A ProcessingLifecycleInterceptor threw an exception while intercepting a completion "
+                                    + "handler dispatch. The exception is ignored so remaining handlers keep running.",
+                            e);
             }
         }
 
         /**
          * Runs the given error-handler {@code action} through the {@link ProcessingLifecycleInterceptor}, or
          * directly when no interceptor is installed.
+         * <p>
+         * A misbehaving interceptor that throws is logged and swallowed here, for the same reason as in
+         * {@link #interceptCompletion(Runnable)}: this dispatch runs on a bare {@code workScheduler.execute(...)}
+         * worker thread, so an escaping exception would otherwise vanish silently and block every error handler still
+         * queued behind it.
          */
-        private void interceptedErrorHandler(@Nullable Phase failedPhase, Throwable cause, Runnable action) {
-            if (intercepting) {
-                interceptor.interceptErrorHandler(this, failedPhase, cause, action);
-            } else {
-                action.run();
+        private void interceptError(@Nullable Phase failedPhase, Throwable cause, Runnable action) {
+            try {
+                if (lifecycleInterceptor != null) {
+                    lifecycleInterceptor.interceptError(this, failedPhase, cause, action);
+                } else {
+                    action.run();
+                }
+            } catch (Exception e) {
+                logger.warn("A ProcessingLifecycleInterceptor threw an exception while intercepting an error "
+                                    + "handler dispatch. The exception is ignored so remaining handlers keep running.",
+                            e);
             }
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWork.java
@@ -75,23 +75,29 @@ public class UnitOfWork implements ProcessingLifecycle {
      * @param identifier         The identifier of this Unit of Work.
      * @param workScheduler      The {@link Executor} for processing unit of work actions.
      * @param applicationContext The {@link ApplicationContext} for component resolution.
+     * @param interceptor        The {@link ProcessingLifecycleInterceptor} invoked immediately around every action
+     *                           and handler dispatch; {@link ProcessingLifecycleInterceptor#PASS_THROUGH} for the
+     *                           direct, zero-overhead path.
      */
     @Internal
     UnitOfWork(
             String identifier,
             Executor workScheduler,
             boolean forceSyncProcessing,
-            ApplicationContext applicationContext
+            ApplicationContext applicationContext,
+            ProcessingLifecycleInterceptor interceptor
     ) {
         Objects.requireNonNull(identifier, "identifier may not be null.");
         Objects.requireNonNull(workScheduler, "workScheduler may not be null.");
         Objects.requireNonNull(applicationContext, "applicationContext may not be null.");
+        Objects.requireNonNull(interceptor, "interceptor may not be null.");
         this.identifier = identifier;
         this.context = new UnitOfWorkProcessingContext(
                 identifier,
                 workScheduler,
                 forceSyncProcessing,
-                applicationContext
+                applicationContext,
+                interceptor
         );
     }
 
@@ -215,18 +221,24 @@ public class UnitOfWork implements ProcessingLifecycle {
         private final ApplicationContext applicationContext;
         private final ConcurrentMap<ResourceKey<?>, Object> resources;
         private final boolean forceSyncProcessing;
+        private final ProcessingLifecycleInterceptor interceptor;
+        private final boolean intercepting;
 
         private UnitOfWorkProcessingContext(
                 String identifier,
                 Executor workScheduler,
                 boolean forceSyncProcessing,
-                ApplicationContext applicationContext
+                ApplicationContext applicationContext,
+                ProcessingLifecycleInterceptor interceptor
         ) {
             this.identifier = identifier;
             this.workScheduler = workScheduler;
             this.forceSyncProcessing = forceSyncProcessing;
             this.resources = new ConcurrentHashMap<>();
             this.applicationContext = applicationContext;
+            this.interceptor = interceptor;
+            // Determined once: the PASS_THROUGH default keeps the original direct execution path (zero overhead).
+            this.intercepting = interceptor != ProcessingLifecycleInterceptor.PASS_THROUGH;
         }
 
         @Override
@@ -394,7 +406,9 @@ public class UnitOfWork implements ProcessingLifecycle {
             while (!completeHandlers.isEmpty()) {
                 Consumer<ProcessingContext> nextCompletionHandler = completeHandlers.poll();
                 if (nextCompletionHandler != null) {
-                    workScheduler.execute(() -> nextCompletionHandler.accept(this));
+                    workScheduler.execute(() -> interceptedCompletionHandler(
+                            () -> nextCompletionHandler.accept(this)
+                    ));
                 }
             }
         }
@@ -408,7 +422,11 @@ public class UnitOfWork implements ProcessingLifecycle {
                 ErrorHandler nextErrorHandler = errorHandlers.poll();
                 if (nextErrorHandler != null) {
                     workScheduler.execute(
-                            () -> nextErrorHandler.handle(this, recordedCause.phase(), recordedCause.cause())
+                            () -> interceptedErrorHandler(
+                                    recordedCause.phase(),
+                                    recordedCause.cause(),
+                                    () -> nextErrorHandler.handle(this, recordedCause.phase(), recordedCause.cause())
+                            )
                     );
                 }
             }
@@ -433,8 +451,8 @@ public class UnitOfWork implements ProcessingLifecycle {
 
             CompletableFuture<Void> phaseResult = actionQueue.stream()
                                                              .map(handler -> FutureUtils.emptyCompletedFuture()
-                                                                                        .thenComposeAsync(result -> handler.apply(
-                                                                                                this), workScheduler)
+                                                                                        .thenComposeAsync(result -> intercepted(
+                                                                                                current, handler), workScheduler)
                                                                                         .thenAccept(FutureUtils::ignoreResult))
                                                              .reduce(CompletableFuture::allOf)
                                                              .orElseGet(FutureUtils::emptyCompletedFuture);
@@ -447,6 +465,41 @@ public class UnitOfWork implements ProcessingLifecycle {
                 }
             }
             return phaseResult;
+        }
+
+        /**
+         * Runs the given phase {@code handler} through the {@link ProcessingLifecycleInterceptor}, or directly
+         * when no interceptor is installed (the {@link ProcessingLifecycleInterceptor#PASS_THROUGH} default),
+         * keeping the original zero-overhead execution path.
+         */
+        private CompletableFuture<?> intercepted(Phase phase, Function<ProcessingContext, CompletableFuture<?>> handler) {
+            return intercepting
+                    ? interceptor.interceptPhaseAction(this, phase, () -> handler.apply(this))
+                    : handler.apply(this);
+        }
+
+        /**
+         * Runs the given completion-handler {@code action} through the {@link ProcessingLifecycleInterceptor},
+         * or directly when no interceptor is installed.
+         */
+        private void interceptedCompletionHandler(Runnable action) {
+            if (intercepting) {
+                interceptor.interceptCompletionHandler(this, action);
+            } else {
+                action.run();
+            }
+        }
+
+        /**
+         * Runs the given error-handler {@code action} through the {@link ProcessingLifecycleInterceptor}, or
+         * directly when no interceptor is installed.
+         */
+        private void interceptedErrorHandler(@Nullable Phase failedPhase, Throwable cause, Runnable action) {
+            if (intercepting) {
+                interceptor.interceptErrorHandler(this, failedPhase, cause, action);
+            } else {
+                action.run();
+            }
         }
 
         @Override

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.axonframework.common.DirectExecutor;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Configuration used for the {@link UnitOfWork} creation in the {@link UnitOfWorkFactory}.
@@ -34,8 +35,9 @@ import org.axonframework.common.DirectExecutor;
  * @param allowAsyncProcessing         Whether the unit of work should allow fully asynchronous processing.
  * @param processingLifecycleEnhancers The enhancers that are applied to the processing lifecycle for each created unit
  *                                     of work.
- * @param interceptor                  The {@link ProcessingLifecycleInterceptor} invoked immediately around every
- *                                     action and handler dispatch executed by the unit of work.
+ * @param lifecycleInterceptor         The {@link ProcessingLifecycleInterceptor} invoked immediately around every
+ *                                     action and handler dispatch executed by the unit of work, or {@code null} when no
+ *                                     interceptor is installed (the direct, zero-overhead path).
  * @author Mateusz Nowak
  * @author John Hendrikx
  * @since 5.0.0
@@ -43,7 +45,23 @@ import org.axonframework.common.DirectExecutor;
 public record UnitOfWorkConfiguration(Executor workScheduler,
                                       boolean allowAsyncProcessing,
                                       List<Consumer<ProcessingLifecycle>> processingLifecycleEnhancers,
-                                      ProcessingLifecycleInterceptor interceptor) {
+                                      @Nullable ProcessingLifecycleInterceptor lifecycleInterceptor) {
+
+    /**
+     * Creates a {@link UnitOfWorkConfiguration} without a {@link ProcessingLifecycleInterceptor}. Retained for backward
+     * compatibility with callers constructing the configuration before the {@link #lifecycleInterceptor() interceptor}
+     * component was introduced.
+     *
+     * @param workScheduler                the {@link Executor} for processing unit of work actions
+     * @param allowAsyncProcessing         whether the unit of work should allow fully asynchronous processing
+     * @param processingLifecycleEnhancers the enhancers applied to the processing lifecycle for each created unit of
+     *                                     work
+     */
+    public UnitOfWorkConfiguration(Executor workScheduler,
+                                   boolean allowAsyncProcessing,
+                                   List<Consumer<ProcessingLifecycle>> processingLifecycleEnhancers) {
+        this(workScheduler, allowAsyncProcessing, processingLifecycleEnhancers, null);
+    }
 
     /**
      * Creates default configuration with direct execution.
@@ -51,10 +69,7 @@ public record UnitOfWorkConfiguration(Executor workScheduler,
      * @return Default {@link UnitOfWorkConfiguration} instance.
      */
     static UnitOfWorkConfiguration defaultValues() {
-        return new UnitOfWorkConfiguration(DirectExecutor.instance(),
-                                           true,
-                                           List.of(),
-                                           ProcessingLifecycleInterceptor.PASS_THROUGH);
+        return new UnitOfWorkConfiguration(DirectExecutor.instance(), true, List.of());
     }
 
     /**
@@ -62,13 +77,14 @@ public record UnitOfWorkConfiguration(Executor workScheduler,
      * configuration uses a direct execution model where all tasks are run immediately on the calling thread, and the
      * coordinating thread will wait for any asynchronous processing to complete.
      * <p>
-     * The {@link #interceptor() interceptor} is preserved, so state-bridging around framework-executed segments
-     * survives the switch to same-thread invocation.
+     * The {@link #processingLifecycleEnhancers() enhancers} and the {@link #lifecycleInterceptor() interceptor} are
+     * preserved, so lifecycle customization and state-bridging around framework-executed segments survive the switch to
+     * same-thread invocation.
      *
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
-        public UnitOfWorkConfiguration forcedSameThreadInvocation() {
-        return new UnitOfWorkConfiguration(Runnable::run, false, processingLifecycleEnhancers, interceptor);
+    public UnitOfWorkConfiguration forcedSameThreadInvocation() {
+        return new UnitOfWorkConfiguration(Runnable::run, false, processingLifecycleEnhancers, lifecycleInterceptor);
     }
 
     /**
@@ -77,9 +93,12 @@ public record UnitOfWorkConfiguration(Executor workScheduler,
      * @param workScheduler The {@link Executor} for processing actions.
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
-        public UnitOfWorkConfiguration workScheduler(Executor workScheduler) {
+    public UnitOfWorkConfiguration workScheduler(Executor workScheduler) {
         Objects.requireNonNull(workScheduler, "workScheduler may not be null");
-        return new UnitOfWorkConfiguration(workScheduler, allowAsyncProcessing, processingLifecycleEnhancers, interceptor);
+        return new UnitOfWorkConfiguration(workScheduler,
+                                           allowAsyncProcessing,
+                                           processingLifecycleEnhancers,
+                                           lifecycleInterceptor);
     }
 
     /**
@@ -88,32 +107,56 @@ public record UnitOfWorkConfiguration(Executor workScheduler,
      * @param enhancer The processing lifecycle enhancer to include.
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
-        public UnitOfWorkConfiguration registerProcessingLifecycleEnhancer(Consumer<ProcessingLifecycle> enhancer) {
+    public UnitOfWorkConfiguration registerProcessingLifecycleEnhancer(Consumer<ProcessingLifecycle> enhancer) {
         Objects.requireNonNull(enhancer, "enhancer may not be null");
 
         return new UnitOfWorkConfiguration(
                 workScheduler,
                 allowAsyncProcessing,
                 Stream.concat(processingLifecycleEnhancers.stream(), Stream.of(enhancer)).toList(),
-                interceptor
+                lifecycleInterceptor
         );
     }
 
     /**
-     * Creates a new configuration that composes the given {@code next} interceptor with any already registered
-     * {@link #interceptor() interceptor}. Composition (rather than replacement) ensures multiple contributors never
-     * clobber each other.
+     * Creates a new configuration that <b>replaces</b> the current {@link #lifecycleInterceptor() interceptor} with the
+     * given one. To compose with an already registered interceptor instead of replacing it, use
+     * {@link #addLifecycleInterceptor(ProcessingLifecycleInterceptor)}.
      *
-     * @param next The {@link ProcessingLifecycleInterceptor} to compose in.
+     * @param lifecycleInterceptor The {@link ProcessingLifecycleInterceptor} to install.
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
-        public UnitOfWorkConfiguration interceptor(ProcessingLifecycleInterceptor next) {
-        Objects.requireNonNull(next, "next may not be null");
+    public UnitOfWorkConfiguration lifecycleInterceptor(ProcessingLifecycleInterceptor lifecycleInterceptor) {
+        Objects.requireNonNull(lifecycleInterceptor, "lifecycleInterceptor may not be null");
         return new UnitOfWorkConfiguration(
                 workScheduler,
                 allowAsyncProcessing,
                 processingLifecycleEnhancers,
-                interceptor.andThen(next)
+                lifecycleInterceptor
+        );
+    }
+
+    /**
+     * Creates a new configuration that <b>chains</b> the given interceptor after any already registered
+     * {@link #lifecycleInterceptor() interceptor} (composing via
+     * {@link ProcessingLifecycleInterceptor#andThen(ProcessingLifecycleInterceptor)}). Chaining (rather than
+     * replacement) ensures multiple contributors never clobber each other, which is the common case when several
+     * framework modules each install their own interceptor. To replace the current interceptor instead, use
+     * {@link #lifecycleInterceptor(ProcessingLifecycleInterceptor)}.
+     *
+     * @param lifecycleInterceptor The {@link ProcessingLifecycleInterceptor} to chain in.
+     * @return A new modified {@link UnitOfWorkConfiguration}.
+     */
+    public UnitOfWorkConfiguration addLifecycleInterceptor(ProcessingLifecycleInterceptor lifecycleInterceptor) {
+        Objects.requireNonNull(lifecycleInterceptor, "lifecycleInterceptor may not be null");
+        ProcessingLifecycleInterceptor chained = this.lifecycleInterceptor == null
+                ? lifecycleInterceptor
+                : this.lifecycleInterceptor.andThen(lifecycleInterceptor);
+        return new UnitOfWorkConfiguration(
+                workScheduler,
+                allowAsyncProcessing,
+                processingLifecycleEnhancers,
+                chained
         );
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfiguration.java
@@ -34,11 +34,16 @@ import org.axonframework.common.DirectExecutor;
  * @param allowAsyncProcessing         Whether the unit of work should allow fully asynchronous processing.
  * @param processingLifecycleEnhancers The enhancers that are applied to the processing lifecycle for each created unit
  *                                     of work.
+ * @param interceptor                  The {@link ProcessingLifecycleInterceptor} invoked immediately around every
+ *                                     action and handler dispatch executed by the unit of work.
  * @author Mateusz Nowak
  * @author John Hendrikx
  * @since 5.0.0
  */
-public record UnitOfWorkConfiguration(Executor workScheduler, boolean allowAsyncProcessing, List<Consumer<ProcessingLifecycle>> processingLifecycleEnhancers) {
+public record UnitOfWorkConfiguration(Executor workScheduler,
+                                      boolean allowAsyncProcessing,
+                                      List<Consumer<ProcessingLifecycle>> processingLifecycleEnhancers,
+                                      ProcessingLifecycleInterceptor interceptor) {
 
     /**
      * Creates default configuration with direct execution.
@@ -46,18 +51,24 @@ public record UnitOfWorkConfiguration(Executor workScheduler, boolean allowAsync
      * @return Default {@link UnitOfWorkConfiguration} instance.
      */
     static UnitOfWorkConfiguration defaultValues() {
-        return new UnitOfWorkConfiguration(DirectExecutor.instance(), true, List.of());
+        return new UnitOfWorkConfiguration(DirectExecutor.instance(),
+                                           true,
+                                           List.of(),
+                                           ProcessingLifecycleInterceptor.PASS_THROUGH);
     }
 
     /**
      * Creates a new {@link UnitOfWorkConfiguration} that forces all handlers to be invoked by the same thread. The
      * configuration uses a direct execution model where all tasks are run immediately on the calling thread, and the
      * coordinating thread will wait for any asynchronous processing to complete.
+     * <p>
+     * The {@link #interceptor() interceptor} is preserved, so state-bridging around framework-executed segments
+     * survives the switch to same-thread invocation.
      *
      * @return A new modified {@link UnitOfWorkConfiguration}.
      */
         public UnitOfWorkConfiguration forcedSameThreadInvocation() {
-        return new UnitOfWorkConfiguration(Runnable::run, false, processingLifecycleEnhancers);
+        return new UnitOfWorkConfiguration(Runnable::run, false, processingLifecycleEnhancers, interceptor);
     }
 
     /**
@@ -68,7 +79,7 @@ public record UnitOfWorkConfiguration(Executor workScheduler, boolean allowAsync
      */
         public UnitOfWorkConfiguration workScheduler(Executor workScheduler) {
         Objects.requireNonNull(workScheduler, "workScheduler may not be null");
-        return new UnitOfWorkConfiguration(workScheduler, allowAsyncProcessing, processingLifecycleEnhancers);
+        return new UnitOfWorkConfiguration(workScheduler, allowAsyncProcessing, processingLifecycleEnhancers, interceptor);
     }
 
     /**
@@ -83,7 +94,26 @@ public record UnitOfWorkConfiguration(Executor workScheduler, boolean allowAsync
         return new UnitOfWorkConfiguration(
                 workScheduler,
                 allowAsyncProcessing,
-                Stream.concat(processingLifecycleEnhancers.stream(), Stream.of(enhancer)).toList()
+                Stream.concat(processingLifecycleEnhancers.stream(), Stream.of(enhancer)).toList(),
+                interceptor
+        );
+    }
+
+    /**
+     * Creates a new configuration that composes the given {@code next} interceptor with any already registered
+     * {@link #interceptor() interceptor}. Composition (rather than replacement) ensures multiple contributors never
+     * clobber each other.
+     *
+     * @param next The {@link ProcessingLifecycleInterceptor} to compose in.
+     * @return A new modified {@link UnitOfWorkConfiguration}.
+     */
+        public UnitOfWorkConfiguration interceptor(ProcessingLifecycleInterceptor next) {
+        Objects.requireNonNull(next, "next may not be null");
+        return new UnitOfWorkConfiguration(
+                workScheduler,
+                allowAsyncProcessing,
+                processingLifecycleEnhancers,
+                interceptor.andThen(next)
         );
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptorTest.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.unitofwork;
+
+import org.axonframework.common.FutureUtils;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.Phase;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests validating the {@link ProcessingLifecycleInterceptor} seam routed inside the {@link UnitOfWork}.
+ *
+ * @author Mateusz Nowak
+ */
+class ProcessingLifecycleInterceptorTest {
+
+    private final SimpleUnitOfWorkFactory factory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
+
+    private UnitOfWork unitOfWorkWith(ProcessingLifecycleInterceptor interceptor) {
+        return (UnitOfWork) factory.create("test", config -> config.interceptor(interceptor));
+    }
+
+    @Nested
+    class Coverage {
+
+        @Test
+        void interceptorWrapsEveryPhaseAction() {
+            // given
+            AtomicInteger interceptions = new AtomicInteger();
+            List<Boolean> contextsPresent = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> {
+                        interceptions.incrementAndGet();
+                        contextsPresent.add(context != null);
+                        return action.get();
+                    });
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.PREPARE_COMMIT, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.COMMIT, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.AFTER_COMMIT, c -> FutureUtils.emptyCompletedFuture());
+
+            // when
+            uow.execute().join();
+
+            // then
+            assertThat(interceptions.get()).isEqualTo(4);
+            assertThat(contextsPresent).containsExactly(true, true, true, true);
+        }
+
+        @Test
+        void interceptorSeesActionsRegisteredFromInsideAnotherAction() {
+            // given — mirrors DefaultEventStoreTransaction, which registers COMMIT/AFTER_COMMIT from an earlier phase
+            AtomicInteger interceptions = new AtomicInteger();
+            AtomicInteger nestedRan = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> {
+                        interceptions.incrementAndGet();
+                        return action.get();
+                    });
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> {
+                c.on(DefaultPhases.COMMIT, c2 -> {
+                    nestedRan.incrementAndGet();
+                    return FutureUtils.emptyCompletedFuture();
+                });
+                return FutureUtils.emptyCompletedFuture();
+            });
+
+            // when
+            uow.execute().join();
+
+            // then — both the outer and the dynamically registered inner action are intercepted
+            assertThat(nestedRan.get()).isEqualTo(1);
+            assertThat(interceptions.get()).isEqualTo(2);
+        }
+
+        @Test
+        void interceptorSeesCompletionHandler() {
+            // given
+            AtomicInteger interceptions = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> {
+                        interceptions.incrementAndGet();
+                        return action.get();
+                    });
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.whenComplete(c -> {
+            });
+
+            // when
+            uow.execute().join();
+
+            // then
+            assertThat(interceptions.get()).isEqualTo(1);
+        }
+
+        @Test
+        void interceptorSeesErrorHandler() {
+            // given
+            AtomicInteger interceptions = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> {
+                        interceptions.incrementAndGet();
+                        return action.get();
+                    });
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> CompletableFuture.failedFuture(new RuntimeException("boom")));
+            uow.onError((c, phase, error) -> {
+            });
+
+            // when / then — one interception for the failing action, one for the error handler dispatch
+            assertThatThrownBy(() -> uow.execute().join()).hasRootCauseMessage("boom");
+            assertThat(interceptions.get()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class KindDiscrimination {
+
+        @Test
+        void phaseActionsReceiveTheirRegistrationPhase() {
+            // given
+            List<Phase> phases = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor interceptor = recordingPhases(phases);
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.PREPARE_COMMIT, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.COMMIT, c -> FutureUtils.emptyCompletedFuture());
+            uow.on(DefaultPhases.AFTER_COMMIT, c -> FutureUtils.emptyCompletedFuture());
+
+            // when
+            uow.execute().join();
+
+            // then
+            assertThat(phases).containsExactly(DefaultPhases.INVOCATION,
+                                               DefaultPhases.PREPARE_COMMIT,
+                                               DefaultPhases.COMMIT,
+                                               DefaultPhases.AFTER_COMMIT);
+        }
+
+        @Test
+        void completionHandlerDispatchIsRoutedToItsOwnMethod() {
+            // given
+            AtomicInteger completions = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    completions.incrementAndGet();
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    action.run();
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.whenComplete(c -> {
+            });
+
+            // when
+            uow.execute().join();
+
+            // then — the completion handler is routed through its own method, distinct from phase actions
+            assertThat(completions.get()).isEqualTo(1);
+        }
+
+        @Test
+        void errorHandlerDispatchReceivesTheFailedPhaseAndTheSameCauseInstance() {
+            // given
+            List<Phase> failedPhases = new CopyOnWriteArrayList<>();
+            List<Throwable> causes = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    failedPhases.add(failedPhase);
+                    causes.add(cause);
+                    action.run();
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            RuntimeException thrown = new RuntimeException("boom");
+            uow.on(DefaultPhases.INVOCATION, c -> CompletableFuture.failedFuture(thrown));
+            uow.onError((c, phase, error) -> {
+            });
+
+            // when / then
+            assertThatThrownBy(() -> uow.execute().join()).hasRootCause(thrown);
+            assertThat(failedPhases).containsExactly(DefaultPhases.INVOCATION);
+            assertThat(causes).containsExactly(thrown);
+        }
+
+        @Test
+        void errorPrecedingTheFirstPhaseReportsANullFailedPhase() {
+            // given — no phase action is registered, so the failure (if any) cannot carry a failed phase; instead we
+            // simulate the "no failing phase action" case directly by never entering a phase before the error.
+            List<Phase> failedPhases = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    failedPhases.add(failedPhase);
+                    action.run();
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.onError((c, phase, error) -> {
+            });
+
+            // when
+            uow.execute().join();
+
+            // then — no phase action failed, so nothing routes through interceptErrorHandler
+            assertThat(failedPhases).isEmpty();
+        }
+
+        @Test
+        void interceptorCanLimitItselfToSpecificPhasesWhileStillCoveringOtherKinds() {
+            // given — an interceptor wrapping COMMIT actions only, passing all other phases through untouched, while
+            // completion/error dispatch (abstract, so they must be implemented) simply run the action.
+            List<String> order = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor commitOnly = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    if (!DefaultPhases.COMMIT.equals(phase)) {
+                        return action.get();
+                    }
+                    order.add("before-commit-action");
+                    CompletableFuture<?> result = action.get();
+                    order.add("after-commit-action");
+                    return result;
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    action.run();
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(commitOnly);
+            uow.on(DefaultPhases.INVOCATION, c -> {
+                order.add("invocation-action");
+                return FutureUtils.emptyCompletedFuture();
+            });
+            uow.on(DefaultPhases.COMMIT, c -> {
+                order.add("commit-action");
+                return FutureUtils.emptyCompletedFuture();
+            });
+
+            // when
+            uow.execute().join();
+
+            // then — only the COMMIT action is wrapped
+            assertThat(order).containsExactly("invocation-action",
+                                              "before-commit-action",
+                                              "commit-action",
+                                              "after-commit-action");
+        }
+
+        private ProcessingLifecycleInterceptor recordingPhases(List<Phase> phases) {
+            return new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    phases.add(phase);
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    action.run();
+                }
+            };
+        }
+    }
+
+    @Nested
+    class Uniform {
+
+        @Test
+        void uniformFiresForAllThreeDispatchKinds() {
+            // given
+            AtomicInteger phaseActions = new AtomicInteger();
+            AtomicInteger completions = new AtomicInteger();
+            AtomicInteger errors = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> action.get());
+            ProcessingLifecycleInterceptor counting = interceptor.andThen(new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    phaseActions.incrementAndGet();
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    completions.incrementAndGet();
+                    action.run();
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    errors.incrementAndGet();
+                    action.run();
+                }
+            });
+            UnitOfWork uow = (UnitOfWork) factory.create("test", config -> config.interceptor(counting));
+            uow.on(DefaultPhases.INVOCATION, c -> CompletableFuture.failedFuture(new RuntimeException("boom")));
+            uow.onError((c, phase, error) -> {
+            });
+            uow.whenComplete(c -> {
+            });
+
+            // when / then — the lifecycle fails, so only the error handler (not the completion handler) dispatches
+            assertThatThrownBy(() -> uow.execute().join()).hasRootCauseMessage("boom");
+            assertThat(phaseActions.get()).isEqualTo(1);
+            assertThat(errors.get()).isEqualTo(1);
+            assertThat(completions.get()).isZero();
+        }
+
+        @Test
+        void uniformNeverUnderCoversASite() {
+            // given — a happy-path lifecycle exercising phase actions and the completion dispatch
+            AtomicInteger interceptions = new AtomicInteger();
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> {
+                        interceptions.incrementAndGet();
+                        return action.get();
+                    });
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> FutureUtils.emptyCompletedFuture());
+            uow.whenComplete(c -> {
+            });
+
+            // when
+            uow.execute().join();
+
+            // then — one for the phase action, one for the completion dispatch
+            assertThat(interceptions.get()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class AndThen {
+
+        @Test
+        void andThenComposesOuterBeforeInnerPerMethod() {
+            // given
+            List<String> order = new CopyOnWriteArrayList<>();
+            ProcessingLifecycleInterceptor outer = wrapping(order, "outer");
+            ProcessingLifecycleInterceptor inner = wrapping(order, "inner");
+            UnitOfWork uow = unitOfWorkWith(outer.andThen(inner));
+            uow.on(DefaultPhases.INVOCATION, c -> {
+                order.add("action");
+                return FutureUtils.emptyCompletedFuture();
+            });
+            uow.whenComplete(c -> order.add("completion"));
+
+            // when
+            uow.execute().join();
+
+            // then — outer wraps inner wraps the action, for every dispatch kind
+            assertThat(order).containsExactly("outer-phase-before", "inner-phase-before", "action",
+                                              "inner-phase-after", "outer-phase-after",
+                                              "outer-completion-before", "inner-completion-before", "completion",
+                                              "inner-completion-after", "outer-completion-after");
+        }
+
+        @Test
+        void multipleContributorsCompose() {
+            // given — two independent installers must both fire, not clobber each other
+            AtomicInteger first = new AtomicInteger();
+            AtomicInteger second = new AtomicInteger();
+            Supplier<UnitOfWork> build = () -> (UnitOfWork) factory.create(
+                    "test",
+                    config -> config.interceptor(ProcessingLifecycleInterceptor.uniform((c, a) -> {
+                                        first.incrementAndGet();
+                                        return a.get();
+                                    }))
+                                    .interceptor(ProcessingLifecycleInterceptor.uniform((c, a) -> {
+                                        second.incrementAndGet();
+                                        return a.get();
+                                    }))
+            );
+            UnitOfWork uow = build.get();
+            uow.on(DefaultPhases.INVOCATION, c -> FutureUtils.emptyCompletedFuture());
+
+            // when
+            uow.execute().join();
+
+            // then
+            assertThat(first.get()).isEqualTo(1);
+            assertThat(second.get()).isEqualTo(1);
+        }
+
+        private ProcessingLifecycleInterceptor wrapping(List<String> order, String label) {
+            return new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                                                                  Supplier<CompletableFuture<?>> action) {
+                    order.add(label + "-phase-before");
+                    CompletableFuture<?> result = action.get();
+                    order.add(label + "-phase-after");
+                    return result;
+                }
+
+                @Override
+                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                    order.add(label + "-completion-before");
+                    action.run();
+                    order.add(label + "-completion-after");
+                }
+
+                @Override
+                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                                                  Throwable cause, Runnable action) {
+                    order.add(label + "-error-before");
+                    action.run();
+                    order.add(label + "-error-after");
+                }
+            };
+        }
+    }
+
+    @Nested
+    class Behavior {
+
+        @Test
+        void exceptionsFromActionPropagateUnchanged() {
+            // given
+            IllegalStateException failure = new IllegalStateException("expected");
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+                    (context, action) -> action.get());
+            UnitOfWork uow = unitOfWorkWith(interceptor);
+            uow.on(DefaultPhases.INVOCATION, c -> {
+                throw failure;
+            });
+
+            // when / then
+            assertThatThrownBy(() -> uow.execute().join()).hasRootCause(failure);
+        }
+
+        @Test
+        void passThroughDefaultKeepsBehaviorUnchanged() {
+            // given — default configuration, PASS_THROUGH interceptor, no custom wrapping
+            AtomicInteger ran = new AtomicInteger();
+            UnitOfWork uow = (UnitOfWork) factory.create("test", config -> config);
+            uow.on(DefaultPhases.INVOCATION, c -> {
+                ran.incrementAndGet();
+                return FutureUtils.emptyCompletedFuture();
+            });
+
+            // when
+            CompletableFuture<Void> result = uow.execute();
+
+            // then
+            result.join();
+            assertThat(ran.get()).isEqualTo(1);
+            assertThat(result).isCompleted();
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycleInterceptorTest.java
@@ -43,7 +43,7 @@ class ProcessingLifecycleInterceptorTest {
     private final SimpleUnitOfWorkFactory factory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
 
     private UnitOfWork unitOfWorkWith(ProcessingLifecycleInterceptor interceptor) {
-        return (UnitOfWork) factory.create("test", config -> config.interceptor(interceptor));
+        return (UnitOfWork) factory.create("test", config -> config.lifecycleInterceptor(interceptor));
     }
 
     @Nested
@@ -54,7 +54,7 @@ class ProcessingLifecycleInterceptorTest {
             // given
             AtomicInteger interceptions = new AtomicInteger();
             List<Boolean> contextsPresent = new CopyOnWriteArrayList<>();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> {
                         interceptions.incrementAndGet();
                         contextsPresent.add(context != null);
@@ -76,10 +76,10 @@ class ProcessingLifecycleInterceptorTest {
 
         @Test
         void interceptorSeesActionsRegisteredFromInsideAnotherAction() {
-            // given — mirrors DefaultEventStoreTransaction, which registers COMMIT/AFTER_COMMIT from an earlier phase
+            // given -- mirrors DefaultEventStoreTransaction, which registers COMMIT/AFTER_COMMIT from an earlier phase
             AtomicInteger interceptions = new AtomicInteger();
             AtomicInteger nestedRan = new AtomicInteger();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> {
                         interceptions.incrementAndGet();
                         return action.get();
@@ -96,7 +96,7 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — both the outer and the dynamically registered inner action are intercepted
+            // then -- both the outer and the dynamically registered inner action are intercepted
             assertThat(nestedRan.get()).isEqualTo(1);
             assertThat(interceptions.get()).isEqualTo(2);
         }
@@ -105,7 +105,7 @@ class ProcessingLifecycleInterceptorTest {
         void interceptorSeesCompletionHandler() {
             // given
             AtomicInteger interceptions = new AtomicInteger();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> {
                         interceptions.incrementAndGet();
                         return action.get();
@@ -125,7 +125,7 @@ class ProcessingLifecycleInterceptorTest {
         void interceptorSeesErrorHandler() {
             // given
             AtomicInteger interceptions = new AtomicInteger();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> {
                         interceptions.incrementAndGet();
                         return action.get();
@@ -135,7 +135,7 @@ class ProcessingLifecycleInterceptorTest {
             uow.onError((c, phase, error) -> {
             });
 
-            // when / then — one interception for the failing action, one for the error handler dispatch
+            // when / then -- one interception for the failing action, one for the error handler dispatch
             assertThatThrownBy(() -> uow.execute().join()).hasRootCauseMessage("boom");
             assertThat(interceptions.get()).isEqualTo(2);
         }
@@ -171,19 +171,19 @@ class ProcessingLifecycleInterceptorTest {
             AtomicInteger completions = new AtomicInteger();
             ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     return action.get();
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     completions.incrementAndGet();
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     action.run();
                 }
@@ -195,7 +195,7 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — the completion handler is routed through its own method, distinct from phase actions
+            // then -- the completion handler is routed through its own method, distinct from phase actions
             assertThat(completions.get()).isEqualTo(1);
         }
 
@@ -206,18 +206,18 @@ class ProcessingLifecycleInterceptorTest {
             List<Throwable> causes = new CopyOnWriteArrayList<>();
             ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     return action.get();
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     failedPhases.add(failedPhase);
                     causes.add(cause);
@@ -238,23 +238,23 @@ class ProcessingLifecycleInterceptorTest {
 
         @Test
         void errorPrecedingTheFirstPhaseReportsANullFailedPhase() {
-            // given — no phase action is registered, so the failure (if any) cannot carry a failed phase; instead we
+            // given -- no phase action is registered, so the failure (if any) cannot carry a failed phase; instead we
             // simulate the "no failing phase action" case directly by never entering a phase before the error.
             List<Phase> failedPhases = new CopyOnWriteArrayList<>();
             ProcessingLifecycleInterceptor interceptor = new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     return action.get();
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     failedPhases.add(failedPhase);
                     action.run();
@@ -267,18 +267,18 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — no phase action failed, so nothing routes through interceptErrorHandler
+            // then -- no phase action failed, so nothing routes through interceptError
             assertThat(failedPhases).isEmpty();
         }
 
         @Test
         void interceptorCanLimitItselfToSpecificPhasesWhileStillCoveringOtherKinds() {
-            // given — an interceptor wrapping COMMIT actions only, passing all other phases through untouched, while
+            // given -- an interceptor wrapping COMMIT actions only, passing all other phases through untouched, while
             // completion/error dispatch (abstract, so they must be implemented) simply run the action.
             List<String> order = new CopyOnWriteArrayList<>();
             ProcessingLifecycleInterceptor commitOnly = new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     if (!DefaultPhases.COMMIT.equals(phase)) {
                         return action.get();
@@ -290,12 +290,12 @@ class ProcessingLifecycleInterceptorTest {
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     action.run();
                 }
@@ -313,7 +313,7 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — only the COMMIT action is wrapped
+            // then -- only the COMMIT action is wrapped
             assertThat(order).containsExactly("invocation-action",
                                               "before-commit-action",
                                               "commit-action",
@@ -323,19 +323,19 @@ class ProcessingLifecycleInterceptorTest {
         private ProcessingLifecycleInterceptor recordingPhases(List<Phase> phases) {
             return new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     phases.add(phase);
                     return action.get();
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     action.run();
                 }
@@ -352,37 +352,37 @@ class ProcessingLifecycleInterceptorTest {
             AtomicInteger phaseActions = new AtomicInteger();
             AtomicInteger completions = new AtomicInteger();
             AtomicInteger errors = new AtomicInteger();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> action.get());
             ProcessingLifecycleInterceptor counting = interceptor.andThen(new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     phaseActions.incrementAndGet();
                     return action.get();
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     completions.incrementAndGet();
                     action.run();
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     errors.incrementAndGet();
                     action.run();
                 }
             });
-            UnitOfWork uow = (UnitOfWork) factory.create("test", config -> config.interceptor(counting));
+            UnitOfWork uow = (UnitOfWork) factory.create("test", config -> config.lifecycleInterceptor(counting));
             uow.on(DefaultPhases.INVOCATION, c -> CompletableFuture.failedFuture(new RuntimeException("boom")));
             uow.onError((c, phase, error) -> {
             });
             uow.whenComplete(c -> {
             });
 
-            // when / then — the lifecycle fails, so only the error handler (not the completion handler) dispatches
+            // when / then -- the lifecycle fails, so only the error handler (not the completion handler) dispatches
             assertThatThrownBy(() -> uow.execute().join()).hasRootCauseMessage("boom");
             assertThat(phaseActions.get()).isEqualTo(1);
             assertThat(errors.get()).isEqualTo(1);
@@ -391,9 +391,9 @@ class ProcessingLifecycleInterceptorTest {
 
         @Test
         void uniformNeverUnderCoversASite() {
-            // given — a happy-path lifecycle exercising phase actions and the completion dispatch
+            // given -- a happy-path lifecycle exercising phase actions and the completion dispatch
             AtomicInteger interceptions = new AtomicInteger();
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> {
                         interceptions.incrementAndGet();
                         return action.get();
@@ -406,7 +406,7 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — one for the phase action, one for the completion dispatch
+            // then -- one for the phase action, one for the completion dispatch
             assertThat(interceptions.get()).isEqualTo(2);
         }
     }
@@ -430,7 +430,7 @@ class ProcessingLifecycleInterceptorTest {
             // when
             uow.execute().join();
 
-            // then — outer wraps inner wraps the action, for every dispatch kind
+            // then -- outer wraps inner wraps the action, for every dispatch kind
             assertThat(order).containsExactly("outer-phase-before", "inner-phase-before", "action",
                                               "inner-phase-after", "outer-phase-after",
                                               "outer-completion-before", "inner-completion-before", "completion",
@@ -439,16 +439,16 @@ class ProcessingLifecycleInterceptorTest {
 
         @Test
         void multipleContributorsCompose() {
-            // given — two independent installers must both fire, not clobber each other
+            // given -- two independent installers must both fire, not clobber each other
             AtomicInteger first = new AtomicInteger();
             AtomicInteger second = new AtomicInteger();
             Supplier<UnitOfWork> build = () -> (UnitOfWork) factory.create(
                     "test",
-                    config -> config.interceptor(ProcessingLifecycleInterceptor.uniform((c, a) -> {
+                    config -> config.addLifecycleInterceptor(ProcessingLifecycleInterceptor.intercept((c, a) -> {
                                         first.incrementAndGet();
                                         return a.get();
                                     }))
-                                    .interceptor(ProcessingLifecycleInterceptor.uniform((c, a) -> {
+                                    .addLifecycleInterceptor(ProcessingLifecycleInterceptor.intercept((c, a) -> {
                                         second.incrementAndGet();
                                         return a.get();
                                     }))
@@ -467,7 +467,7 @@ class ProcessingLifecycleInterceptorTest {
         private ProcessingLifecycleInterceptor wrapping(List<String> order, String label) {
             return new ProcessingLifecycleInterceptor() {
                 @Override
-                public CompletableFuture<?> interceptPhaseAction(ProcessingContext context, Phase phase,
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
                                                                   Supplier<CompletableFuture<?>> action) {
                     order.add(label + "-phase-before");
                     CompletableFuture<?> result = action.get();
@@ -476,14 +476,14 @@ class ProcessingLifecycleInterceptorTest {
                 }
 
                 @Override
-                public void interceptCompletionHandler(ProcessingContext context, Runnable action) {
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
                     order.add(label + "-completion-before");
                     action.run();
                     order.add(label + "-completion-after");
                 }
 
                 @Override
-                public void interceptErrorHandler(ProcessingContext context, @Nullable Phase failedPhase,
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
                                                   Throwable cause, Runnable action) {
                     order.add(label + "-error-before");
                     action.run();
@@ -500,7 +500,7 @@ class ProcessingLifecycleInterceptorTest {
         void exceptionsFromActionPropagateUnchanged() {
             // given
             IllegalStateException failure = new IllegalStateException("expected");
-            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.uniform(
+            ProcessingLifecycleInterceptor interceptor = ProcessingLifecycleInterceptor.intercept(
                     (context, action) -> action.get());
             UnitOfWork uow = unitOfWorkWith(interceptor);
             uow.on(DefaultPhases.INVOCATION, c -> {
@@ -512,8 +512,8 @@ class ProcessingLifecycleInterceptorTest {
         }
 
         @Test
-        void passThroughDefaultKeepsBehaviorUnchanged() {
-            // given — default configuration, PASS_THROUGH interceptor, no custom wrapping
+        void noInterceptorDefaultKeepsBehaviorUnchanged() {
+            // given -- default configuration, no interceptor installed, no custom wrapping
             AtomicInteger ran = new AtomicInteger();
             UnitOfWork uow = (UnitOfWork) factory.create("test", config -> config);
             uow.on(DefaultPhases.INVOCATION, c -> {
@@ -528,6 +528,76 @@ class ProcessingLifecycleInterceptorTest {
             result.join();
             assertThat(ran.get()).isEqualTo(1);
             assertThat(result).isCompleted();
+        }
+
+        @Test
+        void misbehavingCompletionInterceptorIsSwallowedAndDoesNotBlockRemainingHandlersOrFailTheUnitOfWork() {
+            // given -- an interceptor that runs each completion dispatch and then throws
+            AtomicInteger completionsRun = new AtomicInteger();
+            ProcessingLifecycleInterceptor throwingOnCompletion = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
+                                                           Supplier<CompletableFuture<?>> action) {
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
+                    action.run();
+                    throw new RuntimeException("interceptor boom");
+                }
+
+                @Override
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
+                                           Throwable cause, Runnable action) {
+                    action.run();
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(throwingOnCompletion);
+            uow.whenComplete(c -> completionsRun.incrementAndGet());
+            uow.whenComplete(c -> completionsRun.incrementAndGet());
+
+            // when
+            CompletableFuture<Void> result = uow.execute();
+
+            // then -- both completion handlers ran and the throwing interceptor did not fail the unit of work
+            result.join();
+            assertThat(completionsRun.get()).isEqualTo(2);
+            assertThat(result).isCompleted();
+        }
+
+        @Test
+        void misbehavingErrorInterceptorIsSwallowedAndDoesNotBlockRemainingHandlersNorMaskTheOriginalCause() {
+            // given -- an interceptor that runs each error dispatch and then throws
+            AtomicInteger errorsRun = new AtomicInteger();
+            ProcessingLifecycleInterceptor throwingOnError = new ProcessingLifecycleInterceptor() {
+                @Override
+                public CompletableFuture<?> interceptPhase(ProcessingContext context, Phase phase,
+                                                           Supplier<CompletableFuture<?>> action) {
+                    return action.get();
+                }
+
+                @Override
+                public void interceptCompletion(ProcessingContext context, Runnable action) {
+                    action.run();
+                }
+
+                @Override
+                public void interceptError(ProcessingContext context, @Nullable Phase failedPhase,
+                                           Throwable cause, Runnable action) {
+                    action.run();
+                    throw new RuntimeException("interceptor boom");
+                }
+            };
+            UnitOfWork uow = unitOfWorkWith(throwingOnError);
+            RuntimeException failure = new RuntimeException("boom");
+            uow.on(DefaultPhases.INVOCATION, c -> CompletableFuture.failedFuture(failure));
+            uow.onError((c, phase, error) -> errorsRun.incrementAndGet());
+            uow.onError((c, phase, error) -> errorsRun.incrementAndGet());
+
+            // when / then -- both error handlers ran and the lifecycle still fails with the original cause
+            assertThatThrownBy(() -> uow.execute().join()).hasRootCause(failure);
+            assertThat(errorsRun.get()).isEqualTo(2);
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
@@ -37,10 +37,39 @@ class UnitOfWorkConfigurationTest {
         assertThat(defaultConfig.allowAsyncProcessing()).isTrue();
         assertThat(defaultConfig.workScheduler()).isInstanceOf(DirectExecutor.class);
         assertThat(defaultConfig.processingLifecycleEnhancers()).isEmpty();
+        assertThat(defaultConfig.interceptor()).isSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
 
         // check list immutability:
         assertThatThrownBy(() -> defaultConfig.processingLifecycleEnhancers().clear())
             .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void interceptorComposesAndDoesNotModifyPreviousConfig() {
+        ProcessingLifecycleInterceptor interceptor =
+                ProcessingLifecycleInterceptor.uniform((context, action) -> action.get());
+
+        UnitOfWorkConfiguration newConfig = defaultConfig.interceptor(interceptor);
+
+        // previous config keeps the PASS_THROUGH default:
+        assertThat(defaultConfig.interceptor()).isSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
+        // new config composes the interceptor (no longer the PASS_THROUGH sentinel):
+        assertThat(newConfig.interceptor()).isNotSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
+        // unrelated values are preserved:
+        assertThat(newConfig.workScheduler()).isEqualTo(defaultConfig.workScheduler());
+        assertThat(newConfig.allowAsyncProcessing()).isEqualTo(defaultConfig.allowAsyncProcessing());
+    }
+
+    @Test
+    void forcedSameThreadInvocationPreservesActionInterceptor() {
+        ProcessingLifecycleInterceptor interceptor =
+                ProcessingLifecycleInterceptor.uniform((context, action) -> action.get());
+        UnitOfWorkConfiguration config = defaultConfig.interceptor(interceptor);
+
+        UnitOfWorkConfiguration forced = config.forcedSameThreadInvocation();
+
+        assertThat(forced.allowAsyncProcessing()).isFalse();
+        assertThat(forced.interceptor()).isSameAs(config.interceptor());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkConfigurationTest.java
@@ -37,7 +37,7 @@ class UnitOfWorkConfigurationTest {
         assertThat(defaultConfig.allowAsyncProcessing()).isTrue();
         assertThat(defaultConfig.workScheduler()).isInstanceOf(DirectExecutor.class);
         assertThat(defaultConfig.processingLifecycleEnhancers()).isEmpty();
-        assertThat(defaultConfig.interceptor()).isSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
+        assertThat(defaultConfig.lifecycleInterceptor()).isNull();
 
         // check list immutability:
         assertThatThrownBy(() -> defaultConfig.processingLifecycleEnhancers().clear())
@@ -45,31 +45,62 @@ class UnitOfWorkConfigurationTest {
     }
 
     @Test
-    void interceptorComposesAndDoesNotModifyPreviousConfig() {
+    void lifecycleInterceptorReplacesAndDoesNotModifyPreviousConfig() {
         ProcessingLifecycleInterceptor interceptor =
-                ProcessingLifecycleInterceptor.uniform((context, action) -> action.get());
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
 
-        UnitOfWorkConfiguration newConfig = defaultConfig.interceptor(interceptor);
+        UnitOfWorkConfiguration newConfig = defaultConfig.lifecycleInterceptor(interceptor);
 
-        // previous config keeps the PASS_THROUGH default:
-        assertThat(defaultConfig.interceptor()).isSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
-        // new config composes the interceptor (no longer the PASS_THROUGH sentinel):
-        assertThat(newConfig.interceptor()).isNotSameAs(ProcessingLifecycleInterceptor.PASS_THROUGH);
+        // previous config keeps the (absent) default:
+        assertThat(defaultConfig.lifecycleInterceptor()).isNull();
+        // new config installs the interceptor as-is (replacement):
+        assertThat(newConfig.lifecycleInterceptor()).isSameAs(interceptor);
         // unrelated values are preserved:
         assertThat(newConfig.workScheduler()).isEqualTo(defaultConfig.workScheduler());
         assertThat(newConfig.allowAsyncProcessing()).isEqualTo(defaultConfig.allowAsyncProcessing());
     }
 
     @Test
+    void lifecycleInterceptorReplacesAnAlreadyRegisteredInterceptor() {
+        ProcessingLifecycleInterceptor first =
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
+        ProcessingLifecycleInterceptor second =
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
+
+        UnitOfWorkConfiguration config = defaultConfig.lifecycleInterceptor(first)
+                                                      .lifecycleInterceptor(second);
+
+        // the second interceptor replaces the first outright:
+        assertThat(config.lifecycleInterceptor()).isSameAs(second);
+    }
+
+    @Test
+    void addLifecycleInterceptorChainsWithAnAlreadyRegisteredInterceptor() {
+        ProcessingLifecycleInterceptor first =
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
+        ProcessingLifecycleInterceptor second =
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
+
+        // on a default config the first added interceptor is installed directly:
+        UnitOfWorkConfiguration afterFirst = defaultConfig.addLifecycleInterceptor(first);
+        assertThat(afterFirst.lifecycleInterceptor()).isSameAs(first);
+
+        // the second is chained after the first, so it is a distinct composed interceptor:
+        UnitOfWorkConfiguration afterSecond = afterFirst.addLifecycleInterceptor(second);
+        assertThat(afterSecond.lifecycleInterceptor()).isNotSameAs(first);
+        assertThat(afterSecond.lifecycleInterceptor()).isNotSameAs(second);
+    }
+
+    @Test
     void forcedSameThreadInvocationPreservesActionInterceptor() {
         ProcessingLifecycleInterceptor interceptor =
-                ProcessingLifecycleInterceptor.uniform((context, action) -> action.get());
-        UnitOfWorkConfiguration config = defaultConfig.interceptor(interceptor);
+                ProcessingLifecycleInterceptor.intercept((context, action) -> action.get());
+        UnitOfWorkConfiguration config = defaultConfig.lifecycleInterceptor(interceptor);
 
         UnitOfWorkConfiguration forced = config.forcedSameThreadInvocation();
 
         assertThat(forced.allowAsyncProcessing()).isFalse();
-        assertThat(forced.interceptor()).isSameAs(config.interceptor());
+        assertThat(forced.lifecycleInterceptor()).isSameAs(config.lifecycleInterceptor());
     }
 
     @Test

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkTest.java
@@ -49,7 +49,7 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
 
     @Override
     UnitOfWork createTestSubject() {
-        return new UnitOfWork("unit-of-work-id", DirectExecutor.instance(), false, EmptyApplicationContext.INSTANCE);
+        return new UnitOfWork("unit-of-work-id", DirectExecutor.instance(), false, EmptyApplicationContext.INSTANCE, ProcessingLifecycleInterceptor.PASS_THROUGH);
     }
 
     @Override
@@ -159,7 +159,8 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
             UnitOfWork uow = new UnitOfWork("testSingleCoordinatorThread",
                                             Runnable::run,
                                             true,
-                                            EmptyApplicationContext.INSTANCE);
+                                            EmptyApplicationContext.INSTANCE,
+                                            ProcessingLifecycleInterceptor.PASS_THROUGH);
 
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));
             uow.on(ProcessingLifecycle.DefaultPhases.COMMIT, c -> captureThreadName(threadNames, executor));
@@ -183,7 +184,8 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
             UnitOfWork uow = new UnitOfWork("testSingleCoordinatorThread",
                                             Runnable::run,
                                             true,
-                                            EmptyApplicationContext.INSTANCE);
+                                            EmptyApplicationContext.INSTANCE,
+                                            ProcessingLifecycleInterceptor.PASS_THROUGH);
 
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/UnitOfWorkTest.java
@@ -49,7 +49,7 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
 
     @Override
     UnitOfWork createTestSubject() {
-        return new UnitOfWork("unit-of-work-id", DirectExecutor.instance(), false, EmptyApplicationContext.INSTANCE, ProcessingLifecycleInterceptor.PASS_THROUGH);
+        return new UnitOfWork("unit-of-work-id", DirectExecutor.instance(), false, EmptyApplicationContext.INSTANCE, null);
     }
 
     @Override
@@ -160,7 +160,7 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
                                             Runnable::run,
                                             true,
                                             EmptyApplicationContext.INSTANCE,
-                                            ProcessingLifecycleInterceptor.PASS_THROUGH);
+                                            null);
 
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));
             uow.on(ProcessingLifecycle.DefaultPhases.COMMIT, c -> captureThreadName(threadNames, executor));
@@ -185,7 +185,7 @@ class UnitOfWorkTest extends ProcessingLifecycleTest<UnitOfWork> {
                                             Runnable::run,
                                             true,
                                             EmptyApplicationContext.INSTANCE,
-                                            ProcessingLifecycleInterceptor.PASS_THROUGH);
+                                            null);
 
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));
             uow.on(ProcessingLifecycle.DefaultPhases.INVOCATION, c -> captureThreadName(threadNames, executor));


### PR DESCRIPTION
This change is required for context propagation - from thread local variables (from the thread that invoked the action) into the thread that will be executing the lifecycle action. Micromter already support the OTel Context as well as MDC context propagation, but hook for that in the Axon Framework itself is needed.

The only implementation that uses it is in this PR:
https://github.com/AxonIQ/axoniq-framework/pull/259

As such, this PR can be regarded as a necessity to fulfill #3594.

Introduce a vendor-neutral ProcessingLifecycleInterceptor invoked immediately around every action executed by a UnitOfWork (phase actions, completion and error handlers), on the thread that runs the action.

This is the abstraction for bridging thread-bound state (tracing context, MDC, security) into framework-executed segments. The PASS_THROUGH default keeps the original zero-overhead direct-execution path, so behavior is unchanged when no interceptor is installed. UnitOfWorkConfiguration gains a composing actionInterceptor wither so multiple contributors never clobber each other, and it survives forcedSameThreadInvocation().

It has three abstract, kind-specific methods (interceptPhaseAction, interceptCompletionHandler, interceptErrorHandler) so the compiler forces every implementation to consider all three dispatch sites, mitigating the silent-coverage risk of a nullable-phase discriminator. The error dispatch also carries the failed phase and cause directly. A static uniform(...) factory keeps the wrap-everything case (e.g. a tracing bridge) a one-liner.