### PR TITLE
Allow EntityMetamodel to be decorated without breaking ID resolution

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/EventSourcedEntity.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/EventSourcedEntity.java
@@ -28,10 +28,10 @@ import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolver;
+import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolverDefinition;
 import org.axonframework.modelling.annotation.EntityIdResolverDefinition;
 import org.axonframework.modelling.annotation.TargetEntityId;
 import org.axonframework.modelling.entity.EntityCommandHandler;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityIdResolverDefinition;
 import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
 
 import java.lang.annotation.ElementType;
@@ -162,11 +162,11 @@ public @interface EventSourcedEntity {
     /**
      * The definition of the {@link EntityIdResolverDefinition} to use to resolve the entity id from a
      * {@link CommandMessage command message}. Defaults to the
-     * {@link AnnotatedEntityIdResolverDefinition}, which resolves the entity id based on the
-     * {@link TargetEntityId} annotation on a payload field or method, after
-     * converting the payload to the representation wanted by the entity.
+     * {@link AnnotationBasedEntityIdResolverDefinition}, which resolves the entity id based on the
+     * {@link TargetEntityId} annotation on a payload field or method. Conversion of the payload to the
+     * representation wanted by the entity is applied by the module before resolution.
      *
      * @return The definition to construct an {@link EntityIdResolverDefinition}.
      */
-    Class<? extends EntityIdResolverDefinition> entityIdResolverDefinition() default AnnotatedEntityIdResolverDefinition.class;
+    Class<? extends EntityIdResolverDefinition> entityIdResolverDefinition() default AnnotationBasedEntityIdResolverDefinition.class;
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/AnnotatedEventSourcedEntityModule.java
@@ -43,6 +43,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -70,6 +71,7 @@ class AnnotatedEventSourcedEntityModule<I, E>
     private final Class<I> idType;
     private final Class<E> entityType;
     private final Set<Class<? extends E>> concreteTypes;
+    private final AtomicReference<AnnotatedEntityMetamodel<E>> metamodelCache = new AtomicReference<>();
 
     AnnotatedEventSourcedEntityModule(Class<I> idType, Class<E> entityType) {
         super("AnnotatedEventSourcedEntityModule<%s, %s>".formatted(idType.getName(), entityType.getName()));
@@ -84,7 +86,7 @@ class AnnotatedEventSourcedEntityModule<I, E>
 
         OptionalPhase<I, E> phase = EventSourcedEntityModule
                 .declarative(idType, entityType)
-                .messagingModel((c, b) -> this.buildMetaModel(c))
+                .messagingModel((c, b) -> this.getOrBuildMetamodel(c))
                 .entityFactory(entityFactory(annotationAttributes, concreteTypes))
                 .criteriaResolver(criteriaResolver(annotationAttributes))
                 .entityIdResolver(entityIdResolver(annotationAttributes));
@@ -109,6 +111,10 @@ class AnnotatedEventSourcedEntityModule<I, E>
         }
 
         componentRegistry(cr -> cr.registerModule(phase.build()));
+    }
+
+    private AnnotatedEntityMetamodel<E> getOrBuildMetamodel(Configuration c) {
+        return metamodelCache.updateAndGet(existing -> existing != null ? existing : buildMetaModel(c));
     }
 
     private AnnotatedEntityMetamodel<E> buildMetaModel(Configuration c) {
@@ -153,8 +159,14 @@ class AnnotatedEventSourcedEntityModule<I, E>
         var type = (Class<EntityIdResolverDefinition>) annotationAttributes.get("entityIdResolverDefinition");
         var definition = getConstructorFunctionWithZeroArguments(type).get();
         return c -> {
-            var component = (AnnotatedEntityMetamodel<E>) c.getComponent(EntityMetamodel.class, entityName());
-            return definition.createIdResolver(entityType, idType, component, c);
+            AnnotatedEntityMetamodel<E> annotatedMetamodel = getOrBuildMetamodel(c);
+            EntityMetamodel<E> metamodel = c.getComponent(EntityMetamodel.class, entityName());
+            EntityIdResolver<I> inner = definition.createIdResolver(entityType, idType, metamodel, c);
+            return new RepresentationConvertingEntityIdResolver<>(
+                    inner,
+                    annotatedMetamodel::getExpectedRepresentation,
+                    c.getComponent(MessageConverter.class)
+            );
         };
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/RepresentationConvertingEntityIdResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/RepresentationConvertingEntityIdResolver.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.configuration;
+
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.common.infra.DescribableComponent;
+import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.modelling.EntityIdResolutionException;
+import org.axonframework.modelling.EntityIdResolver;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * {@link EntityIdResolver} decorator that converts the message payload to the handler's expected type before
+ * delegating ID resolution. The expected type is determined per message by the supplied
+ * {@code representationProvider}. If no expected type is known for a message, the payload is passed to the
+ * delegate as-is.
+ *
+ * @param <ID> the type of the identifier to resolve
+ * @author John Hendrikx
+ * @since 5.3.0
+ */
+class RepresentationConvertingEntityIdResolver<ID> implements EntityIdResolver<ID>, DescribableComponent {
+
+    private final EntityIdResolver<ID> delegate;
+    private final Function<QualifiedName, @Nullable Class<?>> representationProvider;
+    private final MessageConverter converter;
+
+    RepresentationConvertingEntityIdResolver(
+            EntityIdResolver<ID> delegate,
+            Function<QualifiedName, @Nullable Class<?>> representationProvider,
+            MessageConverter converter
+    ) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate may not be null");
+        this.representationProvider = Objects.requireNonNull(representationProvider,
+                                                             "representationProvider may not be null");
+        this.converter = Objects.requireNonNull(converter, "converter may not be null");
+    }
+
+    @Override
+    public ID resolve(Message message, ProcessingContext context) throws EntityIdResolutionException {
+        Class<?> expectedRepresentation = representationProvider.apply(message.type().qualifiedName());
+        if (expectedRepresentation != null) {
+            return delegate.resolve(message.withConvertedPayload(expectedRepresentation, converter), context);
+        }
+        return delegate.resolve(message, context);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+        descriptor.describeProperty("representationProvider", representationProvider);
+        descriptor.describeProperty("converter", converter);
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/RepresentationConvertingEntityIdResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/RepresentationConvertingEntityIdResolverTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.configuration;
+
+import org.axonframework.conversion.jackson.JacksonConverter;
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.commandhandling.CommandResultMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandMessage;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.MultiParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.axonframework.modelling.EntityIdResolutionException;
+import org.axonframework.modelling.EntityIdResolver;
+import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolver;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.EntityMetamodel;
+import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link RepresentationConvertingEntityIdResolver} correctly converts serialized payloads to the
+ * expected type before ID extraction, and that this works regardless of whether the {@link EntityMetamodel} component
+ * in configuration is a plain decorator (with no knowledge of expected representations).
+ */
+class RepresentationConvertingEntityIdResolverTest {
+
+    private final ParameterResolverFactory parameterResolverFactory =
+            MultiParameterResolverFactory.ordered(
+                    ClasspathParameterResolverFactory.forClass(AnnotatedCourse.class)
+            );
+    private final ClassBasedMessageTypeResolver messageTypeResolver = new ClassBasedMessageTypeResolver();
+    private final MessageConverter messageConverter = new DelegatingMessageConverter(new JacksonConverter());
+    private final EventConverter eventConverter = new DelegatingEventConverter(new JacksonConverter());
+
+    @Test
+    void resolvesIdFromSerializedPayloadUsingAnnotationScan() throws EntityIdResolutionException {
+        // given
+        AnnotatedEntityMetamodel<AnnotatedCourse> annotatedMetamodel = AnnotatedEntityMetamodel.forConcreteType(
+                AnnotatedCourse.class, parameterResolverFactory, messageTypeResolver,
+                messageConverter, eventConverter
+        );
+
+        EntityIdResolver<String> inner = new AnnotationBasedEntityIdResolver<>();
+        var resolver = new RepresentationConvertingEntityIdResolver<>(
+                inner,
+                annotatedMetamodel::getExpectedRepresentation,
+                messageConverter
+        );
+
+        var message = new GenericCommandMessage(
+                new MessageType(RegisterCourseCommand.class),
+                """
+                {"courseId": "course-123"}"""
+        );
+
+        // when
+        String id = resolver.resolve(message, StubProcessingContext.forMessage(message));
+
+        // then
+        assertThat(id).isEqualTo("course-123");
+    }
+
+    @Test
+    void resolvesIdEvenWhenEntityMetamodelIsWrappedInPlainDecorator() throws EntityIdResolutionException {
+        // given
+        AnnotatedEntityMetamodel<AnnotatedCourse> annotatedMetamodel = AnnotatedEntityMetamodel.forConcreteType(
+                AnnotatedCourse.class, parameterResolverFactory, messageTypeResolver,
+                messageConverter, eventConverter
+        );
+
+        // Simulate user-provided decoration: a plain EntityMetamodel wrapper that has no knowledge of
+        // expected payload representations. Previously, this would break ID resolution because the
+        // hard cast to AnnotatedEntityMetamodel would fail. Now the representation info comes from the
+        // annotation scan cached in the module, independently of whatever component is registered.
+        EntityMetamodel<AnnotatedCourse> plainDecorator = new PlainDelegatingEntityMetamodel<>(annotatedMetamodel);
+
+        // The resolver uses the cached annotated metamodel for representation info (as the module does),
+        // and the plain decorator would be the registered component passed to EntityIdResolverDefinition.
+        // Since AnnotationBasedEntityIdResolverDefinition ignores the metamodel parameter, this is transparent.
+        EntityIdResolver<String> inner = new AnnotationBasedEntityIdResolver<>();
+        var resolver = new RepresentationConvertingEntityIdResolver<>(
+                inner,
+                annotatedMetamodel::getExpectedRepresentation,  // from cache, not from the decorated component
+                messageConverter
+        );
+
+        var message = new GenericCommandMessage(
+                new MessageType(RegisterCourseCommand.class),
+                """
+                {"courseId": "course-456"}"""
+        );
+
+        // when
+        String id = resolver.resolve(message, StubProcessingContext.forMessage(message));
+
+        // then — ID resolves correctly despite the EntityMetamodel component being a plain decorator
+        assertThat(id).isEqualTo("course-456");
+    }
+
+    @Test
+    void passesPayloadThroughUnconvertedWhenNoRepresentationKnown() throws EntityIdResolutionException {
+        // given — a representation provider that knows nothing (simulates unknown message type)
+        var resolver = new RepresentationConvertingEntityIdResolver<String>(
+                new AnnotationBasedEntityIdResolver<>(),
+                qualifiedName -> null,
+                messageConverter
+        );
+
+        // Payload is already a proper object (not serialized), so no conversion needed
+        var command = new RegisterCourseCommand("course-789");
+        var message = new GenericCommandMessage(new MessageType(RegisterCourseCommand.class), command);
+
+        // when
+        String id = resolver.resolve(message, StubProcessingContext.forMessage(message));
+
+        // then
+        assertThat(id).isEqualTo("course-789");
+    }
+
+    // --- Domain classes ---
+
+    record RegisterCourseCommand(@TargetEntityId String courseId) {
+
+    }
+
+    @EventSourcedEntity
+    static class AnnotatedCourse {
+
+        private final String id;
+
+        private AnnotatedCourse(String id) {
+            this.id = id;
+        }
+
+        @CommandHandler
+        static AnnotatedCourse register(RegisterCourseCommand command) {
+            return new AnnotatedCourse(command.courseId());
+        }
+    }
+
+    /**
+     * Plain {@link EntityMetamodel} decorator with no knowledge of expected payload representations.
+     * Represents a user-provided decoration that simply delegates all operations.
+     */
+    static class PlainDelegatingEntityMetamodel<E> implements EntityMetamodel<E> {
+
+        private final EntityMetamodel<E> delegate;
+
+        PlainDelegatingEntityMetamodel(EntityMetamodel<E> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Class<E> entityType() {
+            return delegate.entityType();
+        }
+
+        @Override
+        public MessageStream.Single<CommandResultMessage> handleCreate(CommandMessage message,
+                                                                       ProcessingContext context) {
+            return delegate.handleCreate(message, context);
+        }
+
+        @Override
+        public MessageStream.Single<CommandResultMessage> handleInstance(CommandMessage message,
+                                                                         E entity,
+                                                                         ProcessingContext context) {
+            return delegate.handleInstance(message, entity, context);
+        }
+
+        @Override
+        public Set<org.axonframework.messaging.core.QualifiedName> supportedCreationalCommands() {
+            return delegate.supportedCreationalCommands();
+        }
+
+        @Override
+        public Set<org.axonframework.messaging.core.QualifiedName> supportedInstanceCommands() {
+            return delegate.supportedInstanceCommands();
+        }
+
+        @Override
+        public Set<org.axonframework.messaging.core.QualifiedName> supportedCommands() {
+            return delegate.supportedCommands();
+        }
+
+        @Override
+        public E evolve(@Nullable E entity,
+                        org.axonframework.messaging.eventhandling.EventMessage event,
+                        ProcessingContext context) {
+            return delegate.evolve(entity, event, context);
+        }
+
+        @Override
+        public void describeTo(org.axonframework.common.infra.ComponentDescriptor descriptor) {
+            delegate.describeTo(descriptor);
+        }
+    }
+}

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/stereotype/EventSourced.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/stereotype/EventSourced.java
@@ -27,9 +27,9 @@ import org.axonframework.eventsourcing.annotation.EventSourcedEntityFactoryDefin
 import org.axonframework.eventsourcing.annotation.reflection.AnnotationBasedEventSourcedEntityFactoryDefinition;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolverDefinition;
 import org.axonframework.modelling.annotation.EntityIdResolverDefinition;
 import org.axonframework.modelling.annotation.TargetEntityId;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityIdResolverDefinition;
 import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.annotation.AliasFor;
@@ -116,12 +116,12 @@ public @interface EventSourced {
     /**
      * The definition of the {@link EntityIdResolverDefinition} to use to resolve the entity id from a
      * {@link CommandMessage command message}. Defaults to the
-     * {@link AnnotatedEntityIdResolverDefinition}, which resolves the entity id based on the
-     * {@link TargetEntityId} annotation on a payload field or method, after
-     * converting the payload to the representation wanted by the entity.
+     * {@link AnnotationBasedEntityIdResolverDefinition}, which resolves the entity id based on the
+     * {@link TargetEntityId} annotation on a payload field or method. Conversion of the payload to the
+     * representation wanted by the entity is applied by the module before resolution.
      *
      * @return The definition to construct an {@link EntityIdResolverDefinition}.
      */
     @AliasFor(annotation = EventSourcedEntity.class, attribute = "entityIdResolverDefinition")
-    Class<? extends EntityIdResolverDefinition> entityIdResolverDefinition() default AnnotatedEntityIdResolverDefinition.class;
+    Class<? extends EntityIdResolverDefinition> entityIdResolverDefinition() default AnnotationBasedEntityIdResolverDefinition.class;
 }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityIdResolverDefinition.java
@@ -17,7 +17,7 @@
 package org.axonframework.modelling.annotation;
 
 import org.axonframework.common.configuration.Configuration;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.EntityIdResolver;
 
 /**
@@ -31,7 +31,7 @@ public class AnnotationBasedEntityIdResolverDefinition implements EntityIdResolv
     @Override
     public <E, ID> EntityIdResolver<ID> createIdResolver(Class<E> entityType,
                                                          Class<ID> idType,
-                                                         AnnotatedEntityMetamodel<E> entityMetamodel,
+                                                         EntityMetamodel<E> entityMetamodel,
                                                          Configuration configuration
     ) {
         return new AnnotationBasedEntityIdResolver<>();

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/EntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/EntityIdResolverDefinition.java
@@ -18,7 +18,7 @@ package org.axonframework.modelling.annotation;
 
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.modelling.EntityIdResolver;
-import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.EntityMetamodel;
 
 /**
  * Definition describing how to create an {@link EntityIdResolver} for a given entity type and identifier type.
@@ -34,18 +34,18 @@ public interface EntityIdResolverDefinition {
     /**
      * Creates an {@link EntityIdResolver} for the given entity type and identifier type.
      *
-     * @param entityType      The type of the entity for which the resolver is created.
-     * @param idType          The type of the identifier for which the resolver is created.
-     * @param entityMetamodel The metamodel of the entity.
-     * @param configuration   The configuration of the application, providing access to the components available.
-     * @param <E>             The type of the entity for which the resolver is created.
-     * @param <ID>            The type of the identifier for which the resolver is created.
-     * @return The {@link EntityIdResolver} for the given entity type and identifier type.
+     * @param entityType      the type of the entity for which the resolver is created
+     * @param idType          the type of the identifier for which the resolver is created
+     * @param entityMetamodel the metamodel of the entity
+     * @param configuration   the configuration of the application, providing access to the components available
+     * @param <E>             the type of the entity for which the resolver is created
+     * @param <ID>            the type of the identifier for which the resolver is created
+     * @return the {@link EntityIdResolver} for the given entity type and identifier type
      */
     <E, ID> EntityIdResolver<ID> createIdResolver(
             Class<E> entityType,
             Class<ID> idType,
-            AnnotatedEntityMetamodel<E> entityMetamodel,
+            EntityMetamodel<E> entityMetamodel,
             Configuration configuration
     );
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolver.java
@@ -39,7 +39,13 @@ import java.util.Objects;
  * @param <ID> The type of the identifier to resolve.
  * @author Mitchell Herrijgers
  * @since 5.0.0
+ * @deprecated Coupling the id resolver directly to the {@link AnnotatedEntityMetamodel} prevents the
+ * {@code EntityMetamodel} from being decorated or replaced, since resolution would break whenever the registered
+ * component is not an {@code AnnotatedEntityMetamodel}. Payload conversion to the handler's expected representation
+ * is now applied independently of the metamodel component, so annotation-based resolution only needs the plain
+ * {@link AnnotationBasedEntityIdResolver}. No direct replacement is required.
  */
+@Deprecated(since = "5.3.0")
 public class AnnotatedEntityIdResolver<ID> implements EntityIdResolver<ID>, DescribableComponent {
 
     private final AnnotatedEntityMetamodel<?> metamodel;

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverDefinition.java
@@ -20,9 +20,11 @@ import org.axonframework.common.configuration.Configuration;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolver;
+import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolverDefinition;
 import org.axonframework.modelling.annotation.EntityIdResolverDefinition;
 import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.EntityMetamodel;
 
 /**
  * {@link EntityIdResolverDefinition} that converts the payload of incoming messages based on the
@@ -32,16 +34,30 @@ import org.axonframework.modelling.annotation.TargetEntityId;
  *
  * @author Mitchell Herrijgers
  * @since 5.0.0
+ * @deprecated Performing the payload conversion inside the resolver ties it to the {@link AnnotatedEntityMetamodel},
+ * which prevents the {@code EntityMetamodel} component from being decorated or replaced. Payload conversion is now
+ * applied independently of the metamodel component, so annotation-based id resolution only needs the plain
+ * {@link AnnotationBasedEntityIdResolverDefinition}. This definition remains functional for existing configurations
+ * but requires the resolved {@code EntityMetamodel} to be an {@link AnnotatedEntityMetamodel}.
  */
+@Deprecated(since = "5.3.0")
 public class AnnotatedEntityIdResolverDefinition implements EntityIdResolverDefinition {
 
     @Override
     public <E, ID> EntityIdResolver<ID> createIdResolver(Class<E> entityType,
                                                          Class<ID> idType,
-                                                         AnnotatedEntityMetamodel<E> entityMetamodel,
+                                                         EntityMetamodel<E> entityMetamodel,
                                                          Configuration configuration) {
+        if (!(entityMetamodel instanceof AnnotatedEntityMetamodel<E> annotatedEntityMetamodel)) {
+            throw new IllegalArgumentException(
+                    "The deprecated AnnotatedEntityIdResolverDefinition requires an AnnotatedEntityMetamodel, "
+                            + "but received [" + entityMetamodel.getClass().getName() + "]. Use the "
+                            + "AnnotationBasedEntityIdResolverDefinition instead, which does not depend on the "
+                            + "metamodel implementation."
+            );
+        }
         return new AnnotatedEntityIdResolver<>(
-                entityMetamodel,
+                annotatedEntityMetamodel,
                 idType,
                 configuration.getComponent(MessageConverter.class),
                 new AnnotationBasedEntityIdResolver<>()

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -44,6 +44,7 @@ import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.entity.PolymorphicEntityMetamodel;
 import org.axonframework.modelling.entity.child.EntityChildMetamodel;
+import org.axonframework.common.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,12 +84,19 @@ import static org.axonframework.messaging.core.annotation.AnnotatedHandlerInspec
  * annotated methods and fields, but the AnnotatedEntityModel dropped aggregate versioning (conflict resolution), no
  * longer required an id in the entity, and creates a declarative metamodel instead of relying on reflection at
  * runtime.
+ * <p>
+ * This class is marked {@link Internal} because it is an annotation-scanning implementation detail: it is built by the
+ * framework from the entity class and exposes reflection-specific behavior (such as
+ * {@link #getExpectedRepresentation(QualifiedName)}) that is not part of the {@link EntityMetamodel} contract. Users
+ * should interact with entities through the {@code EntityMetamodel} interface, which can be freely decorated or
+ * replaced, rather than depending on this concrete type.
  *
  * @param <E> The type of entity this metamodel describes.
  * @author Mitchell Herrijgers
  * @author Allard Buijze
  * @since 3.1.0
  */
+@Internal
 public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, DescribableComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(AnnotatedEntityMetamodel.class);

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityIdResolverTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation") // Intentionally tests the deprecated AnnotatedEntityIdResolver.
 class AnnotatedEntityIdResolverTest {
 
     @Mock


### PR DESCRIPTION
## Problem

`AnnotatedEventSourcedEntityModule` contained a hard cast to `AnnotatedEntityMetamodel<E>` when building the `EntityIdResolver`. This made the `EntityMetamodel` component impossible to decorate or replace: any plain wrapper would cause a `ClassCastException` at startup. The root cause was that `EntityIdResolverDefinition.createIdResolver` required `AnnotatedEntityMetamodel<E>` as a parameter, leaking an annotation-specific concrete type into what should be a generic SPI.

## Solution

Representation info (the mapping from message `QualifiedName` to expected payload `Class`) is now sourced from the `AnnotatedEntityMetamodel` built and cached by `AnnotatedEventSourcedEntityModule` itself, rather than from whatever component ends up registered in configuration. A new `RepresentationConvertingEntityIdResolver` wraps the delegate resolver and applies payload conversion using this cached provider before delegating ID extraction. The `EntityMetamodel` component in configuration is passed to `EntityIdResolverDefinition.createIdResolver` as the plain `EntityMetamodel<E>` interface — no cast required — and since `AnnotatedEntityIdResolverDefinition` only needs to perform annotation-based ID extraction (the conversion step having moved to the wrapper), it simplifies to returning an `AnnotationBasedEntityIdResolver` directly.

## Impact

`EntityIdResolverDefinition.createIdResolver` now accepts `EntityMetamodel<E>` instead of `AnnotatedEntityMetamodel<E>`, which is a minor breaking change for any custom implementations of the interface. `AnnotatedEntityMetamodel` is marked `@Internal` as it is no longer part of the public API surface. `AnnotatedEntityIdResolver` is deprecated as its responsibility has been absorbed by the new wrapper class.
