### PR TITLE
Do not report rolled-back events in AxonTestFixture

### DIFF
--- a/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
+++ b/test/src/main/java/org/axonframework/test/fixture/RecordingEventSink.java
@@ -33,6 +33,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * An {@link EventSink} implementation recording all the events that are
  * {@link #publish(ProcessingContext, List) published}.
  * <p>
+ * When events are published within a {@link ProcessingContext}, recording is deferred until the context's
+ * {@link ProcessingContext#runOnAfterCommit(java.util.function.Consumer) after-commit phase}. As a result, events
+ * appended in a unit of work that is rolled back — for example because the command handler threw an exception — are
+ * never recorded, mirroring the fact that they are never persisted or published to event handlers. Events published
+ * without a context are recorded immediately.
+ * <p>
  * The recorded events can then be used to assert expectations with test cases.
  *
  * @author Mateusz Nowak
@@ -56,8 +62,12 @@ public class RecordingEventSink implements EventSink {
     @Override
     public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
                                            List<? extends EventMessage> events) {
+        if (context == null) {
+            return delegate.publish(null, events)
+                           .thenRun(() -> recorded.addAll(events));
+        }
         return delegate.publish(context, events)
-                       .thenRun(() -> recorded.addAll(events));
+                       .thenRun(() -> context.runOnAfterCommit(c -> recorded.addAll(events)));
     }
 
     /**

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureRolledBackEventsTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureRolledBackEventsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that the {@link AxonTestFixture} does not report events that were appended in a unit of work that rolled
+ * back. When a command handler appends an event and subsequently throws, the event is never persisted or published, so
+ * the fixture must not report it either.
+ */
+class AxonTestFixtureRolledBackEventsTest {
+
+    private AxonTestFixture fixture;
+
+    @BeforeEach
+    void setUp() {
+        EventSourcingConfigurer configurer = EventSourcingConfigurer.create()
+                .registerEntity(EventSourcedEntityModule.autodetected(String.class, RentableBike.class));
+        fixture = AxonTestFixture.with(configurer);
+    }
+
+    @Test
+    void eventsAppendedBeforeCommandHandlerExceptionAreNotReported() {
+        // given - an existing bike
+        fixture.given()
+               .events(new RentableBikeWasAdded("bike1"))
+               // when - the handler appends ChainWasExchanged and then throws
+               .when()
+               .command(new ExchangeChainCommand("bike1"))
+               // then - the appended event was rolled back, so no events may be reported
+               .then()
+               .exception(IllegalStateException.class)
+               .noEvents();
+    }
+
+    @Test
+    void eventsAppendedBySuccessfulCommandHandlerAreReported() {
+        // given - no prior events
+        fixture.given()
+               .noPriorActivity()
+               // when - the handler appends RentableBikeWasAdded and completes normally
+               .when()
+               .command(new AddNewBikeCommand("bike1"))
+               // then - the committed event is reported
+               .then()
+               .events(new RentableBikeWasAdded("bike1"));
+    }
+
+    public record AddNewBikeCommand(@TargetEntityId String bikeId) {
+    }
+
+    public record ExchangeChainCommand(@TargetEntityId String bikeId) {
+    }
+
+    public record RentableBikeWasAdded(@EventTag(key = "RentableBike") String bikeId) {
+    }
+
+    public record ChainWasExchanged(@EventTag(key = "RentableBike") String bikeId) {
+    }
+
+    @EventSourcedEntity(tagKey = "RentableBike")
+    public static class RentableBike {
+
+        @SuppressWarnings("unused")
+        private String bikeId;
+
+        @EntityCreator
+        RentableBike() {
+        }
+
+        @CommandHandler
+        public static RentableBike on(AddNewBikeCommand command, EventAppender eventAppender) {
+            eventAppender.append(new RentableBikeWasAdded(command.bikeId()));
+            return new RentableBike();
+        }
+
+        @CommandHandler
+        public void handle(ExchangeChainCommand command, EventAppender eventAppender) {
+            eventAppender.append(new ChainWasExchanged(command.bikeId()));
+            throw new IllegalStateException("simulating a business rule violation after appending");
+        }
+
+        @EventSourcingHandler
+        void on(RentableBikeWasAdded event) {
+            this.bikeId = event.bikeId();
+        }
+
+        @EventSourcingHandler
+        void on(ChainWasExchanged event) {
+            this.bikeId = event.bikeId();
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/RecordingEventSinkTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/RecordingEventSinkTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.common.FutureUtils;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.EmptyApplicationContext;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventSink;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecordingEventSinkTest {
+
+    private final List<EventMessage> delegatePublished = new CopyOnWriteArrayList<>();
+    private final EventSink delegate = new EventSink() {
+        @Override
+        public CompletableFuture<Void> publish(@Nullable ProcessingContext context,
+                                               List<? extends EventMessage> events) {
+            delegatePublished.addAll(events);
+            return FutureUtils.emptyCompletedFuture();
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            // No state to describe.
+        }
+    };
+
+    private final RecordingEventSink testSubject = new RecordingEventSink(delegate);
+
+    private static EventMessage testEvent() {
+        return new GenericEventMessage(new MessageType("test-event"), "payload");
+    }
+
+    private static UnitOfWork aUnitOfWork() {
+        return new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE).create("test-unit-of-work");
+    }
+
+    @Nested
+    class WithoutProcessingContext {
+
+        @Test
+        void recordsEventsImmediately() {
+            // given
+            EventMessage event = testEvent();
+
+            // when
+            testSubject.publish(null, List.of(event)).orTimeout(1, TimeUnit.SECONDS).join();
+
+            // then
+            assertThat(testSubject.recorded()).containsExactly(event);
+            assertThat(delegatePublished).containsExactly(event);
+        }
+    }
+
+    @Nested
+    class WithProcessingContext {
+
+        @Test
+        void recordsEventsOnceTheContextCommits() {
+            // given
+            EventMessage event = testEvent();
+            UnitOfWork unitOfWork = aUnitOfWork();
+
+            // when - publishing during invocation defers recording until after commit
+            unitOfWork.runOnInvocation(context -> {
+                testSubject.publish(context, List.of(event)).orTimeout(1, TimeUnit.SECONDS).join();
+                assertThat(testSubject.recorded()).isEmpty();
+            });
+            unitOfWork.execute().orTimeout(5, TimeUnit.SECONDS).join();
+
+            // then
+            assertThat(testSubject.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void doesNotRecordEventsWhenTheContextRollsBack() {
+            // given
+            EventMessage event = testEvent();
+            UnitOfWork unitOfWork = aUnitOfWork();
+
+            // when - the invocation phase fails after publishing
+            unitOfWork.runOnInvocation(context -> {
+                testSubject.publish(context, List.of(event)).orTimeout(1, TimeUnit.SECONDS).join();
+                throw new IllegalStateException("simulating handler failure");
+            });
+            assertThatThrownBy(() -> unitOfWork.execute().orTimeout(5, TimeUnit.SECONDS).join())
+                    .hasRootCauseInstanceOf(IllegalStateException.class);
+
+            // then - the rolled-back event is never reported as recorded
+            assertThat(testSubject.recorded()).isEmpty();
+        }
+    }
+
+    @Test
+    void resetClearsRecordedEvents() {
+        // given
+        testSubject.publish(null, List.of(testEvent())).orTimeout(1, TimeUnit.SECONDS).join();
+        assertThat(testSubject.recorded()).isNotEmpty();
+
+        // when
+        testSubject.reset();
+
+        // then
+        assertThat(testSubject.recorded()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Problem

When a command handler appends an event via `EventAppender` and subsequently throws an exception, the appended event is correctly rolled back with the unit of work: it is never persisted to the event store, and never delivered to event handlers. The `AxonTestFixture`, however, reported it as published, so `then().noEvents()` failed on:

```java
fixture.given().events(...)
       .when().command(new ExchangeChainCommand("bike1")) // handler appends, then throws
       .then().noEvents(); // failed: reported the rolled-back event as published
```

This made it look like AF5 lost the AF4 guarantee that events appended before an exception are not applied. The runtime guarantee is intact — the bug was purely in the fixture's reporting.

## Cause

`RecordingEventSink` recorded events as soon as the delegate's `publish(...)` future completed. For the event store path, publishing only stages events on the `EventStoreTransaction` and returns an already-completed future, so events were recorded at append time — before the unit of work decided to commit or roll back — and recordings were never discarded on rollback.

## Fix

When a `ProcessingContext` is active, `RecordingEventSink` now defers recording to the context's after-commit phase, so events from a rolled-back unit of work are never recorded. Context-less publications are still recorded immediately.

## Tests

- `AxonTestFixtureRolledBackEventsTest` — fixture-level: append-then-throw yields `exception(...)` + `noEvents()`; a successful command still reports its events.
- `RecordingEventSinkTest` — unit-level: immediate recording without a context, deferred recording on commit, no recording on rollback, and `reset()`.