### PR TITLE
Resolve incorrect event routing in heterogeneous Sequencing Policy setup among Event Handling Components

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -27,6 +27,7 @@ import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandlingComponent;
 import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -34,6 +35,7 @@ import org.axonframework.messaging.eventhandling.replay.GenericReplayStatusChang
 import org.axonframework.messaging.eventhandling.replay.ReplayStatus;
 import org.axonframework.messaging.eventhandling.replay.ReplayStatusChanged;
 import org.axonframework.messaging.eventhandling.replay.ResetContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
@@ -104,8 +106,13 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * <p>
      * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that events with the same
      * {@link #sequenceIdentifiersFor(EventMessage, ProcessingContext)} value are processed by a single component in the
-     * order they are received, but sequencing is not preserved across different event handling components — this is
+     * order they are received, but sequencing is not preserved across different event handling components; this is
      * intentional, as they may have different sequencing policies.
+     * <p>
+     * When a {@link Segment} is attached to the {@code context} (as done by a segmented processor), a component only
+     * handles an event when the component's sequence identifier hashes into that segment, ensuring each event is handled
+     * exactly once per component across all segments. Without a {@link Segment} in the {@code context}, every supporting
+     * component handles the event.
      *
      * @param entries the batch of message stream entries to be processed
      * @param context the processing context in which the event messages are processed
@@ -131,6 +138,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     ) {
         Optional<TrackingToken> token = TrackingToken.fromContext(context);
         boolean isReplaying = token.isPresent() && ReplayToken.isReplay(token.get());
+        Segment segment = Segment.fromContext(context).orElse(null);
 
         MessageStream<Message> result = MessageStream.empty();
         for (var component : components) {
@@ -138,7 +146,8 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
             if (isReplaying && !component.supportsReset()) {
                 continue;
             }
-            if (component.supports(event.type().qualifiedName())) {
+            if (component.supports(event.type().qualifiedName())
+                    && canSegmentHandle(segment, component, event, context)) {
                 var componentResult = component.handle(event, context);
                 result = result.concatWith(componentResult);
             }
@@ -150,6 +159,31 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
             }
         }
         return result.ignoreEntries().cast();
+    }
+
+    /**
+     * Determines whether the given {@code segment} should handle the {@code event} through the given
+     * {@code component}.
+     * <p>
+     * A segmented processor claims an event for a segment when the component's
+     * {@link EventHandlingComponent#sequenceIdentifierFor(EventMessage, ProcessingContext) sequence identifier} hashes
+     * into that segment, mirroring the routing decision made while scheduling the event. When {@code segment} is
+     * {@code null} (for example, a
+     * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor}), handling is
+     * not segmented and the component always handles the event.
+     *
+     * @param segment   the {@link Segment} currently handling the event, or {@code null} when handling is not segmented
+     * @param component the component that would handle the event
+     * @param event     the event being handled
+     * @param context   the processing context in which the event is handled
+     * @return {@code true} when the component should handle the event within the given segment
+     */
+    private static boolean canSegmentHandle(@Nullable Segment segment,
+                                            EventHandlingComponent component,
+                                            EventMessage event,
+                                            ProcessingContext context) {
+        return segment == null
+                || segment.matches(component.sequenceIdentifierFor(event, context));
     }
 
     /**
@@ -183,7 +217,9 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * @return A set of sequence identifiers associated with the given event and context.
      */
     public Set<Object> sequenceIdentifiersFor(EventMessage event, ProcessingContext context) {
+        QualifiedName eventName = event.type().qualifiedName();
         return components.stream()
+                         .filter(c -> c.supports(eventName))
                          .map(c -> c.sequenceIdentifierFor(event, context))
                          .collect(Collectors.toSet());
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -28,6 +28,7 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandlingComponent;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentMatcher;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -165,10 +166,10 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * Determines whether the given {@code segment} should handle the {@code event} through the given
      * {@code component}.
      * <p>
-     * A segmented processor claims an event for a segment when the component's
+     * This reuses the same {@link SegmentMatcher} routing that is applied while scheduling the event, so a component
+     * handles an event only when its
      * {@link EventHandlingComponent#sequenceIdentifierFor(EventMessage, ProcessingContext) sequence identifier} hashes
-     * into that segment, mirroring the routing decision made while scheduling the event. When {@code segment} is
-     * {@code null} (for example, a
+     * into that segment. When {@code segment} is {@code null} (for example, a
      * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor}), handling is
      * not segmented and the component always handles the event.
      *
@@ -182,8 +183,11 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
                                             EventHandlingComponent component,
                                             EventMessage event,
                                             ProcessingContext context) {
-        return segment == null
-                || segment.matches(component.sequenceIdentifierFor(event, context));
+        if (segment == null) {
+            return true;
+        }
+        return new SegmentMatcher((e, ctx) -> Optional.of(component.sequenceIdentifierFor(e, ctx)))
+                .matches(segment, event, context);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -148,7 +148,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
                 continue;
             }
             if (component.supports(event.type().qualifiedName())
-                    && canSegmentHandle(segment, component, event, context)) {
+                    && canHandleInSegment(segment, component, event, context)) {
                 var componentResult = component.handle(event, context);
                 result = result.concatWith(componentResult);
             }
@@ -163,8 +163,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     }
 
     /**
-     * Determines whether the given {@code segment} should handle the {@code event} through the given
-     * {@code component}.
+     * Determines whether the given {@code component} can handle the {@code event} in the given {@code segment}.
      * <p>
      * This reuses the same {@link SegmentMatcher} routing that is applied while scheduling the event, so a component
      * handles an event only when its
@@ -177,12 +176,12 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * @param component the component that would handle the event
      * @param event     the event being handled
      * @param context   the processing context in which the event is handled
-     * @return {@code true} when the component should handle the event within the given segment
+     * @return {@code true} when the component can handle the event in the given segment
      */
