### PR TITLE
[#4727] Make pooled processor source and token-store optional when unset

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventProcessorPropertiesAndDefinitionInteractionIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/EventProcessorPropertiesAndDefinitionInteractionIT.java
@@ -31,6 +31,7 @@ import org.axonframework.messaging.core.MessageHandlerInterceptorChain;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.SubscribableEventSource;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.AsyncInMemoryStreamableEventSource;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventTestUtils;
 import org.axonframework.messaging.eventhandling.SimpleEventBus;
@@ -41,6 +42,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.pooled.Poo
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorConfiguration;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
@@ -159,6 +161,44 @@ class EventProcessorPropertiesAndDefinitionInteractionIT {
             return EventProcessorDefinition.subscribing("definition-sourced-processor")
                                            .assigningHandlers(p -> p.beanType().equals(RecordingEventHandler.class))
                                            .customized(c -> c.eventSource(definitionSuppliedSource));
+        }
+    }
+
+    /**
+     * Lean context for pooled definition-source coverage. Avoids scanning the fixture packages so package-named
+     * processors are not created alongside the definition-sourced processor under test.
+     */
+    @ContextConfiguration
+    @EnableAutoConfiguration
+    @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
+    private static class LeanPooledDefinitionContext {
+
+        @Bean(name = "tokenStore")
+        public TokenStore tokenStore() {
+            return new InMemoryTokenStore();
+        }
+    }
+
+    @org.springframework.context.annotation.Configuration
+    public static class DefinitionSuppliedPooledEventSourceContext {
+
+        @Bean
+        public AsyncInMemoryStreamableEventSource definitionSuppliedPooledSource() {
+            return new AsyncInMemoryStreamableEventSource();
+        }
+
+        @Bean
+        public RecordingEventHandler recordingEventHandler() {
+            return new RecordingEventHandler();
+        }
+
+        @Bean
+        public EventProcessorDefinition definitionSourcedPooledProcessorDefinition(
+                AsyncInMemoryStreamableEventSource definitionSuppliedPooledSource
+        ) {
+            return EventProcessorDefinition.pooledStreaming("definition-sourced-pooled-processor")
+                                           .assigningHandlers(p -> p.beanType().equals(RecordingEventHandler.class))
+                                           .customized(c -> c.eventSource(definitionSuppliedPooledSource));
         }
     }
 
