### PR TITLE
[#1470] `QueryBus` and `QueryUpdateEmitter` have and-count `emit`, `complete`, and `completeExceptionally` operations

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
@@ -46,6 +46,14 @@ import java.util.function.Supplier;
 public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableComponent {
 
     /**
+     * Sentinel value returned by {@link #emitUpdateAndCount(Predicate, Supplier, ProcessingContext)},
+     * {@link #completeSubscriptionsAndCount(Predicate, ProcessingContext)}, and
+     * {@link #completeSubscriptionsExceptionallyAndCount(Predicate, Throwable, ProcessingContext)} by
+     * implementations that cannot report how many subscription queries were affected.
+     */
+    int UNKNOWN_MATCH_COUNT = -1;
+
+    /**
      * Dispatch the given {@code query} to a {@link QueryHandler}
      * {@link #subscribe(QualifiedName, QueryHandler) subscribed} to the given {@code query}'s
      * {@link MessageType#qualifiedName() query name}, returning a
@@ -140,6 +148,30 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
                                        @Nullable ProcessingContext context);
 
     /**
+     * Emits the outcome of the {@code updateSupplier} to
+     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching the given
+     * {@code queryName} and given {@code filter}, returning the number of subscription queries the update was emitted
+     * to.
+     * <p>
+     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
+     *                       will only be sent to subscription queries matching this filter
+     * @param updateSupplier the update supplier to emit for
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code filter}
+     * @param context        the processing context under which the updateSupplier is being emitted (can be
+     *                       {@code null})
+     * @return a future completing with the number of subscription queries the update was emitted to, or
+     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     */
+    default CompletableFuture<Integer> emitUpdateAndCount(Predicate<QueryMessage> filter,
+                                                          Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+                                                          @Nullable ProcessingContext context) {
+        return emitUpdate(filter, updateSupplier, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+    }
+
+    /**
      * Completes
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
      * matching the given {@code filter}.
@@ -156,6 +188,23 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      */
     CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
                                                   @Nullable ProcessingContext context);
+
+    /**
+     * Completes {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching
+     * the given {@code filter}, returning the number of subscription queries that were completed.
+     * <p>
+     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
+     *                filter will be completed
+     * @param context the processing context within which to complete subscription queries (can be {@code null})
+     * @return a future completing with the number of subscription queries that were completed, or
+     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     */
+    default CompletableFuture<Integer> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
+                                                                     @Nullable ProcessingContext context) {
+        return completeSubscriptions(filter, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+    }
 
     /**
      * Completes
@@ -177,4 +226,27 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
     CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
                                                                Throwable cause,
                                                                @Nullable ProcessingContext context);
+
+    /**
+     * Completes {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching
+     * the given {@code filter} exceptionally with the given {@code cause}, returning the number of subscription queries
+     * that were completed exceptionally.
+     * <p>
+     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
+     *                filter will be completed exceptionally
+     * @param cause   the cause of an error
+     * @param context the processing context within which to complete subscription queries exceptionally (can be
+     *                {@code null})
+     * @return a future completing with the number of subscription queries that were completed exceptionally, or
+     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     */
+    default CompletableFuture<Integer> completeSubscriptionsExceptionallyAndCount(
+            Predicate<QueryMessage> filter,
+            Throwable cause,
+            @Nullable ProcessingContext context
+    ) {
+        return completeSubscriptionsExceptionally(filter, cause, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
 
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -34,8 +35,8 @@ import java.util.function.Supplier;
  * <p>
  * Hence, queries dispatched (through either {@link #query(QueryMessage, ProcessingContext)},
  * {@link #query(QueryMessage, ProcessingContext)}, and
- * {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)}) match a subscribed query handler based
- * on "query name".
+ * {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)}) match a subscribed query handler based on "query
+ * name".
  * <p>
  * There may be multiple handlers for each query.
  *
@@ -46,26 +47,18 @@ import java.util.function.Supplier;
 public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableComponent {
 
     /**
-     * Sentinel value returned by {@link #emitUpdateAndCount(Predicate, Supplier, ProcessingContext)},
-     * {@link #completeSubscriptionsAndCount(Predicate, ProcessingContext)}, and
-     * {@link #completeSubscriptionsExceptionallyAndCount(Predicate, Throwable, ProcessingContext)} by
-     * implementations that cannot report how many subscription queries were affected.
-     */
-    int UNKNOWN_MATCH_COUNT = -1;
-
-    /**
      * Dispatch the given {@code query} to a {@link QueryHandler}
      * {@link #subscribe(QualifiedName, QueryHandler) subscribed} to the given {@code query}'s
-     * {@link MessageType#qualifiedName() query name}, returning a
-     * {@link MessageStream} of {@link QueryResponseMessage responses} to the given {@code query}.
+     * {@link MessageType#qualifiedName() query name}, returning a {@link MessageStream} of
+     * {@link QueryResponseMessage responses} to the given {@code query}.
      * <p>
      * The resulting {@code MessageStream} will contain 0, 1, or N {@link QueryResponseMessage QueryResponseMessages},
      * depending on the {@code QueryHandler} that handled the given {@code query}.
      * <p>
-     * As several {@code QueryHandlers} can be registered for the same query name, this method will
-     * loop through them (in insert order) until one has a suitable return value. A suitable response is any value or
-     * user exception returned from a {@code QueryHandler}. When no handlers are available that can answer the given
-     * {@code query}, the returned {@code MessageStream} will have {@link MessageStream#failed(Throwable) failed} with a
+     * As several {@code QueryHandlers} can be registered for the same query name, this method will loop through them
+     * (in insert order) until one has a suitable return value. A suitable response is any value or user exception
+     * returned from a {@code QueryHandler}. When no handlers are available that can answer the given {@code query}, the
+     * returned {@code MessageStream} will have {@link MessageStream#failed(Throwable) failed} with a
      * {@link NoHandlerForQueryException}.
      *
      * @param query   the query to dispatch
@@ -80,8 +73,8 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * Dispatch the given {@code query} to a single QueryHandler subscribed to the given {@code query}'s
      * queryName/initialResponseType/updateResponseType. The result is lazily created and there will be no execution of
      * the query handler before there is a subscription to the initial result. In order not to miss update, the query
-     * bus will queue all update which happen after the subscription query is done and once the subscription to the
-     * flux is made, these update will be emitted.
+     * bus will queue all update which happen after the subscription query is done and once the subscription to the flux
+     * is made, these update will be emitted.
      * <p>
      * If there is an error during retrieving or consuming initial result, stream for incremental update is NOT
      * interrupted.
@@ -106,11 +99,11 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
                                                           int updateBufferSize);
 
     /**
-     * Subscribes the given {@code query} with the given {@code updateBufferSize}, and returns the MessageStream
-     * that provides the update of the subscription query.
+     * Subscribes the given {@code query} with the given {@code updateBufferSize}, and returns the MessageStream that
+     * provides the update of the subscription query.
      * <p>
-     * Can be used directly instead when fine-grained control of update handlers is required. If using the
-     * update directly is not mandatory for your use case, we strongly recommend using
+     * Can be used directly instead when fine-grained control of update handlers is required. If using the update
+     * directly is not mandatory for your use case, we strongly recommend using
      * {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)} instead.
      * <p>
      * Note that the returned MessageStream must be consumed from before the buffer fills up. Once the buffer is full,
@@ -131,14 +124,14 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
 
     /**
      * Emits the outcome of the {@code updateSupplier} to
-     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
-     * matching the given {@code queryName} and given {@code filter}.
+     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching the given
+     * {@code queryName} and given {@code filter}.
      *
-     * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The
-     *                       {@code updateSupplier} will only be sent to subscription queries matching this filter
+     * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
+     *                       will only be sent to subscription queries matching this filter
      * @param updateSupplier the update supplier to emit for
-     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
-     *                       subscription queries} matching the given {@code filter}
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code filter}
      * @param context        the processing context under which the updateSupplier is being emitted (can be
      *                       {@code null})
      * @return a future completing whenever the updateSupplier has been emitted
@@ -153,7 +146,7 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * {@code queryName} and given {@code filter}, returning the number of subscription queries the update was emitted
      * to.
      * <p>
-     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
      *                       will only be sent to subscription queries matching this filter
@@ -162,29 +155,28 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      *                       queries} matching the given {@code filter}
      * @param context        the processing context under which the updateSupplier is being emitted (can be
      *                       {@code null})
-     * @return a future completing with the number of subscription queries the update was emitted to, or
-     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @return a future completing with the number of subscription queries the update was emitted to as an
+     * {@link OptionalInt}, which is empty when we couldn't match
      */
-    default CompletableFuture<Integer> emitUpdateAndCount(Predicate<QueryMessage> filter,
-                                                          Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
-                                                          @Nullable ProcessingContext context) {
-        return emitUpdate(filter, updateSupplier, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+    default CompletableFuture<OptionalInt> emitUpdateAndCount(Predicate<QueryMessage> filter,
+                                                              Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+                                                              @Nullable ProcessingContext context) {
+        return emitUpdate(filter, updateSupplier, context).thenApply(v -> OptionalInt.empty());
     }
 
     /**
-     * Completes
-     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
-     * matching the given {@code filter}.
+     * Completes {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching
+     * the given {@code filter}.
      * <p>
      * To be used whenever there are no subsequent update to
      * {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emit} left.
      *
-     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription
-     *                queries matching this filter will be completed
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
+     *                filter will be completed
      * @param context the processing context within which to complete subscription queries (can be {@code null})
      * @return a future completing whenever all matching
-     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have
-     * been completed
+     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have been
+     * completed
      */
     CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
                                                   @Nullable ProcessingContext context);
@@ -193,35 +185,34 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * Completes {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching
      * the given {@code filter}, returning the number of subscription queries that were completed.
      * <p>
-     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed
      * @param context the processing context within which to complete subscription queries (can be {@code null})
-     * @return a future completing with the number of subscription queries that were completed, or
-     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @return a future completing with the number of subscription queries that were completed as an
+     * {@link OptionalInt}, which is empty when we couldn't match
      */
-    default CompletableFuture<Integer> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
-                                                                     @Nullable ProcessingContext context) {
-        return completeSubscriptions(filter, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+    default CompletableFuture<OptionalInt> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
+                                                                         @Nullable ProcessingContext context) {
+        return completeSubscriptions(filter, context).thenApply(v -> OptionalInt.empty());
     }
 
     /**
-     * Completes
-     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
-     * matching the given {@code filter} exceptionally with the given {@code cause}.
+     * Completes {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching
+     * the given {@code filter} exceptionally with the given {@code cause}.
      * <p>
-     * To be used whenever {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emitting update} should be
-     * stopped due to some exception.
+     * To be used whenever {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emitting update} should be stopped
+     * due to some exception.
      *
-     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription
-     *                queries matching this filter will be completed exceptionally
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
+     *                filter will be completed exceptionally
      * @param cause   the cause of an error
      * @param context the processing context within which to complete subscription queries exceptionally (can be
      *                {@code null})
      * @return a future completing whenever all matching
-     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have
-     * been completed exceptionally
+     * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have been completed
+     * exceptionally
      */
     CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
                                                                Throwable cause,
@@ -232,21 +223,21 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * the given {@code filter} exceptionally with the given {@code cause}, returning the number of subscription queries
      * that were completed exceptionally.
      * <p>
-     * Implementations that cannot determine this number return {@link #UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed exceptionally
      * @param cause   the cause of an error
      * @param context the processing context within which to complete subscription queries exceptionally (can be
      *                {@code null})
-     * @return a future completing with the number of subscription queries that were completed exceptionally, or
-     * {@link #UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @return a future completing with the number of subscription queries that were completed exceptionally as an
+     * {@link OptionalInt}, which is empty when we couldn't match
      */
-    default CompletableFuture<Integer> completeSubscriptionsExceptionallyAndCount(
+    default CompletableFuture<OptionalInt> completeSubscriptionsExceptionallyAndCount(
             Predicate<QueryMessage> filter,
             Throwable cause,
             @Nullable ProcessingContext context
     ) {
-        return completeSubscriptionsExceptionally(filter, cause, context).thenApply(v -> UNKNOWN_MATCH_COUNT);
+        return completeSubscriptionsExceptionally(filter, cause, context).thenApply(v -> OptionalInt.empty());
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
@@ -15,12 +15,12 @@
  */
 package org.axonframework.messaging.queryhandling;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
  *
  * @author Marc Gathier
  * @author Allard Buijze
- * @since 3.1
+ * @since 3.1.0
  */
 public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableComponent {
 
@@ -68,11 +68,11 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * {@code query}, the returned {@code MessageStream} will have {@link MessageStream#failed(Throwable) failed} with a
      * {@link NoHandlerForQueryException}.
      *
-     * @param query   The query to dispatch.
-     * @param context The processing context under which the query is being published (can be {@code null}).
-     * @return A {@code MessageStream} containing either 0, 1, or N {@link QueryResponseMessage QueryResponseMessages}.
-     * @throws NoHandlerForQueryException When no {@link QueryHandler} is registered for the given {@code query}'s
-     *                                    {@link MessageType#qualifiedName() query name}.
+     * @param query   the query to dispatch
+     * @param context the processing context under which the query is being published (can be {@code null})
+     * @return a {@code MessageStream} containing either 0, 1, or N {@link QueryResponseMessage QueryResponseMessages}
+     * @throws NoHandlerForQueryException when no {@link QueryHandler} is registered for the given {@code query}'s
+     *                                    {@link MessageType#qualifiedName() query name}
      */
     MessageStream<QueryResponseMessage> query(QueryMessage query, @Nullable ProcessingContext context);
 
@@ -94,12 +94,12 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * {@link SubscriptionQueryAlreadyRegisteredException} instead of throwing the exception. This allows callers to
      * handle double subscription scenarios gracefully through the stream API.
      *
-     * @param query            The subscription query to dispatch.
-     * @param context          The processing context under which the query is being published (can be {@code null}).
-     * @param updateBufferSize The size of the buffer which accumulates update.
+     * @param query            the subscription query to dispatch
+     * @param context          the processing context under which the query is being published (can be {@code null})
+     * @param updateBufferSize the size of the buffer which accumulates update
      * @return query result containing initial result and incremental update, or a failed {@link MessageStream} with
      * {@link SubscriptionQueryAlreadyRegisteredException} if a subscription with the same query identifier already
-     * exists.
+     * exists
      */
     MessageStream<QueryResponseMessage> subscriptionQuery(QueryMessage query,
                                                           @Nullable ProcessingContext context,
@@ -120,11 +120,11 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * {@link MessageStream} will be {@link MessageStream#failed(Throwable) failed} with a
      * {@link SubscriptionQueryAlreadyRegisteredException} instead of throwing the exception.
      *
-     * @param query            The subscription query for which we register an update handler.
-     * @param updateBufferSize The size of the buffer that accumulates update.
+     * @param query            the subscription query for which we register an update handler
+     * @param updateBufferSize the size of the buffer that accumulates update
      * @return a MessageStream of update for the given subscription query, or a failed {@link MessageStream} with
      * {@link SubscriptionQueryAlreadyRegisteredException} if a subscription with the same query identifier already
-     * exists.
+     * exists
      */
     MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(QueryMessage query,
                                                                      int updateBufferSize);
@@ -134,14 +134,14 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
      * matching the given {@code queryName} and given {@code filter}.
      *
-     * @param filter         A predicate filtering on {@link QueryMessage QueryMessages}. The
-     *                       {@code updateSupplier} will only be sent to subscription queries matching this filter.
-     * @param updateSupplier The update supplier to emit for
+     * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The
+     *                       {@code updateSupplier} will only be sent to subscription queries matching this filter
+     * @param updateSupplier the update supplier to emit for
      *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
-     *                       subscription queries} matching the given {@code filter}.
-     * @param context        The processing context under which the updateSupplier is being emitted (can be
-     *                       {@code null}).
-     * @return A future completing whenever the updateSupplier has been emitted.
+     *                       subscription queries} matching the given {@code filter}
+     * @param context        the processing context under which the updateSupplier is being emitted (can be
+     *                       {@code null})
+     * @return a future completing whenever the updateSupplier has been emitted
      */
     CompletableFuture<Void> emitUpdate(Predicate<QueryMessage> filter,
                                        Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
@@ -179,12 +179,12 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * To be used whenever there are no subsequent update to
      * {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emit} left.
      *
-     * @param filter  A predicate filtering on {@link QueryMessage QueryMessages}. Subscription
-     *                queries matching this filter will be completed.
-     * @param context The processing context within which to complete subscription queries (can be {@code null}).
-     * @return A future completing whenever all matching
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription
+     *                queries matching this filter will be completed
+     * @param context the processing context within which to complete subscription queries (can be {@code null})
+     * @return a future completing whenever all matching
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have
-     * been completed.
+     * been completed
      */
     CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
                                                   @Nullable ProcessingContext context);
@@ -214,14 +214,14 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * To be used whenever {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emitting update} should be
      * stopped due to some exception.
      *
-     * @param filter  A predicate filtering on {@link QueryMessage QueryMessages}. Subscription
-     *                queries matching this filter will be completed exceptionally.
+     * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription
+     *                queries matching this filter will be completed exceptionally
      * @param cause   the cause of an error
-     * @param context The processing context within which to complete subscription queries exceptionally (can be
-     *                {@code null}).
-     * @return A future completing whenever all matching
+     * @param context the processing context within which to complete subscription queries exceptionally (can be
+     *                {@code null})
+     * @return a future completing whenever all matching
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have
-     * been completed exceptionally.
+     * been completed exceptionally
      */
     CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
                                                                Throwable cause,

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -30,6 +30,8 @@ import org.jspecify.annotations.Nullable;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.axonframework.messaging.queryhandling.QueryBus.UNKNOWN_MATCH_COUNT;
+
 /**
  * Query-specific component that interacts with
  * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} about
@@ -123,6 +125,34 @@ public interface QueryUpdateEmitter extends DescribableComponent {
                   Supplier<Object> updateSupplier);
 
     /**
+     * Emits the outcome of the {@code updateSupplier} to subscription queries matching the given {@code queryType} and
+     * given {@code filter}, returning the number of subscription queries the update was emitted to.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryType      the type of the {@link QueryMessage} to filter on
+     * @param filter         a predicate to filter matching subscription queries based on the
+     *                       {@link QueryMessage#payload()} converted to the given {@code queryType}
+     * @param updateSupplier the update supplier to emit for
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code queryType} and {@code filter}
+     * @param <Q>            the type of the {@link QueryMessage} to filter on
+     * @return the number of subscription queries the update was emitted to, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if
+     * this implementation cannot determine that number
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
+     */
+    default <Q> int emitAndCount(Class<Q> queryType,
+                                 Predicate<? super Q> filter,
+                                 Supplier<Object> updateSupplier) {
+        emit(queryType, filter, updateSupplier);
+        return UNKNOWN_MATCH_COUNT;
+    }
+
+    /**
      * Emits given {@code update} to subscription queries matching the given {@code queryName} and given
      * {@code filter}.
      *
@@ -155,6 +185,28 @@ public interface QueryUpdateEmitter extends DescribableComponent {
               Supplier<Object> updateSupplier);
 
     /**
+     * Emits the outcome of the {@code updateSupplier} to subscription queries matching the given {@code queryName} and
+     * given {@code filter}, returning the number of subscription queries the update was emitted to.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryName      the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter         a predicate to filter matching subscription queries based on the raw
+     *                       {@link QueryMessage#payload()}
+     * @param updateSupplier the update supplier to emit for
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code queryName} and {@code filter}
+     * @return the number of subscription queries the update was emitted to, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if
+     * this implementation cannot determine that number
+     */
+    default int emitAndCount(QualifiedName queryName,
+                             Predicate<Object> filter,
+                             Supplier<Object> updateSupplier) {
+        emit(queryName, filter, updateSupplier);
+        return UNKNOWN_MATCH_COUNT;
+    }
+
+    /**
      * Completes subscription queries matching the given {@code queryType} and {@code filter}.
      *
      * @param queryType The type of the {@link QueryMessage} to filter on.
@@ -174,12 +226,51 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     <Q> void complete(Class<Q> queryType, Predicate<? super Q> filter);
 
     /**
+     * Completes subscription queries matching the given {@code queryType} and {@code filter}, returning the number of
+     * subscription queries that were completed.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryType the type of the {@link QueryMessage} to filter on.
+     * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}
+     * @param <Q>       the type of the {@link QueryMessage} to filter on.
+     * @return the number of subscription queries that were completed, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if this
+     * implementation cannot determine that number
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
+     */
+    default <Q> int completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
+        complete(queryType, filter);
+        return UNKNOWN_MATCH_COUNT;
+    }
+
+    /**
      * Completes subscription queries matching the given {@code queryName} and {@code filter}.
      *
      * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
      * @param filter    A predicate testing the raw {@link QueryMessage#payload()} as is.
      */
     void complete(QualifiedName queryName, Predicate<Object> filter);
+
+    /**
+     * Completes subscription queries matching the given {@code queryName} and {@code filter}, returning the number of
+     * subscription queries that were completed.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter    a predicate testing the raw {@link QueryMessage#payload()} as is
+     * @return the number of subscription queries that were completed, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if this
+     * implementation cannot determine that number
+     */
+    default int completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
+        complete(queryName, filter);
+        return UNKNOWN_MATCH_COUNT;
+    }
 
     /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryType} and {@code filter}.
@@ -204,6 +295,32 @@ public interface QueryUpdateEmitter extends DescribableComponent {
                                    Throwable cause);
 
     /**
+     * Completes subscription queries with the given {@code cause} matching given {@code queryType} and {@code filter},
+     * returning the number of subscription queries that were completed exceptionally.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryType the type of the {@link QueryMessage} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}
+     * @param cause     the cause of an error leading to exceptionally complete subscription queries
+     * @param <Q>       the type of the {@link QueryMessage} to filter on
+     * @return the number of subscription queries that were completed exceptionally, or
+     * {@link QueryBus#UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
+     */
+    default <Q> int completeExceptionallyAndCount(Class<Q> queryType,
+                                                  Predicate<? super Q> filter,
+                                                  Throwable cause) {
+        completeExceptionally(queryType, filter, cause);
+        return UNKNOWN_MATCH_COUNT;
+    }
+
+    /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryName} and {@code filter}.
      *
      * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
@@ -214,4 +331,24 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     void completeExceptionally(QualifiedName queryName,
                                Predicate<Object> filter,
                                Throwable cause);
+
+    /**
+     * Completes subscription queries with the given {@code cause} matching given {@code queryName} and {@code filter},
+     * returning the number of subscription queries that were completed exceptionally.
+     * <p>
+     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     *
+     * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the raw
+     *                  {@link QueryMessage#payload()}
+     * @param cause     the cause of an error leading to exceptionally complete subscription queries
+     * @return the number of subscription queries that were completed exceptionally, or
+     * {@link QueryBus#UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     */
+    default int completeExceptionallyAndCount(QualifiedName queryName,
+                                              Predicate<Object> filter,
+                                              Throwable cause) {
+        completeExceptionally(queryName, filter, cause);
+        return UNKNOWN_MATCH_COUNT;
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -27,10 +27,9 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandler;
 import org.jspecify.annotations.Nullable;
 
+import java.util.OptionalInt;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-
-import static org.axonframework.messaging.queryhandling.QueryBus.UNKNOWN_MATCH_COUNT;
 
 /**
  * Query-specific component that interacts with
@@ -129,19 +128,19 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
      *                       queries} matching the given {@code queryType} and {@code filter}
      * @param <Q>            the type of the {@link QueryMessage} to filter on
-     * @return the number of subscription queries the update was emitted to, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if
-     * this implementation cannot determine that number
+     * @return the number of subscription queries the update was emitted to as an {@link OptionalInt}, which is empty
+     * when we couldn't match
      * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
      *                                         equivalent required to filter the {@link QueryMessage#payload()}
      * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
      *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
      *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
-    default <Q> int emitAndCount(Class<Q> queryType,
-                                 Predicate<? super Q> filter,
-                                 Supplier<Object> updateSupplier) {
+    default <Q> OptionalInt emitAndCount(Class<Q> queryType,
+                                         Predicate<? super Q> filter,
+                                         Supplier<Object> updateSupplier) {
         emit(queryType, filter, updateSupplier);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 
     /**
@@ -188,14 +187,14 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * @param updateSupplier the update supplier to emit for
      *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
      *                       queries} matching the given {@code queryName} and {@code filter}
-     * @return the number of subscription queries the update was emitted to, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if
-     * this implementation cannot determine that number
+     * @return the number of subscription queries the update was emitted to as an {@link OptionalInt}, which is empty
+     * when we couldn't match
      */
-    default int emitAndCount(QualifiedName queryName,
-                             Predicate<Object> filter,
-                             Supplier<Object> updateSupplier) {
+    default OptionalInt emitAndCount(QualifiedName queryName,
+                                     Predicate<Object> filter,
+                                     Supplier<Object> updateSupplier) {
         emit(queryName, filter, updateSupplier);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 
     /**
@@ -223,17 +222,17 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
      *                  converted to the given {@code queryType}
      * @param <Q>       the type of the {@link QueryMessage} to filter on.
-     * @return the number of subscription queries that were completed, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if this
-     * implementation cannot determine that number
+     * @return the number of subscription queries that were completed as an {@link OptionalInt}, which is empty when we
+     * couldn't match
      * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
      *                                         equivalent required to filter the {@link QueryMessage#payload()}
      * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
      *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
      *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
-    default <Q> int completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
+    default <Q> OptionalInt completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
         complete(queryType, filter);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 
     /**
@@ -252,12 +251,12 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      *
      * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter    a predicate testing the raw {@link QueryMessage#payload()} as is
-     * @return the number of subscription queries that were completed, or {@link QueryBus#UNKNOWN_MATCH_COUNT} if this
-     * implementation cannot determine that number
+     * @return the number of subscription queries that were completed as an {@link OptionalInt}, which is empty when we
+     * couldn't match
      */
-    default int completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
+    default OptionalInt completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
         complete(queryName, filter);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 
     /**
@@ -289,19 +288,19 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      *                  converted to the given {@code queryType}
      * @param cause     the cause of an error leading to exceptionally complete subscription queries
      * @param <Q>       the type of the {@link QueryMessage} to filter on
-     * @return the number of subscription queries that were completed exceptionally, or
-     * {@link QueryBus#UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @return the number of subscription queries that were completed exceptionally as an {@link OptionalInt}, which is
+     * empty when we couldn't match
      * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
      *                                         equivalent required to filter the {@link QueryMessage#payload()}
      * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
      *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
      *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
-    default <Q> int completeExceptionallyAndCount(Class<Q> queryType,
-                                                  Predicate<? super Q> filter,
-                                                  Throwable cause) {
+    default <Q> OptionalInt completeExceptionallyAndCount(Class<Q> queryType,
+                                                          Predicate<? super Q> filter,
+                                                          Throwable cause) {
         completeExceptionally(queryType, filter, cause);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 
     /**
@@ -326,13 +325,13 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * @param filter    a predicate to filter matching subscription queries based on the raw
      *                  {@link QueryMessage#payload()}
      * @param cause     the cause of an error leading to exceptionally complete subscription queries
-     * @return the number of subscription queries that were completed exceptionally, or
-     * {@link QueryBus#UNKNOWN_MATCH_COUNT} if this implementation cannot determine that number
+     * @return the number of subscription queries that were completed exceptionally as an {@link OptionalInt}, which is
+     * empty when we couldn't match
      */
-    default int completeExceptionallyAndCount(QualifiedName queryName,
-                                              Predicate<Object> filter,
-                                              Throwable cause) {
+    default OptionalInt completeExceptionallyAndCount(QualifiedName queryName,
+                                                      Predicate<Object> filter,
+                                                      Throwable cause) {
         completeExceptionally(queryName, filter, cause);
-        return UNKNOWN_MATCH_COUNT;
+        return OptionalInt.empty();
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -51,17 +51,17 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Creates a query update emitter for the given {@link ProcessingContext}.
      * <p>
-     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead
-     * of emitting directly through a {@link QueryBus}: the emitter returned here is bound to that {@code context},
+     * Use this from within a message handler, or any other method that receives a {@link ProcessingContext}, instead of
+     * emitting directly through a {@link QueryBus}: the emitter returned here is bound to that {@code context},
      * ensuring updates are emitted in the correct order relative to the lifecycle of whatever is currently being
      * handled.
      * <p>
-     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may
-     * override resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an
-     * instance across such branches would risk it silently operating against the wrong one.
+     * Every invocation returns a fresh instance bound to the given {@code context}, since {@code context} may override
+     * resources on top of a shared parent (see {@link ProcessingContext#withResource}) - reusing an instance across
+     * such branches would risk it silently operating against the wrong one.
      *
-     * @param context The {@link ProcessingContext} to create the emitter for.
-     * @return A fresh emitter specific for the given {@code context}.
+     * @param context the {@link ProcessingContext} to create the emitter for
+     * @return a fresh emitter specific for the given {@code context}
      */
     static QueryUpdateEmitter forContext(ProcessingContext context) {
         return new SimpleQueryUpdateEmitter(
@@ -76,22 +76,18 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits given {@code update} to subscription queries matching the given {@code queryType} and given
      * {@code filter}.
      *
-     * @param queryType The type of the {@link QueryMessage} to filter on.
-     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
-     *                  converted to the given {@code queryType}.
-     * @param update    The incremental update to emit for
-     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
-     *                  queries} matching the given {@code filter}.
-     * @param <Q>       The type of the {@link QueryMessage} to filter on.
-     * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
-     *                                                             {@link MessageType}
-     *                                                             equivalent required to filter the
-     *                                                             {@link QueryMessage#payload()}.
-     * @throws ConversionException If the {@link QueryMessage#payload()}
-     *                                                             could not be converted to the given {@code queryType}
-     *                                                             to perform the given {@code filter}. Will only occur
-     *                                                             if a {@link MessageType}
-     *                                                             could be found for the given {@code queryType}.
+     * @param queryType the type of the {@link QueryMessage} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     *                  converted to the given {@code queryType}
+     * @param update    the incremental update to emit for
+     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
+     *                  matching the given {@code filter}
+     * @param <Q>       the type of the {@link QueryMessage} to filter on
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
     default <Q> void emit(Class<Q> queryType, Predicate<? super Q> filter, @Nullable Object update) {
         emit(queryType, filter, () -> update);
@@ -103,22 +99,18 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * <p>
      * The {@code updateSupplier} is only invoked whenever there are matching queries.
      *
-     * @param queryType      The type of the {@link QueryMessage} to filter on.
-     * @param filter         A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
-     *                       converted to the given {@code queryType}
-     * @param updateSupplier The update supplier to emit for
-     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
-     *                       subscription queries} matching the given {@code queryType} and {@code filter}.
-     * @param <Q>            The type of the {@link QueryMessage} to filter on.
-     * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
-     *                                                             {@link MessageType}
-     *                                                             equivalent required to filter the
-     *                                                             {@link QueryMessage#payload()}.
-     * @throws ConversionException If the {@link QueryMessage#payload()}
-     *                                                             could not be converted to the given {@code queryType}
-     *                                                             to perform the given {@code filter}. Will only occur
-     *                                                             if a {@link MessageType}
-     *                                                             could be found for the given {@code queryType}.
+     * @param queryType      the type of the {@link QueryMessage} to filter on
+     * @param filter         a predicate to filter matching subscription queries based on the
+     *                       {@link QueryMessage#payload()} converted to the given {@code queryType}
+     * @param updateSupplier the update supplier to emit for
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code queryType} and {@code filter}
+     * @param <Q>            the type of the {@link QueryMessage} to filter on
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
     <Q> void emit(Class<Q> queryType,
                   Predicate<? super Q> filter,
@@ -156,12 +148,12 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits given {@code update} to subscription queries matching the given {@code queryName} and given
      * {@code filter}.
      *
-     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
-     * @param filter    A predicate to filter matching subscription queries based on the raw
-     *                  {@link QueryMessage#payload()}.
-     * @param update    The incremental update to emit for
-     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
-     *                  queries} matching the given {@code filter}.
+     * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the raw
+     *                  {@link QueryMessage#payload()}
+     * @param update    the incremental update to emit for
+     *                  {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries}
+     *                  matching the given {@code filter}
      */
     default void emit(QualifiedName queryName, Predicate<Object> filter, @Nullable Object update) {
         emit(queryName, filter, () -> update);
@@ -173,12 +165,12 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * <p>
      * The {@code updateSupplier} is only invoked whenever there are matching queries.
      *
-     * @param queryName      The qualified name of the {@link QueryMessage#type()} to filter on.
-     * @param filter         A predicate to filter matching subscription queries based on the raw
-     *                       {@link QueryMessage#payload()}.
-     * @param updateSupplier The update supplier to emit for
-     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
-     *                       subscription queries} matching the given {@code queryName} and {@code filter}.
+     * @param queryName      the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter         a predicate to filter matching subscription queries based on the raw
+     *                       {@link QueryMessage#payload()}
+     * @param updateSupplier the update supplier to emit for
+     *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
+     *                       queries} matching the given {@code queryName} and {@code filter}
      */
     void emit(QualifiedName queryName,
               Predicate<Object> filter,
@@ -209,19 +201,15 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries matching the given {@code queryType} and {@code filter}.
      *
-     * @param queryType The type of the {@link QueryMessage} to filter on.
-     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     * @param queryType the type of the {@link QueryMessage} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
      *                  converted to the given {@code queryType}
-     * @param <Q>       The type of the {@link QueryMessage} to filter on.
-     * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
-     *                                                             {@link MessageType}
-     *                                                             equivalent required to filter the
-     *                                                             {@link QueryMessage#payload()}.
-     * @throws ConversionException If the {@link QueryMessage#payload()}
-     *                                                             could not be converted to the given {@code queryType}
-     *                                                             to perform the given {@code filter}. Will only occur
-     *                                                             if a {@link MessageType}
-     *                                                             could be found for the given {@code queryType}.
+     * @param <Q>       the type of the {@link QueryMessage} to filter on
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
     <Q> void complete(Class<Q> queryType, Predicate<? super Q> filter);
 
@@ -251,8 +239,8 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries matching the given {@code queryName} and {@code filter}.
      *
-     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
-     * @param filter    A predicate testing the raw {@link QueryMessage#payload()} as is.
+     * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter    a predicate testing the raw {@link QueryMessage#payload()} as is
      */
     void complete(QualifiedName queryName, Predicate<Object> filter);
 
@@ -275,20 +263,16 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryType} and {@code filter}.
      *
-     * @param queryType The type of the {@link QueryMessage} to filter on.
-     * @param filter    A predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
+     * @param queryType the type of the {@link QueryMessage} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
      *                  converted to the given {@code queryType}
-     * @param cause     The cause of an error leading to exceptionally complete subscription queries.
-     * @param <Q>       The type of the {@link QueryMessage} to filter on.
-     * @throws MessageTypeNotResolvedException                     If the given {@code queryType} has no known
-     *                                                             {@link MessageType}
-     *                                                             equivalent required to filter the
-     *                                                             {@link QueryMessage#payload()}.
-     * @throws ConversionException If the {@link QueryMessage#payload()}
-     *                                                             could not be converted to the given {@code queryType}
-     *                                                             to perform the given {@code filter}. Will only occur
-     *                                                             if a {@link MessageType}
-     *                                                             could be found for the given {@code queryType}.
+     * @param cause     the cause of an error leading to exceptionally complete subscription queries
+     * @param <Q>       the type of the {@link QueryMessage} to filter on
+     * @throws MessageTypeNotResolvedException if the given {@code queryType} has no known {@link MessageType}
+     *                                         equivalent required to filter the {@link QueryMessage#payload()}
+     * @throws ConversionException             if the {@link QueryMessage#payload()} could not be converted to the given
+     *                                         {@code queryType} to perform the given {@code filter}. Will only occur if
+     *                                         a {@link MessageType} could be found for the given {@code queryType}
      */
     <Q> void completeExceptionally(Class<Q> queryType,
                                    Predicate<? super Q> filter,
@@ -323,10 +307,10 @@ public interface QueryUpdateEmitter extends DescribableComponent {
     /**
      * Completes subscription queries with the given {@code cause} matching given {@code queryName} and {@code filter}.
      *
-     * @param queryName The qualified name of the {@link QueryMessage#type()} to filter on.
-     * @param filter    A predicate to filter matching subscription queries based on the raw
-     *                  {@link QueryMessage#payload()}.
-     * @param cause     The cause of an error leading to exceptionally complete subscription queries.
+     * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
+     * @param filter    a predicate to filter matching subscription queries based on the raw
+     *                  {@link QueryMessage#payload()}
+     * @param cause     the cause of an error leading to exceptionally complete subscription queries
      */
     void completeExceptionally(QualifiedName queryName,
                                Predicate<Object> filter,

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -15,7 +15,6 @@
  */
 package org.axonframework.messaging.queryhandling;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.FutureUtils;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Context;
@@ -26,6 +25,7 @@ import org.axonframework.messaging.core.QueueMessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,15 +44,13 @@ import java.util.stream.Collectors;
 
 /**
  * Implementation of the {@code QueryBus} that dispatches queries (through
- * {@link #query(QueryMessage, ProcessingContext)} or
- * {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)}) to the
- * {@link QueryHandler QueryHandlers} subscribed to that specific query's {@link QualifiedName name} and
+ * {@link #query(QueryMessage, ProcessingContext)} or {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)})
+ * to the {@link QueryHandler QueryHandlers} subscribed to that specific query's {@link QualifiedName name} and
  * {@link QualifiedName response type} combination.
  * <p>
  * Allows fine-grained control over
  * {@link #subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} through
- * {@link #subscribeToUpdates(QueryMessage, int)},
- * {@link #emitUpdate(Predicate, Supplier, ProcessingContext)},
+ * {@link #subscribeToUpdates(QueryMessage, int)}, {@link #emitUpdate(Predicate, Supplier, ProcessingContext)},
  * {@link #completeSubscriptions(Predicate, ProcessingContext)}, and
  * {@link #completeSubscriptionsExceptionally(Predicate, Throwable, ProcessingContext)}.
  * <p>
@@ -78,9 +77,8 @@ public class SimpleQueryBus implements QueryBus {
     /**
      * Construct a {@code SimpleQueryBus} with the given {@code unitOfWorkFactory} and {@code queryUpdateEmitter}.
      *
-     * @param unitOfWorkFactory The factory constructing
-     *                          {@link UnitOfWork units of work} to dispatch and
-     *                          handle queries in.
+     * @param unitOfWorkFactory The factory constructing {@link UnitOfWork units of work} to dispatch and handle queries
+     *                          in.
      */
     public SimpleQueryBus(UnitOfWorkFactory unitOfWorkFactory) {
         this.unitOfWorkFactory = Objects.requireNonNull(unitOfWorkFactory, "The UnitOfWorkFactory must be provided.");
@@ -182,7 +180,7 @@ public class SimpleQueryBus implements QueryBus {
         return updateHandlers.keySet().stream().anyMatch(m -> m.identifier().equals(queryId));
     }
 
-        private QueryHandler handlerFor(QueryMessage query) {
+    private QueryHandler handlerFor(QueryMessage query) {
         QualifiedName handlerName = query.type().qualifiedName();
         if (!subscriptions.containsKey(handlerName)) {
             throw NoHandlerForQueryException.forBus(query);
@@ -198,9 +196,9 @@ public class SimpleQueryBus implements QueryBus {
     }
 
     @Override
-    public CompletableFuture<Integer> emitUpdateAndCount(Predicate<QueryMessage> filter,
-                                                         Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
-                                                         @Nullable ProcessingContext context) {
+    public CompletableFuture<OptionalInt> emitUpdateAndCount(Predicate<QueryMessage> filter,
+                                                             Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+                                                             @Nullable ProcessingContext context) {
         return runAfterCommitOrImmediately(context, filter, () -> emitUpdate(filter, updateSupplier));
     }
 
@@ -240,8 +238,8 @@ public class SimpleQueryBus implements QueryBus {
     }
 
     @Override
-    public CompletableFuture<Integer> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
-                                                                    @Nullable ProcessingContext context) {
+    public CompletableFuture<OptionalInt> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
+                                                                        @Nullable ProcessingContext context) {
         return runAfterCommitOrImmediately(context, filter, () -> completeSubscriptions(filter));
     }
 
@@ -270,7 +268,7 @@ public class SimpleQueryBus implements QueryBus {
     }
 
     @Override
-    public CompletableFuture<Integer> completeSubscriptionsExceptionallyAndCount(
+    public CompletableFuture<OptionalInt> completeSubscriptionsExceptionallyAndCount(
             Predicate<QueryMessage> filter,
             Throwable cause,
             @Nullable ProcessingContext context
@@ -289,17 +287,17 @@ public class SimpleQueryBus implements QueryBus {
      * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits, matching
      * {@code updateTask}'s matching subscriptions to the given {@code filter}.
      * <p>
-     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not for
-     * an already-errored {@code context}, since the update is silently dropped in that case and the {@code filter}
-     * must not observe any side effects.
+     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not for an
+     * already-errored {@code context}, since the update is silently dropped in that case and the {@code filter} must
+     * not observe any side effects.
      */
-    private CompletableFuture<Integer> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
-                                                                   Predicate<QueryMessage> filter,
-                                                                   Runnable updateTask) {
+    private CompletableFuture<OptionalInt> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
+                                                                       Predicate<QueryMessage> filter,
+                                                                       Runnable updateTask) {
         if (context == null || context.isCommitted()) {
             int matchCount = matchCount(filter);
             updateTask.run();
-            return CompletableFuture.completedFuture(matchCount);
+            return CompletableFuture.completedFuture(OptionalInt.of(matchCount));
         } else if (!context.isCompleted()) {
             int matchCount = matchCount(filter);
             context.computeResourceIfAbsent(
@@ -311,10 +309,10 @@ public class SimpleQueryBus implements QueryBus {
                            }
                    )
                    .add(updateTask);
-            return CompletableFuture.completedFuture(matchCount);
+            return CompletableFuture.completedFuture(OptionalInt.of(matchCount));
         }
         // else: context completed with error - drop the update
-        return CompletableFuture.completedFuture(0);
+        return CompletableFuture.completedFuture(OptionalInt.empty());
     }
 
     private int matchCount(Predicate<QueryMessage> filter) {

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -194,7 +194,14 @@ public class SimpleQueryBus implements QueryBus {
     public CompletableFuture<Void> emitUpdate(Predicate<QueryMessage> filter,
                                               Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
                                               @Nullable ProcessingContext context) {
-        return runAfterCommitOrImmediately(context, () -> emitUpdate(filter, updateSupplier));
+        return emitUpdateAndCount(filter, updateSupplier, context).thenApply(FutureUtils::ignoreResult);
+    }
+
+    @Override
+    public CompletableFuture<Integer> emitUpdateAndCount(Predicate<QueryMessage> filter,
+                                                         Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+                                                         @Nullable ProcessingContext context) {
+        return runAfterCommitOrImmediately(context, filter, () -> emitUpdate(filter, updateSupplier));
     }
 
     private void emitUpdate(Predicate<QueryMessage> filter,
@@ -229,7 +236,13 @@ public class SimpleQueryBus implements QueryBus {
     @Override
     public CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
                                                          @Nullable ProcessingContext context) {
-        return runAfterCommitOrImmediately(context, () -> completeSubscriptions(filter));
+        return completeSubscriptionsAndCount(filter, context).thenApply(FutureUtils::ignoreResult);
+    }
+
+    @Override
+    public CompletableFuture<Integer> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
+                                                                    @Nullable ProcessingContext context) {
+        return runAfterCommitOrImmediately(context, filter, () -> completeSubscriptions(filter));
     }
 
     private void completeSubscriptions(Predicate<QueryMessage> filter) {
@@ -253,7 +266,16 @@ public class SimpleQueryBus implements QueryBus {
             Throwable cause,
             @Nullable ProcessingContext context
     ) {
-        return runAfterCommitOrImmediately(context, () -> completeSubscriptionsExceptionally(filter, cause));
+        return completeSubscriptionsExceptionallyAndCount(filter, cause, context).thenApply(FutureUtils::ignoreResult);
+    }
+
+    @Override
+    public CompletableFuture<Integer> completeSubscriptionsExceptionallyAndCount(
+            Predicate<QueryMessage> filter,
+            Throwable cause,
+            @Nullable ProcessingContext context
+    ) {
+        return runAfterCommitOrImmediately(context, filter, () -> completeSubscriptionsExceptionally(filter, cause));
     }
 
     private void completeSubscriptionsExceptionally(Predicate<QueryMessage> filter, Throwable cause) {
@@ -263,11 +285,23 @@ public class SimpleQueryBus implements QueryBus {
                       .forEach(entry -> emitError(entry.getValue(), cause, entry.getKey()));
     }
 
-    private CompletableFuture<Void> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
-                                                                Runnable updateTask) {
+    /**
+     * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits, matching
+     * {@code updateTask}'s matching subscriptions to the given {@code filter}.
+     * <p>
+     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not for
+     * an already-errored {@code context}, since the update is silently dropped in that case and the {@code filter}
+     * must not observe any side effects.
+     */
+    private CompletableFuture<Integer> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
+                                                                   Predicate<QueryMessage> filter,
+                                                                   Runnable updateTask) {
         if (context == null || context.isCommitted()) {
+            int matchCount = matchCount(filter);
             updateTask.run();
+            return CompletableFuture.completedFuture(matchCount);
         } else if (!context.isCompleted()) {
+            int matchCount = matchCount(filter);
             context.computeResourceIfAbsent(
                            UPDATE_TASKS_KEY,
                            () -> {
@@ -277,9 +311,17 @@ public class SimpleQueryBus implements QueryBus {
                            }
                    )
                    .add(updateTask);
+            return CompletableFuture.completedFuture(matchCount);
         }
         // else: context completed with error - drop the update
-        return FutureUtils.emptyCompletedFuture();
+        return CompletableFuture.completedFuture(0);
+    }
+
+    private int matchCount(Predicate<QueryMessage> filter) {
+        return (int) updateHandlers.keySet()
+                                   .stream()
+                                   .filter(filter)
+                                   .count();
     }
 
     private void emitError(QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler,

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
+import java.util.OptionalInt;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -110,9 +111,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public <Q> int emitAndCount(Class<Q> queryType,
-                                Predicate<? super Q> filter,
-                                Supplier<Object> updateSupplier) {
+    public <Q> OptionalInt emitAndCount(Class<Q> queryType,
+                                        Predicate<? super Q> filter,
+                                        Supplier<Object> updateSupplier) {
         if (logger.isDebugEnabled()) {
             logger.debug(
                     "Emitting an update to queries matching type [{}] and a given filter, returning the match count.",
@@ -139,9 +140,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public int emitAndCount(QualifiedName queryName,
-                            Predicate<Object> filter,
-                            Supplier<Object> updateSupplier) {
+    public OptionalInt emitAndCount(QualifiedName queryName,
+                                    Predicate<Object> filter,
+                                    Supplier<Object> updateSupplier) {
         if (logger.isDebugEnabled()) {
             logger.debug(
                     "Emitting an update to queries matching name [{}] and a given filter, returning the match count.",
@@ -175,7 +176,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public <Q> int completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
+    public <Q> OptionalInt completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries of type [{}], returning the match count.", queryType);
         }
@@ -195,7 +196,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public int completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
+    public OptionalInt completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries with name [{}], returning the match count.", queryName);
         }
@@ -217,9 +218,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public <Q> int completeExceptionallyAndCount(Class<Q> queryType,
-                                                 Predicate<? super Q> filter,
-                                                 Throwable cause) {
+    public <Q> OptionalInt completeExceptionallyAndCount(Class<Q> queryType,
+                                                         Predicate<? super Q> filter,
+                                                         Throwable cause) {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries of type [{}] exceptionally, returning the match count.",
                          queryType, cause);
@@ -242,9 +243,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
 
     @SuppressWarnings("DataFlowIssue")
     @Override
-    public int completeExceptionallyAndCount(QualifiedName queryName,
-                                             Predicate<Object> filter,
-                                             Throwable cause) {
+    public OptionalInt completeExceptionallyAndCount(QualifiedName queryName,
+                                                     Predicate<Object> filter,
+                                                     Throwable cause) {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries with name [{}] exceptionally, returning the match count.",
                          queryName, cause);

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
@@ -105,8 +105,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Emitting an update to queries matching type [{}] and a given filter.", queryType);
         }
-        queryBus.emitUpdate(queryTypeFilter(queryType, filter), () -> asUpdateMessage(updateSupplier.get()), context)
-                .join();
+        FutureUtils.joinAndUnwrap(queryBus.emitUpdate(queryTypeFilter(queryType, filter),
+                                                      () -> asUpdateMessage(updateSupplier.get()),
+                                                      context));
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -134,8 +135,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Emitting an update to queries matching name [{}] and a given filter.", queryName);
         }
-        queryBus.emitUpdate(queryNameFilter(queryName, filter), () -> asUpdateMessage(updateSupplier.get()), context)
-                .join();
+        FutureUtils.joinAndUnwrap(queryBus.emitUpdate(queryNameFilter(queryName, filter),
+                                                      () -> asUpdateMessage(updateSupplier.get()),
+                                                      context));
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -170,8 +172,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries of type [{}].", queryType);
         }
-        queryBus.completeSubscriptions(queryTypeFilter(queryType, filter), context)
-                .join();
+        FutureUtils.joinAndUnwrap(queryBus.completeSubscriptions(queryTypeFilter(queryType, filter), context));
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -190,8 +191,7 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries with name [{}].", queryName);
         }
-        queryBus.completeSubscriptions(queryNameFilter(queryName, filter), context)
-                .join();
+        FutureUtils.joinAndUnwrap(queryBus.completeSubscriptions(queryNameFilter(queryName, filter), context));
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -212,8 +212,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries of type [{}] exceptionally.", queryType, cause);
         }
-        queryBus.completeSubscriptionsExceptionally(queryTypeFilter(queryType, filter), cause, context)
-                .join();
+        FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsExceptionally(queryTypeFilter(queryType, filter), cause, context)
+        );
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -237,8 +238,9 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         if (logger.isDebugEnabled()) {
             logger.debug("Completing subscription queries with name [{}] exceptionally.", queryName, cause);
         }
-        queryBus.completeSubscriptionsExceptionally(queryNameFilter(queryName, filter), cause, context)
-                .join();
+        FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsExceptionally(queryNameFilter(queryName, filter), cause, context)
+        );
     }
 
     @SuppressWarnings("DataFlowIssue")

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitter.java
@@ -16,14 +16,15 @@
 
 package org.axonframework.messaging.queryhandling;
 
+import org.axonframework.common.FutureUtils;
 import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.Message;
-import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
-import org.axonframework.conversion.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,12 +62,18 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
      * The {@code messageTypeResolver} is used to construct {@link SubscriptionQueryUpdateMessage update messages} for
      * {@link #emit(Class, Predicate, Object)} invocations. Any {@link #emit(Class, Predicate, Object)} or
      * {@link #emit(QualifiedName, Predicate, Object)} is delegated to
-     * {@link QueryBus#emitUpdate(Predicate, Supplier, ProcessingContext)}. Similarly,
+     * {@link QueryBus#emitUpdate(Predicate, Supplier, ProcessingContext)}, while their match-count-returning
+     * counterparts, {@link #emitAndCount(Class, Predicate, Supplier)} and
+     * {@link #emitAndCount(QualifiedName, Predicate, Supplier)}, are delegated to
+     * {@link QueryBus#emitUpdateAndCount(Predicate, Supplier, ProcessingContext)}. Similarly,
      * {@link #complete(Class, Predicate)}/{@link #complete(QualifiedName, Predicate)} and
      * {@link #completeExceptionally(Class, Predicate, Throwable)}/{@link #completeExceptionally(QualifiedName,
      * Predicate, Throwable)} are respectively delegated to
      * {@link QueryBus#completeSubscriptions(Predicate, ProcessingContext)} and
-     * {@link QueryBus#completeSubscriptionsExceptionally(Predicate, Throwable, ProcessingContext)}.
+     * {@link QueryBus#completeSubscriptionsExceptionally(Predicate, Throwable, ProcessingContext)}, with their
+     * match-count-returning counterparts delegated to
+     * {@link QueryBus#completeSubscriptionsAndCount(Predicate, ProcessingContext)} and
+     * {@link QueryBus#completeSubscriptionsExceptionallyAndCount(Predicate, Throwable, ProcessingContext)}.
      *
      * @param queryBus            The {@code QueryBus} to delegate the {@link #emit(Class, Predicate, Object)},
      *                            {@link #complete(Class, Predicate)}, and
@@ -101,6 +108,24 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
                 .join();
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public <Q> int emitAndCount(Class<Q> queryType,
+                                Predicate<? super Q> filter,
+                                Supplier<Object> updateSupplier) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Emitting an update to queries matching type [{}] and a given filter, returning the match count.",
+                    queryType
+            );
+        }
+        return FutureUtils.joinAndUnwrap(queryBus.emitUpdateAndCount(
+                queryTypeFilter(queryType, filter),
+                () -> asUpdateMessage(updateSupplier.get()),
+                context
+        ));
+    }
+
     @Override
     public void emit(QualifiedName queryName,
                      Predicate<Object> filter,
@@ -110,6 +135,24 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         }
         queryBus.emitUpdate(queryNameFilter(queryName, filter), () -> asUpdateMessage(updateSupplier.get()), context)
                 .join();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public int emitAndCount(QualifiedName queryName,
+                            Predicate<Object> filter,
+                            Supplier<Object> updateSupplier) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Emitting an update to queries matching name [{}] and a given filter, returning the match count.",
+                    queryName
+            );
+        }
+        return FutureUtils.joinAndUnwrap(queryBus.emitUpdateAndCount(
+                queryNameFilter(queryName, filter),
+                () -> asUpdateMessage(updateSupplier.get()),
+                context
+        ));
     }
 
     private SubscriptionQueryUpdateMessage asUpdateMessage(Object update) {
@@ -130,6 +173,17 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
                 .join();
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public <Q> int completeAndCount(Class<Q> queryType, Predicate<? super Q> filter) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completing subscription queries of type [{}], returning the match count.", queryType);
+        }
+        return FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsAndCount(queryTypeFilter(queryType, filter), context)
+        );
+    }
+
     @Override
     public void complete(QualifiedName queryName, Predicate<Object> filter) {
         if (logger.isDebugEnabled()) {
@@ -137,6 +191,17 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
         }
         queryBus.completeSubscriptions(queryNameFilter(queryName, filter), context)
                 .join();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public int completeAndCount(QualifiedName queryName, Predicate<Object> filter) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completing subscription queries with name [{}], returning the match count.", queryName);
+        }
+        return FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsAndCount(queryNameFilter(queryName, filter), context)
+        );
     }
 
     @Override
@@ -150,6 +215,20 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
                 .join();
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public <Q> int completeExceptionallyAndCount(Class<Q> queryType,
+                                                 Predicate<? super Q> filter,
+                                                 Throwable cause) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completing subscription queries of type [{}] exceptionally, returning the match count.",
+                         queryType, cause);
+        }
+        return FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsExceptionallyAndCount(queryTypeFilter(queryType, filter), cause, context)
+        );
+    }
+
     @Override
     public void completeExceptionally(QualifiedName queryName,
                                       Predicate<Object> filter,
@@ -161,7 +240,21 @@ public class SimpleQueryUpdateEmitter implements QueryUpdateEmitter {
                 .join();
     }
 
-        private static Predicate<QueryMessage> queryNameFilter(QualifiedName queryName,
+    @SuppressWarnings("DataFlowIssue")
+    @Override
+    public int completeExceptionallyAndCount(QualifiedName queryName,
+                                             Predicate<Object> filter,
+                                             Throwable cause) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completing subscription queries with name [{}] exceptionally, returning the match count.",
+                         queryName, cause);
+        }
+        return FutureUtils.joinAndUnwrap(
+                queryBus.completeSubscriptionsExceptionallyAndCount(queryNameFilter(queryName, filter), cause, context)
+        );
+    }
+
+    private static Predicate<QueryMessage> queryNameFilter(QualifiedName queryName,
                                                            Predicate<Object> filter) {
         return message -> queryName.equals(message.type().qualifiedName()) && filter.test(message.payload());
     }

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -668,7 +669,10 @@ class SimpleQueryBusTest {
             testSubject.subscriptionQuery(testQueryTwo, null, Queues.SMALL_BUFFER_SIZE);
             testSubject.subscriptionQuery(testQueryThree, null, Queues.SMALL_BUFFER_SIZE);
             // when...
-            Integer matchCount = testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, null).join();
+            Integer matchCount = testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, null)
+                                            .orTimeout(1, TimeUnit.SECONDS)
+                                            .join()
+                                            .orElseThrow();
             // then...
             assertThat(matchCount).isEqualTo(2);
         }
@@ -682,7 +686,10 @@ class SimpleQueryBusTest {
             testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
             // when...
             Integer matchCount =
-                    testSubject.emitUpdateAndCount(query -> false, () -> updateMessage, null).join();
+                    testSubject.emitUpdateAndCount(query -> false, () -> updateMessage, null)
+                               .orTimeout(1, TimeUnit.SECONDS)
+                               .join()
+                               .orElseThrow();
             // then...
             assertThat(matchCount).isZero();
         }
@@ -700,10 +707,10 @@ class SimpleQueryBusTest {
             AtomicReference<Integer> matchCountRef = new AtomicReference<>();
             // when emitting on invocation, before the ProcessingContext has committed...
             uow.onInvocation(context -> {
-                CompletableFuture<Integer> matchCountFuture =
+                CompletableFuture<OptionalInt> matchCountFuture =
                         testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, context);
                 // then the match count is already available, without waiting for the after-commit phase...
-                matchCountRef.set(matchCountFuture.join());
+                matchCountRef.set(matchCountFuture.orTimeout(1, TimeUnit.SECONDS).join().orElseThrow());
                 return CompletableFuture.completedFuture(null);
             });
             uow.execute().join();
@@ -848,7 +855,10 @@ class SimpleQueryBusTest {
             testSubject.subscriptionQuery(testQueryTwo, null, Queues.SMALL_BUFFER_SIZE);
             testSubject.subscriptionQuery(testQueryThree, null, Queues.SMALL_BUFFER_SIZE);
             // when...
-            Integer matchCount = testSubject.completeSubscriptionsAndCount(queryFilter, null).join();
+            Integer matchCount = testSubject.completeSubscriptionsAndCount(queryFilter, null)
+                                            .orTimeout(1, TimeUnit.SECONDS)
+                                            .join()
+                                            .orElseThrow();
             // then...
             assertThat(matchCount).isEqualTo(2);
         }
@@ -859,7 +869,10 @@ class SimpleQueryBusTest {
             QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
             testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
             // when...
-            Integer matchCount = testSubject.completeSubscriptionsAndCount(query -> false, null).join();
+            Integer matchCount = testSubject.completeSubscriptionsAndCount(query -> false, null)
+                                            .orTimeout(1, TimeUnit.SECONDS)
+                                            .join()
+                                            .orElseThrow();
             // then...
             assertThat(matchCount).isZero();
         }
@@ -1015,7 +1028,9 @@ class SimpleQueryBusTest {
             // when...
             Integer matchCount =
                     testSubject.completeSubscriptionsExceptionallyAndCount(queryFilter, mockException, null)
-                               .join();
+                               .orTimeout(1, TimeUnit.SECONDS)
+                               .join()
+                               .orElseThrow();
             // then...
             assertThat(matchCount).isEqualTo(2);
         }
@@ -1029,7 +1044,9 @@ class SimpleQueryBusTest {
             // when...
             Integer matchCount =
                     testSubject.completeSubscriptionsExceptionallyAndCount(query -> false, mockException, null)
-                               .join();
+                               .orTimeout(1, TimeUnit.SECONDS)
+                               .join()
+                               .orElseThrow();
             // then...
             assertThat(matchCount).isZero();
         }

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -650,6 +650,66 @@ class SimpleQueryBusTest {
             // then...
             assertThat(updateSupplierInvoked).isFalse();
         }
+
+        @Test
+        void emitUpdateReturningCountReturnsNumberOfMatchingSubscriptions() {
+            // given...
+            QueryMessage testQueryOne = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryTwo = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryThree = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            // Filter matches subscription queries one and two only
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryOne.identifier())
+                            || query.identifier().equals(testQueryTwo.identifier());
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            SubscriptionQueryUpdateMessage updateMessage =
+                    new GenericSubscriptionQueryUpdateMessage(UPDATE_PAYLOAD_TYPE, UPDATE_PAYLOAD);
+            testSubject.subscriptionQuery(testQueryOne, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryTwo, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryThree, null, Queues.SMALL_BUFFER_SIZE);
+            // when...
+            Integer matchCount = testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, null).join();
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+        }
+
+        @Test
+        void emitUpdateReturningCountReturnsZeroWhenNoSubscriptionsMatch() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            SubscriptionQueryUpdateMessage updateMessage =
+                    new GenericSubscriptionQueryUpdateMessage(UPDATE_PAYLOAD_TYPE, UPDATE_PAYLOAD);
+            testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
+            // when...
+            Integer matchCount =
+                    testSubject.emitUpdateAndCount(query -> false, () -> updateMessage, null).join();
+            // then...
+            assertThat(matchCount).isZero();
+        }
+
+        @Test
+        void emitUpdateReturningCountReflectsMatchCountAtCallTimeEvenWhenEmitIsDeferredToAfterCommit() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
+            Predicate<QueryMessage> queryFilter = query -> query.identifier().equals(testQuery.identifier());
+            SubscriptionQueryUpdateMessage updateMessage =
+                    new GenericSubscriptionQueryUpdateMessage(UPDATE_PAYLOAD_TYPE, UPDATE_PAYLOAD);
+            UnitOfWork uow = UnitOfWorkTestUtils.aUnitOfWork();
+            AtomicReference<Integer> matchCountRef = new AtomicReference<>();
+            // when emitting on invocation, before the ProcessingContext has committed...
+            uow.onInvocation(context -> {
+                CompletableFuture<Integer> matchCountFuture =
+                        testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, context);
+                // then the match count is already available, without waiting for the after-commit phase...
+                matchCountRef.set(matchCountFuture.join());
+                return CompletableFuture.completedFuture(null);
+            });
+            uow.execute().join();
+            // then...
+            assertThat(matchCountRef.get()).isEqualTo(1);
+        }
     }
 
     @Nested
@@ -771,6 +831,37 @@ class SimpleQueryBusTest {
             uow.execute().join();
             // then we expect the update to be emitted, validated by the filter being invoked...
             assertThat(filterInvoked).isTrue();
+        }
+
+        @Test
+        void completeSubscriptionsReturningCountReturnsNumberOfCompletedSubscriptions() {
+            // given...
+            QueryMessage testQueryOne = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryTwo = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryThree = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            // Filter matches subscription queries one and two only
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryOne.identifier())
+                            || query.identifier().equals(testQueryTwo.identifier());
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            testSubject.subscriptionQuery(testQueryOne, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryTwo, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryThree, null, Queues.SMALL_BUFFER_SIZE);
+            // when...
+            Integer matchCount = testSubject.completeSubscriptionsAndCount(queryFilter, null).join();
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+        }
+
+        @Test
+        void completeSubscriptionsReturningCountReturnsZeroWhenNoSubscriptionsMatch() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
+            // when...
+            Integer matchCount = testSubject.completeSubscriptionsAndCount(query -> false, null).join();
+            // then...
+            assertThat(matchCount).isZero();
         }
     }
 
@@ -904,6 +995,43 @@ class SimpleQueryBusTest {
             uow.execute().join();
             // then we expect the update to be emitted, validated by the filter being invoked...
             assertThat(filterInvoked).isTrue();
+        }
+
+        @Test
+        void completeSubscriptionsExceptionallyReturningCountReturnsNumberOfCompletedSubscriptions() {
+            // given...
+            QueryMessage testQueryOne = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryTwo = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryThree = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            // Filter matches subscription queries one and two only
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryOne.identifier())
+                            || query.identifier().equals(testQueryTwo.identifier());
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            testSubject.subscriptionQuery(testQueryOne, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryTwo, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryThree, null, Queues.SMALL_BUFFER_SIZE);
+            MockException mockException = new MockException("Mock");
+            // when...
+            Integer matchCount =
+                    testSubject.completeSubscriptionsExceptionallyAndCount(queryFilter, mockException, null)
+                               .join();
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+        }
+
+        @Test
+        void completeSubscriptionsExceptionallyReturningCountReturnsZeroWhenNoSubscriptionsMatch() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
+            MockException mockException = new MockException("Mock");
+            // when...
+            Integer matchCount =
+                    testSubject.completeSubscriptionsExceptionallyAndCount(query -> false, mockException, null)
+                               .join();
+            // then...
+            assertThat(matchCount).isZero();
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.*;
 
 import java.lang.reflect.Type;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -75,11 +76,11 @@ class SimpleQueryUpdateEmitterTest {
         when(queryBus.completeSubscriptionsExceptionally(any(), any(), eq(context)))
                 .thenReturn(FutureUtils.emptyCompletedFuture());
         when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
-                .thenReturn(CompletableFuture.completedFuture(1));
+                .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(1)));
         when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
-                .thenReturn(CompletableFuture.completedFuture(1));
+                .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(1)));
         when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
-                .thenReturn(CompletableFuture.completedFuture(1));
+                .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(1)));
         filterCaptor = ArgumentCaptor.captor();
         updateCaptor = ArgumentCaptor.captor();
     }
@@ -305,11 +306,12 @@ class SimpleQueryUpdateEmitterTest {
             when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
             when(messageTypeResolver.resolveOrThrow(testUpdatePayload)).thenReturn(UPDATE_PAYLOAD_TYPE);
             when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(3));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(3)));
             // when...
-            int matchCount = testSubject.emitAndCount(String.class, query -> true, () -> testUpdatePayload);
+            OptionalInt matchCount = testSubject.emitAndCount(String.class, query -> true, () -> testUpdatePayload);
             // then...
-            assertThat(matchCount).isEqualTo(3);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(3);
             verify(queryBus).emitUpdateAndCount(filterCaptor.capture(), updateCaptor.capture(), eq(context));
             assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
@@ -321,13 +323,14 @@ class SimpleQueryUpdateEmitterTest {
             Update testUpdatePayload = new Update("some-update");
             when(messageTypeResolver.resolveOrThrow(testUpdatePayload)).thenReturn(UPDATE_PAYLOAD_TYPE);
             when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(2));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(2)));
             // when...
-            int matchCount = testSubject.emitAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(),
-                                                            query -> true,
-                                                      () -> testUpdatePayload);
+            OptionalInt matchCount = testSubject.emitAndCount(
+                    QUERY_PAYLOAD_TYPE.qualifiedName(), query -> true, () -> testUpdatePayload
+            );
             // then...
-            assertThat(matchCount).isEqualTo(2);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(2);
             verify(queryBus).emitUpdateAndCount(filterCaptor.capture(), updateCaptor.capture(), eq(context));
             assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
@@ -455,11 +458,12 @@ class SimpleQueryUpdateEmitterTest {
             QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
             when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
             when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(3));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(3)));
             // when...
-            int matchCount = testSubject.completeAndCount(String.class, query -> true);
+            OptionalInt matchCount = testSubject.completeAndCount(String.class, query -> true);
             // then...
-            assertThat(matchCount).isEqualTo(3);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(3);
             verify(queryBus).completeSubscriptionsAndCount(filterCaptor.capture(), eq(context));
             assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
@@ -469,11 +473,12 @@ class SimpleQueryUpdateEmitterTest {
             // given...
             QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
             when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(2));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(2)));
             // when...
-            int matchCount = testSubject.completeAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(), query -> true);
+            OptionalInt matchCount = testSubject.completeAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(), query -> true);
             // then...
-            assertThat(matchCount).isEqualTo(2);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(2);
             verify(queryBus).completeSubscriptionsAndCount(filterCaptor.capture(), eq(context));
             assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
@@ -593,11 +598,12 @@ class SimpleQueryUpdateEmitterTest {
             QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
             when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
             when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(3));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(3)));
             // when...
-            int matchCount = testSubject.completeExceptionallyAndCount(String.class, query -> true, CAUSE);
+            OptionalInt matchCount = testSubject.completeExceptionallyAndCount(String.class, query -> true, CAUSE);
             // then...
-            assertThat(matchCount).isEqualTo(3);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(3);
             verify(queryBus).completeSubscriptionsExceptionallyAndCount(filterCaptor.capture(),
                                                                         eq(CAUSE),
                                                                         eq(context));
@@ -609,13 +615,14 @@ class SimpleQueryUpdateEmitterTest {
             // given...
             QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
             when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
-                    .thenReturn(CompletableFuture.completedFuture(2));
+                    .thenReturn(CompletableFuture.completedFuture(OptionalInt.of(2)));
             // when...
-            int matchCount = testSubject.completeExceptionallyAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(),
-                                                                             query -> true,
-                                                                       CAUSE);
+            OptionalInt matchCount = testSubject.completeExceptionallyAndCount(
+                    QUERY_PAYLOAD_TYPE.qualifiedName(), query -> true, CAUSE
+            );
             // then...
-            assertThat(matchCount).isEqualTo(2);
+            assertThat(matchCount).isPresent();
+            assertThat(matchCount).hasValue(2);
             verify(queryBus).completeSubscriptionsExceptionallyAndCount(filterCaptor.capture(),
                                                                         eq(CAUSE),
                                                                         eq(context));

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitterTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryUpdateEmitterTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.*;
 import org.mockito.*;
 
 import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -73,6 +74,12 @@ class SimpleQueryUpdateEmitterTest {
         when(queryBus.completeSubscriptions(any(), eq(context))).thenReturn(FutureUtils.emptyCompletedFuture());
         when(queryBus.completeSubscriptionsExceptionally(any(), any(), eq(context)))
                 .thenReturn(FutureUtils.emptyCompletedFuture());
+        when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
+                .thenReturn(CompletableFuture.completedFuture(1));
+        when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
+                .thenReturn(CompletableFuture.completedFuture(1));
+        when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
+                .thenReturn(CompletableFuture.completedFuture(1));
         filterCaptor = ArgumentCaptor.captor();
         updateCaptor = ArgumentCaptor.captor();
     }
@@ -289,6 +296,51 @@ class SimpleQueryUpdateEmitterTest {
             verify(messageTypeResolver, times(0)).resolveOrThrow(String.class);
             verifyNoInteractions(converter);
         }
+
+        @Test
+        void emitReturningCountForQueryTypeReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            Update testUpdatePayload = new Update("some-update");
+            when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
+            when(messageTypeResolver.resolveOrThrow(testUpdatePayload)).thenReturn(UPDATE_PAYLOAD_TYPE);
+            when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(3));
+            // when...
+            int matchCount = testSubject.emitAndCount(String.class, query -> true, () -> testUpdatePayload);
+            // then...
+            assertThat(matchCount).isEqualTo(3);
+            verify(queryBus).emitUpdateAndCount(filterCaptor.capture(), updateCaptor.capture(), eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
+        }
+
+        @Test
+        void emitReturningCountForQueryNameReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            Update testUpdatePayload = new Update("some-update");
+            when(messageTypeResolver.resolveOrThrow(testUpdatePayload)).thenReturn(UPDATE_PAYLOAD_TYPE);
+            when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(2));
+            // when...
+            int matchCount = testSubject.emitAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(),
+                                                            query -> true,
+                                                      () -> testUpdatePayload);
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+            verify(queryBus).emitUpdateAndCount(filterCaptor.capture(), updateCaptor.capture(), eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
+        }
+
+        @Test
+        void emitReturningCountPropagatesTheOriginalExceptionThrownByTheQueryBus() {
+            // given...
+            when(queryBus.emitUpdateAndCount(any(), any(), eq(context)))
+                    .thenReturn(CompletableFuture.failedFuture(CAUSE));
+            // when/then...
+            assertThatThrownBy(() -> testSubject.emitAndCount(String.class, query -> true, () -> "update"))
+                    .isSameAs(CAUSE);
+        }
     }
 
     @Nested
@@ -395,6 +447,35 @@ class SimpleQueryUpdateEmitterTest {
 
             verifyNoInteractions(messageTypeResolver);
             verifyNoInteractions(converter);
+        }
+
+        @Test
+        void completeReturningCountForQueryTypeReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
+            when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(3));
+            // when...
+            int matchCount = testSubject.completeAndCount(String.class, query -> true);
+            // then...
+            assertThat(matchCount).isEqualTo(3);
+            verify(queryBus).completeSubscriptionsAndCount(filterCaptor.capture(), eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
+        }
+
+        @Test
+        void completeReturningCountForQueryNameReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            when(queryBus.completeSubscriptionsAndCount(any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(2));
+            // when...
+            int matchCount = testSubject.completeAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(), query -> true);
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+            verify(queryBus).completeSubscriptionsAndCount(filterCaptor.capture(), eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
     }
 
@@ -504,6 +585,41 @@ class SimpleQueryUpdateEmitterTest {
 
             verifyNoInteractions(messageTypeResolver);
             verifyNoInteractions(converter);
+        }
+
+        @Test
+        void completeExceptionallyReturningCountForQueryTypeReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            when(messageTypeResolver.resolveOrThrow(String.class)).thenReturn(QUERY_PAYLOAD_TYPE);
+            when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(3));
+            // when...
+            int matchCount = testSubject.completeExceptionallyAndCount(String.class, query -> true, CAUSE);
+            // then...
+            assertThat(matchCount).isEqualTo(3);
+            verify(queryBus).completeSubscriptionsExceptionallyAndCount(filterCaptor.capture(),
+                                                                        eq(CAUSE),
+                                                                        eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
+        }
+
+        @Test
+        void completeExceptionallyReturningCountForQueryNameReturnsMatchCountFromQueryBus() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_PAYLOAD_TYPE, "some-query");
+            when(queryBus.completeSubscriptionsExceptionallyAndCount(any(), any(), eq(context)))
+                    .thenReturn(CompletableFuture.completedFuture(2));
+            // when...
+            int matchCount = testSubject.completeExceptionallyAndCount(QUERY_PAYLOAD_TYPE.qualifiedName(),
+                                                                             query -> true,
+                                                                       CAUSE);
+            // then...
+            assertThat(matchCount).isEqualTo(2);
+            verify(queryBus).completeSubscriptionsExceptionallyAndCount(filterCaptor.capture(),
+                                                                        eq(CAUSE),
+                                                                        eq(context));
+            assertThat(filterCaptor.getValue().test(testQuery)).isTrue();
         }
     }
 


### PR DESCRIPTION
This pull request adjusts the `QueryBus` and `QueryUpdateEmitter`, by adding versions of `emit`, `complete`, and `completeExceptionally` that include an `...AndCount` semantic.
These methods make it so that emitting an update, completing subscription queries or completing  subscription queries exceptionally results in an `integer` stating the amount of subscriptions that were hit by the adjustment.

This feature is introduced in a backwards compatible fashion, by providing a `default` implementation of the new methods on the `QueryBus` and `QueryUpdateEmitter`.
The `SimpleQueryBus`, however, has the previous version invoke the `...AndCount` counter part, to ensure the exact same flow is taken.
This pointer is not followed for the `SimpleQueryUpdateEmitter`, as it is not the component counting (that's the `QueryBus`).

Furthermore, tests were added, as well as some minor JavaDoc clean-up (performed in a separate commit for reviewer convenience).

In doing so, this PR only partially resolves the referred to issue, #1470.
What's left, as an adjustment to the Axon Server integration.
As this moved to Axoniq Framework, another pull request is thus required to finalize this feature fully.