-    private static boolean canSegmentHandle(@Nullable Segment segment,
-                                            EventHandlingComponent component,
-                                            EventMessage event,
-                                            ProcessingContext context) {
+    private static boolean canHandleInSegment(@Nullable Segment segment,
+                                              EventHandlingComponent component,
+                                              EventMessage event,
+                                              ProcessingContext context) {
         if (segment == null) {
             return true;
         }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
@@ -19,17 +19,23 @@ package org.axonframework.messaging.eventhandling.processing;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventTestUtils;
+import org.axonframework.messaging.eventhandling.RecordingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -183,6 +189,121 @@ class ProcessorEventHandlingComponentsTest {
             assertThat(capturedContext.get().getResource(batchKey)).isEqualTo("batch-value");
             assertThat(capturedContext.get().getResource(TrackingToken.RESOURCE_KEY))
                     .isEqualTo(perEventToken);
+        }
+    }
+
+    @Nested
+    class SegmentAwareRouting {
+
+        private static final QualifiedName EVENT_NAME = new QualifiedName(String.class);
+
+        // Integer.hashCode(n) == n, so a component whose sequence identifier is 0 routes to the
+        // even segment (segments[0] = id 0, mask 1) and identifier 1 routes to the odd segment
+        // (segments[1] = id 1, mask 1).
+        private final Segment[] segments = Segment.ROOT_SEGMENT.split();
+
+        private RecordingEventHandlingComponent componentRoutedToSegmentZero;
+        private RecordingEventHandlingComponent componentRoutedToSegmentOne;
+        private ProcessorEventHandlingComponents testSubject;
+
+        @BeforeEach
+        void setUp() {
+            componentRoutedToSegmentZero = recordingComponent("even", EVENT_NAME, 0);
+            componentRoutedToSegmentOne = recordingComponent("odd", EVENT_NAME, 1);
+            testSubject = new ProcessorEventHandlingComponents(
+                    List.of(componentRoutedToSegmentZero, componentRoutedToSegmentOne));
+        }
+
+        @Test
+        void handlesInSegmentZeroOnlyWithComponentRoutedToSegmentZero() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when
+            handleInSegment(event, segments[0]);
+
+            // then only the component whose sequence identifier routes to segment 0 handled the event
+            assertThat(componentRoutedToSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentOne.recorded()).isEmpty();
+        }
+
+        @Test
+        void handlesInSegmentOneOnlyWithComponentRoutedToSegmentOne() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when
+            handleInSegment(event, segments[1]);
+
+            // then only the component whose sequence identifier routes to segment 1 handled the event
+            assertThat(componentRoutedToSegmentOne.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentZero.recorded()).isEmpty();
+        }
+
+        @Test
+        void invokesAllSupportingComponentsWhenNoSegmentInContext() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when no Segment is attached to the context (e.g. a SubscribingEventProcessor)
+            handleWithoutSegment(event);
+
+            // then every supporting component handles the event
+            assertThat(componentRoutedToSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentOne.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void sequenceIdentifiersForExcludesNonSupportingComponents() {
+            // given a component that supports the event and one that does not
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+            RecordingEventHandlingComponent supporting =
+                    recordingComponent("supporting", EVENT_NAME, "supported-id");
+            RecordingEventHandlingComponent notSupporting =
+                    recordingComponent("not-supporting", new QualifiedName(Integer.class), "unsupported-id");
+            ProcessorEventHandlingComponents subject =
+                    new ProcessorEventHandlingComponents(List.of(supporting, notSupporting));
+            AtomicReference<Set<Object>> capturedIdentifiers = new AtomicReference<>();
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   capturedIdentifiers.set(subject.sequenceIdentifiersFor(event, ctx));
+                                   return CompletableFuture.completedFuture(null);
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then only the supporting component contributes a sequence identifier
+            assertThat(capturedIdentifiers.get()).containsExactly("supported-id");
+        }
+
+        private static RecordingEventHandlingComponent recordingComponent(String name,
+                                                                          QualifiedName supportedEvent,
+                                                                          Object sequenceIdentifier) {
+            SimpleEventHandlingComponent component =
+                    SimpleEventHandlingComponent.create(name, (event, context) -> Optional.of(sequenceIdentifier));
+            component.subscribe(supportedEvent, (event, context) -> MessageStream.empty());
+            return new RecordingEventHandlingComponent(component);
+        }
+
+        private void handleInSegment(EventMessage event, Segment segment) {
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, Context.empty());
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   ProcessingContext segmentContext = ctx.withResource(Segment.RESOURCE_KEY, segment);
+                                   return testSubject.handle(List.of(entry), segmentContext).asCompletableFuture();
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+        }
+
+        private void handleWithoutSegment(EventMessage event) {
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, Context.empty());
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> testSubject.handle(List.of(entry), ctx).asCompletableFuture())
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -79,6 +79,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -260,6 +261,98 @@ class PooledStreamingEventProcessorTest {
                    long currentPosition = testSubject.processingStatus().get(0).getCurrentPosition().orElse(0);
                    assertThat(currentPosition).isEqualTo(2);
                });
