### PR TITLE
Make EntityModel decoratable

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
@@ -38,6 +38,7 @@ import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.annotation.EntityIdResolverDefinition;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.annotation.RepresentationResolvingEntityEvolver;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -153,8 +154,12 @@ class AnnotatedEventSourcedEntityModule<I, E>
         var type = (Class<EntityIdResolverDefinition>) annotationAttributes.get("entityIdResolverDefinition");
         var definition = getConstructorFunctionWithZeroArguments(type).get();
         return c -> {
-            var component = (AnnotatedEntityMetamodel<E>) c.getComponent(EntityMetamodel.class, entityName());
-            return definition.createIdResolver(entityType, idType, component, c);
+            var component = c.getComponent(EntityMetamodel.class, entityName());
+            if(component instanceof RepresentationResolvingEntityEvolver representationResolvingEntityEvolver) {
+                return definition.createIdResolver(entityType, idType, representationResolvingEntityEvolver, c);
+            }
+            // Not possible, except when decorating, as this is a component configured by this module.
+            throw new IllegalArgumentException("The EntityMetamodel does not implement RepresentationResolvingEntityEvolver. Make sure that all decorators implement and delegate this interface.");
         };
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
@@ -155,11 +155,11 @@ class AnnotatedEventSourcedEntityModule<I, E>
         var definition = getConstructorFunctionWithZeroArguments(type).get();
         return c -> {
             var component = c.getComponent(EntityMetamodel.class, entityName());
-            if(component instanceof RepresentationResolvingEntityEvolver representationResolvingEntityEvolver) {
+            if (component instanceof RepresentationResolvingEntityEvolver representationResolvingEntityEvolver) {
                 return definition.createIdResolver(entityType, idType, representationResolvingEntityEvolver, c);
             }
             // Not possible, except when decorating, as this is a component configured by this module.
-            throw new IllegalArgumentException("The EntityMetamodel does not implement RepresentationResolvingEntityEvolver. Make sure that all decorators implement and delegate this interface.");
+            throw new AxonConfigurationException("The EntityMetamodel does not implement RepresentationResolvingEntityEvolver. Make sure that all decorators implement and delegate this interface.");
         };
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
@@ -449,7 +449,7 @@ class AnnotatedEventSourcedEntityModuleTest {
             Configuration entityConfiguration =
                     entityModuleConfiguration(componentRegistry.build(lifecycleRegistry), COURSE_ENTITY_NAME);
 
-            // Sanity check that the decorator actually reached the entity's (nested) EntityMetamodel component —
+            // Sanity check that the decorator actually reached the entity's (nested) EntityMetamodel component,
             // otherwise the id-resolver assertion below would pass vacuously against the undecorated metamodel.
             assertThat(entityConfiguration.getComponent(EntityMetamodel.class, COURSE_ENTITY_NAME))
                     .isInstanceOf(RepresentationResolvingEntityEvolver.class)

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModuleTest.java
@@ -19,6 +19,7 @@ package org.axonframework.eventsourcing.configuration;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.DecoratorDefinition;
 import org.axonframework.common.configuration.DefaultComponentRegistry;
 import org.axonframework.common.configuration.StubLifecycleRegistry;
 import org.axonframework.common.infra.ComponentDescriptor;
@@ -38,7 +39,12 @@ import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.annotation.AnnotatedEntityIdResolver;
+import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.annotation.RepresentationResolvingEntityEvolver;
 import org.axonframework.modelling.repository.Repository;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -57,10 +63,12 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * Test class validating the {@link AnnotatedEventSourcedEntityModule}.
@@ -421,6 +429,72 @@ class AnnotatedEventSourcedEntityModuleTest {
             result.describeTo(componentDescriptor);
 
             verify(componentDescriptor).describeProperty(eq("entityLifecycleHandler"), isA(SnapshottingEntityLifecycleHandler.class));
+        }
+    }
+
+    @Nested
+    class WhenEntityMetamodelIsDecorated {
+
+        private static final String COURSE_ENTITY_NAME = Course.class.getName() + "#" + CourseId.class.getName();
+
+        @Test
+        void idResolverBuildsAgainstDecoratedMetamodelThatImplementsRepresentationResolvingEntityEvolver() {
+            componentRegistry.registerModule(EventSourcedEntityModule.autodetected(CourseId.class, Course.class));
+            componentRegistry.registerDecorator(DecoratorDefinition
+                    .forType(EntityMetamodel.class)
+                    .with((config, name, delegate) -> mock(EntityMetamodel.class,
+                            withSettings().extraInterfaces(RepresentationResolvingEntityEvolver.class)
+                                          .defaultAnswer(delegatesTo(delegate)))));
+
+            Configuration entityConfiguration =
+                    entityModuleConfiguration(componentRegistry.build(lifecycleRegistry), COURSE_ENTITY_NAME);
+
+            // Sanity check that the decorator actually reached the entity's (nested) EntityMetamodel component —
+            // otherwise the id-resolver assertion below would pass vacuously against the undecorated metamodel.
+            assertThat(entityConfiguration.getComponent(EntityMetamodel.class, COURSE_ENTITY_NAME))
+                    .isInstanceOf(RepresentationResolvingEntityEvolver.class)
+                    .isNotInstanceOf(AnnotatedEntityMetamodel.class);
+
+            // Building the EntityIdResolver resolves that decorated metamodel; the module accepts it precisely
+            // because the decorator preserved RepresentationResolvingEntityEvolver.
+            assertThat(entityConfiguration.getComponent(EntityIdResolver.class, COURSE_ENTITY_NAME))
+                    .isInstanceOf(AnnotatedEntityIdResolver.class);
+        }
+
+        @Test
+        void idResolverBuildFailsWhenDecoratedMetamodelDropsRepresentationResolvingEntityEvolver() {
+            componentRegistry.registerModule(EventSourcedEntityModule.autodetected(CourseId.class, Course.class));
+            // Decorate the EntityMetamodel with a wrapper that does NOT implement
+            // RepresentationResolvingEntityEvolver. Building the EntityIdResolver must fail fast with a
+            // helpful message rather than an opaque ClassCastException.
+            componentRegistry.registerDecorator(DecoratorDefinition
+                    .forType(EntityMetamodel.class)
+                    .with((config, name, delegate) -> mock(EntityMetamodel.class, delegatesTo(delegate))));
+
+            Configuration entityConfiguration =
+                    entityModuleConfiguration(componentRegistry.build(lifecycleRegistry), COURSE_ENTITY_NAME);
+
+            assertThatThrownBy(() -> entityConfiguration.getComponent(EntityIdResolver.class, COURSE_ENTITY_NAME))
+                    .hasStackTraceContaining("does not implement RepresentationResolvingEntityEvolver");
+        }
+
+        /**
+         * Returns the (nested) module configuration that holds the entity's components. Annotated event-sourced
+         * entities register their components in a nested module, so a plain {@code getComponent} on the parent does
+         * not find them. Located via the always-buildable {@code EntityMetamodel} so it works for both the positive
+         * and negative cases above.
+         */
+        private static Configuration entityModuleConfiguration(Configuration configuration, String name) {
+            if (configuration.getOptionalComponent(EntityMetamodel.class, name).isPresent()) {
+                return configuration;
+            }
+            for (Configuration child : configuration.getModuleConfigurations()) {
+                Configuration found = entityModuleConfiguration(child, name);
+                if (found != null) {
+                    return found;
+                }
+            }
+            return null;
         }
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolverDefinition.java
@@ -17,7 +17,7 @@
 package org.axonframework.modelling.annotation;
 
 import org.axonframework.common.configuration.Configuration;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.annotation.RepresentationResolvingEntityEvolver;
 import org.axonframework.modelling.EntityIdResolver;
 
 /**
@@ -31,7 +31,7 @@ public class AnnotationBasedEntityIdResolverDefinition implements EntityIdResolv
     @Override
     public <E, ID> EntityIdResolver<ID> createIdResolver(Class<E> entityType,
                                                          Class<ID> idType,
-                                                         AnnotatedEntityMetamodel<E> entityMetamodel,
+                                                         RepresentationResolvingEntityEvolver<E> entityEvolver,
                                                          Configuration configuration
     ) {
         return new AnnotationBasedEntityIdResolver<>();

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/EntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/EntityIdResolverDefinition.java
@@ -18,7 +18,7 @@ package org.axonframework.modelling.annotation;
 
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.modelling.EntityIdResolver;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.annotation.RepresentationResolvingEntityEvolver;
 
 /**
  * Definition describing how to create an {@link EntityIdResolver} for a given entity type and identifier type.
@@ -36,7 +36,7 @@ public interface EntityIdResolverDefinition {
      *
      * @param entityType      The type of the entity for which the resolver is created.
      * @param idType          The type of the identifier for which the resolver is created.
-     * @param entityMetamodel The metamodel of the entity.
+     * @param entityEvolver   The evolver of the entity, exposing the expected payload representation of its handlers.
      * @param configuration   The configuration of the application, providing access to the components available.
      * @param <E>             The type of the entity for which the resolver is created.
      * @param <ID>            The type of the identifier for which the resolver is created.
@@ -45,7 +45,7 @@ public interface EntityIdResolverDefinition {
     <E, ID> EntityIdResolver<ID> createIdResolver(
             Class<E> entityType,
             Class<ID> idType,
-            AnnotatedEntityMetamodel<E> entityMetamodel,
+            RepresentationResolvingEntityEvolver<E> entityEvolver,
             Configuration configuration
     );
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 /**
  * Implementation of the {@link EntityIdResolver} that converts the payload through the configured
  * {@link MessageConverter} then takes the expected representation of the message handler from the
- * {@link AnnotatedEntityMetamodel}.
+ * {@link RepresentationResolvingEntityEvolver}.
  * <p>
  * It will then use the delegate {@link EntityIdResolver} to resolve the id, defaulting to the
  * {@link AnnotationBasedEntityIdResolver}.
@@ -42,33 +42,33 @@ import java.util.Objects;
  */
 public class AnnotatedEntityIdResolver<ID> implements EntityIdResolver<ID>, DescribableComponent {
 
-    private final AnnotatedEntityMetamodel<?> metamodel;
+    private final RepresentationResolvingEntityEvolver<?> entityEvolver;
     private final MessageConverter converter;
     private final EntityIdResolver<ID> delegate;
     private final Class<ID> idType;
 
     /**
      * Constructs an {@code AnnotatedEntityMetamodelEntityIdResolver} for the provided
-     * {@link AnnotatedEntityMetamodel}.
+     * {@link RepresentationResolvingEntityEvolver}.
      *
-     * @param metamodel The metamodel that dictates the expected representation of the message.
+     * @param entityEvolver The entity evolver that dictates the expected representation of the message.
      * @param idType    The type of the id that will be resolved.
      * @param converter The {@link MessageConverter} to use.
      * @param delegate  The {@link EntityIdResolver} to use on the message after conversion.
      */
-    public AnnotatedEntityIdResolver(AnnotatedEntityMetamodel<?> metamodel,
+    public AnnotatedEntityIdResolver(RepresentationResolvingEntityEvolver<?> entityEvolver,
                                      Class<ID> idType,
                                      MessageConverter converter,
                                      EntityIdResolver<ID> delegate) {
         this.idType = Objects.requireNonNull(idType, "The idType should not be null.");
-        this.metamodel = Objects.requireNonNull(metamodel, "The metamodel should not be null,");
+        this.entityEvolver = Objects.requireNonNull(entityEvolver, "The entityEvolver should not be null,");
         this.converter = Objects.requireNonNull(converter, "The converter should not be null.");
         this.delegate = Objects.requireNonNull(delegate, "The delegate should not be null.");
     }
 
     @Override
     public ID resolve(Message message, ProcessingContext context) throws EntityIdResolutionException {
-        Class<?> expectedRepresentation = metamodel.getExpectedRepresentation(message.type().qualifiedName());
+        Class<?> expectedRepresentation = entityEvolver.getExpectedRepresentation(message.type().qualifiedName());
         if (expectedRepresentation != null) {
             return delegate.resolve(message.withConvertedPayload(expectedRepresentation, converter), context);
         }
@@ -82,6 +82,6 @@ public class AnnotatedEntityIdResolver<ID> implements EntityIdResolver<ID>, Desc
         descriptor.describeWrapperOf(delegate);
         descriptor.describeProperty("converter", converter);
         descriptor.describeProperty("idType", idType);
-        descriptor.describeProperty("metaModel", metamodel);
+        descriptor.describeProperty("entityEvolver", entityEvolver);
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
@@ -61,7 +61,7 @@ public class AnnotatedEntityIdResolver<ID> implements EntityIdResolver<ID>, Desc
                                      MessageConverter converter,
                                      EntityIdResolver<ID> delegate) {
         this.idType = Objects.requireNonNull(idType, "The idType should not be null.");
-        this.entityEvolver = Objects.requireNonNull(entityEvolver, "The entityEvolver should not be null,");
+        this.entityEvolver = Objects.requireNonNull(entityEvolver, "The entityEvolver should not be null.");
         this.converter = Objects.requireNonNull(converter, "The converter should not be null.");
         this.delegate = Objects.requireNonNull(delegate, "The delegate should not be null.");
     }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverDefinition.java
@@ -26,8 +26,8 @@ import org.axonframework.modelling.annotation.TargetEntityId;
 
 /**
  * {@link EntityIdResolverDefinition} that converts the payload of incoming messages based on the
- * {@link AnnotatedEntityMetamodel#getExpectedRepresentation(QualifiedName) expected payload type} of the message
- * handler in the model, and then looks for a {@link TargetEntityId}-annotated
+ * {@link RepresentationResolvingEntityEvolver#getExpectedRepresentation(QualifiedName) expected payload type}
+ * of the message handler in the model, and then looks for a {@link TargetEntityId}-annotated
  * member in the payload, through the {@link AnnotationBasedEntityIdResolver}.
  *
  * @author Mitchell Herrijgers
@@ -38,10 +38,10 @@ public class AnnotatedEntityIdResolverDefinition implements EntityIdResolverDefi
     @Override
     public <E, ID> EntityIdResolver<ID> createIdResolver(Class<E> entityType,
                                                          Class<ID> idType,
-                                                         AnnotatedEntityMetamodel<E> entityMetamodel,
+                                                         RepresentationResolvingEntityEvolver<E> entityEvolver,
                                                          Configuration configuration) {
         return new AnnotatedEntityIdResolver<>(
-                entityMetamodel,
+                entityEvolver,
                 idType,
                 configuration.getComponent(MessageConverter.class),
                 new AnnotationBasedEntityIdResolver<>()

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -89,7 +89,8 @@ import static org.axonframework.messaging.core.annotation.AnnotatedHandlerInspec
  * @author Allard Buijze
  * @since 3.1.0
  */
-public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, DescribableComponent {
+public class AnnotatedEntityMetamodel<E>
+        implements EntityMetamodel<E>, DescribableComponent, RepresentationResolvingEntityEvolver<E> {
 
     private static final Logger logger = LoggerFactory.getLogger(AnnotatedEntityMetamodel.class);
 
@@ -367,6 +368,7 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
      * @return The {@link Class} of the expected representation for handlers of the given {@code qualifiedName}, or
      * {@code null} if no such representation is found.
      */
+    @Override
     @Nullable
     public Class<?> getExpectedRepresentation(QualifiedName qualifiedName) {
         if (payloadTypes.containsKey(qualifiedName)) {

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RepresentationResolvingEntityEvolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RepresentationResolvingEntityEvolver.java
@@ -25,7 +25,7 @@ import org.jspecify.annotations.Nullable;
  * {@link QualifiedName}. This is useful for components that provide annotation-based usage of entities as it provides
  * information on the wanted Java class (the representation) by the user.
  *
- * @param <E> The entity type this evolver applies to.
+ * @param <E> the entity type this evolver applies to
  * @author Mitchell Herrijgers
  * @since 5.3.0
  */
@@ -34,9 +34,9 @@ public interface RepresentationResolvingEntityEvolver<E> extends EntityEvolver<E
     /**
      * Returns the {@link Class} of the expected representation for handlers of the given {@code qualifiedName}.
      *
-     * @param qualifiedName The {@link QualifiedName} of the handler to look for.
-     * @return The {@link Class} of the expected representation for handlers of the given {@code qualifiedName}, or
-     * {@code null} if no such representation is found.
+     * @param qualifiedName the {@link QualifiedName} of the handler to look for
+     * @return the {@link Class} of the expected representation for handlers of the given {@code qualifiedName}, or
+     * {@code null} if no such representation is found
      */
     @Nullable
     Class<?> getExpectedRepresentation(QualifiedName qualifiedName);

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RepresentationResolvingEntityEvolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/RepresentationResolvingEntityEvolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.modelling.EntityEvolver;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An {@link EntityEvolver} that can additionally expose the expected payload representation for handlers of a given
+ * {@link QualifiedName}. This is useful for components that provide annotation-based usage of entities as it provides
+ * information on the wanted Java class (the representation) by the user.
+ *
+ * @param <E> The entity type this evolver applies to.
+ * @author Mitchell Herrijgers
+ * @since 5.3.0
+ */
+public interface RepresentationResolvingEntityEvolver<E> extends EntityEvolver<E> {
+
+    /**
+     * Returns the {@link Class} of the expected representation for handlers of the given {@code qualifiedName}.
+     *
+     * @param qualifiedName The {@link QualifiedName} of the handler to look for.
+     * @return The {@link Class} of the expected representation for handlers of the given {@code qualifiedName}, or
+     * {@code null} if no such representation is found.
+     */
+    @Nullable
+    Class<?> getExpectedRepresentation(QualifiedName qualifiedName);
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverTest.java
@@ -38,13 +38,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnnotatedEntityIdResolverTest {
 
     @Mock
-    private AnnotatedEntityMetamodel<String> metamodel;
+    private RepresentationResolvingEntityEvolver<String> entityEvolver;
 
     private AnnotatedEntityIdResolver<String> resolver;
 
     @BeforeEach
     void setUp() {
-        resolver = new AnnotatedEntityIdResolver<>(metamodel,
+        resolver = new AnnotatedEntityIdResolver<>(entityEvolver,
                                                    String.class,
                                                    new DelegatingMessageConverter(new JacksonConverter()),
                                                    new AnnotationBasedEntityIdResolver<>());
@@ -58,7 +58,7 @@ class AnnotatedEntityIdResolverTest {
 
         QualifiedName qualifiedName = messageType.qualifiedName();
         Mockito.doReturn(MyIdHoldingObject.class)
-               .when(metamodel)
+               .when(entityEvolver)
                .getExpectedRepresentation(qualifiedName);
 
 
@@ -73,7 +73,7 @@ class AnnotatedEntityIdResolverTest {
 
         QualifiedName qualifiedName = messageType.qualifiedName();
         Mockito.doReturn(MyIdHoldingObject.class)
-               .when(metamodel)
+               .when(entityEvolver)
                .getExpectedRepresentation(qualifiedName);
 
         assertThatThrownBy(() -> resolver.resolve(serializedMessage, new StubProcessingContext()))


### PR DESCRIPTION
The `AnnotatedEntityMetamodel` is casting the `EntityEvolver` to an implementation; the `AnnotatedEntityMetamodel`. It's doing this because the AnnotatedEntityIdResolver needs access to the type information, which is an annotation-specific concern and should not be on the EntityEvolver interface.

The result was that the `EntityEvolver` could never be decorated, as it's impossible to satisfy the cast. This leads to the Platform client having to destruct and re-construct the `EventSourcingRepository`, creating very close coupling for something that should be easy.

This PR splits the annotation-specific functionality, the providing of class information about handlers, to the `RepresentationResolvingEntityEvolver`. Now, the `EntityEvolver` can be decorated, as long as decorators implement `RepresentationResolvingEntityEvolver` as well. The module configuration is no longer bound to an implementation, but to an interface, removing the brittle re-construct logic for Platform