### PR TITLE
Enforce correct qualified name and version use

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageType.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageType.java
@@ -16,9 +16,6 @@
 
 package org.axonframework.messaging.core;
 
-import org.axonframework.common.Assert;
-import org.axonframework.common.StringUtils;
-
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,10 +31,12 @@ import static java.util.Objects.requireNonNull;
  * When you do not require a version for typing, consider using the {@code QualifiedName} directly instead.
  *
  * @param qualifiedName The {@code QualifiedName} of this {@code MessageType}.
- * @param version       the version of this {@code MessageType}.
+ * @param version       the version of this {@code MessageType}. Must not be blank, or contain a hash ({@code #}),
+ *                      since that character is reserved as the separator in this record's String representation.
  * @author Allard Buijze
  * @author Mateusz Nowak
  * @author Steven van Beelen
+ * @author John Hendrikx
  * @since 5.0.0
  */
 public record MessageType(QualifiedName qualifiedName, String version) {
@@ -47,24 +46,44 @@ public record MessageType(QualifiedName qualifiedName, String version) {
      */
     public static final String DEFAULT_VERSION = "0.0.1";
 
-    private static final String VERSION_DELIMITER = "#";
-    private static final String DEBUG_STRING_REGEX = "^([^#]+)#([^#]+)$";
-    private static final Pattern DEBUG_STRING_PATTERN = Pattern.compile(DEBUG_STRING_REGEX);
-    private static final int QUALIFIED_NAME_GROUP = 1;
-    private static final int VERSION_GROUP = 2;
+    /**
+     * The separator between a {@link #qualifiedName()} and {@link #version()} in the String representation produced
+     * by {@link #toString()} and parsed by {@link #fromString(String)}. Also enforced as forbidden in
+     * {@link QualifiedName#QualifiedName(String) QualifiedName's name} and in {@link #version}, since either
+     * containing this separator would make that representation ambiguous to parse back.
+     */
+    public static final String VERSION_DELIMITER = "#";
 
     /**
-     * Compact constructor validating that the given {@code qualifiedName} is non-null.
+     * Pattern identifying a single valid segment of a {@code MessageType}'s String representation - either the
+     * {@link #qualifiedName()} or the {@link #version()} - requiring at least one non-whitespace character and no
+     * {@value #VERSION_DELIMITER}. Shared by this record's and {@link QualifiedName}'s constructors, and
+     * combined with itself (separated by {@value #VERSION_DELIMITER}) to build
+     * {@code VALID_STRING_REPRESENTATION_PATTERN}, so a single definition governs what is considered valid
+     * everywhere.
+     */
+    static final Pattern VALID_SEGMENT = Pattern.compile("(?!\\s*$)[^#]+");
+
+    private static final Pattern VALID_STRING_REPRESENTATION = Pattern.compile(
+            "^(?<qualifiedName>" + VALID_SEGMENT.pattern() + ")" + VERSION_DELIMITER
+                    + "(?<version>" + VALID_SEGMENT.pattern() + ")$"
+    );
+
+    /**
+     * Constructor validating that the given {@code qualifiedName} is non-null, and that {@code version} is
+     * non-null, not blank, and does not contain the hash ({@code #}) used as version delimiter.
      */
     public MessageType {
         requireNonNull(qualifiedName, "The qualifiedName cannot be null.");
-        Assert.assertThat(
-                requireNonNull(version, "The given version is unsupported because it is null."),
-                StringUtils::nonEmpty,
-                () -> new IllegalArgumentException(
-                        "The given version is unsupported because it is empty."
-                )
-        );
+        requireNonNull(version, "The version is unsupported because it is null.");
+
+        if (!VALID_SEGMENT.matcher(version).matches()) {
+            throw new IllegalArgumentException(
+                    "The version [" + version + "] is unsupported because it is blank, or contains \""
+                            + VERSION_DELIMITER + "\", which is reserved as the separator in MessageType's "
+                            + "String representation."
+            );
+        }
     }
 
     /**
@@ -157,7 +176,7 @@ public record MessageType(QualifiedName qualifiedName, String version) {
      * Reconstruct a {@code MessageType} based on the output of {@link MessageType#toString()}.
      * <p>
      * The output of {@code MessageType#toString()} is a concatenation of the {@link #qualifiedName()} and
-     * {@link #version()}, split by means of a hashtag ({@code #}).
+     * {@link #version()}, split by means of a hash ({@code #}).
      * <p>
      * Thus, if the given {@code String} equals {@code "my.context.BusinessName#1.0.5"}, the {@code #qualifiedName()} is
      * set to a {@link QualifiedName} of {@code "my.context.BusinessName"} and the {@link #version()} is set to
@@ -168,23 +187,28 @@ public record MessageType(QualifiedName qualifiedName, String version) {
      * @return A reconstructed {@code MessageType} based on the expected output of {@link MessageType#toString()}.
      */
     public static MessageType fromString(String messageTypeString) {
-        Matcher matcher = DEBUG_STRING_PATTERN.matcher(Objects.requireNonNull(
+        Matcher matcher = VALID_STRING_REPRESENTATION.matcher(Objects.requireNonNull(
                 messageTypeString,
                 "Cannot construct a MessageType based on a null or empty String."
         ));
-        Assert.isTrue(matcher.matches(),
-                      () -> "The given simple String [" + messageTypeString + "] does not match the expected pattern.");
-        return new MessageType(new QualifiedName(matcher.group(QUALIFIED_NAME_GROUP)), matcher.group(VERSION_GROUP));
+
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    "The given simple String [" + messageTypeString + "] does not match the expected pattern."
+            );
+        }
+
+        return new MessageType(new QualifiedName(matcher.group("qualifiedName")), matcher.group("version"));
     }
 
     /**
      * The output of {@code MessageType#toString()} is a concatenation of the {@link #qualifiedName()} and
-     * {@link #version()}, split by means of a hashtag ({@code #}).
+     * {@link #version()}, split by means of a hash ({@code #}).
      * <p>
      * Thus, if {@code #qualifiedName()} returns {@code "my.context.BusinessName"} and the {@code #version()} returns
      * {@code "1.0.5"}, the result of <b>this</b> operation would be {@code "my.context.BusinessName#1.0.5"}.
      *
-     * @return A combination of the {@link #qualifiedName()} and {@link #version()}, separated by a hashtag.
+     * @return A combination of the {@link #qualifiedName()} and {@link #version()}, separated by a hash.
      */
     @Override
     public String toString() {

--- a/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/QualifiedName.java
@@ -36,10 +36,13 @@ import static org.axonframework.common.ReflectionUtils.resolvePrimitiveWrapperTy
  * {@link MessageHandler MessageHandlers}, and other components that require naming. To combine a qualified
  * qualifiedName with a version, consider using the {@link MessageType}.
  *
- * @param name The qualifiedName of this {@code QualifiedName}. Must not be {@code null} or empty.
+ * @param name The qualifiedName of this {@code QualifiedName}. Must not be {@code null}, blank, or contain a hash
+ *             ({@code #}), since that character is reserved by {@link MessageType} as the separator between a
+ *             qualified name and version in its String representation.
  * @author Allard Buijze
  * @author Mitchell Herrijgers
  * @author Steven van Beelen
+ * @author John Hendrikx
  * @see MessageType
  * @since 5.0.0
  */
@@ -48,14 +51,19 @@ public record QualifiedName(String name) {
     private static final String DELIMITER = ".";
 
     /**
-     * Compact constructor asserting whether the {@code qualifiedName} is non-null and not empty.
+     * Creates a new instance and asserts whether the {@code qualifiedName} is non-null, not blank, and does not
+     * contain {@link MessageType#VERSION_DELIMITER}.
      */
     public QualifiedName {
-        Assert.assertThat(
-                requireNonNull(name, "The given name is unsupported because it is null."),
-                StringUtils::nonEmpty,
-                () -> new IllegalArgumentException("The given name is unsupported because it is empty.")
-        );
+        requireNonNull(name, "The given name is unsupported because it is null.");
+
+        if (!MessageType.VALID_SEGMENT.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                    "The given name [" + name + "] is unsupported because it is blank, or contains \""
+                            + MessageType.VERSION_DELIMITER + "\", which is reserved by MessageType as the "
+                            + "separator between a qualified name and version in its String representation."
+            );
+        }
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTypeTest.java
@@ -18,12 +18,14 @@ package org.axonframework.messaging.core;
 
 import org.junit.jupiter.api.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class validating the {@link MessageType}.
  *
  * @author Steven van Beelen
+ * @author John Hendrikx
  */
 class MessageTypeTest {
 
@@ -96,6 +98,28 @@ class MessageTypeTest {
     }
 
     @Test
+    void throwsIllegalArgumentExceptionForBlankVersion() {
+        assertThrows(IllegalArgumentException.class, () -> new MessageType(QUALIFIED_NAME, "   "));
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionForVersionContainingHash() {
+        // the hash is reserved as the separator between a qualified name and version in toString()/fromString()
+        assertThatThrownBy(() -> new MessageType(QUALIFIED_NAME, "1#0"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("#");
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionForQualifiedNameContainingHash() {
+        // delegates to QualifiedName's own validation, but verified here too since MessageType's
+        // String representation is what actually depends on it being absent
+        assertThatThrownBy(() -> new MessageType(NAME + "#suffix", VERSION))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("#");
+    }
+
+    @Test
     void throwsNullPointerExceptionForNullClass() {
         //noinspection DataFlowIssue
         assertThrows(NullPointerException.class, () -> new MessageType((Class<?>) null));
@@ -120,7 +144,7 @@ class MessageTypeTest {
     }
 
     @Test
-    void toStringDelimitsQualifiedNameAndVersionWithHashtag() {
+    void toStringDelimitsQualifiedNameAndVersionWithHash() {
         String expectedToString = NAME + "#" + VERSION;
 
         MessageType testSubject = new MessageType(QUALIFIED_NAME, VERSION);

--- a/messaging/src/test/java/org/axonframework/messaging/core/QualifiedNameTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/QualifiedNameTest.java
@@ -18,12 +18,14 @@ package org.axonframework.messaging.core;
 
 import org.junit.jupiter.api.*;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class validating the {@link QualifiedName}.
  *
  * @author Steven van Beelen
+ * @author John Hendrikx
  */
 class QualifiedNameTest {
 
@@ -76,6 +78,26 @@ class QualifiedNameTest {
     @Test
     void throwsIllegalArgumentExceptionForEmptyName() {
         assertThrows(IllegalArgumentException.class, () -> new QualifiedName(""));
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionForBlankName() {
+        assertThrows(IllegalArgumentException.class, () -> new QualifiedName("   "));
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionForNameContainingHash() {
+        // the hash is reserved by MessageType as the separator between a qualified name and version
+        assertThatThrownBy(() -> new QualifiedName("my.context.Business#Name"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("#");
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionForLocalNameContainingHash() {
+        assertThatThrownBy(() -> new QualifiedName(NAMESPACE, "local#Name"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("#");
     }
 
     @Test


### PR DESCRIPTION
- Disallow blank names and versions
- Disallow use of hash (#) in names and versions

Although using hashes in names/versions is no longer a problem for Postgres (it will store type/version separately soon), this is apparently still relied upon by the Spring Extension `DefaultEventMessageConverter`:

It converts Axon EventMessages to and from Spring's generic Message type — the abstraction used by Spring Integration channel adapters and similar Spring messaging bridges. When converting an event to a Spring message, it writes the event's `MessageType` into a header called `axon-message-type` using `event.type().toString()`. When converting a Spring message back into an Axon event  (e.g. a consumer reading from that channel), it reads that same header and reconstructs the `MessageType` via `MessageType.fromString(...)`.

For example, an event annotated `@Event(name = "Order#Placed", version = "1.0")` would (before this fix) have produced the header axon-message-type: `Order#Placed#1.0`. When something tries to convert that Spring message back into an Axon event, `fromString()` expects exactly one `#` splitting the name from the version - but this string has two, so parsing fails and the event can't be reconstructed, even though nothing else in the framework ever rejected "Order#Placed" as an invalid name. This fix closes that gap by rejecting # in QualifiedName/MessageType at construction time, so a name like "Order#Placed" is caught immediately when the event type is first defined, rather than failing later and further downstream when a Spring message tries to round-trip it.