### PR TITLE
Only resolve replay context during an active replay

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/ReplayToken.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/ReplayToken.java
@@ -169,7 +169,8 @@ public class ReplayToken implements WrappedToken {
      * Extracts the {@link ReplayToken#resetContext()} from the given {@code token}, converting it to the given
      * {@code type} with the given {@code converter}.
      * <p>
-     * If the {@code token} is not a {@code ReplayToken}, and empty {@link Optional} will be returned.
+     * If the {@code token} is not a {@code ReplayToken}, or is not currently part of a replay, an empty
+     * {@link Optional} will be returned.
      *
      * @param token     the token to extract and convert the {@link ReplayToken#resetContext()} from, if it is a
      *                  {@code ReplayToken}
@@ -178,7 +179,7 @@ public class ReplayToken implements WrappedToken {
      * @param converter the {@code Converter} used to convert the {@link ReplayToken#resetContext()} with
      * @param <T>       the generic defining the desired type to convert the {@link ReplayToken#resetContext()} to
      * @return an {@code Optional} carrying the converted {@link ReplayToken#resetContext()}. Empty if the given
-     * {@code token} was not of type {@code ReplayToken}
+     * {@code token} was not of type {@code ReplayToken}, or is not currently part of a replay
      */
     public static <T> Optional<T> replayContext(
             TrackingToken token,
@@ -186,6 +187,7 @@ public class ReplayToken implements WrappedToken {
             Converter converter
     ) {
         return WrappedToken.unwrap(token, ReplayToken.class)
+                           .filter(rt -> rt.isReplay())
                            .map(ReplayToken::resetContext)
                            .map(rc -> converter.convert(rc, type));
     }
@@ -199,6 +201,7 @@ public class ReplayToken implements WrappedToken {
      */
     public static OptionalLong getTokenAtReset(TrackingToken trackingToken) {
         return WrappedToken.unwrap(trackingToken, ReplayToken.class)
+                           .filter(rt -> rt.isReplay())
                            .map(rt -> rt.getTokenAtReset().position())
                            .orElse(OptionalLong.empty());
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/ReplayTokenTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/ReplayTokenTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.axonframework.conversion.PassThroughConverter;
 import org.junit.jupiter.api.*;
 
 /**
@@ -100,6 +101,54 @@ class ReplayTokenTest {
         TrackingToken actual = testSubject.advancedTo(GapAwareTrackingToken.newInstance(6, emptySet()));
         assertInstanceOf(ReplayToken.class, actual);
         assertEquals(testSubject.getTokenAtReset(), innerToken);
+    }
+
+    @Test
+    void replayContextIsResolvedWhileReplaying() {
+        byte[] context = "context".getBytes();
+        TrackingToken tokenAtReset = new GlobalSequenceTrackingToken(10);
+        TrackingToken startPosition = new GlobalSequenceTrackingToken(2);
+
+        TrackingToken replayToken = ReplayToken.createReplayToken(tokenAtReset, startPosition, context);
+
+        assertTrue(ReplayToken.isReplay(replayToken), "Precondition: token should still be replaying");
+        assertThat(ReplayToken.replayContext(replayToken, byte[].class, PassThroughConverter.INSTANCE))
+                .containsSame(context);
+    }
+
+    @Test
+    void replayContextIsNotResolvedForNonReplayEventWhileTokenIsStillWrapped() {
+        // A gap in the current token that the reset token doesn't share makes the freshly delivered event a "new"
+        // event that does not strictly pass the reset point. The ReplayToken therefore keeps its wrapper (and context)
+        // while reporting lastMessageWasReplay=false. Such live events must not resolve the reset context.
+        byte[] context = "context".getBytes();
+        TrackingToken tokenAtReset = GapAwareTrackingToken.newInstance(10, Collections.singleton(8L));
+        TrackingToken startPosition = GapAwareTrackingToken.newInstance(8, emptySet());
+
+        TrackingToken replayToken = ReplayToken.createReplayToken(tokenAtReset, startPosition, context);
+
+        assertInstanceOf(ReplayToken.class, replayToken, "Precondition: token should still be wrapped");
+        assertFalse(ReplayToken.isReplay(replayToken), "Precondition: token should not be replaying");
+        assertThat(ReplayToken.replayContext(replayToken, byte[].class, PassThroughConverter.INSTANCE))
+                .as("Context must not be resolved once the token is no longer replaying")
+                .isEmpty();
+    }
+
+    @Test
+    void getTokenAtResetIsEmptyForNonReplayEventWhileTokenIsStillWrapped() {
+        // Same still-wrapped-but-not-replaying scenario: getResetPosition must report empty, matching its documented
+        // contract ("In case a replay finished or no replay is active, an OptionalLong.empty()").
+        byte[] context = "context".getBytes();
+        TrackingToken tokenAtReset = GapAwareTrackingToken.newInstance(10, Collections.singleton(8L));
+        TrackingToken startPosition = GapAwareTrackingToken.newInstance(8, emptySet());
+
+        TrackingToken replayToken = ReplayToken.createReplayToken(tokenAtReset, startPosition, context);
+
+        assertInstanceOf(ReplayToken.class, replayToken, "Precondition: token should still be wrapped");
+        assertFalse(ReplayToken.isReplay(replayToken), "Precondition: token should not be replaying");
+        assertThat(ReplayToken.getTokenAtReset(replayToken))
+                .as("Reset position must not be reported once the token is no longer replaying")
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Problem
`@ReplayContext` handlers rely on the documented contract that the context
is empty/`null` when the processor is not replaying. In practice,
`ReplayToken.replayContext(...)` returned the reset context whenever a
`ReplayToken` wrapper was present, without consulting the replay status.

As a result, a live event delivered while the token is still wrapped
(`lastMessageWasReplay = false`) wrongly received the context. Handlers that
treat "context present" as "this is a replay" kept applying their
replay-only filter to live events. (Reported against 4.13.x; the same defect
exists here.)

The accessors disagreed: `isReplay(...)` correctly gated on the replay flag,
while `replayContext(...)` and `getTokenAtReset(...)` did not.

## Fix
- Gate `replayContext(...)` on `isReplay()` so it matches the `isReplay`
  semantics and the documented contract.
- Apply the same gate to `getTokenAtReset(...)`, which had the same omission
  despite its Javadoc promising an empty result once a replay has finished.

The inverted type-filter bug from the 4.13.x fix does not apply here — AF5
already resolves the context type through a `Converter`.

## Tests
Added regression tests in `ReplayTokenTest` covering context resolution
during replay, and empty results from both `replayContext` and
`getTokenAtReset` for a still-wrapped, non-replaying token. Verified the new
negative tests fail without the fix. The pre-existing
`replayContextIsNullOutsideReplay` test only used a plain unwrapped token, so
it did not catch this.
