### PR TITLE
[#4757] Reintroduce Map-support for entity members

### DIFF
--- a/docs/reference-guide/modules/commands/pages/entities/entity-hierarchies.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/entity-hierarchies.adoc
@@ -35,6 +35,13 @@ include::example$commands/entities/entityhierarchies/EnrollmentEntity.java[tag=c
 <4> A getter exposing the value that identifies this particular child instance.
 The name matches the field used to address this child in incoming commands.
 
+A child field can take one of three shapes:
+
+* A single field, for exactly one child instance.
+* A `List<Child>`, for an ordered collection of children.
+* A `Map<Key, Child>`, for children addressed by their own key.
+The map's keys are independent of the routing key and are preserved automatically as children are added, evolved, or removed.
+
 == Configuring the hierarchy
 
 Three approaches are available:
@@ -77,7 +84,7 @@ include::example$commands/entities/entityhierarchies/AxonConfiguration.java[tag=
 ----
 
 <1> `EntityChildMetamodel.list()` wires the child into the parent for a `List` field.
-Other factory methods cover a single child field or different collection shapes.
+`EntityChildMetamodel.single()` covers a single child field, and `EntityChildMetamodel.map()` covers a `Map` field the same way, taking a `Map`-typed getter and evolver instead of a `List`-typed one.
 
 <2> The getter that reads the child list from a parent instance, plus the evolver that produces a new parent instance with an updated list.
 
@@ -110,13 +117,6 @@ Register the entity:
 ----
 include::example$commands/entities/entityhierarchies/autodetected/CourseHierarchyConfiguration.java[tag=autodetected-registration,indent=0]
 ----
-
-[NOTE]
-====
-Only `List` fields are supported for collections of child entities in the annotated approach.
-Using a `Map` field will not route commands to the map values.
-Use a `List` instead and manage key-based lookup within the entity.
-====
 
 [#_spring_boot]
 === Spring Boot

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/multi-entity-migration.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/multi-entity-migration.adoc
@@ -102,10 +102,9 @@ If you need to suppress event forwarding entirely, do not declare `@EventSourcin
 
 - xref:commands:entities/entity-hierarchies.adoc[Entity Hierarchies]: full reference for `@EntityMember`, routing key configuration, and event routing in Axon Framework 5
 
-[IMPORTANT]
-.Maps are not supported
+[NOTE]
+.Maps are supported too
 ====
-`@AggregateMember` could be used on `Map<Key,Value>` fields to represent child entities identified by a key.
-
-The `@EntityMember` annotation in Axon Framework 5 supports `List<Value>` only. If you need to model child entities identified by a key, consider using a `List<Value>` and managing the identification logic within the entity itself or through a custom resolver.
+`@AggregateMember` on a `Map<Key,Value>` field maps directly to `@EntityMember` on the same `Map<Key,Value>` field.
+The map's own keys are preserved automatically as entries are added, evolved, or removed, so no extra identification logic is needed.
 ====

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
@@ -154,6 +154,7 @@ public abstract class AbstractAdministrationIT extends AbstractIT {
     void canGrantAndRevokeCertificationsForEmployee() {
         sendCommand(CREATE_EMPLOYEE_1_COMMAND);
 
+        sendCommand(new GrantCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "Axon Pro", "Axoniq"));
         sendCommand(new GrantCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "AWS-SAA", "Amazon"));
 
         assertThrowsExceptionWithText("Employee already holds certification AWS-SAA", () -> {

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/AbstractAdministrationIT.java
@@ -25,6 +25,8 @@ import org.axonframework.integrationtests.testsuite.administration.commands.Comp
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateCustomer;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
 import org.axonframework.integrationtests.testsuite.administration.commands.GiveRaise;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonType;
 import org.junit.jupiter.api.*;
@@ -146,6 +148,23 @@ public abstract class AbstractAdministrationIT extends AbstractIT {
 
         // And assign a new one
         sendCommand(new AssignTaskCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "task-4", "Task " + 4));
+    }
+
+    @Test
+    void canGrantAndRevokeCertificationsForEmployee() {
+        sendCommand(CREATE_EMPLOYEE_1_COMMAND);
+
+        sendCommand(new GrantCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "AWS-SAA", "Amazon"));
+
+        assertThrowsExceptionWithText("Employee already holds certification AWS-SAA", () -> {
+            sendCommand(new GrantCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "AWS-SAA", "Amazon"));
+        });
+
+        sendCommand(new RevokeCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "AWS-SAA"));
+
+        assertThrowsExceptionWithText("Certification is already revoked", () -> {
+            sendCommand(new RevokeCertificationCommand(CREATE_EMPLOYEE_1_COMMAND.identifier(), "AWS-SAA"));
+        });
     }
 
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/ImmutableBuilderEntityModelAdministrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/ImmutableBuilderEntityModelAdministrationIT.java
@@ -26,10 +26,14 @@ import org.axonframework.integrationtests.testsuite.administration.commands.Comp
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateCustomer;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
 import org.axonframework.integrationtests.testsuite.administration.commands.GiveRaise;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationRevoked;
 import org.axonframework.integrationtests.testsuite.administration.events.CustomerCreated;
 import org.axonframework.integrationtests.testsuite.administration.events.EmployeeCreated;
 import org.axonframework.integrationtests.testsuite.administration.events.TaskCompleted;
+import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutableCertification;
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutableCustomer;
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutableEmployee;
 import org.axonframework.integrationtests.testsuite.administration.state.immutable.ImmutablePerson;
@@ -91,6 +95,22 @@ public abstract class ImmutableBuilderEntityModelAdministrationIT extends Abstra
                                         })
                 .build();
 
+        // Certification is the map-based child-metamodel of Employee
+        EntityMetamodel<ImmutableCertification> certificationMetamodel = ConcreteEntityMetamodel
+                .forEntityClass(ImmutableCertification.class)
+                .entityEvolver(new AnnotationBasedEntityEvolvingComponent<>(
+                        ImmutableCertification.class, eventConverter, typeResolver
+                ))
+                .instanceCommandHandler(typeResolver.resolveOrThrow(RevokeCertificationCommand.class).qualifiedName(),
+                                        (command, entity, context) -> {
+                                            EventAppender eventAppender = EventAppender.forContext(context);
+                                            RevokeCertificationCommand convertedPayload =
+                                                    command.payloadAs(RevokeCertificationCommand.class);
+                                            entity.handle(convertedPayload, eventAppender);
+                                            return MessageStream.empty().cast();
+                                        })
+                .build();
+
         // Employee is a concrete entity type
         EntityMetamodel<ImmutableEmployee> employeeMetamodel = ConcreteEntityMetamodel
                 .forEntityClass(ImmutableEmployee.class)
@@ -111,6 +131,49 @@ public abstract class ImmutableBuilderEntityModelAdministrationIT extends Abstra
                                             entity.handle(convertedPayload, eventAppender);
                                             return MessageStream.empty().cast();
                                         }))
+                .instanceCommandHandler(typeResolver.resolveOrThrow(GrantCertificationCommand.class).qualifiedName(),
+                                        ((command, entity, context) -> {
+                                            EventAppender eventAppender = EventAppender.forContext(context);
+                                            GrantCertificationCommand convertedPayload =
+                                                    command.payloadAs(GrantCertificationCommand.class);
+                                            entity.handle(convertedPayload, eventAppender);
+                                            return MessageStream.empty().cast();
+                                        }))
+                .addChild(EntityChildMetamodel
+                                  .<String, ImmutableCertification, ImmutableEmployee>map(
+                                          ImmutableEmployee.class, certificationMetamodel
+                                  )
+                                  .childEntityFieldDefinition(ChildEntityFieldDefinition.forGetterEvolver(
+                                          ImmutableEmployee::getCertifications, ImmutableEmployee::evolveCertifications
+                                  ))
+                                  .commandTargetResolver((candidates, commandMessage, ctx) -> {
+                                      if (commandMessage.type().name().equals(RevokeCertificationCommand.class.getName())) {
+                                          RevokeCertificationCommand convertedPayload =
+                                                  commandMessage.payloadAs(RevokeCertificationCommand.class);
+                                          return candidates.stream()
+                                                           .filter(cert -> cert.getCertificationName().equals(
+                                                                   convertedPayload.certificationName()
+                                                           ))
+                                                           .findFirst()
+                                                           .orElse(null);
+                                      }
+                                      return null;
+                                  })
+                                  .eventTargetMatcher((o, eventMessage, ctx) -> {
+                                      if (eventMessage.type().name().equals(CertificationRevoked.class.getName())) {
+                                          CertificationRevoked certificationRevoked = eventConverter.convertPayload(
+                                                  eventMessage, CertificationRevoked.class
+                                          );
+                                          Objects.requireNonNull(
+                                                  certificationRevoked,
+                                                  "CertificationRevoked event payload cannot be null"
+                                          );
+                                          return o.getCertificationName().equals(certificationRevoked.certificationName());
+                                      }
+                                      return false;
+                                  })
+                                  .build()
+                )
                 .addChild(EntityChildMetamodel
                                   .list(ImmutableEmployee.class, taskMetamodel)
                                   .childEntityFieldDefinition(ChildEntityFieldDefinition.forGetterEvolver(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/MutableBuilderEntityModelAdministrationIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/MutableBuilderEntityModelAdministrationIT.java
@@ -26,9 +26,13 @@ import org.axonframework.integrationtests.testsuite.administration.commands.Comp
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateCustomer;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
 import org.axonframework.integrationtests.testsuite.administration.commands.GiveRaise;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonType;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationRevoked;
 import org.axonframework.integrationtests.testsuite.administration.events.TaskCompleted;
+import org.axonframework.integrationtests.testsuite.administration.state.mutable.MutableCertification;
 import org.axonframework.integrationtests.testsuite.administration.state.mutable.MutableCustomer;
 import org.axonframework.integrationtests.testsuite.administration.state.mutable.MutableEmployee;
 import org.axonframework.integrationtests.testsuite.administration.state.mutable.MutablePerson;
@@ -90,6 +94,22 @@ public abstract class MutableBuilderEntityModelAdministrationIT extends Abstract
                                         })
                 .build();
 
+        // Certification is the map-based child-model of Employee
+        EntityMetamodel<MutableCertification> certificationMetamodel = ConcreteEntityMetamodel
+                .forEntityClass(MutableCertification.class)
+                .entityEvolver(new AnnotationBasedEntityEvolvingComponent<>(
+                        MutableCertification.class, eventConverter, typeResolver
+                ))
+                .instanceCommandHandler(typeResolver.resolveOrThrow(RevokeCertificationCommand.class).qualifiedName(),
+                                        (command, entity, context) -> {
+                                            EventAppender eventAppender = EventAppender.forContext(context);
+                                            RevokeCertificationCommand convertedPayload =
+                                                    command.payloadAs(RevokeCertificationCommand.class);
+                                            entity.handle(convertedPayload, eventAppender);
+                                            return MessageStream.empty().cast();
+                                        })
+                .build();
+
         // Employee is a concrete entity type
         EntityMetamodel<MutableEmployee> employeeMetamodel = ConcreteEntityMetamodel
                 .forEntityClass(MutableEmployee.class)
@@ -112,6 +132,48 @@ public abstract class MutableBuilderEntityModelAdministrationIT extends Abstract
                                             entity.handle(convertedPayload, eventAppender);
                                             return MessageStream.empty().cast();
                                         }))
+                .instanceCommandHandler(typeResolver.resolveOrThrow(GrantCertificationCommand.class).qualifiedName(),
+                                        ((command, entity, context) -> {
+                                            EventAppender eventAppender = EventAppender.forContext(context);
+                                            GrantCertificationCommand convertedPayload =
+                                                    command.payloadAs(GrantCertificationCommand.class);
+                                            entity.handle(convertedPayload, eventAppender);
+                                            return MessageStream.empty().cast();
+                                        }))
+                .addChild(EntityChildMetamodel
+                                  .<String, MutableCertification, MutableEmployee>map(
+                                          MutableEmployee.class, certificationMetamodel
+                                  )
+                                  .childEntityFieldDefinition(ChildEntityFieldDefinition.forGetterSetter(
+                                          MutableEmployee::getCertifications, MutableEmployee::setCertifications
+                                  ))
+                                  .commandTargetResolver((candidates, commandMessage, ctx) -> {
+                                      if (commandMessage.type().name().equals(RevokeCertificationCommand.class.getName())) {
+                                          RevokeCertificationCommand convertedPayload = commandMessage.payloadAs(
+                                                  RevokeCertificationCommand.class);
+                                          Objects.requireNonNull(convertedPayload,
+                                                                 "RevokeCertificationCommand payload cannot be null");
+                                          return candidates.stream()
+                                                           .filter(cert -> cert.getCertificationName().equals(
+                                                                   convertedPayload.certificationName()
+                                                           ))
+                                                           .findFirst()
+                                                           .orElse(null);
+                                      }
+                                      return null;
+                                  })
+                                  .eventTargetMatcher((o, eventMessage, ctx) -> {
+                                      if (eventMessage.type().name().equals(CertificationRevoked.class.getName())) {
+                                          CertificationRevoked certificationRevoked =
+                                                  eventConverter.convertPayload(eventMessage, CertificationRevoked.class);
+                                          Objects.requireNonNull(certificationRevoked,
+                                                                 "CertificationRevoked event payload cannot be null");
+                                          return o.getCertificationName().equals(certificationRevoked.certificationName());
+                                      }
+                                      return false;
+                                  })
+                                  .build()
+                )
                 .addChild(EntityChildMetamodel
                                   .list(MutableEmployee.class, taskMetamodel)
                                   .childEntityFieldDefinition(ChildEntityFieldDefinition.forGetterSetter(

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/PersonIdentifierEntityIdResolver.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/PersonIdentifierEntityIdResolver.java
@@ -20,7 +20,9 @@ import org.axonframework.integrationtests.testsuite.administration.commands.Assi
 import org.axonframework.integrationtests.testsuite.administration.commands.ChangeEmailAddress;
 import org.axonframework.integrationtests.testsuite.administration.commands.CompleteTaskCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.GiveRaise;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.PersonCommand;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -43,7 +45,9 @@ class PersonIdentifierEntityIdResolver implements EntityIdResolver<PersonIdentif
                 AssignTaskCommand.class,
                 ChangeEmailAddress.class,
                 CompleteTaskCommand.class,
-                GiveRaise.class
+                GiveRaise.class,
+                GrantCertificationCommand.class,
+                RevokeCertificationCommand.class
         );
         var clazz = personCommandTypes.stream()
                                       .filter(type -> type.getName().equals(message.type().name()))

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/commands/GrantCertificationCommand.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/commands/GrantCertificationCommand.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.commands;
+
+import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+public record GrantCertificationCommand(
+        @TargetEntityId
+        PersonIdentifier identifier,
+        String certificationName,
+        String issuingBody
+) implements PersonCommand {
+
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/commands/RevokeCertificationCommand.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/commands/RevokeCertificationCommand.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.commands;
+
+import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+public record RevokeCertificationCommand(
+        @TargetEntityId
+        PersonIdentifier identifier,
+        String certificationName
+) implements PersonCommand {
+
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/events/CertificationGranted.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/events/CertificationGranted.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.events;
+
+import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+
+public record CertificationGranted(
+        PersonIdentifier identifier,
+        String certificationName,
+        String issuingBody
+) implements PersonEvent {
+
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/events/CertificationRevoked.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/events/CertificationRevoked.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.events;
+
+import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+
+public record CertificationRevoked(
+        PersonIdentifier identifier,
+        String certificationName
+) implements PersonEvent {
+
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/ImmutableCertification.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/ImmutableCertification.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.state.immutable;
+
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationRevoked;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+
+public record ImmutableCertification(
+        String certificationName,
+        String issuingBody,
+        Boolean revoked
+) {
+    @CommandHandler
+    public void handle(RevokeCertificationCommand command, EventAppender eventAppender) {
+        if (this.revoked) {
+            throw new IllegalStateException("Certification is already revoked");
+        }
+
+        eventAppender.append(new CertificationRevoked(command.identifier(), command.certificationName()));
+    }
+
+    @EventSourcingHandler
+    public ImmutableCertification on(CertificationRevoked event) {
+        return new ImmutableCertification(certificationName, issuingBody, true);
+    }
+
+    public String getCertificationName() {
+        return certificationName;
+    }
+
+    public Boolean isRevoked() {
+        return revoked;
+    }
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/ImmutableEmployee.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/ImmutableEmployee.java
@@ -22,14 +22,18 @@ import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.integrationtests.testsuite.administration.commands.AssignTaskCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationGranted;
 import org.axonframework.integrationtests.testsuite.administration.events.EmailAddressChanged;
 import org.axonframework.integrationtests.testsuite.administration.events.EmployeeCreated;
 import org.axonframework.integrationtests.testsuite.administration.events.TaskAssigned;
 import org.axonframework.modelling.entity.annotation.EntityMember;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public record ImmutableEmployee(
@@ -38,7 +42,9 @@ public record ImmutableEmployee(
         @EntityMember
         ImmutableSalaryInformation salaryInformation,
         @EntityMember(routingKey = "taskId")
-        List<ImmutableTask> taskList
+        List<ImmutableTask> taskList,
+        @EntityMember(routingKey = "certificationName")
+        Map<String, ImmutableCertification> certifications
 ) implements ImmutablePerson {
 
     @EntityCreator
@@ -46,7 +52,8 @@ public record ImmutableEmployee(
         this(employeeCreated.identifier(),
              employeeCreated.emailAddress(),
              new ImmutableSalaryInformation(employeeCreated.initialSalary(), employeeCreated.role()),
-             new ArrayList<>()
+             new ArrayList<>(),
+             new HashMap<>()
         );
     }
 
@@ -72,13 +79,26 @@ public record ImmutableEmployee(
         ));
     }
 
+    @CommandHandler
+    public void handle(GrantCertificationCommand command, EventAppender eventAppender) {
+        if (certifications.containsKey(command.certificationName())) {
+            throw new IllegalStateException("Employee already holds certification " + command.certificationName());
+        }
+        eventAppender.append(new CertificationGranted(
+                command.identifier(),
+                command.certificationName(),
+                command.issuingBody()
+        ));
+    }
+
     @EventSourcingHandler
     public ImmutableEmployee on(EmployeeCreated event) {
         return new ImmutableEmployee(
                 event.identifier(),
                 event.emailAddress(),
                 new ImmutableSalaryInformation(event.initialSalary(), event.role()),
-                new ArrayList<>()
+                new ArrayList<>(),
+                new HashMap<>()
         );
     }
 
@@ -90,7 +110,24 @@ public record ImmutableEmployee(
                 identifier,
                 emailAddress,
                 salaryInformation,
-                newTaskList
+                newTaskList,
+                certifications
+        );
+    }
+
+    @EventSourcingHandler
+    public ImmutableEmployee on(CertificationGranted event) {
+        Map<String, ImmutableCertification> newCertifications = new HashMap<>(certifications);
+        newCertifications.put(
+                event.certificationName(),
+                new ImmutableCertification(event.certificationName(), event.issuingBody(), false)
+        );
+        return new ImmutableEmployee(
+                identifier,
+                emailAddress,
+                salaryInformation,
+                taskList,
+                newCertifications
         );
     }
 
@@ -98,13 +135,27 @@ public record ImmutableEmployee(
         return taskList;
     }
 
-    public ImmutableEmployee evolveTaskList(
-            List<ImmutableTask> taskList) {
+    public ImmutableEmployee evolveTaskList(List<ImmutableTask> taskList) {
         return new ImmutableEmployee(
                 identifier,
                 emailAddress,
                 salaryInformation,
-                taskList
+                taskList,
+                certifications
+        );
+    }
+
+    public Map<String, ImmutableCertification> getCertifications() {
+        return certifications;
+    }
+
+    public ImmutableEmployee evolveCertifications(Map<String, ImmutableCertification> certifications) {
+        return new ImmutableEmployee(
+                identifier,
+                emailAddress,
+                salaryInformation,
+                taskList,
+                certifications
         );
     }
 
@@ -114,7 +165,8 @@ public record ImmutableEmployee(
                 identifier,
                 event.emailAddress(),
                 salaryInformation,
-                taskList
+                taskList,
+                certifications
         );
     }
 
@@ -123,9 +175,8 @@ public record ImmutableEmployee(
                 identifier,
                 emailAddress,
                 immutableSalaryInformation,
-                taskList
+                taskList,
+                certifications
         );
     }
 }
-
-

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/SealedEmployee.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/immutable/SealedEmployee.java
@@ -20,7 +20,9 @@ import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.integrationtests.testsuite.administration.commands.AssignTaskCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
 import org.axonframework.integrationtests.testsuite.administration.common.PersonIdentifier;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationGranted;
 import org.axonframework.integrationtests.testsuite.administration.events.EmailAddressChanged;
 import org.axonframework.integrationtests.testsuite.administration.events.EmployeeCreated;
 import org.axonframework.integrationtests.testsuite.administration.events.TaskAssigned;
@@ -29,7 +31,9 @@ import org.axonframework.messaging.eventhandling.gateway.EventAppender;
 import org.axonframework.modelling.entity.annotation.EntityMember;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public record SealedEmployee(
@@ -38,7 +42,9 @@ public record SealedEmployee(
         @EntityMember
         ImmutableSalaryInformation salaryInformation,
         @EntityMember(routingKey = "taskId")
-        List<ImmutableTask> taskList
+        List<ImmutableTask> taskList,
+        @EntityMember(routingKey = "certificationName")
+        Map<String, ImmutableCertification> certifications
 ) implements SealedPerson {
 
     @EntityCreator
@@ -46,7 +52,8 @@ public record SealedEmployee(
         this(employeeCreated.identifier(),
              employeeCreated.emailAddress(),
              new ImmutableSalaryInformation(employeeCreated.initialSalary(), employeeCreated.role()),
-             new ArrayList<>()
+             new ArrayList<>(),
+             new HashMap<>()
         );
     }
 
@@ -72,13 +79,26 @@ public record SealedEmployee(
         ));
     }
 
+    @CommandHandler
+    public void handle(GrantCertificationCommand command, EventAppender eventAppender) {
+        if (certifications.containsKey(command.certificationName())) {
+            throw new IllegalStateException("Employee already holds certification " + command.certificationName());
+        }
+        eventAppender.append(new CertificationGranted(
+                command.identifier(),
+                command.certificationName(),
+                command.issuingBody()
+        ));
+    }
+
     @EventSourcingHandler
     public SealedEmployee on(EmployeeCreated event) {
         return new SealedEmployee(
                 event.identifier(),
                 event.emailAddress(),
                 new ImmutableSalaryInformation(event.initialSalary(), event.role()),
-                new ArrayList<>()
+                new ArrayList<>(),
+                new HashMap<>()
         );
     }
 
@@ -90,7 +110,24 @@ public record SealedEmployee(
                 identifier,
                 emailAddress,
                 salaryInformation,
-                newTaskList
+                newTaskList,
+                certifications
+        );
+    }
+
+    @EventSourcingHandler
+    public SealedEmployee on(CertificationGranted event) {
+        Map<String, ImmutableCertification> newCertifications = new HashMap<>(certifications);
+        newCertifications.put(
+                event.certificationName(),
+                new ImmutableCertification(event.certificationName(), event.issuingBody(), false)
+        );
+        return new SealedEmployee(
+                identifier,
+                emailAddress,
+                salaryInformation,
+                taskList,
+                newCertifications
         );
     }
 
@@ -98,13 +135,27 @@ public record SealedEmployee(
         return taskList;
     }
 
-    public SealedEmployee evolveTaskList(
-            List<ImmutableTask> taskList) {
+    public SealedEmployee evolveTaskList(List<ImmutableTask> taskList) {
         return new SealedEmployee(
                 identifier,
                 emailAddress,
                 salaryInformation,
-                taskList
+                taskList,
+                certifications
+        );
+    }
+
+    public Map<String, ImmutableCertification> getCertifications() {
+        return certifications;
+    }
+
+    public SealedEmployee evolveCertifications(Map<String, ImmutableCertification> certifications) {
+        return new SealedEmployee(
+                identifier,
+                emailAddress,
+                salaryInformation,
+                taskList,
+                certifications
         );
     }
 
@@ -114,7 +165,8 @@ public record SealedEmployee(
                 identifier,
                 event.emailAddress(),
                 salaryInformation,
-                taskList
+                taskList,
+                certifications
         );
     }
 
@@ -123,9 +175,8 @@ public record SealedEmployee(
                 identifier,
                 emailAddress,
                 immutableSalaryInformation,
-                taskList
+                taskList,
+                certifications
         );
     }
 }
-
-

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/mutable/MutableCertification.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/mutable/MutableCertification.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.administration.state.mutable;
+
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.integrationtests.testsuite.administration.commands.RevokeCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationRevoked;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+
+public class MutableCertification {
+
+    private final String certificationName;
+    private final String issuingBody;
+    private Boolean revoked;
+
+    public MutableCertification(String certificationName, String issuingBody) {
+        this.certificationName = certificationName;
+        this.issuingBody = issuingBody;
+        this.revoked = false;
+    }
+
+    @CommandHandler
+    public void handle(RevokeCertificationCommand command, EventAppender eventAppender) {
+        if (this.revoked) {
+            throw new IllegalStateException("Certification is already revoked");
+        }
+
+        eventAppender.append(new CertificationRevoked(command.identifier(), command.certificationName()));
+    }
+
+    @EventSourcingHandler
+    public void on(CertificationRevoked event) {
+        this.revoked = true;
+    }
+
+    public String getCertificationName() {
+        return certificationName;
+    }
+
+    public Boolean isRevoked() {
+        return revoked;
+    }
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/mutable/MutableEmployee.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/administration/state/mutable/MutableEmployee.java
@@ -19,6 +19,8 @@ package org.axonframework.integrationtests.testsuite.administration.state.mutabl
 import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
 import org.axonframework.integrationtests.testsuite.administration.commands.AssignTaskCommand;
 import org.axonframework.integrationtests.testsuite.administration.commands.CreateEmployee;
+import org.axonframework.integrationtests.testsuite.administration.commands.GrantCertificationCommand;
+import org.axonframework.integrationtests.testsuite.administration.events.CertificationGranted;
 import org.axonframework.integrationtests.testsuite.administration.events.EmployeeCreated;
 import org.axonframework.integrationtests.testsuite.administration.events.TaskAssigned;
 import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
@@ -26,7 +28,9 @@ import org.axonframework.messaging.eventhandling.gateway.EventAppender;
 import org.axonframework.modelling.entity.annotation.EntityMember;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MutableEmployee extends MutablePerson {
@@ -35,6 +39,8 @@ public class MutableEmployee extends MutablePerson {
     private MutableSalaryInformation salary;
     @EntityMember(routingKey = "taskId")
     private List<MutableTask> taskList = new ArrayList<>();
+    @EntityMember(routingKey = "certificationName")
+    private Map<String, MutableCertification> certifications = new HashMap<>();
 
     @CommandHandler
     public static void handle(CreateEmployee command, EventAppender eventAppender) {
@@ -58,6 +64,18 @@ public class MutableEmployee extends MutablePerson {
         ));
     }
 
+    @CommandHandler
+    public void handle(GrantCertificationCommand command, EventAppender eventAppender) {
+        if (certifications.containsKey(command.certificationName())) {
+            throw new IllegalStateException("Employee already holds certification " + command.certificationName());
+        }
+        eventAppender.append(new CertificationGranted(
+                command.identifier(),
+                command.certificationName(),
+                command.issuingBody()
+        ));
+    }
+
     @EventSourcingHandler
     public void on(EmployeeCreated event) {
         this.identifier = event.identifier();
@@ -70,14 +88,27 @@ public class MutableEmployee extends MutablePerson {
         taskList.add(new MutableTask(event.taskId()));
     }
 
+    @EventSourcingHandler
+    public void on(CertificationGranted event) {
+        certifications.put(
+                event.certificationName(),
+                new MutableCertification(event.certificationName(), event.issuingBody())
+        );
+    }
+
     public List<MutableTask> getTaskList() {
         return taskList;
     }
 
-    public void setTaskList(
-            List<MutableTask> taskList) {
+    public void setTaskList(List<MutableTask> taskList) {
         this.taskList = taskList;
     }
+
+    public Map<String, MutableCertification> getCertifications() {
+        return certifications;
+    }
+
+    public void setCertifications(Map<String, MutableCertification> certifications) {
+        this.certifications = certifications;
+    }
 }
-
-

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/MapEntityChildModelDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/MapEntityChildModelDefinition.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.ReflectionUtils;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.child.ChildEntityFieldDefinition;
+import org.axonframework.modelling.entity.child.CommandTargetResolver;
+import org.axonframework.modelling.entity.child.EntityChildMetamodel;
+import org.axonframework.modelling.entity.child.EventTargetMatcher;
+import org.axonframework.modelling.entity.child.MapEntityChildMetamodel;
+
+import java.lang.reflect.Member;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.axonframework.common.ReflectionUtils.resolveMemberGenericType;
+
+/**
+ * {@link EntityChildModelDefinition} for creating {@link EntityChildMetamodel} instances for child entities that are
+ * represented as a {@link Map}.
+ * <p>
+ * It resolves the child type from the member's value generic type and creates a {@link MapEntityChildMetamodel}
+ * accordingly. The key type of the {@link Map} is not resolved, as it is not needed to construct the child
+ * {@link EntityMetamodel}: the key of an entry is preserved as-is when the entity is evolved.
+ *
+ * @author Steven van Beelen
+ * @since 5.3.0
+ */
+public class MapEntityChildModelDefinition extends AbstractEntityChildModelDefinition {
+
+    @Override
+    protected boolean isMemberTypeSupported(Class<?> memberType) {
+        return Map.class.isAssignableFrom(memberType);
+    }
+
+    @Override
+    protected Class<?> getChildTypeFromMember(Member member) {
+        return getChildTypeFromMap(member);
+    }
+
+    @Override
+    protected <C, P> EntityChildMetamodel<C, P> doCreate(
+            Class<P> parentClass,
+            EntityMetamodel<C> entityMetamodel,
+            String fieldName,
+            EventTargetMatcher<C> eventTargetMatcher,
+            CommandTargetResolver<C> commandTargetResolver
+    ) {
+        ChildEntityFieldDefinition<P, Map<Object, C>> fieldDefinition =
+                ChildEntityFieldDefinition.forFieldName(parentClass, fieldName);
+        return MapEntityChildMetamodel.forEntityModel(parentClass, entityMetamodel)
+                                      .childEntityFieldDefinition(fieldDefinition)
+                                      .commandTargetResolver(commandTargetResolver)
+                                      .eventTargetMatcher(eventTargetMatcher)
+                                      .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C> Class<C> getChildTypeFromMap(Member member) {
+        return (Class<C>) resolveMemberGenericType(member, 1).orElseThrow(
+                () -> new AxonConfigurationException(format(
+                        "Unable to resolve entity type of member [%s].", ReflectionUtils.getMemberGenericString(member)
+                )));
+    }
+}

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RoutingKeyCommandTargetResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RoutingKeyCommandTargetResolverDefinition.java
@@ -21,6 +21,7 @@ import org.axonframework.modelling.entity.child.CommandTargetResolver;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
+import java.util.Map;
 
 import static java.lang.String.format;
 import static org.axonframework.common.ReflectionUtils.getMemberValueType;
@@ -51,7 +52,7 @@ public class RoutingKeyCommandTargetResolverDefinition implements CommandTargetR
 
         // No routing key found, perhaps we are dealing with a single occurrence entity member.
         Class<?> memberValueType = getMemberValueType(member);
-        if (Iterable.class.isAssignableFrom(memberValueType)) {
+        if (Iterable.class.isAssignableFrom(memberValueType) || Map.class.isAssignableFrom(memberValueType)) {
             throw new AxonConfigurationException(
                     format("Member [%s] of type [%s] is a collection type, but the child does not define a routing key. "
                                    + "Please set the \"routingKey\" property on the @EntityMember annotation "

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RoutingKeyEventTargetMatcherDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RoutingKeyEventTargetMatcherDefinition.java
@@ -21,6 +21,7 @@ import org.axonframework.modelling.entity.child.EventTargetMatcher;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Member;
+import java.util.Map;
 
 import static java.lang.String.format;
 import static org.axonframework.common.ReflectionUtils.getMemberValueType;
@@ -49,7 +50,7 @@ public class RoutingKeyEventTargetMatcherDefinition implements EventTargetMatche
 
         // No routing key found, perhaps we are dealing with a single occurrence entity member.
         Class<?> memberValueType = getMemberValueType(member);
-        if (Iterable.class.isAssignableFrom(memberValueType)) {
+        if (Iterable.class.isAssignableFrom(memberValueType) || Map.class.isAssignableFrom(memberValueType)) {
             throw new AxonConfigurationException(
                     format("Member [%s] of type [%s] is a collection type, but the child does not define a routing key. "
                                    + "Please set the \"routingKey\" property on the @EntityMember annotation "

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/SingleEntityChildModelDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/SingleEntityChildModelDefinition.java
@@ -24,13 +24,14 @@ import org.axonframework.modelling.entity.child.EventTargetMatcher;
 import org.axonframework.modelling.entity.child.SingleEntityChildMetamodel;
 
 import java.lang.reflect.Member;
+import java.util.Map;
 
 import static org.axonframework.common.ReflectionUtils.getMemberValueType;
 
 /**
  * {@link EntityChildModelDefinition} that creates {@link EntityChildMetamodel} instances for child entities that are
- * represented as a single entity (not iterable). It resolves the child type from the member's type and creates a
- * {@link SingleEntityChildMetamodel} accordingly.
+ * represented as a single entity (not iterable, and not a {@link Map}). It resolves the child type from the member's
+ * type and creates a {@link SingleEntityChildMetamodel} accordingly.
  * <p>
  * Before version 5.0.0, this class was known as the
  * {@code org.axonframework.modelling.command.inspection.AggregateMemberAnnotatedChildEntityDefinition}. The class has
@@ -43,7 +44,7 @@ public class SingleEntityChildModelDefinition extends AbstractEntityChildModelDe
 
     @Override
     protected boolean isMemberTypeSupported(Class<?> memberType) {
-        return !Iterable.class.isAssignableFrom(memberType);
+        return !Iterable.class.isAssignableFrom(memberType) && !Map.class.isAssignableFrom(memberType);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
@@ -165,8 +165,9 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
 
         @SuppressWarnings("unused") // Is used for generics
         protected Builder(Class<P> parentClass, EntityMetamodel<C> metamodel) {
-            requireNonNull(parentClass, "The parentClass may not be null.");
-            this.metamodel = requireNonNull(metamodel, "The metamodel may not be null.");
+            assertNonNull(parentClass, "The parentClass may not be null.");
+            assertNonNull(metamodel, "The metamodel may not be null.");
+            this.metamodel = metamodel;
         }
 
         /**
@@ -179,16 +180,9 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
          */
         @SuppressWarnings("unchecked")
         public R commandTargetResolver(CommandTargetResolver<C> commandTargetResolver) {
-            this.commandTargetResolver = requireNonNull(commandTargetResolver,
-                                                        "The commandTargetResolver may not be null.");
+            assertNonNull(commandTargetResolver, "The commandTargetResolver may not be null.");
+            this.commandTargetResolver = commandTargetResolver;
             return (R) this;
-        }
-
-        protected void validate() {
-            assertNonNull(commandTargetResolver,
-                          "The commandTargetResolver must be set before building the metamodel.");
-            assertNonNull(eventTargetMatcher,
-                          "The eventTargetMatcher must be set before building the metamodel.");
         }
 
         /**
@@ -201,8 +195,16 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
          */
         @SuppressWarnings("unchecked")
         public R eventTargetMatcher(EventTargetMatcher<C> eventTargetMatcher) {
-            this.eventTargetMatcher = requireNonNull(eventTargetMatcher, "The eventTargetMatcher may not be null.");
+            assertNonNull(eventTargetMatcher, "The eventTargetMatcher may not be null.");
+            this.eventTargetMatcher = eventTargetMatcher;
             return (R) this;
+        }
+
+        protected void validate() {
+            assertNonNull(commandTargetResolver,
+                          "The commandTargetResolver must be set before building the metamodel.");
+            assertNonNull(eventTargetMatcher,
+                          "The eventTargetMatcher must be set before building the metamodel.");
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.entity.child;
 
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.core.MessageStream;
@@ -53,6 +54,7 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  * @author Steven van Beelen
  * @since 5.0.0
  */
+@Internal
 public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildMetamodel<C, P> {
 
     protected final EntityMetamodel<C> metamodel;

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
@@ -129,8 +129,9 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
     /**
      * Resolves the child entities of the given {@code parent}, keyed by an implementation-specific identity.
      * <p>
-     * The returned {@link Map} must preserve iteration order (e.g. {@link LinkedHashMap}), as that order determines the
-     * order in which candidates are offered to the {@link CommandTargetResolver} and {@link EventTargetMatcher}.
+     * The returned immutable {@link Map} must preserve iteration order (e.g. {@link LinkedHashMap}), as that order
+     * determines the order in which candidates are offered to the {@link CommandTargetResolver} and
+     * {@link EventTargetMatcher}.
      *
      * @param parent the parent entity to resolve the child entities from
      * @return the child entities of the given {@code parent}, keyed by an implementation-specific identity

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
@@ -26,11 +26,11 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.entity.ChildEntityNotFoundException;
 import org.axonframework.modelling.entity.EntityMetamodel;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -75,7 +75,7 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
         if (!supportedCommands().contains(message.type().qualifiedName())) {
             return false;
         }
-        List<C> childEntities = getChildEntities(parentEntity);
+        List<C> childEntities = new ArrayList<>(getChildEntities(parentEntity).values());
         if (childEntities.isEmpty()) {
             return false;
         }
@@ -86,7 +86,7 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
     public MessageStream.Single<CommandResultMessage> handle(CommandMessage message,
                                                              P parentEntity,
                                                              ProcessingContext context) {
-        List<C> childEntities = getChildEntities(parentEntity);
+        List<C> childEntities = new ArrayList<>(getChildEntities(parentEntity).values());
         C targetChildEntity = commandTargetResolver.getTargetChildEntity(childEntities, message, context);
         if (targetChildEntity == null) {
             return MessageStream.failed(new ChildEntityNotFoundException(message, parentEntity));
@@ -94,29 +94,52 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
         return metamodel.handleInstance(message, targetChildEntity, context);
     }
 
-    protected abstract List<C> getChildEntities(P entity);
-
     @Override
     public P evolve(P entity, EventMessage event, ProcessingContext context) {
-        final AtomicBoolean evolvedChildEntity = new AtomicBoolean(false);
-        var evolvedEntities = getChildEntities(entity)
-                .stream()
-                .map(child -> {
-                    if (eventTargetMatcher.matches(child, event, context)) {
-                        evolvedChildEntity.set(true);
-                        return metamodel.evolve(child, event, context);
-                    }
-                    return child;
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-        if (!evolvedChildEntity.get()) {
+        Map<Object, C> children = getChildEntities(entity);
+        boolean evolvedAnyChild = false;
+        Map<Object, C> evolvedChildren = new LinkedHashMap<>();
+        for (Map.Entry<Object, C> childEntry : children.entrySet()) {
+            C child = childEntry.getValue();
+            if (eventTargetMatcher.matches(child, event, context)) {
+                evolvedAnyChild = true;
+                C evolvedChild = metamodel.evolve(child, event, context);
+                if (evolvedChild != null) {
+                    evolvedChildren.put(childEntry.getKey(), evolvedChild);
+                }
+            } else {
+                evolvedChildren.put(childEntry.getKey(), child);
+            }
+        }
+        if (!evolvedAnyChild) {
             return entity;
         }
-        return applyEvolvedChildEntities(entity, evolvedEntities);
+        return applyEvolvedChildEntities(entity, evolvedChildren);
     }
 
-    protected abstract P applyEvolvedChildEntities(P entity, List<C> evolvedChildEntities);
+    /**
+     * Resolves the child entities of the given {@code parent}, keyed by an implementation-specific identity.
+     * <p>
+     * The returned {@link Map} must preserve iteration order (e.g. {@link LinkedHashMap}), as that order determines the
+     * order in which candidates are offered to the {@link CommandTargetResolver} and {@link EventTargetMatcher}.
+     *
+     * @param parent the parent entity to resolve the child entities from
+     * @return the child entities of the given {@code parent}, keyed by an implementation-specific identity
+     */
+    protected abstract Map<Object, C> getChildEntities(P parent);
+
+    /**
+     * Applies the evolved child entities, keyed by the same implementation-specific identity returned by
+     * {@link #getChildEntities(Object)}, to the given {@code entity}. A key that was present in
+     * {@link #getChildEntities(Object)} but is absent from {@code evolvedChildEntities} indicates that the
+     * corresponding child entity was evolved to {@code null} and should be removed.
+     *
+     * @param entity               the parent entity to apply the evolved child entities to
+     * @param evolvedChildEntities the evolved child entities, keyed by the same identity as
+     *                             {@link #getChildEntities(Object)}
+     * @return the evolved parent entity
+     */
+    protected abstract P applyEvolvedChildEntities(P entity, Map<Object, C> evolvedChildEntities);
 
     @Override
     public Class<C> entityType() {

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/AbstractEntityChildMetamodel.java
@@ -18,11 +18,10 @@ package org.axonframework.modelling.entity.child;
 
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
-import org.axonframework.common.BuilderUtils;
-import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.modelling.entity.ChildEntityNotFoundException;
 import org.axonframework.modelling.entity.EntityMetamodel;
 
@@ -33,16 +32,25 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Abstract {@link EntityChildMetamodel} that implements common functionality for most implementations. It
- * defines how to handle commands and events for a child entity. The implementor is responsible for defining how to
- * resolve the child entities from the parent ({@link #getChildEntities(Object)}) and how to apply the evolved child
- * entities to the parent ({@link #applyEvolvedChildEntities(Object, List)}).
+ * Abstract {@link EntityChildMetamodel} that implements common functionality for most implementations.
+ * <p>
+ * It defines how to handle commands and events for a child entity. The implementor is responsible for defining how to
+ * resolve the child entities from the parent, keyed by an implementation-specific identity
+ * ({@link #getChildEntities(Object)}), and how to apply the evolved child entities to the parent
+ * ({@link #applyEvolvedChildEntities(Object, Map)}).
+ * <p>
+ * The keys returned by {@link #getChildEntities(Object)} are opaque to this class; they only exist so that
+ * {@link #evolve(Object, EventMessage, ProcessingContext)} can preserve the association between a child entity and its
+ * identity when a child is evolved or removed, regardless of whether the parent stores its children in a {@code List}
+ * (keyed by index), as a single field (keyed by a constant), or in a {@code Map} (keyed by the map's own keys).
  *
- * @param <C> The type of the child entity.
- * @param <P> The type of the parent entity.
+ * @param <C> the type of the child entity
+ * @param <P> the type of the parent entity
  * @author Mitchell Herrijgers
+ * @author Steven van Beelen
  * @since 5.0.0
  */
 public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildMetamodel<C, P> {
@@ -59,8 +67,7 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
         this.metamodel = requireNonNull(metamodel, "The metamodel may not be null.");
         this.commandTargetResolver =
                 requireNonNull(commandTargetResolver, "The commandTargetResolver may not be null.");
-        this.eventTargetMatcher =
-                requireNonNull(eventTargetMatcher, "The eventTargetMatcher may not be null.");
+        this.eventTargetMatcher = requireNonNull(eventTargetMatcher, "The eventTargetMatcher may not be null.");
     }
 
     @Override
@@ -149,12 +156,13 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
     protected abstract static class Builder<C, P, R extends Builder<C, P, R>> {
 
         protected final EntityMetamodel<C> metamodel;
+        @SuppressWarnings("NotNullFieldNotInitialized") // Ensured by validate()
         protected CommandTargetResolver<C> commandTargetResolver;
+        @SuppressWarnings("NotNullFieldNotInitialized") // Ensured by validate()
         protected EventTargetMatcher<C> eventTargetMatcher;
 
         @SuppressWarnings("unused") // Is used for generics
-        protected Builder(Class<P> parentClass,
-                          EntityMetamodel<C> metamodel) {
+        protected Builder(Class<P> parentClass, EntityMetamodel<C> metamodel) {
             requireNonNull(parentClass, "The parentClass may not be null.");
             this.metamodel = requireNonNull(metamodel, "The metamodel may not be null.");
         }
@@ -163,9 +171,9 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
          * Sets the {@link CommandTargetResolver} to use for resolving the child entity to handle the command. This
          * should return one child entity, or {@code null} if no child entity should handle the command.
          *
-         * @param commandTargetResolver The {@link CommandTargetResolver} to use for resolving the child entity to
-         *                              handle the command.
-         * @return This builder instance.
+         * @param commandTargetResolver the {@link CommandTargetResolver} to use for resolving the child entity to
+         *                              handle the command
+         * @return this builder instance
          */
         @SuppressWarnings("unchecked")
         public R commandTargetResolver(CommandTargetResolver<C> commandTargetResolver) {
@@ -175,10 +183,10 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
         }
 
         protected void validate() {
-            BuilderUtils.assertNonNull(commandTargetResolver,
-                                       "The commandTargetResolver must be set before building the metamodel.");
-            BuilderUtils.assertNonNull(eventTargetMatcher,
-                                       "The eventTargetMatcher must be set before building the metamodel.");
+            assertNonNull(commandTargetResolver,
+                          "The commandTargetResolver must be set before building the metamodel.");
+            assertNonNull(eventTargetMatcher,
+                          "The eventTargetMatcher must be set before building the metamodel.");
         }
 
         /**
@@ -186,9 +194,8 @@ public abstract class AbstractEntityChildMetamodel<C, P> implements EntityChildM
          * {@link EventMessage}. This should return {@code true} if the child entity should handle the event, or
          * {@code false} if it should not.
          *
-         * @param eventTargetMatcher The {@link EventTargetMatcher} to use for matching the child entities to the
-         *                           event.
-         * @return This builder instance.
+         * @param eventTargetMatcher the {@link EventTargetMatcher} to use for matching the child entities to the event
+         * @return this builder instance
          */
         @SuppressWarnings("unchecked")
         public R eventTargetMatcher(EventTargetMatcher<C> eventTargetMatcher) {

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/EntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/EntityChildMetamodel.java
@@ -111,4 +111,21 @@ public interface EntityChildMetamodel<C, P> extends EntityEvolver<P> {
             EntityMetamodel<C> metamodel) {
         return ListEntityChildMetamodel.forEntityModel(parentClass, metamodel);
     }
+
+    /**
+     * Starts a builder for a map of child entities within the given parent entity type.
+     *
+     * @param parentClass the class of the parent entity
+     * @param metamodel   the {@link EntityMetamodel} of the child entity
+     * @param <K>         the type of the key of the {@link java.util.Map} containing the child entities
+     * @param <C>         the type of the child entity
+     * @param <P>         the type of the parent entity
+     * @return a {@link MapEntityChildMetamodel.Builder} for the child entity
+     */
+    static <K, C, P> MapEntityChildMetamodel.Builder<K, C, P> map(
+            Class<P> parentClass,
+            EntityMetamodel<C> metamodel
+    ) {
+        return MapEntityChildMetamodel.forEntityModel(parentClass, metamodel);
+    }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/EntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/EntityChildMetamodel.java
@@ -31,8 +31,8 @@ import java.util.Set;
  * commands for this metamodel is done in the context of the parent. This metamodel resolves the child from the given
  * parent and can then invoke the right child instance to handle the command.
  *
- * @param <C> The type of the child entity.
- * @param <P> The type of the parent entity.
+ * @param <C> the type of the child entity
+ * @param <P> the type of the parent entity
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
@@ -41,7 +41,7 @@ public interface EntityChildMetamodel<C, P> extends EntityEvolver<P> {
     /**
      * Returns the set of all {@link QualifiedName QualifiedNames} that this metamodel supports for command handlers.
      *
-     * @return A set of {@link QualifiedName} instances representing the supported command names.
+     * @return a set of {@link QualifiedName} instances representing the supported command names
      */
     Set<QualifiedName> supportedCommands();
 
@@ -49,20 +49,20 @@ public interface EntityChildMetamodel<C, P> extends EntityEvolver<P> {
      * Checks if this child can handle the given {@link CommandMessage} for the given parent entity, and a child entity
      * is available to handle it.
      *
-     * @param message      The {@link CommandMessage} to check.
-     * @param parentEntity The parent entity instance to check against.
-     * @param context      The {@link ProcessingContext} for the command.
-     * @return {@code true} if this child can handle the command, {@code false} otherwise.
+     * @param message      the {@link CommandMessage} to check
+     * @param parentEntity the parent entity instance to check against
+     * @param context      the {@link ProcessingContext} for the command
+     * @return {@code true} if this child can handle the command, {@code false} otherwise
      */
     boolean canHandle(CommandMessage message, P parentEntity, ProcessingContext context);
 
     /**
      * Handles the given {@link CommandMessage} for the given child entity, using the provided parent entity.
      *
-     * @param message      The {@link CommandMessage} to handle.
-     * @param parentEntity The child entity instance to handle the command for.
-     * @param context      The {@link ProcessingContext} for the command.
-     * @return The result of the command handling, which may be a {@link CommandResultMessage} or an error message.
+     * @param message      the {@link CommandMessage} to handle
+     * @param parentEntity the child entity instance to handle the command for
+     * @param context      the {@link ProcessingContext} for the command
+     * @return the result of the command handling, which may be a {@link CommandResultMessage} or an error message
      */
     MessageStream.Single<CommandResultMessage> handle(CommandMessage message,
                                                       P parentEntity,
@@ -71,44 +71,46 @@ public interface EntityChildMetamodel<C, P> extends EntityEvolver<P> {
     /**
      * Returns the {@link Class} of the child entity this metamodel describes.
      *
-     * @return The {@link Class} of the child entity this metamodel describes.
+     * @return the {@link Class} of the child entity this metamodel describes
      */
     Class<C> entityType();
 
     /**
      * Returns the {@link EntityMetamodel} of the child entity this metamodel describes.
      *
-     * @return The {@link EntityMetamodel} of the child entity this metamodel describes.
+     * @return the {@link EntityMetamodel} of the child entity this metamodel describes
      */
     EntityMetamodel<C> entityMetamodel();
 
     /**
      * Starts a builder for a single child entity within the given parent entity type.
      *
-     * @param parentClass The class of the parent entity.
-     * @param metamodel   The {@link EntityMetamodel} of the child entity.
-     * @param <C>         The type of the child entity.
-     * @param <P>         The type of the parent entity.
-     * @return A {@link SingleEntityChildMetamodel.Builder} for the child entity.
+     * @param parentClass the class of the parent entity
+     * @param metamodel   the {@link EntityMetamodel} of the child entity
+     * @param <C>         the type of the child entity
+     * @param <P>         the type of the parent entity
+     * @return a {@link SingleEntityChildMetamodel.Builder} for the child entity.
      */
     static <C, P> SingleEntityChildMetamodel.Builder<C, P> single(
             Class<P> parentClass,
-            EntityMetamodel<C> metamodel) {
+            EntityMetamodel<C> metamodel
+    ) {
         return SingleEntityChildMetamodel.forEntityModel(parentClass, metamodel);
     }
 
     /**
      * Starts a builder for a list of child entities within the given parent entity type.
      *
-     * @param parentClass The class of the parent entity.
-     * @param metamodel   The {@link EntityMetamodel} of the child entity.
-     * @param <C>         The type of the child entity.
-     * @param <P>         The type of the parent entity.
-     * @return A {@link ListEntityChildMetamodel.Builder} for the child entity.
+     * @param parentClass the class of the parent entity
+     * @param metamodel   the {@link EntityMetamodel} of the child entity
+     * @param <C>         the type of the child entity
+     * @param <P>         the type of the parent entity
+     * @return a {@link ListEntityChildMetamodel.Builder} for the child entity
      */
     static <C, P> ListEntityChildMetamodel.Builder<C, P> list(
             Class<P> parentClass,
-            EntityMetamodel<C> metamodel) {
+            EntityMetamodel<C> metamodel
+    ) {
         return ListEntityChildMetamodel.forEntityModel(parentClass, metamodel);
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
@@ -131,10 +131,9 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
          *                        the parent entity
          * @return builder instance for a fluent API
          */
-        public Builder<C, P> childEntityFieldDefinition(
-                ChildEntityFieldDefinition<P, List<C>> fieldDefinition) {
-            this.childEntityFieldDefinition =
-                    requireNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
+        public Builder<C, P> childEntityFieldDefinition(ChildEntityFieldDefinition<P, List<C>> fieldDefinition) {
+            assertNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
+            this.childEntityFieldDefinition = fieldDefinition;
             return this;
         }
 

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.entity.child;
 import org.axonframework.modelling.entity.EntityMetamodel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
         for (int i = 0; i < childEntities.size(); i++) {
             indexedChildEntities.put(i, childEntities.get(i));
         }
-        return indexedChildEntities;
+        return Collections.unmodifiableMap(indexedChildEntities);
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
@@ -18,7 +18,10 @@ package org.axonframework.modelling.entity.child;
 
 import org.axonframework.modelling.entity.EntityMetamodel;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,18 +52,23 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
     }
 
     @Override
-    protected List<C> getChildEntities(P entity) {
-        List<C> childEntities = childEntityFieldDefinition
-                .getChildValue(entity);
+    protected Map<Object, C> getChildEntities(P parent) {
+        List<C> childEntities = childEntityFieldDefinition.getChildValue(parent);
         if (childEntities == null) {
-            return List.of();
+            return Map.of();
         }
-        return childEntities;
+        Map<Object, C> indexedChildEntities = new LinkedHashMap<>();
+        for (int i = 0; i < childEntities.size(); i++) {
+            indexedChildEntities.put(i, childEntities.get(i));
+        }
+        return indexedChildEntities;
     }
 
     @Override
-    protected P applyEvolvedChildEntities(P entity, List<C> evolvedChildEntities) {
-        return childEntityFieldDefinition.evolveParentBasedOnChildInput(entity, evolvedChildEntities);
+    protected P applyEvolvedChildEntities(P entity, Map<Object, C> evolvedChildEntities) {
+        return childEntityFieldDefinition.evolveParentBasedOnChildInput(
+                entity, new ArrayList<>(evolvedChildEntities.values())
+        );
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodel.java
@@ -24,15 +24,17 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
+import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * An {@link EntityChildMetamodel} that handles commands and events for a list of child entities. It will use
- * the provided {@link ChildEntityFieldDefinition} to resolve the child entities from the parent entity. Once the
- * entities are resolved, it will delegate the command- and event-handling to the child entity metamodel(s), based on
- * the {@code commandTargetResolver} and {@code eventTargetMatcher} respectively.
+ * An {@link EntityChildMetamodel} that handles commands and events for a list of child entities.
+ * <p>
+ * It will use the provided {@link ChildEntityFieldDefinition} to resolve the child entities from the parent entity.
+ * Once the entities are resolved, it will delegate the command- and event-handling to the child entity metamodel(s),
+ * based on the {@code commandTargetResolver} and {@code eventTargetMatcher} respectively.
  *
- * @param <C> The type of the child entity.
- * @param <P> The type of the parent entity.
+ * @param <C> the type of the child entity
+ * @param <P> the type of the parent entity
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
@@ -88,31 +90,32 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
      * {@link EventTargetMatcher eventTargetMatcher} are both required, as they are used to match the child entities to
      * the command and event respectively.
      *
-     * @param parentClass              The class of the parent entity.
+     * @param parentClass     The class of the parent entity.
      * @param entityMetamodel The {@link EntityMetamodel} of the child entity.
-     * @param <C>                      The type of the child entity.
-     * @param <P>                      The type of the parent entity.
+     * @param <C>             The type of the child entity.
+     * @param <P>             The type of the parent entity.
      * @return A new {@link Builder} for the given parent class and child entity metamodel.
      */
-        public static <C, P> Builder<C, P> forEntityModel(Class<P> parentClass,
+    public static <C, P> Builder<C, P> forEntityModel(Class<P> parentClass,
                                                       EntityMetamodel<C> entityMetamodel
     ) {
         return new Builder<>(parentClass, entityMetamodel);
     }
 
     /**
-     * Builder for creating a {@link ListEntityChildMetamodel} for the given parent class and child entity
-     * metamodel. The builder can be used to configure the child entity metamodel and create a new instance of
-     * {@link ListEntityChildMetamodel}. The {@link ChildEntityFieldDefinition} is required to resolve the
-     * child entities from the parent entity and evolve the parent entity based on the child entities. The
+     * Builder for creating a {@link ListEntityChildMetamodel} for the given parent class and child entity metamodel.
+     * The builder can be used to configure the child entity metamodel and create a new instance of
+     * {@link ListEntityChildMetamodel}. The {@link ChildEntityFieldDefinition} is required to resolve the child
+     * entities from the parent entity and evolve the parent entity based on the child entities. The
      * {@link CommandTargetResolver commandTargetResolver} and {@link EventTargetMatcher eventTargetMatcher} are both
      * required, as they are used to match the child entities to the command and event respectively.
      *
-     * @param <C> The type of the child entity.
-     * @param <P> The type of the parent entity.
+     * @param <C> the type of the child entity
+     * @param <P> the type of the parent entity
      */
     public static class Builder<C, P> extends AbstractEntityChildMetamodel.Builder<C, P, Builder<C, P>> {
 
+        @SuppressWarnings("NotNullFieldNotInitialized") // Ensured by validate()
         private ChildEntityFieldDefinition<P, List<C>> childEntityFieldDefinition;
 
         @SuppressWarnings("unused") // Is used for generics
@@ -124,14 +127,14 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
          * Sets the {@link ChildEntityFieldDefinition} to use for resolving the child entities from the parent entity
          * and evolving the parent entity based on the evolved child entities.
          *
-         * @param fieldDefinition The {@link ChildEntityFieldDefinition} to use for resolving the child entities from
+         * @param fieldDefinition the {@link ChildEntityFieldDefinition} to use for resolving the child entities from
          *                        the parent entity
-         * @return This builder instance for a fluent API.
+         * @return builder instance for a fluent API
          */
         public Builder<C, P> childEntityFieldDefinition(
                 ChildEntityFieldDefinition<P, List<C>> fieldDefinition) {
-            this.childEntityFieldDefinition = requireNonNull(fieldDefinition,
-                                                             "The childEntityFieldDefinition may not be null.");
+            this.childEntityFieldDefinition =
+                    requireNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
             return this;
         }
 
@@ -140,16 +143,20 @@ public class ListEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel
          * {@link ChildEntityFieldDefinition}, {@link EventTargetMatcher}, and {@link CommandTargetResolver} are
          * required to be set before calling this method.
          *
-         * @return A new {@link ListEntityChildMetamodel} instance with the configured properties.
+         * @return a new {@link ListEntityChildMetamodel} instance with the configured properties
          */
         public ListEntityChildMetamodel<C, P> build() {
             this.validate();
             return new ListEntityChildMetamodel<>(
-                    metamodel,
-                    childEntityFieldDefinition,
-                    commandTargetResolver,
-                    eventTargetMatcher
+                    metamodel, childEntityFieldDefinition, commandTargetResolver, eventTargetMatcher
             );
+        }
+
+        @Override
+        protected void validate() {
+            assertNonNull(childEntityFieldDefinition,
+                          "The ChildEntityFieldDefinition must be set before building the metamodel.");
+            super.validate();
         }
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
@@ -18,6 +18,7 @@ package org.axonframework.modelling.entity.child;
 
 import org.axonframework.modelling.entity.EntityMetamodel;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -78,7 +79,7 @@ public class MapEntityChildMetamodel<K, C, P> extends AbstractEntityChildMetamod
     @Override
     protected Map<Object, C> getChildEntities(P parent) {
         Map<K, C> childEntities = childEntityFieldDefinition.getChildValue(parent);
-        return childEntities == null ? Map.of() : new LinkedHashMap<>(childEntities);
+        return childEntities == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(childEntities));
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.child;
+
+import org.axonframework.modelling.entity.EntityMetamodel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+
+/**
+ * An {@link EntityChildMetamodel} that handles commands and events for child entities stored in a {@link Map}.
+ * <p>
+ * It will use the provided {@link ChildEntityFieldDefinition} to resolve the child entities from the parent entity.
+ * Once the entities are resolved, it will delegate the command- and event-handling to the child entity metamodel(s),
+ * based on the {@code commandTargetResolver} and {@code eventTargetMatcher} respectively.
+ * <p>
+ * The identity of a child entity is the {@link Map}'s own key. This means the key of a child entity is preserved across
+ * events: a child that is evolved keeps its original key, and a child that is evolved to {@code null} is removed from
+ * the map under that same key.
+ *
+ * @param <K> the type of the key of the {@link Map} containing the child entities
+ * @param <C> the type of the child entity
+ * @param <P> the type of the parent entity
+ * @author Steven van Beelen
+ * @since 5.3.0
+ */
+public class MapEntityChildMetamodel<K, C, P> extends AbstractEntityChildMetamodel<C, P> {
+
+    private final ChildEntityFieldDefinition<P, Map<K, C>> childEntityFieldDefinition;
+
+    private MapEntityChildMetamodel(
+            EntityMetamodel<C> metamodel,
+            ChildEntityFieldDefinition<P, Map<K, C>> childEntityFieldDefinition,
+            CommandTargetResolver<C> commandTargetResolver,
+            EventTargetMatcher<C> eventTargetMatcher
+    ) {
+        super(metamodel, commandTargetResolver, eventTargetMatcher);
+        this.childEntityFieldDefinition =
+                requireNonNull(childEntityFieldDefinition, "The childEntityFieldDefinition may not be null.");
+    }
+
+    /**
+     * Creates a new {@link Builder} for the given parent class and child entity metamodel.
+     * <p>
+     * The {@link ChildEntityFieldDefinition} is required to resolve the child entities from the parent entity and
+     * evolve the parent entity based on the child entities. The {@link CommandTargetResolver} and
+     * {@link EventTargetMatcher} are both required, as they are used to match the child entities to the command and
+     * event respectively.
+     *
+     * @param parentClass     the class of the parent entity
+     * @param entityMetamodel the {@link EntityMetamodel} of the child entity
+     * @param <K>             the type of the key of the {@link Map} containing the child entities
+     * @param <C>             the type of the child entity
+     * @param <P>             the type of the parent entity
+     * @return a new {@link Builder} for the given parent class and child entity metamodel
+     */
+    public static <K, C, P> Builder<K, C, P> forEntityModel(Class<P> parentClass, EntityMetamodel<C> entityMetamodel) {
+        return new Builder<>(parentClass, entityMetamodel);
+    }
+
+    @Override
+    protected Map<Object, C> getChildEntities(P parent) {
+        Map<K, C> childEntities = childEntityFieldDefinition.getChildValue(parent);
+        return childEntities == null ? Map.of() : new LinkedHashMap<>(childEntities);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected P applyEvolvedChildEntities(P entity, Map<Object, C> evolvedChildEntities) {
+        return childEntityFieldDefinition.evolveParentBasedOnChildInput(entity, (Map<K, C>) evolvedChildEntities);
+    }
+
+    @Override
+    public EntityMetamodel<C> entityMetamodel() {
+        return metamodel;
+    }
+
+    @Override
+    public String toString() {
+        return "MapEntityChildModel{entityType=" + entityType().getName() + '}';
+    }
+
+    /**
+     * Builder for creating a {@link MapEntityChildMetamodel} for the given parent class and child entity metamodel. The
+     * builder can be used to configure the child entity metamodel and create a new instance of
+     * {@link MapEntityChildMetamodel}. The {@link ChildEntityFieldDefinition} is required to resolve the child entities
+     * from the parent entity and evolve the parent entity based on the child entities. The
+     * {@link CommandTargetResolver commandTargetResolver} and {@link EventTargetMatcher eventTargetMatcher} are both
+     * required, as they are used to match the child entities to the command and event respectively.
+     *
+     * @param <K> the type of the key of the {@link Map} containing the child entities
+     * @param <C> the type of the child entity
+     * @param <P> the type of the parent entity
+     */
+    public static class Builder<K, C, P> extends AbstractEntityChildMetamodel.Builder<C, P, Builder<K, C, P>> {
+
+        @SuppressWarnings("NotNullFieldNotInitialized")
+        private ChildEntityFieldDefinition<P, Map<K, C>> childEntityFieldDefinition;
+
+        @SuppressWarnings("unused") // Is used for generics
+        private Builder(Class<P> parentClass, EntityMetamodel<C> metamodel) {
+            super(parentClass, metamodel);
+        }
+
+        /**
+         * Sets the {@link ChildEntityFieldDefinition} to use for resolving the child entities from the parent entity
+         * and evolving the parent entity based on the evolved child entities.
+         *
+         * @param fieldDefinition the {@link ChildEntityFieldDefinition} to use for resolving the child entities from
+         *                        the parent entity
+         * @return this builder instance for a fluent API
+         */
+        public Builder<K, C, P> childEntityFieldDefinition(
+                ChildEntityFieldDefinition<P, Map<K, C>> fieldDefinition
+        ) {
+            this.childEntityFieldDefinition =
+                    requireNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
+            return this;
+        }
+
+        /**
+         * Builds a new {@link MapEntityChildMetamodel} instance with the configured properties. The
+         * {@link ChildEntityFieldDefinition}, {@link EventTargetMatcher}, and {@link CommandTargetResolver} are
+         * required to be set before calling this method.
+         *
+         * @return a new {@link MapEntityChildMetamodel} instance with the configured properties
+         */
+        public MapEntityChildMetamodel<K, C, P> build() {
+            this.validate();
+            return new MapEntityChildMetamodel<>(
+                    metamodel, childEntityFieldDefinition, commandTargetResolver, eventTargetMatcher
+            );
+        }
+
+        @Override
+        protected void validate() {
+            assertNonNull(childEntityFieldDefinition,
+                          "The ChildEntityFieldDefinition must be set before building the metamodel.");
+            super.validate();
+        }
+    }
+}

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodel.java
@@ -127,11 +127,9 @@ public class MapEntityChildMetamodel<K, C, P> extends AbstractEntityChildMetamod
          *                        the parent entity
          * @return this builder instance for a fluent API
          */
-        public Builder<K, C, P> childEntityFieldDefinition(
-                ChildEntityFieldDefinition<P, Map<K, C>> fieldDefinition
-        ) {
-            this.childEntityFieldDefinition =
-                    requireNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
+        public Builder<K, C, P> childEntityFieldDefinition(ChildEntityFieldDefinition<P, Map<K, C>> fieldDefinition) {
+            assertNonNull(fieldDefinition, "The childEntityFieldDefinition may not be null.");
+            this.childEntityFieldDefinition = fieldDefinition;
             return this;
         }
 

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
@@ -18,7 +18,7 @@ package org.axonframework.modelling.entity.child;
 
 import org.axonframework.modelling.entity.EntityMetamodel;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -37,6 +37,8 @@ import java.util.Objects;
  * @since 5.0.0
  */
 public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamodel<C, P> {
+
+    private static final Object SINGLE_KEY = new Object();
 
     private final ChildEntityFieldDefinition<P, C> childEntityFieldDefinition;
 
@@ -57,24 +59,19 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
     }
 
     @Override
-    protected List<C> getChildEntities(P entity) {
-        C childEntity = childEntityFieldDefinition
-                .getChildValue(entity);
-        if (childEntity != null) {
-            return List.of(childEntity);
-        }
-        return List.of();
+    protected Map<Object, C> getChildEntities(P parent) {
+        C childEntity = childEntityFieldDefinition.getChildValue(parent);
+        return childEntity != null ? Map.of(SINGLE_KEY, childEntity) : Map.of();
     }
 
     @Override
-    protected P applyEvolvedChildEntities(P entity, List<C> evolvedChildEntities) {
+    protected P applyEvolvedChildEntities(P entity, Map<Object, C> evolvedChildEntities) {
         if (evolvedChildEntities.isEmpty()) {
             return childEntityFieldDefinition.evolveParentBasedOnChildInput(entity, null);
         }
-        if (evolvedChildEntities.size() > 1) {
-            throw new IllegalStateException("The SingleEntityChildModel field should only return a single child entity.");
-        }
-        return childEntityFieldDefinition.evolveParentBasedOnChildInput(entity, evolvedChildEntities.getFirst());
+        return childEntityFieldDefinition.evolveParentBasedOnChildInput(
+                entity, evolvedChildEntities.values().iterator().next()
+        );
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
@@ -134,8 +134,8 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
          * @return this builder instance
          */
         public Builder<C, P> childEntityFieldDefinition(ChildEntityFieldDefinition<P, C> fieldDefinition) {
-            this.childEntityFieldDefinition =
-                    Objects.requireNonNull(fieldDefinition, "The fieldDefinition may not be null.");
+            assertNonNull(fieldDefinition, "The fieldDefinition may not be null.");
+            this.childEntityFieldDefinition = fieldDefinition;
             return this;
         }
 

--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodel.java
@@ -21,18 +21,21 @@ import org.axonframework.modelling.entity.EntityMetamodel;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+
 /**
- * An {@link EntityChildMetamodel} that handles commands and events for a single child entity. It will use the provided
- * {@link ChildEntityFieldDefinition} to resolve the child entity from the parent entity. Once the entity is resolved,
- * it will delegate the command- and event-handling to the child entity metamodel.
+ * An {@link EntityChildMetamodel} that handles commands and events for a single child entity.
+ * <p>
+ * It will use the provided {@link ChildEntityFieldDefinition} to resolve the child entity from the parent entity. Once
+ * the entity is resolved, it will delegate the command- and event-handling to the child entity metamodel.
  * <p>
  * The commands and events will, by default, be forwarded unconditionally to the child entity. If you have multiple
  * member fields, and want to match commands and events to a specific child entity, you can configure the
  * {@link CommandTargetResolver} and {@link EventTargetMatcher} to match the child entity based on the command or
  * event.
  *
- * @param <C> The type of the child entity.
- * @param <P> The type of the parent entity.
+ * @param <C> the type of the child entity
+ * @param <P> the type of the parent entity
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
@@ -42,20 +45,15 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
 
     private final ChildEntityFieldDefinition<P, C> childEntityFieldDefinition;
 
-    private SingleEntityChildMetamodel(EntityMetamodel<C> metamodel,
-                                       ChildEntityFieldDefinition<P, C> childEntityFieldDefinition,
-                                       CommandTargetResolver<C> commandTargetMatcher,
-                                       EventTargetMatcher<C> eventTargetMatcher
+    private SingleEntityChildMetamodel(
+            EntityMetamodel<C> metamodel,
+            ChildEntityFieldDefinition<P, C> childEntityFieldDefinition,
+            CommandTargetResolver<C> commandTargetMatcher,
+            EventTargetMatcher<C> eventTargetMatcher
     ) {
-        super(
-                metamodel,
-                commandTargetMatcher,
-                eventTargetMatcher
-        );
-        this.childEntityFieldDefinition = Objects.requireNonNull(
-                childEntityFieldDefinition,
-                "The childEntityFieldDefinition may not be null."
-        );
+        super(metamodel, commandTargetMatcher, eventTargetMatcher);
+        this.childEntityFieldDefinition =
+                Objects.requireNonNull(childEntityFieldDefinition, "The childEntityFieldDefinition may not be null.");
     }
 
     @Override
@@ -89,11 +87,11 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
      * {@link ChildEntityFieldDefinition} is required to resolve the child entity from the parent entity and evolve the
      * parent entity based on the child entities.
      *
-     * @param parentClass The class of the parent entity.
-     * @param metamodel   The {@link EntityMetamodel} of the child entity.
-     * @param <C>         The type of the child entity.
-     * @param <P>         The type of the parent entity.
-     * @return A new {@link Builder} for the given parent class and child entity metamodel.
+     * @param parentClass the class of the parent entity
+     * @param metamodel   the {@link EntityMetamodel} of the child entity
+     * @param <C>         the type of the child entity
+     * @param <P>         the type of the parent entity
+     * @return a new {@link Builder} for the given parent class and child entity metamodel
      */
     public static <C, P> Builder<C, P> forEntityModel(Class<P> parentClass,
                                                       EntityMetamodel<C> metamodel) {
@@ -112,17 +110,16 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
      * match commands and events to a specific child entity, you can configure the {@link CommandTargetResolver} and
      * {@link EventTargetMatcher} to match the child entity based on the command or event.
      *
-     * @param <C> The type of the child entity.
-     * @param <P> The type of the parent entity.
+     * @param <C> the type of the child entity
+     * @param <P> the type of the parent entity
      */
     public static class Builder<C, P> extends AbstractEntityChildMetamodel.Builder<C, P, Builder<C, P>> {
 
+        @SuppressWarnings("NotNullFieldNotInitialized") // Ensured by validate()
         private ChildEntityFieldDefinition<P, C> childEntityFieldDefinition;
 
         @SuppressWarnings("unused") // Uses for generics
-        private Builder(Class<P> parentClass,
-                        EntityMetamodel<C> childEntityMetamodel
-        ) {
+        private Builder(Class<P> parentClass, EntityMetamodel<C> childEntityMetamodel) {
             super(parentClass, childEntityMetamodel);
             this.commandTargetResolver = CommandTargetResolver.MATCH_ANY();
             this.eventTargetMatcher = EventTargetMatcher.MATCH_ANY();
@@ -132,13 +129,13 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
          * Sets the {@link ChildEntityFieldDefinition} to use for resolving the child entity from the parent entity and
          * evolving the parent entity based on the evolved child entity.
          *
-         * @param fieldDefinition The {@link ChildEntityFieldDefinition} to use for resolving the child entities from
+         * @param fieldDefinition the {@link ChildEntityFieldDefinition} to use for resolving the child entities from
          *                        the parent entity
-         * @return This builder instance.
+         * @return this builder instance
          */
         public Builder<C, P> childEntityFieldDefinition(ChildEntityFieldDefinition<P, C> fieldDefinition) {
-            this.childEntityFieldDefinition = Objects.requireNonNull(fieldDefinition,
-                                                                     "The fieldDefinition may not be null.");
+            this.childEntityFieldDefinition =
+                    Objects.requireNonNull(fieldDefinition, "The fieldDefinition may not be null.");
             return this;
         }
 
@@ -146,15 +143,20 @@ public class SingleEntityChildMetamodel<C, P> extends AbstractEntityChildMetamod
          * Builds a new {@link SingleEntityChildMetamodel} instance with the configured properties. The
          * {@link ChildEntityFieldDefinition} is required to be set before calling this method.
          *
-         * @return A new {@link SingleEntityChildMetamodel} instance with the configured properties.
+         * @return a new {@link SingleEntityChildMetamodel} instance with the configured properties
          */
         public SingleEntityChildMetamodel<C, P> build() {
             this.validate();
-            return new SingleEntityChildMetamodel<>(metamodel,
-                                                    childEntityFieldDefinition,
-                                                    commandTargetResolver,
-                                                    eventTargetMatcher
+            return new SingleEntityChildMetamodel<>(
+                    metamodel, childEntityFieldDefinition, commandTargetResolver, eventTargetMatcher
             );
+        }
+
+        @Override
+        protected void validate() {
+            assertNonNull(childEntityFieldDefinition,
+                          "The ChildEntityFieldDefinition must be set before building the metamodel.");
+            super.validate();
         }
     }
 }

--- a/modelling/src/main/resources/META-INF/services/org.axonframework.modelling.entity.annotation.EntityChildModelDefinition
+++ b/modelling/src/main/resources/META-INF/services/org.axonframework.modelling.entity.annotation.EntityChildModelDefinition
@@ -15,4 +15,5 @@
 #
 
 org.axonframework.modelling.entity.annotation.ListEntityChildModelDefinition
+org.axonframework.modelling.entity.annotation.MapEntityChildModelDefinition
 org.axonframework.modelling.entity.annotation.SingleEntityChildModelDefinition

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/MapEntityChildModelDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/MapEntityChildModelDefinitionTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.junit.jupiter.api.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the {@link MapEntityChildModelDefinition} directly (type support and child type resolution), and end-to-end
+ * through the {@link MapDefinitionTestTeam} domain model to validate that a {@code Map}-typed {@link EntityMember} is
+ * wired up correctly by {@link AnnotatedEntityMetamodel}: command and event routing by routing key, and no ambiguity
+ * with {@link SingleEntityChildModelDefinition}.
+ *
+ * @author Steven van Beelen
+ */
+class MapEntityChildModelDefinitionTest extends AbstractAnnotatedEntityMetamodelTest<MapDefinitionTestTeam> {
+
+    private final MapEntityChildModelDefinition definition = new MapEntityChildModelDefinition();
+
+    @Override
+    protected AnnotatedEntityMetamodel<MapDefinitionTestTeam> getMetamodel() {
+        return AnnotatedEntityMetamodel.forConcreteType(
+                MapDefinitionTestTeam.class, parameterResolverFactory, messageTypeResolver, messageConverter,
+                eventConverter
+        );
+    }
+
+    @Test
+    void mapTypedEntityMemberIsWiredWithoutAmbiguityAgainstSingleEntityChildModelDefinition() {
+        // If MapEntityChildModelDefinition and SingleEntityChildModelDefinition both matched the "members" field,
+        // getMetamodel() (invoked during field initialization) would have already thrown an IllegalStateException.
+        assertThat(metamodel).isNotNull();
+    }
+
+    @Test
+    void commandIsRoutedToMapEntryByRoutingKeyAndEventEvolvesItInPlace() {
+        entityState = new MapDefinitionTestTeam("team-1");
+
+        dispatchInstanceCommand(new AddTeamMember("team-1", "m1", "Alice"));
+        dispatchInstanceCommand(new AddTeamMember("team-1", "m2", "Bob"));
+        dispatchInstanceCommand(new RenameTeamMember("m2", "Bobby"));
+
+        assertThat(entityState.getMembers()).containsOnlyKeys("m1", "m2");
+        assertThat(entityState.getMembers().get("m1").getName()).isEqualTo("Alice");
+        assertThat(entityState.getMembers().get("m2").getName()).isEqualTo("Bobby");
+    }
+
+    @Nested
+    @DisplayName("isMemberTypeSupported / getChildTypeFromMember")
+    class DefinitionUnitTests {
+
+        @Test
+        void supportsMapTypes() {
+            assertThat(definition.isMemberTypeSupported(Map.class)).isTrue();
+            assertThat(definition.isMemberTypeSupported(HashMap.class)).isTrue();
+        }
+
+        @Test
+        void doesNotSupportListOrPlainTypes() {
+            assertThat(definition.isMemberTypeSupported(List.class)).isFalse();
+            assertThat(definition.isMemberTypeSupported(String.class)).isFalse();
+        }
+
+        @Test
+        void resolvesValueTypeOfMapToChildType() throws NoSuchFieldException {
+            Class<?> childType = definition.getChildTypeFromMember(
+                    FieldOwner.class.getDeclaredField("typedMap")
+            );
+
+            assertThat(childType).isEqualTo(MapDefinitionTestTeamMember.class);
+        }
+
+        @Test
+        void throwsWhenGenericValueTypeCannotBeResolved() throws NoSuchFieldException {
+            assertThatThrownBy(() -> definition.getChildTypeFromMember(
+                    FieldOwner.class.getDeclaredField("rawMap")
+            )).isInstanceOf(AxonConfigurationException.class);
+        }
+
+        @SuppressWarnings("unused")
+        static class FieldOwner {
+
+            Map<String, MapDefinitionTestTeamMember> typedMap;
+            @SuppressWarnings("rawtypes")
+            Map rawMap;
+        }
+    }
+}
+
+class MapDefinitionTestTeam {
+
+    @SuppressWarnings("unused")
+    private final String id;
+
+    @EntityMember(routingKey = "memberId")
+    private final Map<String, MapDefinitionTestTeamMember> members = new HashMap<>();
+
+    MapDefinitionTestTeam(String id) {
+        this.id = id;
+    }
+
+    @CommandHandler
+    public void handle(AddTeamMember command, EventAppender appender) {
+        appender.append(new TeamMemberAdded(command.teamId(), command.memberId(), command.name()));
+    }
+
+    @EventHandler
+    public void on(TeamMemberAdded event) {
+        members.put(event.memberId(), new MapDefinitionTestTeamMember(event.memberId(), event.name()));
+    }
+
+    public Map<String, MapDefinitionTestTeamMember> getMembers() {
+        return members;
+    }
+}
+
+class MapDefinitionTestTeamMember {
+
+    private final String memberId;
+    private String name;
+
+    MapDefinitionTestTeamMember(String memberId, String name) {
+        this.memberId = memberId;
+        this.name = name;
+    }
+
+    @CommandHandler
+    public void handle(RenameTeamMember command) {
+        this.name = command.newName();
+    }
+
+    @SuppressWarnings("unused")
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}
+
+record AddTeamMember(String teamId, String memberId, String name) {
+
+}
+
+record RenameTeamMember(String memberId, String newName) {
+
+}
+
+record TeamMemberAdded(String teamId, String memberId, String name) {
+
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/RoutingKeyCommandTargetResolverDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/RoutingKeyCommandTargetResolverDefinitionTest.java
@@ -27,6 +27,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -78,10 +79,51 @@ class RoutingKeyCommandTargetResolverDefinitionTest {
     }
 
     @Test
-    void doesNotAllowRoutingKeyMismatchBetweenMessageAndEntity() throws NoSuchFieldException {
+    void doesNotAllowRoutingKeyMismatchBetweenMessageAndListEntity() throws NoSuchFieldException {
         CommandTargetResolver<ChildEntity> result = definition.createCommandTargetResolver(
                 childEntityMetamodel,
                 ListChildEntityWithNonMatchingRoutingKey.class.getDeclaredField("child")
+        );
+
+        MessageType messageType = new MessageType(TestCommand.class);
+        //noinspection unchecked,rawtypes
+        when(childEntityMetamodel.getExpectedRepresentation(messageType.qualifiedName()))
+                .thenReturn((Class) TestCommand.class);
+
+        assertThatThrownBy(() -> result.getTargetChildEntity(
+                List.of(new ChildEntity()),
+                new GenericCommandMessage(messageType, new TestCommand("someValue")),
+                new StubProcessingContext()
+        )).isInstanceOf(UnknownRoutingKeyException.class);
+    }
+
+    @Test
+    void doesNotAllowMissingRoutingKeyOnMapTypeMember() {
+        assertThatThrownBy(
+                () -> definition.createCommandTargetResolver(
+                        childEntityMetamodel,
+                        MapChildEntityWithoutRoutingKey.class.getDeclaredField("child")
+                ),
+                "Expected AxonConfigurationException when no routing key is present on a Map type member"
+        ).isInstanceOf(AxonConfigurationException.class);
+    }
+
+    @Test
+    void returnsMatcherForMapChildEntityWithRoutingKey() throws NoSuchFieldException {
+        CommandTargetResolver<ChildEntity> result = definition.createCommandTargetResolver(
+                childEntityMetamodel,
+                MapChildEntityWithRoutingKey.class.getDeclaredField("child")
+        );
+
+        assertThat(result).isNotNull()
+                          .isNotEqualTo(CommandTargetResolver.MATCH_ANY());
+    }
+
+    @Test
+    void doesNotAllowRoutingKeyMismatchBetweenMessageAndMapEntity() throws NoSuchFieldException {
+        CommandTargetResolver<ChildEntity> result = definition.createCommandTargetResolver(
+                childEntityMetamodel,
+                MapChildEntityWithNonMatchingRoutingKey.class.getDeclaredField("child")
         );
 
         MessageType messageType = new MessageType(TestCommand.class);
@@ -122,6 +164,27 @@ class RoutingKeyCommandTargetResolverDefinitionTest {
         @SuppressWarnings("unused")
         @EntityMember(routingKey = "incorrect")
         private List<ChildEntity> child;
+    }
+
+    static class MapChildEntityWithoutRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember
+        private Map<String, ChildEntity> child;
+    }
+
+    static class MapChildEntityWithRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember(routingKey = "key")
+        private Map<String, ChildEntity> child;
+    }
+
+    static class MapChildEntityWithNonMatchingRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember(routingKey = "incorrect")
+        private Map<String, ChildEntity> child;
     }
 
     static class ChildEntity {

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/RoutingKeyEventTargetMatcherDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/RoutingKeyEventTargetMatcherDefinitionTest.java
@@ -27,6 +27,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -78,10 +79,51 @@ class RoutingKeyEventTargetMatcherDefinitionTest {
     }
 
     @Test
-    void doesNotAllowRoutingKeyMismatchBetweenMessageAndEntity() throws NoSuchFieldException {
+    void doesNotAllowRoutingKeyMismatchBetweenMessageAndListEntity() throws NoSuchFieldException {
         EventTargetMatcher<ChildEntity> result = definition.createChildEntityMatcher(
                 childEntityMetamodel,
                 ListChildEntityWithNonMatchingRoutingKey.class.getDeclaredField("child")
+        );
+
+        MessageType messageType = new MessageType(TestEvent.class);
+        //noinspection unchecked,rawtypes
+        when(childEntityMetamodel.getExpectedRepresentation(messageType.qualifiedName()))
+                .thenReturn((Class) TestEvent.class);
+
+        assertThatThrownBy(() -> result.matches(
+                new ChildEntity(),
+                new GenericEventMessage(messageType, new TestEvent("someValue")),
+                new StubProcessingContext()
+        )).isInstanceOf(UnknownRoutingKeyException.class);
+    }
+
+    @Test
+    void doesNotAllowMissingRoutingKeyOnMapTypeMember() {
+        assertThatThrownBy(
+                () -> definition.createChildEntityMatcher(
+                        childEntityMetamodel,
+                        MapChildEntityWithoutRoutingKey.class.getDeclaredField("child")
+                ),
+                "Expected AxonConfigurationException when no routing key is present on a Map type member"
+        ).isInstanceOf(AxonConfigurationException.class);
+    }
+
+    @Test
+    void returnsMatcherForListMapEntityWithRoutingKey() throws NoSuchFieldException {
+        EventTargetMatcher<ChildEntity> result = definition.createChildEntityMatcher(
+                childEntityMetamodel,
+                MapChildEntityWithRoutingKey.class.getDeclaredField("child")
+        );
+
+        assertThat(result).isNotNull()
+                          .isNotEqualTo(EventTargetMatcher.MATCH_ANY());
+    }
+
+    @Test
+    void doesNotAllowRoutingKeyMismatchBetweenMessageAndMapEntity() throws NoSuchFieldException {
+        EventTargetMatcher<ChildEntity> result = definition.createChildEntityMatcher(
+                childEntityMetamodel,
+                MapChildEntityWithNonMatchingRoutingKey.class.getDeclaredField("child")
         );
 
         MessageType messageType = new MessageType(TestEvent.class);
@@ -123,6 +165,27 @@ class RoutingKeyEventTargetMatcherDefinitionTest {
         @SuppressWarnings("unused")
         @EntityMember(routingKey = "incorrect")
         private List<ChildEntity> child;
+    }
+
+    static class MapChildEntityWithoutRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember
+        private Map<String, ChildEntity> child;
+    }
+
+    static class MapChildEntityWithRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember(routingKey = "key")
+        private Map<String, ChildEntity> child;
+    }
+
+    static class MapChildEntityWithNonMatchingRoutingKey {
+
+        @SuppressWarnings("unused")
+        @EntityMember(routingKey = "incorrect")
+        private Map<String, ChildEntity> child;
     }
 
     static class ChildEntity {

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
@@ -258,13 +258,13 @@ class ListEntityChildMetamodelTest {
 
         @Test
         void canNotStartBuilderWithNullParentEntityClass() {
-            assertThrows(NullPointerException.class,
+            assertThrows(AxonConfigurationException.class,
                          () -> ListEntityChildMetamodel.forEntityModel(null, childEntityMetamodel));
         }
 
         @Test
         void canNotStartBuilderWithNullEntityModel() {
-            assertThrows(NullPointerException.class,
+            assertThrows(AxonConfigurationException.class,
                          () -> ListEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, null));
         }
 

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/ListEntityChildMetamodelTest.java
@@ -253,7 +253,7 @@ class ListEntityChildMetamodelTest {
                                                                                           .findFirst()
                                                                                           .orElse(null))
                                                   .eventTargetMatcher((o, eventMessage, ctx) -> o.getId().contains(EVENT_MATCHING_ID));
-            assertThrows(NullPointerException.class, builder::build);
+            assertThrows(AxonConfigurationException.class, builder::build);
         }
 
         @Test

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodelTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.child;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageStreamTestUtils;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.modelling.entity.ChildEntityNotFoundException;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.child.mock.RecordingChildEntity;
+import org.axonframework.modelling.entity.child.mock.RecordingEntity;
+import org.axonframework.modelling.entity.child.mock.RecordingParentEntity;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+import org.mockito.quality.Strictness;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link MapEntityChildMetamodel}.
+ *
+ * @author Steven van Beelen
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MapEntityChildMetamodelTest {
+
+    private static final QualifiedName COMMAND = new QualifiedName("Command");
+    private static final QualifiedName EVENT = new QualifiedName("Event");
+    private static final String COMMAND_MATCHING_ID = "1337";
+    private static final String COMMAND_SKIPPING_ID = "123";
+    private static final String EVENT_MATCHING_ID = "42";
+    private static final String EVENT_SKIPPING_ID = "456";
+
+    @Mock
+    private EntityMetamodel<RecordingChildEntity> childEntityMetamodel;
+    @Mock
+    private ChildEntityFieldDefinition<RecordingParentEntity, Map<String, RecordingChildEntity>> childEntityFieldDefinition;
+    private RecordingParentEntity parentEntity;
+
+    private MapEntityChildMetamodel<String, RecordingChildEntity, RecordingParentEntity> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        parentEntity = new RecordingParentEntity();
+
+        testSubject = MapEntityChildMetamodel.<String, RecordingChildEntity, RecordingParentEntity>forEntityModel(
+                                                     RecordingParentEntity.class, childEntityMetamodel
+                                             )
+                                             .childEntityFieldDefinition(childEntityFieldDefinition)
+                                             .commandTargetResolver((candidates, command, context) -> {
+                                                 return candidates.stream()
+                                                                  .filter(
+                                                                          c -> c.getId()
+                                                                                .contains(COMMAND_MATCHING_ID)
+                                                                  )
+                                                                  .findFirst()
+                                                                  .orElse(null);
+                                             })
+                                             .eventTargetMatcher(
+                                                     (e, event, context) -> e.getId().contains(EVENT_MATCHING_ID)
+                                             )
+                                             .build();
+    }
+
+    @Nested
+    @DisplayName("Command handling")
+    public class CommandHandling {
+
+        private final CommandMessage commandMessage = new GenericCommandMessage(new MessageType(COMMAND), "myPayload");
+        private final ProcessingContext context = StubProcessingContext.forMessage(commandMessage);
+
+        @BeforeEach
+        void setUp() {
+            when(childEntityMetamodel.handleInstance(any(), any(), any())).thenAnswer(answer -> {
+                RecordingChildEntity child = answer.getArgument(1);
+                return MessageStream.just(
+                        new GenericCommandResultMessage(new MessageType(String.class), child.getId() + "-result")
+                );
+            });
+        }
+
+        @Test
+        void commandForChildIsForwardedToMatchingChildEntity() {
+            RecordingChildEntity entityToBeFound = new RecordingChildEntity(COMMAND_MATCHING_ID);
+            RecordingChildEntity entityToBeSkipped = new RecordingChildEntity(COMMAND_SKIPPING_ID);
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(
+                    Map.of("found", entityToBeFound, "skipped", entityToBeSkipped)
+            );
+
+            var result = testSubject.handle(commandMessage, parentEntity, context);
+            assertThat(result.asCompletableFuture().join().message().payload()).isEqualTo("1337-result");
+
+            verify(childEntityFieldDefinition).getChildValue(parentEntity);
+            verify(childEntityMetamodel).handleInstance(commandMessage, entityToBeFound, context);
+            verify(childEntityMetamodel, times(0)).handleInstance(commandMessage, entityToBeSkipped, context);
+        }
+
+        @Test
+        void commandResultsInFailedMessageStreamWhenChildEntityIsNotFound() {
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(null);
+
+            MessageStreamTestUtils.assertCompletedExceptionally(
+                    testSubject.handle(commandMessage, parentEntity, context),
+                    ChildEntityNotFoundException.class,
+                    "No available child entity found for command of type [Command#0.0.1]. State of parent entity ["
+            );
+        }
+
+        @Test
+        void commandResultsInFailedMessageStreamWhenNoChildEntityMatches() {
+            RecordingChildEntity entityToBeSkipped = new RecordingChildEntity("l0ser");
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(Map.of("skipped", entityToBeSkipped));
+
+            MessageStreamTestUtils.assertCompletedExceptionally(
+                    testSubject.handle(commandMessage, parentEntity, context),
+                    ChildEntityNotFoundException.class,
+                    "No available child entity found for command of type [Command#0.0.1]. State of parent entity ["
+            );
+        }
+    }
+
+    @Test
+    void supportedCommandsIsSameAsChildEntity() {
+        when(childEntityMetamodel.supportedCommands()).thenReturn(Set.of(COMMAND));
+
+        assertThat(testSubject.supportedCommands()).isEqualTo(Set.of(COMMAND));
+    }
+
+    @Test
+    void entityTypeIsSameAsChildEntity() {
+        when(childEntityMetamodel.entityType()).thenReturn(RecordingChildEntity.class);
+
+        assertThat(testSubject.entityType()).isEqualTo(RecordingChildEntity.class);
+    }
+
+    @Test
+    void returnsEntityModel() {
+        assertThat(testSubject.entityMetamodel()).isEqualTo(childEntityMetamodel);
+    }
+
+    @Nested
+    @DisplayName("Event handling")
+    public class EventHandling {
+
+        private final EventMessage event = new GenericEventMessage(new MessageType(EVENT), "myPayload");
+        private final ProcessingContext context = StubProcessingContext.forMessage(event);
+
+        @BeforeEach
+        void setUp() {
+            when(childEntityMetamodel.evolve(any(), any(), any())).thenAnswer(answ -> {
+                RecordingChildEntity child = answ.getArgument(0);
+                EventMessage event = answ.getArgument(1);
+                return child.evolve("child evolve: " + event.payload());
+            });
+            when(childEntityFieldDefinition.evolveParentBasedOnChildInput(any(), any())).thenAnswer(answ -> {
+                RecordingParentEntity parent = answ.getArgument(0);
+                Map<String, RecordingChildEntity> children = answ.getArgument(1);
+                return parent.evolve(
+                        "parent evolve: [" + children.values().stream().map(RecordingEntity::getEvolves)
+                                                     .map(Objects::toString)
+                                                     .reduce((a, b) -> a + "," + b).orElse("") + "]");
+            });
+        }
+
+        @Test
+        void doesNotEvolveEntityWhenChildEntityIsNotFound() {
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(null);
+
+            RecordingParentEntity result = testSubject.evolve(parentEntity, event, context);
+
+            verify(childEntityFieldDefinition).getChildValue(parentEntity);
+            verify(childEntityFieldDefinition, never()).evolveParentBasedOnChildInput(any(), any());
+
+            assertThat(result).isEqualTo(parentEntity);
+            assertThat(parentEntity.getEvolves()).isEmpty();
+        }
+
+        @Test
+        void evolvesChildEntityAndParentEntityWhenChildEntityIsFound() {
+            RecordingChildEntity childEntity = new RecordingChildEntity("42");
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(Map.of("theKey", childEntity));
+
+            RecordingParentEntity result = testSubject.evolve(parentEntity, event, context);
+
+            assertThat(result.getEvolves().getFirst()).isEqualTo("parent evolve: [[child evolve: myPayload]]");
+            verify(childEntityFieldDefinition).getChildValue(parentEntity);
+            verify(childEntityFieldDefinition).evolveParentBasedOnChildInput(
+                    eq(parentEntity),
+                    argThat(m -> m.get("theKey").getEvolves().contains("child evolve: myPayload"))
+            );
+            verify(childEntityMetamodel).evolve(childEntity, event, context);
+        }
+
+        @Test
+        void evolvesOnlyMatchingChildEvolvesAndPreservesOriginalKeys() {
+            RecordingChildEntity matchingEntityOne = new RecordingChildEntity(EVENT_MATCHING_ID + "-1");
+            RecordingChildEntity matchingEntityTwo = new RecordingChildEntity(EVENT_MATCHING_ID + "-2");
+            RecordingChildEntity nonMatchingEntity1 = new RecordingChildEntity(EVENT_SKIPPING_ID + "-3");
+            RecordingChildEntity nonMatchingEntity2 = new RecordingChildEntity(EVENT_SKIPPING_ID + "-4");
+            Map<String, RecordingChildEntity> children = new LinkedHashMap<>();
+            children.put("one", matchingEntityOne);
+            children.put("two", nonMatchingEntity2);
+            children.put("three", matchingEntityTwo);
+            children.put("four", nonMatchingEntity1);
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(children);
+
+            testSubject.evolve(parentEntity, event, context);
+
+            verify(childEntityFieldDefinition).getChildValue(parentEntity);
+            verify(childEntityMetamodel).evolve(matchingEntityOne, event, context);
+            verify(childEntityMetamodel).evolve(matchingEntityTwo, event, context);
+            verify(childEntityMetamodel, times(0)).evolve(nonMatchingEntity1, event, context);
+            verify(childEntityMetamodel, times(0)).evolve(nonMatchingEntity2, event, context);
+            verify(childEntityFieldDefinition).evolveParentBasedOnChildInput(
+                    eq(parentEntity),
+                    argThat(
+                            m -> m.keySet().equals(Set.of("one", "two", "three", "four"))
+                                    && m.get("one").getEvolves().contains("child evolve: myPayload")
+                                    && m.get("three").getEvolves().contains("child evolve: myPayload")
+                                    && m.get("two") == nonMatchingEntity2
+                                    && m.get("four") == nonMatchingEntity1
+                    ));
+        }
+
+        @Test
+        void evolvedChildEntitiesToNullAreRemovedFromParentWhileOtherKeysAreUnaffected() {
+            RecordingChildEntity evolvingEntity = new RecordingChildEntity(EVENT_MATCHING_ID);
+            RecordingChildEntity untouchedEntity = new RecordingChildEntity(EVENT_SKIPPING_ID);
+            Map<String, RecordingChildEntity> children = new LinkedHashMap<>();
+            children.put("removeMe", evolvingEntity);
+            children.put("keepMe", untouchedEntity);
+            when(childEntityFieldDefinition.getChildValue(any())).thenReturn(children);
+
+            // Reset the standard evolve, to evolve to null
+            reset(childEntityMetamodel);
+            when(childEntityMetamodel.evolve(any(), any(), any())).thenAnswer(answ -> null);
+
+            testSubject.evolve(parentEntity, event, context);
+
+            verify(childEntityFieldDefinition).getChildValue(parentEntity);
+            verify(childEntityFieldDefinition).evolveParentBasedOnChildInput(
+                    eq(parentEntity),
+                    argThat(m -> !m.containsKey("removeMe") && m.get("keepMe") == untouchedEntity && m.size() == 1)
+            );
+            verify(childEntityMetamodel).evolve(evolvingEntity, event, context);
+        }
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Nested
+    @DisplayName("Builder verification")
+    public class BuilderVerification {
+
+        @Mock
+        private ChildEntityFieldDefinition<RecordingParentEntity, Map<Object, RecordingChildEntity>> mockEntityFieldDefinition;
+        @Mock
+        private CommandTargetResolver<RecordingChildEntity> mockCommandTargetResolver;
+        @Mock
+        private EventTargetMatcher<RecordingChildEntity> mockEventTargetMatcher;
+
+        @Test
+        void canNotStartBuilderWithNullEntityModel() {
+            assertThatThrownBy(() -> MapEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void canNotStartBuilderWithNullParentEntityClass() {
+            assertThatThrownBy(() -> MapEntityChildMetamodel.forEntityModel(null, childEntityMetamodel))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void canNotCompleteBuilderWithoutFieldDefinition() {
+            var builder = MapEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, childEntityMetamodel)
+                                                 .commandTargetResolver(mockCommandTargetResolver)
+                                                 .eventTargetMatcher(mockEventTargetMatcher);
+            assertThatThrownBy(builder::build).isInstanceOf(AxonConfigurationException.class);
+        }
+
+        @Test
+        void canNotCompleteBuilderWithoutCommandTargetResolver() {
+            var builder = MapEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, childEntityMetamodel)
+                                                 .childEntityFieldDefinition(mockEntityFieldDefinition)
+                                                 .eventTargetMatcher(mockEventTargetMatcher);
+            assertThatThrownBy(builder::build).isInstanceOf(AxonConfigurationException.class);
+        }
+
+        @Test
+        void canNotCompleteBuilderWithoutEventTargetMatcher() {
+            var builder = MapEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, childEntityMetamodel)
+                                                 .childEntityFieldDefinition(mockEntityFieldDefinition)
+                                                 .commandTargetResolver(mockCommandTargetResolver);
+            assertThatThrownBy(builder::build).isInstanceOf(AxonConfigurationException.class);
+        }
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/MapEntityChildMetamodelTest.java
@@ -294,13 +294,13 @@ class MapEntityChildMetamodelTest {
         @Test
         void canNotStartBuilderWithNullEntityModel() {
             assertThatThrownBy(() -> MapEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, null))
-                    .isInstanceOf(NullPointerException.class);
+                    .isInstanceOf(AxonConfigurationException.class);
         }
 
         @Test
         void canNotStartBuilderWithNullParentEntityClass() {
             assertThatThrownBy(() -> MapEntityChildMetamodel.forEntityModel(null, childEntityMetamodel))
-                    .isInstanceOf(NullPointerException.class);
+                    .isInstanceOf(AxonConfigurationException.class);
         }
 
         @Test

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.entity.child;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
@@ -196,7 +197,7 @@ class SingleEntityChildMetamodelTest {
         void canNotCompleteBuilderWithoutFieldDefinition() {
             var builder = SingleEntityChildMetamodel.forEntityModel(RecordingParentEntity.class,
                                                                     childEntityMetamodel);
-            assertThrows(NullPointerException.class, builder::build);
+            assertThrows(AxonConfigurationException.class, builder::build);
         }
 
         @Test

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/SingleEntityChildMetamodelTest.java
@@ -202,13 +202,13 @@ class SingleEntityChildMetamodelTest {
 
         @Test
         void canNotStartBuilderWithNullParentEntityClass() {
-            assertThrows(NullPointerException.class,
+            assertThrows(AxonConfigurationException.class,
                          () -> SingleEntityChildMetamodel.forEntityModel(null, childEntityMetamodel));
         }
 
         @Test
         void canNotStartBuilderWithNullEntityModel() {
-            assertThrows(NullPointerException.class,
+            assertThrows(AxonConfigurationException.class,
                          () -> SingleEntityChildMetamodel.forEntityModel(RecordingParentEntity.class, null));
         }
     }


### PR DESCRIPTION
This pull request introduces `Map` support for child entity members.
The child entity member map will have the identifier as the key and the child entity itself as the value.
Both the declarative and annotated routes are support.

For declarative, the `EntityChildMetamodel` now has `map` static factory that provides a builder for the new `MapEntityChildMetamodel`.
For automated, the `MapEntityChildMetamodel` was introduced.
Both declarative and automated are validated with tests and integration tests.

To support a map of child entities, the `AbstractEntityChildMetamodel` has been adjusted slightly.
Although marked `public`, the `AbstractEntityChildMetamodel` really is an internal class.
As per this PR, it's marked as internal.
Furthermore, the internal marker justifies the API changes to support map-based child entities.

By introducing this, we reintroduce the map-based entity support as was present in Axon Framework 4.
By doing the above, this PR resolves #4757.