@@ -486,6 +526,55 @@ class EventProcessorPropertiesAndDefinitionInteractionIT {
             await().atMost(Duration.ofSeconds(2))
                    .untilAsserted(() -> assertThat(recordingEventHandler.handledEvents())
                            .contains("definition-sourced-event"));
+        }
+    }
+
+    @Nested
+    @SpringBootTest(
+            classes = {LeanPooledDefinitionContext.class, DefinitionSuppliedPooledEventSourceContext.class},
+            properties = {
+                    "axon.eventstorage.jpa.polling-interval=0",
+                    // empty source so settings customization does not require a named StreamableEventSource
+                    "axon.eventhandling.processors[definition-sourced-pooled-processor].source="
+            },
+            webEnvironment = SpringBootTest.WebEnvironment.NONE
+    )
+    class DefinitionSuppliedPooledEventSourceTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Autowired
+        private AsyncInMemoryStreamableEventSource definitionSuppliedPooledSource;
+
+        @Autowired
+        private RecordingEventHandler recordingEventHandler;
+
+        @Test
+        void processorUsesTheDefinitionSuppliedEventSourceWhenNoSourceSettingIsPresent() {
+            // given - no unique type-level StreamableEventSource is resolvable (the event store and the
+            // definition-supplied source are both candidates), so only the EventProcessorDefinition can
+            // supply the source for the processor
+            assertThat(context.getBeanProvider(StreamableEventSource.class).getIfUnique()).isNull();
+
+            AxonConfiguration axonApplication = context.getBean(AxonConfiguration.class);
+            Configuration processorConfig = axonApplication.getModuleConfiguration(
+                    "EventProcessor[definition-sourced-pooled-processor]").orElseThrow();
+            assertThat(processorConfig.getOptionalComponent(StreamingEventProcessor.class,
+                                                            "definition-sourced-pooled-processor"))
+                    .isPresent();
+            assertThat(processorConfig.getOptionalComponent(PooledStreamingEventProcessorConfiguration.class))
+                    .hasValueSatisfying(
+                            config -> assertThat(config.eventSource()).isSameAs(definitionSuppliedPooledSource)
+                    );
+
+            // when
+            definitionSuppliedPooledSource.publishMessage(EventTestUtils.asEventMessage("definition-sourced-pooled-event"));
+
+            // then
+            await().atMost(Duration.ofSeconds(5))
+                   .untilAsserted(() -> assertThat(recordingEventHandler.handledEvents())
+                           .contains("definition-sourced-pooled-event"));
         }
     }
 

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
@@ -113,6 +113,15 @@ interface SpringCustomizations {
 
     /**
      * Customization executed based on the {@link EventProcessorSettings.PooledEventProcessorSettings}.
+     * <p>
+     * The {@link StreamableEventSource} and {@link TokenStore} are only mandatory when the corresponding
+     * {@link EventProcessorSettings#source() source} or
+     * {@link EventProcessorSettings.PooledEventProcessorSettings#tokenStore() token-store} setting is explicitly set.
+     * When a setting is unset (or empty), this customization falls back to resolving the unique, type-level component
+     * and only applies it when one is found. Otherwise, it leaves that part of the configuration untouched, allowing
+     * customizations applied after this one, like an {@code EventProcessorDefinition}, to supply it. A still-missing
+     * source or token store is reported when the resulting {@link PooledStreamingEventProcessorConfiguration} is
+     * validated.
      */
     class SpringPooledStreamingEventProcessingModuleCustomization
             implements PooledStreamingEventProcessorModule.Customization {
@@ -138,34 +147,38 @@ interface SpringCustomizations {
                     new AxonThreadFactory(executorName)
             );
 
-            var eventStore = getComponent(configuration,
-                                          StreamableEventSource.class,
-                                          settings.source(),
-                                          null);
-            require(eventStore != null,
-                    "Could not find a mandatory Source with name '" + settings.source()
-                            + "' for event processor '" + name + "'.");
-
-            var tokenStore = getComponent(configuration,
-                                          TokenStore.class,
-                                          settings.tokenStore(),
-                                          null);
-            require(tokenStore != null,
-                    "Could not find a mandatory TokenStore with name '" + settings.tokenStore()
-                            + "' for event processor '" + name + "'."
-            );
             var unitOfWorkFactory = getComponent(configuration, UnitOfWorkFactory.class, null, null);
             require(unitOfWorkFactory != null,
                     "Could not find a mandatory UnitOfWorkFactory for event processor '" + name + "'.");
 
-            return eventProcessorConfiguration
+            var result = eventProcessorConfiguration
                     .workerExecutor(scheduledExecutorService)
                     .tokenClaimInterval(settings.tokenClaimIntervalInMillis())
                     .batchSize(settings.batchSize())
                     .initialSegmentCount(settings.initialSegmentCount())
-                    .eventSource(eventStore)
-                    .tokenStore(tokenStore)
                     .unitOfWorkFactory(unitOfWorkFactory);
+
+            String sourceName = StringUtils.nonEmptyOrNull(settings.source()) ? settings.source() : null;
+            var eventSource = getComponent(configuration, StreamableEventSource.class, sourceName, null);
+            if (sourceName != null) {
+                require(eventSource != null, "Could not find a mandatory Source with name '" + settings.source()
+                        + "' for event processor '" + name + "'.");
+            }
+            if (eventSource != null) {
+                result = result.eventSource(eventSource);
+            }
+
+            String tokenStoreName = StringUtils.nonEmptyOrNull(settings.tokenStore()) ? settings.tokenStore() : null;
+            var tokenStore = getComponent(configuration, TokenStore.class, tokenStoreName, null);
+            if (tokenStoreName != null) {
+                require(tokenStore != null, "Could not find a mandatory TokenStore with name '" + settings.tokenStore()
+                        + "' for event processor '" + name + "'.");
+            }
+            if (tokenStore != null) {
+                result = result.tokenStore(tokenStore);
+            }
+
+            return result;
         }
     }
 

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
@@ -27,7 +27,11 @@ import org.axonframework.messaging.eventhandling.EventBus;
 import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventhandling.configuration.EventBusConfigurationDefaults;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorConfiguration;
