### PR TITLE
[Port] fix(messaging): resolve incorrect event routing in heterogeneous Sequencing Policy setup among Event Handling Components (#4769)

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -27,6 +27,8 @@ import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandlingComponent;
 import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SegmentMatcher;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequencingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -34,6 +36,7 @@ import org.axonframework.messaging.eventhandling.replay.GenericReplayStatusChang
 import org.axonframework.messaging.eventhandling.replay.ReplayStatus;
 import org.axonframework.messaging.eventhandling.replay.ReplayStatusChanged;
 import org.axonframework.messaging.eventhandling.replay.ResetContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
@@ -104,8 +107,13 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * <p>
      * The result of handling is an {@link MessageStream.Empty empty stream}. It's guaranteed that events with the same
      * {@link #sequenceIdentifiersFor(EventMessage, ProcessingContext)} value are processed by a single component in the
-     * order they are received, but sequencing is not preserved across different event handling components — this is
+     * order they are received, but sequencing is not preserved across different event handling components; this is
      * intentional, as they may have different sequencing policies.
+     * <p>
+     * When a {@link Segment} is attached to the {@code context} (as done by a segmented processor), a component only
+     * handles an event when the component's sequence identifier hashes into that segment, ensuring each event is handled
+     * exactly once per component across all segments. Without a {@link Segment} in the {@code context}, every supporting
+     * component handles the event.
      *
      * @param entries the batch of message stream entries to be processed
      * @param context the processing context in which the event messages are processed
@@ -131,6 +139,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
     ) {
         Optional<TrackingToken> token = TrackingToken.fromContext(context);
         boolean isReplaying = token.isPresent() && ReplayToken.isReplay(token.get());
+        Segment segment = Segment.fromContext(context).orElse(null);
 
         MessageStream<Message> result = MessageStream.empty();
         for (var component : components) {
@@ -138,7 +147,8 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
             if (isReplaying && !component.supportsReset()) {
                 continue;
             }
-            if (component.supports(event.type().qualifiedName())) {
+            if (component.supports(event.type().qualifiedName())
+                    && canHandleInSegment(segment, component, event, context)) {
                 var componentResult = component.handle(event, context);
                 result = result.concatWith(componentResult);
             }
@@ -150,6 +160,33 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
             }
         }
         return result.ignoreEntries().cast();
+    }
+
+    /**
+     * Determines whether the given {@code component} can handle the {@code event} in the given {@code segment}.
+     * <p>
+     * This reuses the same {@link SegmentMatcher} routing that is applied while scheduling the event, so a component
+     * handles an event only when its
+     * {@link EventHandlingComponent#sequenceIdentifierFor(EventMessage, ProcessingContext) sequence identifier} hashes
+     * into that segment. When {@code segment} is {@code null} (for example, a
+     * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor}), handling is
+     * not segmented and the component always handles the event.
+     *
+     * @param segment   the {@link Segment} currently handling the event, or {@code null} when handling is not segmented
+     * @param component the component that would handle the event
+     * @param event     the event being handled
+     * @param context   the processing context in which the event is handled
+     * @return {@code true} when the component can handle the event in the given segment
+     */
+    private static boolean canHandleInSegment(@Nullable Segment segment,
+                                              EventHandlingComponent component,
+                                              EventMessage event,
+                                              ProcessingContext context) {
+        if (segment == null) {
+            return true;
+        }
+        return new SegmentMatcher((e, ctx) -> Optional.of(component.sequenceIdentifierFor(e, ctx)))
+                .matches(segment, event, context);
     }
 
     /**
@@ -183,7 +220,9 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * @return A set of sequence identifiers associated with the given event and context.
      */
     public Set<Object> sequenceIdentifiersFor(EventMessage event, ProcessingContext context) {
+        QualifiedName eventName = event.type().qualifiedName();
         return components.stream()
+                         .filter(c -> c.supports(eventName))
                          .map(c -> c.sequenceIdentifierFor(event, context))
                          .collect(Collectors.toSet());
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
@@ -19,17 +19,23 @@ package org.axonframework.messaging.eventhandling.processing;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.LegacyResources;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.EventTestUtils;
+import org.axonframework.messaging.eventhandling.RecordingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.SimpleEventHandlingComponent;
+import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -183,6 +189,121 @@ class ProcessorEventHandlingComponentsTest {
             assertThat(capturedContext.get().getResource(batchKey)).isEqualTo("batch-value");
             assertThat(capturedContext.get().getResource(TrackingToken.RESOURCE_KEY))
                     .isEqualTo(perEventToken);
+        }
+    }
+
+    @Nested
+    class SegmentAwareRouting {
+
+        private static final QualifiedName EVENT_NAME = new QualifiedName(String.class);
+
+        // Integer.hashCode(n) == n, so a component whose sequence identifier is 0 routes to the
+        // even segment (segments[0] = id 0, mask 1) and identifier 1 routes to the odd segment
+        // (segments[1] = id 1, mask 1).
+        private final Segment[] segments = Segment.ROOT_SEGMENT.split();
+
+        private RecordingEventHandlingComponent componentRoutedToSegmentZero;
+        private RecordingEventHandlingComponent componentRoutedToSegmentOne;
+        private ProcessorEventHandlingComponents testSubject;
+
+        @BeforeEach
+        void setUp() {
+            componentRoutedToSegmentZero = recordingComponent("even", EVENT_NAME, 0);
+            componentRoutedToSegmentOne = recordingComponent("odd", EVENT_NAME, 1);
+            testSubject = new ProcessorEventHandlingComponents(
+                    List.of(componentRoutedToSegmentZero, componentRoutedToSegmentOne));
+        }
+
+        @Test
+        void handlesInSegmentZeroOnlyWithComponentRoutedToSegmentZero() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when
+            handleInSegment(event, segments[0]);
+
+            // then only the component whose sequence identifier routes to segment 0 handled the event
+            assertThat(componentRoutedToSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentOne.recorded()).isEmpty();
+        }
+
+        @Test
+        void handlesInSegmentOneOnlyWithComponentRoutedToSegmentOne() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when
+            handleInSegment(event, segments[1]);
+
+            // then only the component whose sequence identifier routes to segment 1 handled the event
+            assertThat(componentRoutedToSegmentOne.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentZero.recorded()).isEmpty();
+        }
+
+        @Test
+        void invokesAllSupportingComponentsWhenNoSegmentInContext() {
+            // given
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when no Segment is attached to the context (e.g. a SubscribingEventProcessor)
+            handleWithoutSegment(event);
+
+            // then every supporting component handles the event
+            assertThat(componentRoutedToSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentRoutedToSegmentOne.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void sequenceIdentifiersForExcludesNonSupportingComponents() {
+            // given a component that supports the event and one that does not
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+            RecordingEventHandlingComponent supporting =
+                    recordingComponent("supporting", EVENT_NAME, "supported-id");
+            RecordingEventHandlingComponent notSupporting =
+                    recordingComponent("not-supporting", new QualifiedName(Integer.class), "unsupported-id");
+            ProcessorEventHandlingComponents subject =
+                    new ProcessorEventHandlingComponents(List.of(supporting, notSupporting));
+            AtomicReference<Set<Object>> capturedIdentifiers = new AtomicReference<>();
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   capturedIdentifiers.set(subject.sequenceIdentifiersFor(event, ctx));
+                                   return CompletableFuture.completedFuture(null);
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then only the supporting component contributes a sequence identifier
+            assertThat(capturedIdentifiers.get()).containsExactly("supported-id");
+        }
+
+        private static RecordingEventHandlingComponent recordingComponent(String name,
+                                                                          QualifiedName supportedEvent,
+                                                                          Object sequenceIdentifier) {
+            SimpleEventHandlingComponent component =
+                    SimpleEventHandlingComponent.create(name, (event, context) -> Optional.of(sequenceIdentifier));
+            component.subscribe(supportedEvent, (event, context) -> MessageStream.empty());
+            return new RecordingEventHandlingComponent(component);
+        }
+
+        private void handleInSegment(EventMessage event, Segment segment) {
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, Context.empty());
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   ProcessingContext segmentContext = ctx.withResource(Segment.RESOURCE_KEY, segment);
+                                   return testSubject.handle(List.of(entry), segmentContext).asCompletableFuture();
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+        }
+
+        private void handleWithoutSegment(EventMessage event) {
+            MessageStream.Entry<EventMessage> entry = new SimpleEntry<>(event, Context.empty());
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> testSubject.handle(List.of(entry), ctx).asCompletableFuture())
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -241,6 +242,98 @@ class PooledStreamingEventProcessorTest {
                    long currentPosition = testSubject.processingStatus().get(0).getCurrentPosition().orElse(0);
                    assertThat(currentPosition).isEqualTo(2);
                });
