### PR TITLE
[Port] [#4766] fix(eventsourcing): Active entities should only receive tag-matching events during command handling phase (#4770)

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -17,8 +17,8 @@
 package org.axonframework.eventsourcing;
 
 import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
 import org.axonframework.eventsourcing.eventstore.EventStore;
-import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.handler.EntityLifecycleHandler;
 import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
 import org.axonframework.eventsourcing.handler.SimpleEntityLifecycleHandler;
@@ -78,9 +78,12 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      * <ul>
      *   <li>sources events from the given event store</li>
      *   <li>uses the criteria resolver to locate the event stream</li>
+     *   <li>uses the framework-default {@link AnnotationBasedTagResolver} to resolve event tags</li>
      *   <li>applies the provided entity evolver for state transitions</li>
      *   <li>initializes entities when no event stream exists</li>
      * </ul>
+     * To use a custom tag resolver, construct an {@link EntityLifecycleHandler} and use
+     * {@link #EventSourcingRepository(Class, Class, EntityLifecycleHandler)} instead.
      *
      * @param idType           the type of the identifier for the event sourced entity this repository serves
      * @param entityType       the type of the event sourced entity this repository serves
@@ -89,8 +92,6 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      *                         provided identifier
      * @param criteriaResolver converts the given identifier to an {@link EventCriteria} used to load a matching event
      *                         stream
-     * @param tagResolver      resolves the tags of events appended during an entity's lifetime, so live updates can be
-     *                         filtered by the entity's {@link EventCriteria}
      * @param entityEvolver    the function used to evolve the state of loaded entities based on events
      * @deprecated use {@link EventSourcingRepository#EventSourcingRepository(Class, Class, EntityLifecycleHandler)}
      */
@@ -100,7 +101,6 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
                                    EventStore eventStore,
                                    EventSourcedEntityFactory<ID, E> entityFactory,
                                    CriteriaResolver<ID> criteriaResolver,
-                                   TagResolver tagResolver,
                                    EntityEvolver<E> entityEvolver
     ) {
         this(
@@ -109,7 +109,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
             new SimpleEntityLifecycleHandler<>(
                 requireNonNull(eventStore, "The event store must not be null."),
                 requireNonNull(criteriaResolver, "The criteria resolver must not be null."),
-                requireNonNull(tagResolver, "The tag resolver must not be null."),
+                new AnnotationBasedTagResolver(),
                 new InitializingEntityEvolver<>(
                     requireNonNull(entityFactory, "The entity factory must not be null."),
                     requireNonNull(entityEvolver, "The entity evolver must not be null.")

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -18,6 +18,7 @@ package org.axonframework.eventsourcing;
 
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.handler.EntityLifecycleHandler;
 import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
 import org.axonframework.eventsourcing.handler.SimpleEntityLifecycleHandler;
@@ -88,6 +89,8 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      *                         provided identifier
      * @param criteriaResolver converts the given identifier to an {@link EventCriteria} used to load a matching event
      *                         stream
+     * @param tagResolver      resolves the tags of events appended during an entity's lifetime, so live updates can be
+     *                         filtered by the entity's {@link EventCriteria}
      * @param entityEvolver    the function used to evolve the state of loaded entities based on events
      * @deprecated use {@link EventSourcingRepository#EventSourcingRepository(Class, Class, EntityLifecycleHandler)}
      */
@@ -97,6 +100,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
                                    EventStore eventStore,
                                    EventSourcedEntityFactory<ID, E> entityFactory,
                                    CriteriaResolver<ID> criteriaResolver,
+                                   TagResolver tagResolver,
                                    EntityEvolver<E> entityEvolver
     ) {
         this(
@@ -105,6 +109,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
             new SimpleEntityLifecycleHandler<>(
                 requireNonNull(eventStore, "The event store must not be null."),
                 requireNonNull(criteriaResolver, "The criteria resolver must not be null."),
+                requireNonNull(tagResolver, "The tag resolver must not be null."),
                 new InitializingEntityEvolver<>(
                     requireNonNull(entityFactory, "The entity factory must not be null."),
                     requireNonNull(entityEvolver, "The entity evolver must not be null.")

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModule.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SimpleEventSourcedEntityModule.java
@@ -30,6 +30,7 @@ import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.EventSourcedEntityFactory;
 import org.axonframework.eventsourcing.EventSourcingRepository;
 import org.axonframework.eventsourcing.eventstore.EventStore;
+import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.handler.EntityLifecycleHandler;
 import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
 import org.axonframework.eventsourcing.handler.SimpleEntityLifecycleHandler;
@@ -184,6 +185,7 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
                     @SuppressWarnings("unchecked")
                     CriteriaResolver<ID> criteriaResolver = config.getComponent(CriteriaResolver.class, entityName());
                     EventStore eventStore = config.getComponent(EventStore.class);
+                    TagResolver tagResolver = config.getComponent(TagResolver.class);
                     SnapshotPolicy snapshotPolicy = config.getOptionalComponent(SnapshotPolicy.class, entityName()).orElse(null);
                     EntityLifecycleHandler<ID, E> entityLifecycleHandler;
 
@@ -194,7 +196,7 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
                     );
 
                     if (snapshotPolicy == null) {
-                        entityLifecycleHandler = new SimpleEntityLifecycleHandler<>(eventStore, criteriaResolver, evolver);
+                        entityLifecycleHandler = new SimpleEntityLifecycleHandler<>(eventStore, criteriaResolver, tagResolver, evolver);
                     }
                     else {
                         Converter converter = config.getOptionalComponent(GeneralConverter.class)
@@ -208,6 +210,7 @@ class SimpleEventSourcedEntityModule<ID, E> extends BaseModule<SimpleEventSource
                         entityLifecycleHandler = new SnapshottingEntityLifecycleHandler<>(
                             eventStore,
                             criteriaResolver,
+                            tagResolver,
                             evolver,
                             snapshotPolicy,
                             messageType,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
@@ -80,7 +80,8 @@ public class StorageEngineBackedEventStore implements EventStore {
         return processingContext.computeResourceIfAbsent(
                 eventStoreTransactionKey,
                 () -> {
-                    var eventStoreTransaction = new DefaultEventStoreTransaction(eventStorageEngine, processingContext, this::tagEvents);
+                    var eventStoreTransaction = new DefaultEventStoreTransaction(
+                            eventStorageEngine, processingContext, event -> tagEvents(event, processingContext));
                     eventStoreTransaction.onAppend(events -> eventBus.publish(processingContext, events).join());
                     return eventStoreTransaction;
                 }
@@ -111,6 +112,10 @@ public class StorageEngineBackedEventStore implements EventStore {
 
     private TaggedEventMessage<EventMessage> tagEvents(EventMessage event) {
         return new GenericTaggedEventMessage<>(event, tagResolver.resolve(event));
+    }
+
+    private TaggedEventMessage<EventMessage> tagEvents(EventMessage event, ProcessingContext context) {
+        return new GenericTaggedEventMessage<>(event, tagResolver.resolve(event, context));
     }
 
     private void appendToTransaction(ProcessingContext context,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
@@ -44,8 +44,8 @@ public interface TagResolver {
     /**
      * Resolves a {@link Set} of {@link Tag Tags} for the given {@code event}.
      *
-     * @param event The event to resolve a {@link Set} of {@link Tag Tags} for.
-     * @return A {@link Set} of {@link Tag Tags} for the given {@code event}.
+     * @param event the event to resolve a {@link Set} of {@link Tag Tags} for
+     * @return a {@link Set} of {@link Tag Tags} for the given {@code event}
      */
     Set<Tag> resolve(EventMessage event);
 
@@ -53,15 +53,16 @@ public interface TagResolver {
      * Resolves a {@link Set} of {@link Tag Tags} for the given {@code event}, caching the result in the given
      * {@code context} so repeated resolutions of the same event within one unit of work are computed only once.
      * <p>
-     * The same event is frequently tagged more than once within a single {@link ProcessingContext} — for example while
+     * The same event is frequently tagged more than once within a single {@link ProcessingContext} -- for example while
      * appending an event and while filtering it against the {@link org.axonframework.messaging.eventstreaming.EventCriteria}
      * of each entity loaded in that unit of work. This default implementation caches per
      * {@link EventMessage#identifier() event identifier} to avoid re-resolving; implementations that are genuinely
      * context-aware may override it.
      *
-     * @param event   The event to resolve a {@link Set} of {@link Tag Tags} for.
-     * @param context The {@link ProcessingContext} used to cache resolved tags, if available.
-     * @return A {@link Set} of {@link Tag Tags} for the given {@code event}.
+     * @param event   the event to resolve a {@link Set} of {@link Tag Tags} for
+     * @param context the {@link ProcessingContext} used to cache resolved tags, or {@code null} to resolve without
+     *                caching
+     * @return a {@link Set} of {@link Tag Tags} for the given {@code event}
      */
     default Set<Tag> resolve(EventMessage event, @Nullable ProcessingContext context) {
         if (context == null) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
@@ -16,10 +16,14 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.messaging.core.Context.ResourceKey;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.Tag;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Functional interface towards resolving a {@link Set} of {@link Tag Tags} for a given {@link EventMessage}.
@@ -31,10 +35,36 @@ import java.util.Set;
 public interface TagResolver {
 
     /**
+     * {@link ResourceKey} under which {@link #resolve(EventMessage, ProcessingContext)} caches resolved tags, keyed by
+     * {@link EventMessage#identifier() event identifier}, for the lifetime of a {@link ProcessingContext}.
+     */
+    ResourceKey<Map<String, Set<Tag>>> RESOLVED_TAGS_CACHE_KEY = ResourceKey.withLabel("resolvedEventTags");
+
+    /**
      * Resolves a {@link Set} of {@link Tag Tags} for the given {@code event}.
      *
      * @param event The event to resolve a {@link Set} of {@link Tag Tags} for.
      * @return A {@link Set} of {@link Tag Tags} for the given {@code event}.
      */
     Set<Tag> resolve(EventMessage event);
+
+    /**
+     * Resolves a {@link Set} of {@link Tag Tags} for the given {@code event}, caching the result in the given
+     * {@code context} so repeated resolutions of the same event within one unit of work are computed only once.
+     * <p>
+     * The same event is frequently tagged more than once within a single {@link ProcessingContext} — for example while
+     * appending an event and while filtering it against the {@link org.axonframework.messaging.eventstreaming.EventCriteria}
+     * of each entity loaded in that unit of work. This default implementation caches per
+     * {@link EventMessage#identifier() event identifier} to avoid re-resolving; implementations that are genuinely
+     * context-aware may override it.
+     *
+     * @param event   The event to resolve a {@link Set} of {@link Tag Tags} for.
+     * @param context The {@link ProcessingContext} used to cache resolved tags.
+     * @return A {@link Set} of {@link Tag Tags} for the given {@code event}.
+     */
+    default Set<Tag> resolve(EventMessage event, ProcessingContext context) {
+        return context
+                .computeResourceIfAbsent(RESOLVED_TAGS_CACHE_KEY, ConcurrentHashMap::new)
+                .computeIfAbsent(event.identifier(), id -> resolve(event));
+    }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/TagResolver.java
@@ -20,6 +20,7 @@ import org.axonframework.messaging.core.Context.ResourceKey;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.Tag;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -59,10 +60,13 @@ public interface TagResolver {
      * context-aware may override it.
      *
      * @param event   The event to resolve a {@link Set} of {@link Tag Tags} for.
-     * @param context The {@link ProcessingContext} used to cache resolved tags.
+     * @param context The {@link ProcessingContext} used to cache resolved tags, if available.
      * @return A {@link Set} of {@link Tag Tags} for the given {@code event}.
      */
-    default Set<Tag> resolve(EventMessage event, ProcessingContext context) {
+    default Set<Tag> resolve(EventMessage event, @Nullable ProcessingContext context) {
+        if (context == null) {
+            return resolve(event);
+        }
         return context
                 .computeResourceIfAbsent(RESOLVED_TAGS_CACHE_KEY, ConcurrentHashMap::new)
                 .computeIfAbsent(event.identifier(), id -> resolve(event));

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandler.java
@@ -84,7 +84,7 @@ public class SimpleEntityLifecycleHandler<I, E> implements EntityLifecycleHandle
         EventCriteria criteria = criteriaResolver.resolve(entity.identifier(), context);
         eventStore.transaction(context)
             .onAppend(event -> {
-                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event))) {
+                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event, context))) {
                     entity.applyStateChange(e -> evolver.evolve(
                         entity.identifier(),
                         entity.entity(),

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandler.java
@@ -22,6 +22,7 @@ import org.axonframework.eventsourcing.CriteriaResolver;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
+import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -52,6 +53,7 @@ public class SimpleEntityLifecycleHandler<I, E> implements EntityLifecycleHandle
 
     private final EventStore eventStore;
     private final CriteriaResolver<I> criteriaResolver;
+    private final TagResolver tagResolver;
     private final InitializingEntityEvolver<I, E> evolver;
 
     /**
@@ -59,12 +61,16 @@ public class SimpleEntityLifecycleHandler<I, E> implements EntityLifecycleHandle
      *
      * @param eventStore the {@link EventStore} from which events are sourced, cannot be {@code null}
      * @param criteriaResolver the resolver to use to create the {@link EventCriteria} for sourcing, cannot be {@code null}
+     * @param tagResolver the {@link TagResolver} used to resolve the tags of events appended during the entity's
+     *                    lifetime, so live updates can be filtered by the entity's {@link EventCriteria}, cannot be
+     *                    {@code null}
      * @param evolver the {@link InitializingEntityEvolver} used to initialize and evolve the entity, cannot be {@code null}
      * @throws NullPointerException when any argument is {@code null}
      */
-    public SimpleEntityLifecycleHandler(EventStore eventStore, CriteriaResolver<I> criteriaResolver, InitializingEntityEvolver<I, E> evolver) {
+    public SimpleEntityLifecycleHandler(EventStore eventStore, CriteriaResolver<I> criteriaResolver, TagResolver tagResolver, InitializingEntityEvolver<I, E> evolver) {
         this.eventStore = Objects.requireNonNull(eventStore, "The eventStore parameter must not be null.");
         this.criteriaResolver = Objects.requireNonNull(criteriaResolver, "The criteriaResolver parameter must not be null.");
+        this.tagResolver = Objects.requireNonNull(tagResolver, "The tagResolver parameter must not be null.");
         this.evolver = Objects.requireNonNull(evolver, "The evolver parameter must not be null.");
     }
 
@@ -75,13 +81,18 @@ public class SimpleEntityLifecycleHandler<I, E> implements EntityLifecycleHandle
 
     @Override
     public void subscribe(ManagedEntity<I, E> entity, ProcessingContext context) {
+        EventCriteria criteria = criteriaResolver.resolve(entity.identifier(), context);
         eventStore.transaction(context)
-            .onAppend(event -> entity.applyStateChange(e -> evolver.evolve(
-                entity.identifier(),
-                entity.entity(),
-                event,
-                context
-            )));
+            .onAppend(event -> {
+                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event))) {
+                    entity.applyStateChange(e -> evolver.evolve(
+                        entity.identifier(),
+                        entity.entity(),
+                        event,
+                        context
+                    ));
+                }
+            });
     }
 
     @Override
@@ -100,6 +111,7 @@ public class SimpleEntityLifecycleHandler<I, E> implements EntityLifecycleHandle
     public void describeTo(ComponentDescriptor descriptor) {
         descriptor.describeProperty("eventStore", eventStore);
         descriptor.describeProperty("criteriaResolver", criteriaResolver);
+        descriptor.describeProperty("tagResolver", tagResolver);
         descriptor.describeProperty("evolver", evolver);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -136,7 +136,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
         EventCriteria criteria = criteriaResolver.resolve(entity.identifier(), context);
         eventStore.transaction(context)
             .onAppend(event -> {
-                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event))) {
+                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event, context))) {
                     entity.applyStateChange(e -> evolver.evolve(
                             entity.identifier(),
                             entity.entity(),

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandler.java
@@ -27,6 +27,7 @@ import org.axonframework.eventsourcing.eventstore.Position;
 import org.axonframework.eventsourcing.eventstore.SnapshotEventMessage;
 import org.axonframework.eventsourcing.eventstore.SourcingCondition;
 import org.axonframework.eventsourcing.eventstore.SourcingStrategy;
+import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.snapshot.api.EvolutionResult;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
@@ -79,6 +80,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
 
     private final EventStore eventStore;
     private final CriteriaResolver<I> criteriaResolver;
+    private final TagResolver tagResolver;
     private final MessageType messageType;
     private final SnapshotPolicy snapshotPolicy;
     private final Class<?> entityType;
@@ -91,6 +93,9 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
      *
      * @param eventStore the {@link EventStore} used to source events, cannot be {@code null}
      * @param criteriaResolver the resolver to use to create the {@link EventCriteria} for sourcing, cannot be {@code null}
+     * @param tagResolver the {@link TagResolver} used to resolve the tags of events appended during the entity's
+     *                    lifetime, so live updates can be filtered by the entity's {@link EventCriteria}, cannot be
+     *                    {@code null}
      * @param evolver the {@link InitializingEntityEvolver} used to initialize and evolve the entity, cannot be {@code null}
      * @param snapshotPolicy the {@link SnapshotPolicy}, cannot be {@code null}
      * @param messageType the {@link MessageType}, cannot be {@code null}
@@ -102,6 +107,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
     public SnapshottingEntityLifecycleHandler(
         EventStore eventStore,
         CriteriaResolver<I> criteriaResolver,
+        TagResolver tagResolver,
         InitializingEntityEvolver<I, E> evolver,
         SnapshotPolicy snapshotPolicy,
         MessageType messageType,
@@ -111,6 +117,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
     ) {
         this.eventStore = Objects.requireNonNull(eventStore, "The eventStore parameter must not be null.");
         this.criteriaResolver = Objects.requireNonNull(criteriaResolver, "The criteriaResolver parameter must not be null.");
+        this.tagResolver = Objects.requireNonNull(tagResolver, "The tagResolver parameter must not be null.");
         this.evolver = Objects.requireNonNull(evolver, "The evolver parameter must not be null.");
         this.snapshotPolicy = Objects.requireNonNull(snapshotPolicy, "The snapshotPolicy parameter must not be null.");
         this.messageType = Objects.requireNonNull(messageType, "The messageType parameter must not be null.");
@@ -126,13 +133,18 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
 
     @Override
     public void subscribe(ManagedEntity<I, E> entity, ProcessingContext context) {
+        EventCriteria criteria = criteriaResolver.resolve(entity.identifier(), context);
         eventStore.transaction(context)
-            .onAppend(event -> entity.applyStateChange(e -> evolver.evolve(
-                    entity.identifier(),
-                    entity.entity(),
-                    event,
-                    context
-            )));
+            .onAppend(event -> {
+                if (criteria.matches(event.type().qualifiedName(), tagResolver.resolve(event))) {
+                    entity.applyStateChange(e -> evolver.evolve(
+                            entity.identifier(),
+                            entity.entity(),
+                            event,
+                            context
+                    ));
+                }
+            });
     }
 
     @Override
@@ -230,6 +242,7 @@ public class SnapshottingEntityLifecycleHandler<I, E> implements EntityLifecycle
     public void describeTo(ComponentDescriptor descriptor) {
         descriptor.describeProperty("eventStore", eventStore);
         descriptor.describeProperty("criteriaResolver", criteriaResolver);
+        descriptor.describeProperty("tagResolver", tagResolver);
         descriptor.describeProperty("evolver", evolver);
         descriptor.describeProperty("messageType", messageType);
         descriptor.describeProperty("entityType", entityType);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing;
 
+import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.EventStoreTransaction;
 import org.axonframework.eventsourcing.handler.InitializingEntityEvolver;
@@ -87,6 +88,7 @@ class EventSourcingRepositoryIT {
             new SimpleEntityLifecycleHandler<>(
                 eventStore,
                 (id, context) -> EventCriteria.havingAnyTag(),
+                new AnnotationBasedTagResolver(),
                 new InitializingEntityEvolver<>(
                     (id, event, context) -> factory.create(id, event, context),
                     (entity, event, context) -> entity + "-" + event.payload()

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
@@ -87,11 +87,11 @@ class TagResolverTest {
         };
         EventMessage event = new GenericEventMessage(new MessageType("SomeEvent"), "payload");
 
-        // when — resolving the same event in two different contexts
+        // when -- resolving the same event in two different contexts
         resolver.resolve(event, new StubProcessingContext());
         resolver.resolve(event, new StubProcessingContext());
 
-        // then — each context resolves independently
+        // then -- each context resolves independently
         assertThat(resolveCalls.get()).isEqualTo(2);
     }
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventstreaming.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for the caching {@link TagResolver#resolve(EventMessage, ProcessingContext)} default method.
+ */
+class TagResolverTest {
+
+    private final AtomicInteger resolveCalls = new AtomicInteger();
+
+    @Test
+    void resolvesEachEventOnlyOncePerContext() {
+        // given
+        Tag tag = new Tag("key", "value");
+        TagResolver resolver = event -> {
+            resolveCalls.incrementAndGet();
+            return Set.of(tag);
+        };
+        ProcessingContext context = new StubProcessingContext();
+        EventMessage event = new GenericEventMessage(new MessageType("SomeEvent"), "payload");
+
+        // when
+        Set<Tag> first = resolver.resolve(event, context);
+        Set<Tag> second = resolver.resolve(event, context);
+
+        // then
+        assertThat(first).containsExactly(tag);
+        assertThat(second).isEqualTo(first);
+        assertThat(resolveCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void resolvesDistinctEventsSeparately() {
+        // given
+        TagResolver resolver = event -> {
+            resolveCalls.incrementAndGet();
+            return Set.of(new Tag("id", event.identifier()));
+        };
+        ProcessingContext context = new StubProcessingContext();
+        EventMessage eventOne = new GenericEventMessage(new MessageType("SomeEvent"), "one");
+        EventMessage eventTwo = new GenericEventMessage(new MessageType("SomeEvent"), "two");
+
+        // when
+        Set<Tag> tagsOne = resolver.resolve(eventOne, context);
+        Set<Tag> tagsTwo = resolver.resolve(eventTwo, context);
+
+        // then
+        assertThat(tagsOne).containsExactly(new Tag("id", eventOne.identifier()));
+        assertThat(tagsTwo).containsExactly(new Tag("id", eventTwo.identifier()));
+        assertThat(resolveCalls.get()).isEqualTo(2);
+    }
+
+    @Test
+    void cacheIsScopedToTheGivenContext() {
+        // given
+        TagResolver resolver = event -> {
+            resolveCalls.incrementAndGet();
+            return Set.of(new Tag("key", "value"));
+        };
+        EventMessage event = new GenericEventMessage(new MessageType("SomeEvent"), "payload");
+
+        // when — resolving the same event in two different contexts
+        resolver.resolve(event, new StubProcessingContext());
+        resolver.resolve(event, new StubProcessingContext());
+
+        // then — each context resolves independently
+        assertThat(resolveCalls.get()).isEqualTo(2);
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/TagResolverTest.java
@@ -94,4 +94,24 @@ class TagResolverTest {
         // then — each context resolves independently
         assertThat(resolveCalls.get()).isEqualTo(2);
     }
+
+    @Test
+    void resolvesWithoutCachingWhenContextIsNull() {
+        // given
+        Tag tag = new Tag("key", "value");
+        TagResolver resolver = event -> {
+            resolveCalls.incrementAndGet();
+            return Set.of(tag);
+        };
+        EventMessage event = new GenericEventMessage(new MessageType("SomeEvent"), "payload");
+
+        // when
+        Set<Tag> first = resolver.resolve(event, null);
+        Set<Tag> second = resolver.resolve(event, null);
+
+        // then
+        assertThat(first).containsExactly(tag);
+        assertThat(second).isEqualTo(first);
+        assertThat(resolveCalls.get()).isEqualTo(2);
+    }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.handler;
+
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
+import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStore;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.SimpleEventBus;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.eventstreaming.Tag;
+import org.axonframework.modelling.repository.ManagedEntity;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link SimpleEntityLifecycleHandler}.
+ * <p>
+ * Focuses on the live {@link SimpleEntityLifecycleHandler#subscribe(ManagedEntity, ProcessingContext) subscribe} path:
+ * events appended within the same {@link ProcessingContext} must only evolve a loaded entity when they match that
+ * entity's {@link EventCriteria} (tags), mirroring the filtering already performed while
+ * {@link SimpleEntityLifecycleHandler#source(Object, ProcessingContext) sourcing}. Without that filter two entities of
+ * the same type loaded in one unit of work would both react to an event that belongs to only one of them (the
+ * "speedometer moved between bikes" scenario).
+ */
+class SimpleEntityLifecycleHandlerTest {
+
+    private record BikeAdded(@EventTag(key = "RentableBike") String bikeId) {}
+
+    private record SpeedometerMounted(@EventTag(key = "RentableBike") String bikeId, String speedometerId) {}
+
+    private record SpeedometerRemoved(@EventTag(key = "RentableBike") String bikeId, String speedometerId) {}
+
+    private record Bike(String id, String mountedSpeedometerId) {}
+
+    private final StorageEngineBackedEventStore eventStore = new StorageEngineBackedEventStore(
+            new InMemoryEventStorageEngine(),
+            new SimpleEventBus(),
+            new AnnotationBasedTagResolver()
+    );
+
+    private final SimpleEntityLifecycleHandler<String, Bike> handler = new SimpleEntityLifecycleHandler<>(
+            eventStore,
+            (id, ctx) -> EventCriteria.havingTags(Tag.of("RentableBike", id)),
+            new AnnotationBasedTagResolver(),
+            new InitializingEntityEvolver<>(
+                    (id, msg, ctx) -> new Bike(id, null),
+                    (entity, event, ctx) -> switch (event.payload()) {
+                        case SpeedometerMounted m -> new Bike(entity.id(), m.speedometerId());
+                        case SpeedometerRemoved ignored -> new Bike(entity.id(), null);
+                        default -> entity;
+                    }
+            )
+    );
+
+    @Nested
+    class WhenSubscribed {
+
+        @Test
+        void liveEventForAnotherEntityIsNotApplied() {
+            // given
+            publish(new BikeAdded("bike1"), new SpeedometerMounted("bike1", "speedo1"));
+            ProcessingContext pc = new StubProcessingContext();
+            Bike initial = handler.source("bike1", pc).join();
+            AtomicReference<Bike> stateRef = new AtomicReference<>(initial);
+            handler.subscribe(managedEntity("bike1", stateRef), pc);
+
+            // when — an event tagged for bike2 is appended within the same context
+            eventStore.transaction(pc).appendEvent(new GenericEventMessage(
+                    new MessageType(SpeedometerRemoved.class),
+                    new SpeedometerRemoved("bike2", "speedo2")
+            ));
+
+            // then — bike1 must be untouched, it does not carry bike2's tag
+            assertThat(stateRef.get()).isEqualTo(initial);
+            assertThat(stateRef.get().mountedSpeedometerId()).isEqualTo("speedo1");
+        }
+
+        @Test
+        void liveEventForThisEntityIsApplied() {
+            // given
+            publish(new BikeAdded("bike1"), new SpeedometerMounted("bike1", "speedo1"));
+            ProcessingContext pc = new StubProcessingContext();
+            Bike initial = handler.source("bike1", pc).join();
+            AtomicReference<Bike> stateRef = new AtomicReference<>(initial);
+            handler.subscribe(managedEntity("bike1", stateRef), pc);
+
+            // when — an event tagged for bike1 is appended within the same context
+            eventStore.transaction(pc).appendEvent(new GenericEventMessage(
+                    new MessageType(SpeedometerRemoved.class),
+                    new SpeedometerRemoved("bike1", "speedo1")
+            ));
+
+            // then — bike1 evolves, the event carries its tag
+            assertThat(stateRef.get().mountedSpeedometerId()).isNull();
+        }
+    }
+
+    private void publish(Object... events) {
+        eventStore.publish(
+                null,
+                Arrays.stream(events)
+                      .map(e -> (EventMessage) new GenericEventMessage(new MessageType(e.getClass()), e))
+                      .toList()
+        ).join();
+    }
+
+    private ManagedEntity<String, Bike> managedEntity(String id, AtomicReference<Bike> stateRef) {
+        return new ManagedEntity<>() {
+            @Override
+            public String identifier() {
+                return id;
+            }
+
+            @Override
+            public Bike entity() {
+                return stateRef.get();
+            }
+
+            @Override
+            public Bike applyStateChange(UnaryOperator<Bike> change) {
+                return stateRef.updateAndGet(change);
+            }
+        };
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
@@ -90,13 +90,13 @@ class SimpleEntityLifecycleHandlerTest {
             AtomicReference<Bike> stateRef = new AtomicReference<>(initial);
             handler.subscribe(managedEntity("bike1", stateRef), pc);
 
-            // when — an event tagged for bike2 is appended within the same context
+            // when -- an event tagged for bike2 is appended within the same context
             eventStore.transaction(pc).appendEvent(new GenericEventMessage(
                     new MessageType(SpeedometerRemoved.class),
                     new SpeedometerRemoved("bike2", "speedo2")
             ));
 
-            // then — bike1 must be untouched, it does not carry bike2's tag
+            // then -- bike1 must be untouched, it does not carry bike2's tag
             assertThat(stateRef.get()).isEqualTo(initial);
             assertThat(stateRef.get().mountedSpeedometerId()).isEqualTo("speedo1");
         }
@@ -110,13 +110,13 @@ class SimpleEntityLifecycleHandlerTest {
             AtomicReference<Bike> stateRef = new AtomicReference<>(initial);
             handler.subscribe(managedEntity("bike1", stateRef), pc);
 
-            // when — an event tagged for bike1 is appended within the same context
+            // when -- an event tagged for bike1 is appended within the same context
             eventStore.transaction(pc).appendEvent(new GenericEventMessage(
                     new MessageType(SpeedometerRemoved.class),
                     new SpeedometerRemoved("bike1", "speedo1")
             ));
 
-            // then — bike1 evolves, the event carries its tag
+            // then -- bike1 evolves, the event carries its tag
             assertThat(stateRef.get().mountedSpeedometerId()).isNull();
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -34,6 +34,8 @@ import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.api.SnapshotPolicy;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
 import org.axonframework.messaging.eventhandling.EventMessage;
@@ -49,7 +51,6 @@ import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
@@ -96,6 +97,7 @@ class SnapshottingEntityLifecycleHandlerTest {
     private final SnapshottingEntityLifecycleHandler<String, Account> handler = new SnapshottingEntityLifecycleHandler<>(
         eventStore,
         (id, ctx) -> EventCriteria.havingTags(Tag.of("account", id)),
+        new AnnotationBasedTagResolver(),
         new InitializingEntityEvolver<>(
             (id, msg, ctx) -> {
                 AccountCreated ac = (AccountCreated) msg.payload();
@@ -287,24 +289,39 @@ class SnapshottingEntityLifecycleHandlerTest {
         void liveEventUpdatesEntityState() {
             publish(new AccountCreated(ACCOUNT_ID, "Alice"), new FundsDeposited(ACCOUNT_ID, 100));
 
-            UnitOfWork uow = UnitOfWorkTestUtils.aUnitOfWork();
+            ProcessingContext pc = new StubProcessingContext();
+            Account initial = handler.source(ACCOUNT_ID, pc).join();
+            AtomicReference<Account> stateRef = new AtomicReference<>(initial);
 
-            uow.executeWithResult(pc -> {
-                Account initial = handler.source(ACCOUNT_ID, pc).join();
-                AtomicReference<Account> stateRef = new AtomicReference<>(initial);
+            handler.subscribe(managedEntity(stateRef), pc);
+            eventStore.transaction(pc).appendEvent(
+                new GenericEventMessage(
+                    new MessageType(FundsDeposited.class),
+                    new FundsDeposited(ACCOUNT_ID, 50)
+                )
+            );
 
-                handler.subscribe(managedEntity(stateRef), pc);
-                eventStore.transaction(pc).appendEvent(
-                    new GenericEventMessage(
-                        new MessageType(FundsDeposited.class),
-                        new FundsDeposited(ACCOUNT_ID, 50)
-                    )
-                );
+            assertThat(stateRef.get().balance()).isEqualTo(150);
+        }
 
-                assertThat(stateRef.get().balance()).isEqualTo(150);
+        @Test
+        void liveEventForAnotherEntityIsNotApplied() {
+            publish(new AccountCreated(ACCOUNT_ID, "Alice"), new FundsDeposited(ACCOUNT_ID, 100));
 
-                return CompletableFuture.completedFuture(null);
-            }).join();
+            ProcessingContext pc = new StubProcessingContext();
+            Account initial = handler.source(ACCOUNT_ID, pc).join();
+            AtomicReference<Account> stateRef = new AtomicReference<>(initial);
+
+            handler.subscribe(managedEntity(stateRef), pc);
+            // A deposit tagged for a different account must not evolve this account.
+            eventStore.transaction(pc).appendEvent(
+                new GenericEventMessage(
+                    new MessageType(FundsDeposited.class),
+                    new FundsDeposited("account-2", 50)
+                )
+            );
+
+            assertThat(stateRef.get().balance()).isEqualTo(100);
         }
     }
 
@@ -343,6 +360,7 @@ class SnapshottingEntityLifecycleHandlerTest {
         return new SnapshottingEntityLifecycleHandler<>(
             eventStore,
             (id, ctx) -> EventCriteria.havingTags(Tag.of("account", id)),
+            new AnnotationBasedTagResolver(),
             new InitializingEntityEvolver<>(
                 (id, msg, ctx) -> {
                     AccountCreated ac = (AccountCreated) msg.payload();

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersIT.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Integration test proving that when a single command handler loads two entities in one unit of work, an appended event
- * is only applied to the entity it belongs to (as determined by the entity's {@link EventCriteria}/tags) — not to every
+ * is only applied to the entity it belongs to (as determined by the entity's {@link EventCriteria}/tags) -- not to every
  * loaded entity that happens to declare an {@link EventSourcingHandler} for that event type.
  * <p>
  * The scenario is the "speedometer moved between bikes" case: two {@code RentableBike} entities are injected into one
@@ -84,15 +84,15 @@ public abstract class MultiEntitySameEventHandlersIT extends AbstractIT {
 
     @Test
     void appendedEventEvolvesOnlyTheEntityItBelongsTo() {
-        // given — bike1 has a speedometer mounted, bike2 exists without one
+        // given -- bike1 has a speedometer mounted, bike2 exists without one
         publish(new RentableBikeWasAdded(BIKE_1));
         publish(new SpeedoMeterMounted(BIKE_1, SPEEDO));
         publish(new RentableBikeWasAdded(BIKE_2));
 
-        // when — a single handler loads both bikes and moves the speedometer from bike1 to bike2
+        // when -- a single handler loads both bikes and moves the speedometer from bike1 to bike2
         sendCommand(new MoveSpeedometerCommand(BIKE_1, BIKE_2));
 
-        // then — SpeedoMeterRemoved(bike1) must not have been applied to bike2, and the move succeeds
+        // then -- SpeedoMeterRemoved(bike1) must not have been applied to bike2, and the move succeeds
         assertNull(loadBike(BIKE_1).mountedSpeedometer(), "bike1 should no longer have a speedometer");
         assertEquals(SPEEDO, loadBike(BIKE_2).mountedSpeedometer(), "bike2 should now hold the speedometer");
     }

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersIT.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.multientity;
+
+import org.axonframework.common.configuration.ApplicationConfigurer;
+import org.axonframework.eventsourcing.annotation.EventCriteriaBuilder;
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.integrationtests.testsuite.AbstractIT;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.unitofwork.UnitOfWork;
+import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.messaging.eventhandling.gateway.EventGateway;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.modelling.StateManager;
+import org.axonframework.modelling.annotation.InjectEntity;
+import org.axonframework.modelling.repository.ManagedEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Integration test proving that when a single command handler loads two entities in one unit of work, an appended event
+ * is only applied to the entity it belongs to (as determined by the entity's {@link EventCriteria}/tags) — not to every
+ * loaded entity that happens to declare an {@link EventSourcingHandler} for that event type.
+ * <p>
+ * The scenario is the "speedometer moved between bikes" case: two {@code RentableBike} entities are injected into one
+ * {@code MoveSpeedometerCommand} handler. Appending {@code SpeedoMeterRemoved} for {@code bike1} must not evolve
+ * {@code bike2}. The two bikes are the same class here, so they trivially share the same event-sourcing handlers, which
+ * is exactly the condition that triggers the defect: the trigger is <em>shared event handlers on co-loaded entities</em>,
+ * not the entity <em>type</em>.
+ */
+public abstract class MultiEntitySameEventHandlersIT extends AbstractIT {
+
+    private static final String BIKE_1 = "bike1";
+    private static final String BIKE_2 = "bike2";
+    private static final SpeedometerId SPEEDO = new SpeedometerId("speedo1");
+
+    protected UnitOfWorkFactory unitOfWorkFactory;
+
+    @Override
+    protected ApplicationConfigurer applicationConfigurer() {
+        var configurer = EventSourcingConfigurer.create();
+        var bikeEntity = EventSourcedEntityModule.autodetected(String.class, RentableBike.class);
+        var commandHandlingModule = CommandHandlingModule.named("move-speedometer")
+                                                         .commandHandlers()
+                                                         .autodetectedCommandHandlingComponent(c -> new DomainService())
+                                                         .build();
+        return configurer.registerEntity(bikeEntity)
+                         .registerCommandHandlingModule(commandHandlingModule);
+    }
+
+    @BeforeEach
+    void doStartApp() {
+        super.startApp();
+        unitOfWorkFactory = startedConfiguration.getComponent(UnitOfWorkFactory.class);
+    }
+
+    @Test
+    void appendedEventEvolvesOnlyTheEntityItBelongsTo() {
+        // given — bike1 has a speedometer mounted, bike2 exists without one
+        publish(new RentableBikeWasAdded(BIKE_1));
+        publish(new SpeedoMeterMounted(BIKE_1, SPEEDO));
+        publish(new RentableBikeWasAdded(BIKE_2));
+
+        // when — a single handler loads both bikes and moves the speedometer from bike1 to bike2
+        sendCommand(new MoveSpeedometerCommand(BIKE_1, BIKE_2));
+
+        // then — SpeedoMeterRemoved(bike1) must not have been applied to bike2, and the move succeeds
+        assertNull(loadBike(BIKE_1).mountedSpeedometer(), "bike1 should no longer have a speedometer");
+        assertEquals(SPEEDO, loadBike(BIKE_2).mountedSpeedometer(), "bike2 should now hold the speedometer");
+    }
+
+    private void sendCommand(Object command) {
+        commandGateway.send(command).getResultMessage().join();
+    }
+
+    private void publish(Object payload) {
+        UnitOfWork uow = unitOfWorkFactory.create();
+        var eventMessage = new GenericEventMessage(new MessageType(payload.getClass()), payload);
+        uow.runOnInvocation(context -> context.component(EventGateway.class).publish(context, eventMessage));
+        uow.execute().join();
+    }
+
+    private RentableBike loadBike(String id) {
+        UnitOfWork uow = unitOfWorkFactory.create();
+        return uow.executeWithResult(context -> context.component(StateManager.class)
+                                                       .repository(RentableBike.class, String.class)
+                                                       .load(id, context)
+                                                       .thenApply(ManagedEntity::entity))
+                  .join();
+    }
+
+    // ========== Supporting domain (self-contained, adapted from the reported SpeedometerMigrationTest) ==========
+
+    record SpeedometerId(String id) {}
+
+    record MoveSpeedometerCommand(String fromBikeId, String toBikeId) {}
+
+    record RentableBikeWasAdded(@EventTag(key = "RentableBike") String bikeId) {}
+
+    record SpeedoMeterMounted(@EventTag(key = "RentableBike") String bikeId, SpeedometerId speedometerId) {}
+
+    record SpeedoMeterRemoved(@EventTag(key = "RentableBike") String bikeId, SpeedometerId speedometerId) {}
+
+    @EventSourcedEntity
+    public static class RentableBike {
+
+        private String bikeId;
+        private SpeedometerId mountedSpeedometerId;
+
+        @EntityCreator
+        public RentableBike() {
+        }
+
+        public SpeedometerId mountedSpeedometer() {
+            return mountedSpeedometerId;
+        }
+
+        Optional<SpeedometerId> removeSpeedoMeter(EventAppender eventAppender) {
+            SpeedometerId speedometerId = this.mountedSpeedometerId;
+            eventAppender.append(new SpeedoMeterRemoved(bikeId, speedometerId));
+            return Optional.ofNullable(speedometerId);
+        }
+
+        void mountSpeedometer(SpeedometerId speedometerId, EventAppender eventAppender) {
+            eventAppender.append(new SpeedoMeterMounted(bikeId, speedometerId));
+        }
+
+        @EventSourcingHandler
+        void on(RentableBikeWasAdded event) {
+            this.bikeId = event.bikeId();
+        }
+
+        @EventSourcingHandler
+        void on(SpeedoMeterMounted event) {
+            this.mountedSpeedometerId = event.speedometerId();
+        }
+
+        @EventSourcingHandler
+        void on(SpeedoMeterRemoved event) {
+            if (this.mountedSpeedometerId == null) {
+                throw new IllegalStateException(
+                        "No speedometer mounted on bike " + bikeId + " to remove. Event contains bike " + event.bikeId());
+            }
+            this.mountedSpeedometerId = null;
+        }
+
+        @EventCriteriaBuilder
+        private static EventCriteria resolve(String id) {
+            return EventCriteria.havingTags("RentableBike", id);
+        }
+    }
+
+    public static class DomainService {
+
+        @CommandHandler
+        void handle(MoveSpeedometerCommand command,
+                    @InjectEntity(idProperty = "fromBikeId") RentableBike fromBike,
+                    @InjectEntity(idProperty = "toBikeId") RentableBike toBike,
+                    EventAppender eventAppender) {
+            SpeedometerId speedometerId = fromBike.removeSpeedoMeter(eventAppender)
+                                                  .orElseThrow(() -> new IllegalStateException(
+                                                          "No speedometer mounted on bike " + command.fromBikeId()));
+            toBike.mountSpeedometer(speedometerId, eventAppender);
+        }
+    }
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersInMemoryIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/multientity/MultiEntitySameEventHandlersInMemoryIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.multientity;
+
+import org.axonframework.integrationtests.testsuite.infrastructure.InMemoryTestInfrastructure;
+import org.axonframework.integrationtests.testsuite.infrastructure.TestInfrastructure;
+
+/**
+ * Runs {@link MultiEntitySameEventHandlersIT} against the in-memory framework defaults.
+ */
+public class MultiEntitySameEventHandlersInMemoryIT extends MultiEntitySameEventHandlersIT {
+
+    private static final TestInfrastructure INFRASTRUCTURE = new InMemoryTestInfrastructure();
+
+    @Override
+    protected TestInfrastructure testInfrastructure() {
+        return INFRASTRUCTURE;
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -251,6 +251,7 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                                     c.getComponent(EventStore.class),
                                     EventSourcedEntityFactory.fromIdentifier(Student::new),
                                     (id, context) -> EventCriteria.havingTags("Student", id),
+                                    new AnnotationBasedTagResolver(),
                                     new AnnotationBasedEntityEvolvingComponent<>(
                                             Student.class,
                                             c.getComponent(EventConverter.class),

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureStatefulCommandHandlerTest.java
@@ -251,7 +251,6 @@ class AxonTestFixtureStatefulCommandHandlerTest {
                                     c.getComponent(EventStore.class),
                                     EventSourcedEntityFactory.fromIdentifier(Student::new),
                                     (id, context) -> EventCriteria.havingTags("Student", id),
-                                    new AnnotationBasedTagResolver(),
                                     new AnnotationBasedEntityEvolvingComponent<>(
                                             Student.class,
                                             c.getComponent(EventConverter.class),


### PR DESCRIPTION
## Port

Cherry-pick of commits 0368916114, 12e00f4251, 0ad60f91a5, a2695e0c0c from `main` (original PR #4770) into `axon-5.2.x`.

## Summary

When a command handler loads two or more entities in one unit of work (e.g. via `@InjectEntity`), an event appended for one entity was also applied to every other loaded entity that declares an `@EventSourcingHandler` for that event type (the reported "move speedometer from bike1 to bike2" case), throwing `IllegalStateException`.

Root cause was an asymmetry between the two event-routing paths in the lifecycle handlers: initial sourcing (`source`) filters events by the entity's `EventCriteria` (tags), but live updates within the unit of work (`subscribe` -> `EventStoreTransaction.onAppend`) evolved the entity for every appended event with no tag/criteria check. `subscribe` now resolves the entity's `EventCriteria` and only evolves the entity for appended events whose tags match, making the live path consistent with sourcing (both `SimpleEntityLifecycleHandler` and `SnapshottingEntityLifecycleHandler`). A follow-up caches resolved tags per unit of work via an additive `TagResolver.resolve(EventMessage, ProcessingContext)` default method, and the deprecated `EventSourcingRepository` convenience constructor stays source/binary compatible.

## Tests

- `SimpleEntityLifecycleHandlerTest` (new), `SnapshottingEntityLifecycleHandlerTest` (extended), `TagResolverTest` (new).
- `MultiEntitySameEventHandlersIT` (new, + in-memory leaf) -- end-to-end reproduction through the real command bus and `@InjectEntity`; fails before the fix with the original `IllegalStateException`.

## Verification

`./mvnw test -pl eventsourcing` (19 tests, green) and `./mvnw -Pintegration-test verify -pl integrationtests -Dit.test=MultiEntitySameEventHandlersInMemoryIT` (green).


this is a port of #4770 to 5.2.1