+import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 
@@ -35,11 +39,11 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 /**
- * Test class validating how the {@link SpringCustomizations.SpringSubscribingEventProcessingModuleCustomization}
- * resolves the {@link SubscribableEventSource} from the
- * {@link EventProcessorSettings.SubscribingEventProcessorSettings#source() source setting}.
+ * Test class validating how {@link SpringCustomizations} resolve processor components from
+ * {@link EventProcessorSettings}.
  *
  * @author Jakob Hatzl
  */
@@ -48,7 +52,7 @@ class SpringCustomizationsTest {
     private static final String PROCESSOR_NAME = "test-processor";
 
     @Nested
-    class ExplicitlyConfiguredSource {
+    class SubscribingExplicitlyConfiguredSource {
 
         @Test
         void appliesTheSourceRegisteredUnderTheConfiguredName() {
@@ -59,7 +63,7 @@ class SpringCustomizationsTest {
             );
 
             // when
-            var result = customize(configuration, "my-source");
+            var result = customizeSubscribing(configuration, "my-source");
 
             // then
             assertThat(result.eventSource()).isSameAs(namedSource);
@@ -73,7 +77,7 @@ class SpringCustomizationsTest {
             });
 
             // when / then
-            assertThatThrownBy(() -> customize(configuration, "unknown-source"))
+            assertThatThrownBy(() -> customizeSubscribing(configuration, "unknown-source"))
                     .isInstanceOf(AxonConfigurationException.class)
                     .hasMessageContaining("'unknown-source'")
                     .hasMessageContaining(PROCESSOR_NAME);
@@ -81,7 +85,7 @@ class SpringCustomizationsTest {
     }
 
     @Nested
-    class UnsetSource {
+    class SubscribingUnsetSource {
 
         @Test
         void appliesTheUniqueTypeLevelDefaultWhenTheSourceIsUnset() {
@@ -90,7 +94,7 @@ class SpringCustomizationsTest {
             });
 
             // when
-            var result = customize(configuration, null);
+            var result = customizeSubscribing(configuration, null);
 
             // then - the default EventBus is the unique type-level SubscribableEventSource
             assertThat(result.eventSource()).isSameAs(configuration.getComponent(EventBus.class));
@@ -99,14 +103,14 @@ class SpringCustomizationsTest {
         @Test
         void leavesTheSourceUnsetWhenNoTypeLevelDefaultIsPresent() {
             // given - only a named source is registered, which an unset source setting must not resolve to
-            var configuration = configurationWithoutTypeLevelSource(
+            var configuration = configurationWithoutTypeLevelSubscribableSource(
                     cr -> cr.registerComponent(SubscribableEventSource.class,
                                                "named-source",
                                                cfg -> new SimpleEventBus())
             );
 
             // when
-            var result = customize(configuration, null);
+            var result = customizeSubscribing(configuration, null);
 
             // then - a customization applied after this one, like an EventProcessorDefinition, may supply the source
             assertThat(result.eventSource()).isNull();
@@ -116,9 +120,9 @@ class SpringCustomizationsTest {
         void keepsAnAlreadyAssignedSourceWhenNoTypeLevelDefaultIsPresent() {
             // given
             SimpleEventBus assignedSource = new SimpleEventBus();
-            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            var configuration = configurationWithoutTypeLevelSubscribableSource(cr -> {
             });
-            var processorConfiguration = processorConfiguration().eventSource(assignedSource);
+            var processorConfiguration = subscribingProcessorConfiguration().eventSource(assignedSource);
 
             // when
             var result = SpringCustomizations
@@ -133,7 +137,7 @@ class SpringCustomizationsTest {
         void allowsASubsequentCustomizationToSupplyTheSourceWhenTheSettingIsUnset() {
             // given
             SimpleEventBus definitionSource = new SimpleEventBus();
-            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            var configuration = configurationWithoutTypeLevelSubscribableSource(cr -> {
             });
             // mirrors how settings customizations are chained before definition customizations
             var chained = SpringCustomizations
@@ -141,7 +145,7 @@ class SpringCustomizationsTest {
                     .andThen((cfg, processorConfig) -> processorConfig.eventSource(definitionSource));
 
             // when
-            var result = chained.apply(configuration, processorConfiguration());
+            var result = chained.apply(configuration, subscribingProcessorConfiguration());
 
             // then
             assertThat(result.eventSource()).isSameAs(definitionSource);
@@ -149,7 +153,7 @@ class SpringCustomizationsTest {
     }
 
     @Nested
-    class EmptySourceName {
+    class SubscribingEmptySourceName {
 
         @Test
         void appliesTheUniqueTypeLevelDefaultWhenTheSourceIsEmpty() {
@@ -158,7 +162,7 @@ class SpringCustomizationsTest {
             });
 
             // when
-            var result = customize(configuration, "");
+            var result = customizeSubscribing(configuration, "");
 
             // then
             assertThat(result.eventSource()).isSameAs(configuration.getComponent(EventBus.class));
@@ -167,14 +171,144 @@ class SpringCustomizationsTest {
         @Test
         void leavesTheSourceUnsetWhenTheSourceIsEmptyAndNoTypeLevelDefaultIsPresent() {
             // given
-            var configuration = configurationWithoutTypeLevelSource(cr -> {
+            var configuration = configurationWithoutTypeLevelSubscribableSource(cr -> {
             });
 
             // when
-            var result = customize(configuration, "");
+            var result = customizeSubscribing(configuration, "");
 
             // then
             assertThat(result.eventSource()).isNull();
+        }
+    }
+
+    @Nested
+    class PooledExplicitlyConfiguredComponents {
+
+        @Test
+        void appliesTheSourceAndTokenStoreRegisteredUnderTheConfiguredNames() {
+            // given
+            StreamableEventSource namedSource = mock(StreamableEventSource.class);
+            TokenStore namedTokenStore = new InMemoryTokenStore();
+            var configuration = configuration(cr -> cr
+                    .registerComponent(StreamableEventSource.class, "my-source", cfg -> namedSource)
+                    .registerComponent(TokenStore.class, "my-token-store", cfg -> namedTokenStore)
+            );
+
+            // when
+            var result = customizePooled(configuration, "my-source", "my-token-store");
+
+            // then
+            assertThat(result.eventSource()).isSameAs(namedSource);
+            assertThat(result.tokenStore()).isSameAs(namedTokenStore);
+            assertThat(result.unitOfWorkFactory()).isSameAs(configuration.getComponent(UnitOfWorkFactory.class));
+        }
+
+        @Test
+        void failsWhenTheConfiguredSourceCannotBeResolved() {
+            // given
+            var configuration = configuration(cr -> cr.registerComponent(TokenStore.class,
+                                                                         "tokenStore",
+                                                                         cfg -> new InMemoryTokenStore()));
+
+            // when / then
+            assertThatThrownBy(() -> customizePooled(configuration, "unknown-source", "tokenStore"))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("'unknown-source'")
+                    .hasMessageContaining(PROCESSOR_NAME);
+        }
+
+        @Test
+        void failsWhenTheConfiguredTokenStoreCannotBeResolved() {
+            // given
+            StreamableEventSource namedSource = mock(StreamableEventSource.class);
+            var configuration = configuration(cr -> cr.registerComponent(StreamableEventSource.class,
+                                                                         "my-source",
+                                                                         cfg -> namedSource));
+
+            // when / then
+            assertThatThrownBy(() -> customizePooled(configuration, "my-source", "unknown-token-store"))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("'unknown-token-store'")
+                    .hasMessageContaining(PROCESSOR_NAME);
+        }
+    }
+
+    @Nested
+    class PooledUnsetComponents {
+
+        @Test
+        void appliesUniqueTypeLevelDefaultsWhenSourceAndTokenStoreAreUnset() {
+            // given
+            StreamableEventSource typeLevelSource = mock(StreamableEventSource.class);
+            TokenStore typeLevelTokenStore = new InMemoryTokenStore();
+            var configuration = configuration(cr -> cr
+                    .registerComponent(StreamableEventSource.class, cfg -> typeLevelSource)
+                    .registerComponent(TokenStore.class, cfg -> typeLevelTokenStore)
+            );
+
+            // when
+            var result = customizePooled(configuration, null, null);
+
+            // then
+            assertThat(result.eventSource()).isSameAs(typeLevelSource);
+            assertThat(result.tokenStore()).isSameAs(typeLevelTokenStore);
+        }
+
+        @Test
+        void leavesSourceAndTokenStoreUnsetWhenNoTypeLevelDefaultsArePresent() {
+            // given - only named components are registered
+            var configuration = configuration(cr -> cr
+                    .registerComponent(StreamableEventSource.class, "named-source", cfg -> mock(StreamableEventSource.class))
+                    .registerComponent(TokenStore.class, "named-token-store", cfg -> new InMemoryTokenStore())
+            );
+
+            // when
+            var result = customizePooled(configuration, null, null);
+
+            // then
+            assertThat(result.eventSource()).isNull();
+            assertThat(result.tokenStore()).isNull();
+        }
+
+        @Test
+        void allowsASubsequentCustomizationToSupplySourceAndTokenStoreWhenSettingsAreUnset() {
+            // given
+            StreamableEventSource definitionSource = mock(StreamableEventSource.class);
+            TokenStore definitionTokenStore = new InMemoryTokenStore();
+            var configuration = configuration(cr -> {
+            });
+            var chained = SpringCustomizations
+                    .pooledStreamingCustomizations(PROCESSOR_NAME, new TestPooledSettings(null, null))
+                    .andThen((cfg, processorConfig) -> processorConfig.eventSource(definitionSource)
+                                                                      .tokenStore(definitionTokenStore));
+
+            // when
+            var result = chained.apply(configuration, pooledProcessorConfiguration());
+
+            // then
+            assertThat(result.eventSource()).isSameAs(definitionSource);
+            assertThat(result.tokenStore()).isSameAs(definitionTokenStore);
+        }
+    }
+
+    @Nested
+    class PooledEmptyComponentNames {
+
+        @Test
+        void treatsEmptySourceAndTokenStoreNamesAsUnset() {
+            // given
+            var configuration = configuration(cr -> cr
+                    .registerComponent(StreamableEventSource.class, "named-source", cfg -> mock(StreamableEventSource.class))
+                    .registerComponent(TokenStore.class, "named-token-store", cfg -> new InMemoryTokenStore())
+            );
+
+            // when
+            var result = customizePooled(configuration, "", "");
+
+            // then
+            assertThat(result.eventSource()).isNull();
+            assertThat(result.tokenStore()).isNull();
         }
     }
 
@@ -186,7 +320,9 @@ class SpringCustomizationsTest {
         return configurer.build();
     }
 
-    private static AxonConfiguration configurationWithoutTypeLevelSource(Consumer<ComponentRegistry> components) {
+    private static AxonConfiguration configurationWithoutTypeLevelSubscribableSource(
+            Consumer<ComponentRegistry> components
+    ) {
         MessagingConfigurer configurer = MessagingConfigurer.create();
         // without the default EventBus and classpath enhancers no type-level SubscribableEventSource is present
         configurer.componentRegistry(cr -> cr.disableEnhancerScanning()
@@ -195,19 +331,55 @@ class SpringCustomizationsTest {
         return configurer.build();
     }
 
-    private static SubscribingEventProcessorConfiguration customize(Configuration configuration,
-                                                                    @Nullable String source) {
+    private static SubscribingEventProcessorConfiguration customizeSubscribing(Configuration configuration,
+                                                                               @Nullable String source) {
         return SpringCustomizations
                 .subscribingCustomizations(PROCESSOR_NAME, new TestSubscribingSettings(source))
-                .apply(configuration, processorConfiguration());
+                .apply(configuration, subscribingProcessorConfiguration());
     }
 
-    private static SubscribingEventProcessorConfiguration processorConfiguration() {
+    private static PooledStreamingEventProcessorConfiguration customizePooled(Configuration configuration,
+                                                                              @Nullable String source,
+                                                                              @Nullable String tokenStore) {
+        return SpringCustomizations
+                .pooledStreamingCustomizations(PROCESSOR_NAME, new TestPooledSettings(source, tokenStore))
+                .apply(configuration, pooledProcessorConfiguration());
+    }
+
+    private static SubscribingEventProcessorConfiguration subscribingProcessorConfiguration() {
         return new SubscribingEventProcessorConfiguration(new EventProcessorConfiguration(PROCESSOR_NAME, null));
+    }
+
+    private static PooledStreamingEventProcessorConfiguration pooledProcessorConfiguration() {
+        return new PooledStreamingEventProcessorConfiguration(new EventProcessorConfiguration(PROCESSOR_NAME, null));
     }
 
     private record TestSubscribingSettings(@Nullable String source)
             implements EventProcessorSettings.SubscribingEventProcessorSettings {
 
+    }
+
+    private record TestPooledSettings(@Nullable String source, @Nullable String tokenStore)
+            implements EventProcessorSettings.PooledEventProcessorSettings {
+
+        @Override
+        public int initialSegmentCount() {
+            return 1;
+        }
+
+        @Override
+        public long tokenClaimIntervalInMillis() {
+            return 5000;
+        }
+
+        @Override
+        public int threadCount() {
+            return 1;
+        }
+
+        @Override
+        public int batchSize() {
+            return 1;
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -496,8 +496,12 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
     @Override
     protected void validate() throws AxonConfigurationException {
         super.validate();
-        assertNonNull(eventSource, "The StreamableEventSource is a hard requirement and should be provided");
-        assertNonNull(tokenStore, "The TokenStore is a hard requirement and should be provided");
+        assertNonNull(eventSource,
+                      "The StreamableEventSource is a hard requirement for event processor '" + processorName
+                              + "' and should be provided. Set it through this configuration's eventSource method.");
+        assertNonNull(tokenStore,
+                      "The TokenStore is a hard requirement for event processor '" + processorName
+                              + "' and should be provided. Set it through this configuration's tokenStore method.");
         assertNonNull(unitOfWorkFactory, "The UnitOfWorkFactory is a hard requirement and should be provided");
         assertNonNull(
                 coordinatorExecutor,

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.MessageHandlerInterceptor;
@@ -48,6 +49,7 @@ import org.axonframework.messaging.eventstreaming.StreamableEventSource;
 import org.junit.jupiter.api.*;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -57,6 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 /**
@@ -709,6 +712,44 @@ class PooledStreamingEventProcessorModuleTest {
             assertThat(processorConfig).isNotNull();
             assertThat(customCoordinator.get()).isNotNull();
             assertThat(customWorker.get()).isNotNull();
+        }
+    }
+
+    @Nested
+    class MissingHardRequirementsValidationTest {
+
+        @Test
+        void constructingProcessorWithoutEventSourceReportsProcessorNameAndRemedies() {
+            // given
+            String processorName = "no-source-processor";
+            var configurationWithoutSource = new PooledStreamingEventProcessorConfiguration(
+                    new EventProcessorConfiguration(processorName, null)
+            );
+
+            // when / then
+            assertThatThrownBy(() -> new PooledStreamingEventProcessor(processorName,
+                                                                       List.of(),
+                                                                       configurationWithoutSource))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("event processor '" + processorName + "'")
+                    .hasMessageContaining("StreamableEventSource");
+        }
+
+        @Test
+        void constructingProcessorWithoutTokenStoreReportsProcessorNameAndRemedies() {
+            // given
+            String processorName = "no-token-store-processor";
+            var configurationWithoutTokenStore = new PooledStreamingEventProcessorConfiguration(
+                    new EventProcessorConfiguration(processorName, null)
+            ).eventSource(new AsyncInMemoryStreamableEventSource());
+
+            // when / then
+            assertThatThrownBy(() -> new PooledStreamingEventProcessor(processorName,
+                                                                       List.of(),
+                                                                       configurationWithoutTokenStore))
+                    .isInstanceOf(AxonConfigurationException.class)
+                    .hasMessageContaining("event processor '" + processorName + "'")
+                    .hasMessageContaining("TokenStore");
         }
     }
 


### PR DESCRIPTION
## Summary
- Align pooled Spring settings customization with the #4721 subscribing behavior
- Allow `EventProcessorDefinition` to supply source/token-store when settings are unset
- Improve pooled processor validation messages to name the affected processor
Fixes #4727 