+    }
+
+    @Nested
+    class SegmentRouting {
+
+        // Integer.hashCode(n) == n, so with two segments a sequence identifier of 0 routes to segment 0
+        // (matches even hashes) and 1 routes to segment 1 (matches odd hashes).
+
+        @Test
+        void eachComponentHandlesEventOnceInItsOwnSegment() {
+            // given two components supporting the same event but routing to different segments
+            var componentForSegmentZero = recordingComponent("even", new QualifiedName(String.class), 0);
+            var componentForSegmentOne = recordingComponent("odd", new QualifiedName(String.class), 1);
+            List<EventHandlingComponent> components = List.of(componentForSegmentZero, componentForSegmentOne);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when a single event is published
+            EventMessage event = EventTestUtils.asEventMessage("Payload");
+            stubMessageSource.publishMessage(event);
+            startEventProcessor();
+
+            // then both segments consume the event (each claims it via its own matching component)
+            awaitSegmentsAtPosition(1L, 0, 1);
+
+            // then each component handles the event exactly once, in the single segment its identifier routes to
+            assertThat(componentForSegmentZero.recorded()).containsExactly(event);
+            assertThat(componentForSegmentOne.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void eventIsHandledOnlyByComponentsSupportingItsType() {
+            // given two components supporting different event types, routing to different segments
+            var stringComponent = recordingComponent("string", new QualifiedName(String.class), 0);
+            var longComponent = recordingComponent("long", new QualifiedName(Long.class), 1);
+            List<EventHandlingComponent> components = List.of(stringComponent, longComponent);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when one event of each type is published
+            EventMessage stringEvent = EventTestUtils.asEventMessage("Payload");
+            EventMessage longEvent = EventTestUtils.asEventMessage(42L);
+            stubMessageSource.publishMessage(stringEvent);
+            stubMessageSource.publishMessage(longEvent);
+            startEventProcessor();
+
+            // then both segments advance past both events (a segment advances its token past events it does not handle)
+            awaitSegmentsAtPosition(2L, 0, 1);
+
+            // then each component only handles the event whose type it supports
+            assertThat(stringComponent.recorded()).containsExactly(stringEvent);
+            assertThat(longComponent.recorded()).containsExactly(longEvent);
+        }
+
+        @Test
+        void componentsSharingSequenceIdentifierHandleEventInSameSegment() {
+            // given two components supporting the same event with the same sequence identifier
+            var firstComponent = recordingComponent("first", new QualifiedName(String.class), 0);
+            var secondComponent = recordingComponent("second", new QualifiedName(String.class), 0);
+            List<EventHandlingComponent> components = List.of(firstComponent, secondComponent);
+            withTestSubject(components, c -> c.initialSegmentCount(2));
+
+            // when a single event is published
+            EventMessage event = EventTestUtils.asEventMessage("Payload");
+            stubMessageSource.publishMessage(event);
+            startEventProcessor();
+
+            // then both segments advance, but only segment 0 claims the event
+            awaitSegmentsAtPosition(1L, 0, 1);
+
+            // then both components sharing that segment handle the event exactly once
+            assertThat(firstComponent.recorded()).containsExactly(event);
+            assertThat(secondComponent.recorded()).containsExactly(event);
+        }
+
+        private RecordingEventHandlingComponent recordingComponent(String name,
+                                                                   QualifiedName supportedEvent,
+                                                                   Object sequenceIdentifier) {
+            SimpleEventHandlingComponent component =
+                    SimpleEventHandlingComponent.create(name, (event, ctx) -> Optional.of(sequenceIdentifier));
+            component.subscribe(supportedEvent, (event, ctx) -> MessageStream.empty());
+            return new RecordingEventHandlingComponent(component);
+        }
+
+        private void awaitSegmentsAtPosition(long position, int... segmentIds) {
+            await().atMost(1, TimeUnit.SECONDS)
+                   .untilAsserted(() -> {
+                       for (int segmentId : segmentIds) {
+                           assertThat(testSubject.processingStatus()).containsKey(segmentId);
+                           assertThat(testSubject.processingStatus().get(segmentId).getCurrentPosition().orElse(0))
+                                   .isEqualTo(position);
+                       }
+                   });
+        }
     }
 
     private ProcessingContext createProcessingContext() {


### PR DESCRIPTION
## Port

Cherry-pick of commit c66751903c00850c1d43a09cbeaa009487d01c8a from `main` (original PR #4769) into `axon-5.2.x`.

## Summary

A `PooledStreamingEventProcessor` could handle the **same event more than once** and in the **wrong segment** whenever a single processor hosted multiple `EventHandlingComponent`s using **different `SequencingPolicy`** instances. Handling now applies the same per-component segment routing that the admission filter already relies on, so each component handles an event exactly once, in the single segment it belongs to.

Routing had been decided in two disconnected places that could disagree:

* **Admission** (`DefaultWorkPackageEventFilter.canHandle`) admitted an event into a segment when *any* component's sequence identifier hashed into that segment - a per-(segment, event) boolean that did not record *which* component matched.
* **Handling** (`ProcessorEventHandlingComponents.handle`) then invoked *every* supporting component and never consulted the segment, even though it is available under `Segment.RESOURCE_KEY`.

Because the per-component admission reason was discarded, a component whose identifier belongs to segment 1 was still executed in segment 0 (and vice versa), duplicating side effects and violating the single-writer-per-sequence guarantee. With the common setup (every component yields the same identifier), the set collapses to one segment and the defect stays hidden.

Handling now routes each component through the same `SegmentMatcher` used during scheduling, so both phases share one routing implementation and cannot drift. When no `Segment` is attached (e.g. `SubscribingEventProcessor`), handling is not segmented and every supporting component runs, preserving existing behaviour. Tracking-token advancement is unaffected. Additionally, `sequenceIdentifiersFor` now ignores components that do not support the event.

## Verification

`./mvnw test -pl messaging -Dtest='ProcessorEventHandlingComponentsTest,PooledStreamingEventProcessorTest'` - green (all routing tests pass).