+    }
+
+    @Nested
+    class SegmentRouting {
+
+        // Integer.hashCode(n) == n, so with two segments a sequence identifier of 0 routes to segment 0
+        // (matches even hashes) and 1 routes to segment 1 (matches odd hashes).
+
+        @Test
+        void eachComponentHandlesEventOnceInItsOwnSegment() {
+            // given two components supporting the same event but routing to different segments
+            var componentForSegmentZero = recordingComponent("even", new QualifiedName(String.class), 0);
+            var componentForSegmentOne = recordingComponent("odd", new QualifiedName(String.class), 1);
+            List<EventHandlingComponent> components = List.of(componentForSegmentZero, componentForSegmentOne);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when a single event is published
+            EventMessage event = EventTestUtils.asEventMessage("Payload");
+            stubMessageSource.publishMessage(event);
+            startEventProcessor();
+
+            // then both segments consume the event (each claims it via its own matching component)
+            awaitSegmentsAtPosition(1L, 0, 1);
+
+            // then each component handles the event exactly once, in the single segment its identifier routes to
+            assertThat(componentForSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentForSegmentOne.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void eventIsHandledOnlyByComponentsSupportingItsType() {
+            // given two components supporting different event types, routing to different segments
+            var stringComponent = recordingComponent("string", new QualifiedName(String.class), 0);
+            var longComponent = recordingComponent("long", new QualifiedName(Long.class), 1);
+            List<EventHandlingComponent> components = List.of(stringComponent, longComponent);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when one event of each type is published
+            EventMessage stringEvent = EventTestUtils.asEventMessage("Payload");
+            EventMessage longEvent = EventTestUtils.asEventMessage(42L);
+            stubMessageSource.publishMessage(stringEvent);
+            stubMessageSource.publishMessage(longEvent);
+            startEventProcessor();
+
+            // then both segments advance past both events (a segment advances its token past events it does not handle)
+            awaitSegmentsAtPosition(2L, 0, 1);
+
+            // then each component only handles the event whose type it supports
+            assertThat(stringComponent.recorded()).containsExactly(stringEvent);
+            assertThat(longComponent.recorded()).containsExactly(longEvent);
+        }
+
+        @Test
+        void componentsSharingSequenceIdentifierHandleEventInSameSegment() {
+            // given two components supporting the same event with the same sequence identifier
+            var firstComponent = recordingComponent("first", new QualifiedName(String.class), 0);
+            var secondComponent = recordingComponent("second", new QualifiedName(String.class), 0);
+            List<EventHandlingComponent> components = List.of(firstComponent, secondComponent);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when a single event is published
+            EventMessage event = EventTestUtils.asEventMessage("Payload");
+            stubMessageSource.publishMessage(event);
+            startEventProcessor();
+
+            // then both segments advance, but only segment 0 claims the event
+            awaitSegmentsAtPosition(1L, 0, 1);
+
+            // then both components sharing that segment handle the event exactly once
+            assertThat(firstComponent.recorded()).containsExactly(event);
+            assertThat(secondComponent.recorded()).containsExactly(event);
+        }
+
+        private RecordingEventHandlingComponent recordingComponent(String name,
+                                                                   QualifiedName supportedEvent,
+                                                                   Object sequenceIdentifier) {
+            SimpleEventHandlingComponent component =
+                    SimpleEventHandlingComponent.create(name, (event, ctx) -> Optional.of(sequenceIdentifier));
+            component.subscribe(supportedEvent, (event, ctx) -> MessageStream.empty());
+            return new RecordingEventHandlingComponent(component);
+        }
+
+        private void awaitSegmentsAtPosition(long position, int... segmentIds) {
+            await().atMost(1, TimeUnit.SECONDS)
+                   .untilAsserted(() -> {
+                       for (int segmentId : segmentIds) {
+                           assertThat(testSubject.processingStatus()).containsKey(segmentId);
+                           assertThat(testSubject.processingStatus().get(segmentId).getCurrentPosition().orElse(0))
+                                   .isEqualTo(position);
+                       }
+                   });
+        }
     }
 
     private ProcessingContext createProcessingContext() {


### PR DESCRIPTION
# Route events per component when handling across segments

## Summary

A `PooledStreamingEventProcessor` could handle the **same event more than once** and in the
**wrong segment** whenever a single processor hosted multiple `EventHandlingComponent`s that use
**different `SequencingPolicy`** instances. This PR makes event handling apply the same
per-component segment routing that the admission filter already relies on, so each component
handles an event exactly once, in the single segment it belongs to.

## Background: how a pooled processor routes an event

A `PooledStreamingEventProcessor` runs one `WorkPackage` per `Segment`, and every work package
shares the **same** set of `EventHandlingComponent`s (wrapped in `ProcessorEventHandlingComponents`).
Which segment an event belongs to is derived from a component's **sequence identifier**
(`SequencingPolicy.sequenceIdentifierFor(...)`), hashed and masked against the segment.

Crucially, routing is decided in **two separate phases**:

```mermaid
sequenceDiagram
    participant Coord as Coordinator
    participant WP as WorkPackage for Segment S
    participant Filter as DefaultWorkPackageEventFilter
    participant PEHC as ProcessorEventHandlingComponents

    Note over Coord,Filter: Phase 1 - Scheduling / admission
    Coord->>WP: scheduleEvent(E)
    WP->>Filter: canHandle(E, ctx, Segment S)
    Filter-->>WP: boolean - does ANY component identifier hash to S
    Note over WP: result stored per entry, E enqueued only if true

    Note over WP,PEHC: Phase 2 - Handling, later, per batch
    WP->>PEHC: handle(batch, ctx) with Segment S in context
    Note over PEHC: BEFORE - runs EVERY supporting component, segment ignored
    Note over PEHC: AFTER - runs only components whose identifier hashes to S
```

The important detail: **admission** produces a single `boolean` per `(segment, event)`. It answers
*"does this event belong in this segment for anybody?"* using `anyMatch` over all component
identifiers. It does **not** record *which* component caused the match.

## The problem

Each `EventHandlingComponent` may declare its own `SequencingPolicy`. So for one and the same
event, component A and component B can resolve **different** sequence identifiers and therefore
legitimately belong to **different** segments. This is a supported topology, not a
misconfiguration.

Before this change:

- **Admission** (`DefaultWorkPackageEventFilter.canHandle`) admitted the event into a segment's
  queue when *any* component's identifier hashed into that segment.
- **Handling** (`ProcessorEventHandlingComponents.handle`) then invoked **every** component that
  `supports(...)` the event and never consulted the segment - even though the `Segment` is sitting
  in the `ProcessingContext` under `Segment.RESOURCE_KEY`.

Because the per-component reason for admission was discarded, every admitting segment re-ran *all*
components:

```mermaid
flowchart TD
    E["Event E<br/>A -> hashes to segment 0<br/>B -> hashes to segment 1"]

    E --> F0
    E --> F1

    subgraph S0["WorkPackage - Segment 0"]
        F0{"Filter: any identifier hashes to seg 0?<br/>YES (via A)"}
        H0["handle(): run ALL supporting components"]
        A0["A handles E   (correct)"]
        B0["B handles E   (WRONG - B belongs to seg 1)"]
        F0 -->|admitted| H0
        H0 --> A0
        H0 --> B0
    end

    subgraph S1["WorkPackage - Segment 1"]
        F1{"Filter: any identifier hashes to seg 1?<br/>YES (via B)"}
        H1["handle(): run ALL supporting components"]
        A1["A handles E   (WRONG - A belongs to seg 0)"]
        B1["B handles E   (correct)"]
        F1 -->|admitted| H1
        H1 --> A1
        H1 --> B1
    end
```

Net result: **A is handled twice and B is handled twice** (once per segment) instead of exactly
once each. This duplicates side effects (projections, notifications, mailings, ...) and breaks the
single-writer-per-sequence guarantee the sequencing policy is meant to provide.

### Why it stayed hidden

In the common configuration every component yields the **same** identifier for a given event
(e.g. all sequence by aggregate id, or all use the default policy). Then `sequenceIdentifiersFor`
collapses to a single-element set that hashes to exactly one segment: only that segment admits the
event and all components run once. No duplication. The defect only appears once components use
**heterogeneous** sequencing policies for the same event - which is exactly the case that was
untested.

## The fix

Handling now applies the **same per-component routing decision the filter already relies on**: a
component handles an event only when its own sequence identifier hashes into the segment currently
attached to the context.

```mermaid
flowchart TD
    E["Event E<br/>A -> hashes to segment 0<br/>B -> hashes to segment 1"]

    E --> F0
    E --> F1

    subgraph S0["WorkPackage - Segment 0"]
        F0{"Filter: any identifier hashes to seg 0?<br/>YES (via A)"}
        H0["handle(): canSegmentHandle(seg0, component) per component"]
        A0["A: id hashes to 0 -> HANDLES E"]
        B0["B: id hashes to 1 -> skipped"]
        F0 -->|admitted| H0
        H0 --> A0
        H0 --> B0
    end

    subgraph S1["WorkPackage - Segment 1"]
        F1{"Filter: any identifier hashes to seg 1?<br/>YES (via B)"}
        H1["handle(): canSegmentHandle(seg1, component) per component"]
        A1["A: id hashes to 0 -> skipped"]
        B1["B: id hashes to 1 -> HANDLES E"]
        F1 -->|admitted| H1
        H1 --> A1
        H1 --> B1
    end
```

Net result: **A once, B once** - each in the single segment it belongs to. Admission and handling
now agree.

Concretely, in `ProcessorEventHandlingComponents`:

1. **Per-component segment gate while handling.** `handle(...)` reads the `Segment` from the
   context (`Segment.fromContext`) and invokes a component only when it supports the event *and*
   `canSegmentHandle(segment, component, event, context)` is true. The check is
   `segment.matches(component.sequenceIdentifierFor(event, context))` - the identical computation
   the filter performs, so the two phases can no longer diverge.

2. **Non-segmented fallback preserved.** When no `Segment` is attached to the context (for example
   a `SubscribingEventProcessor`), `canSegmentHandle` returns `true` and every supporting component
   handles the event, exactly as before.

3. **`sequenceIdentifiersFor(...)` now ignores non-supporting components.** A component that does
   not support the event no longer contributes an identifier, so it can no longer cause a segment
   to claim an event it will never handle. This keeps the admission and handling views of "which
   components route here" symmetric.

`DefaultWorkPackageEventFilter`, `WorkPackage`, `Segment` and `SegmentMatcher` are unchanged.

## Testing

Added, following TDD (written to fail against the previous behaviour first):

**Unit tests** (`ProcessorEventHandlingComponentsTest` -> `@Nested SegmentAwareRouting`)
- an event handled within a segment only invokes the component whose identifier routes to that
  segment (one test per segment);
- with no segment in the context, every supporting component handles the event;
- `sequenceIdentifiersFor(...)` excludes components that do not support the event.

**End-to-end tests** (`PooledStreamingEventProcessorTest` -> `@Nested SegmentRouting`, `initialSegmentCount(2)`)
- two components with different identifiers each handle the event exactly once, in their own
  segment;
- components supporting different event types each handle only their own type, exactly once;
- two components sharing a sequence identifier both handle the event once in the same segment
  (guards against over-restriction).

Verification:
- Temporarily reverting the production fix turns the relevant unit tests and 2 of the 3 end-to-end
  tests **red** (duplicate deliveries), confirming they are genuine regression guards.
- Full `messaging` module: **4139 tests, 0 failures, 0 errors** (505 skipped).

## Compatibility

- Single-segment processors (default, `mask == 0`) are unaffected: `Segment.matches` always
  returns `true`, so every supporting component still handles every supported event.
- `SubscribingEventProcessor` and any non-segmented handling path are unaffected (no `Segment` in
  context -> all supporting components run).
- Behaviour changes only for multi-segment pooled processors whose components use different
  sequencing policies - the case that was previously duplicating deliveries.
