### PR TITLE
Enable direct metadata on Command- and QueryGateway dispatch

### DIFF
--- a/axon-5/api-changes/04-commands.md
+++ b/axon-5/api-changes/04-commands.md
@@ -54,8 +54,9 @@ handler should dispatch a command (e.g., as with process automations), it is str
 
 For a removal perspective, similarly as with the `CommandBus`, the `CommandCallback` has not returned on this interface.
 To deal with successes or failures of command handling, the now default `CompletableFuture` should be consulted instead.
-Furthermore, the `Metadata` adding operations have mostly been removed. The only version left expects the user to deal
-with the `CommandResult` manually. Lastly, we dropped the timeout options on the `sendAndWait` operations. Whenever
+Furthermore, metadata can be attached to a command upon dispatch: besides the `CommandResult`-returning `send`
+operations, both the typed `send` and `sendAndWait` operations accept a `Metadata` argument next to the result `Class`
+and a nullable `ProcessingContext`. Lastly, we dropped the timeout options on the `sendAndWait` operations. Whenever
 needed, adding these yourself around the `CompletableFuture` or `CommandResult` are straightforward. However, as with
 anything, if you feel strongly about certain supported features that have been adjusted, please
 construct [an issue](https://github.com/AxonFramework/AxonFramework/issues) for us.

--- a/axon-5/api-changes/09-queries-and-minor-changes.md
+++ b/axon-5/api-changes/09-queries-and-minor-changes.md
@@ -104,6 +104,15 @@ As is clear, the `ResponseType` did not return for any of these methods either. 
 changes to the subscription query, for which we suggest you read up on
 in [this](#subscription-queries-and-the-query-update-emitter) section.
 
+Each of these dispatch operations also has a metadata-carrying variant, accepting a `Metadata` argument right before the
+(nullable) `ProcessingContext`. This allows attaching metadata directly on the dispatch, without pre-wrapping the query
+into a `QueryMessage`:
+
+1. `CompletableFuture<R> QueryGateway#query(Object, Class<R>, Metadata, ProcessingContext)`
+2. `CompletableFuture<List<R>> QueryGateway#queryMany(Object, Class<R>, Metadata, ProcessingContext)`
+3. `Publisher<R> QueryGateway#streamingQuery(Object, Class<R>, Metadata, ProcessingContext)`
+4. `Publisher<R> QueryGateway#subscriptionQuery(Object, Class<R>, Metadata, ProcessingContext, int)`
+
 As might be clear, the `QueryGateway` has an entirely new look and feel. If there are any operations we have
 removed/adjusted you miss, or if you have any other suggestions for improvement, please
 construct [an issue](https://github.com/AxonFramework/AxonFramework/issues) for us.

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/gateway/CommandGateway.java
@@ -55,14 +55,14 @@ public interface CommandGateway extends DescribableComponent {
      * {@link CommandMessage} that is eventually posted on the
      * {@link CommandBus}, unless the {@code command} already implements
      * {@link Message}. In that case, a {@code CommandMessage} is constructed from that
-     * message's payload and {@link org.axonframework.messaging.core.Metadata}. The provided {@code metadata} is attached
+     * message's payload and {@link Metadata}. The provided {@code metadata} is attached
      * afterward in this case.
      *
-     * @param command  The command payload or {@link CommandMessage} to send.
-     * @param metadata Meta-data that must be registered with the {@code command}.
-     * @param context  The processing context, if any, to dispatch the given {@code command} in.
-     * @return A command result success and failure hooks can be registered. The
-     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
+     * @param command  the command payload or {@link CommandMessage} to send
+     * @param metadata the metadata to register with the {@code command}
+     * @param context  the processing context, if any, to dispatch the given {@code command} in
+     * @return a command result to which success and failure hooks can be registered; the
+     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response
      */
     CommandResult send(Object command, Metadata metadata, @Nullable ProcessingContext context);
 
@@ -80,16 +80,16 @@ public interface CommandGateway extends DescribableComponent {
      * <p/>
      * The given {@code command} is wrapped as the payload of the
      * {@link CommandMessage} that is eventually posted on the {@code CommandBus},
-     * unless the {@code command} already implements {@link org.axonframework.messaging.core.Message}. In that case, a
+     * unless the {@code command} already implements {@link Message}. In that case, a
      * {@code CommandMessage} is constructed from that message's payload and
-     * {@link org.axonframework.messaging.core.Metadata}.
+     * {@link Metadata}.
      *
-     * @param command The command payload or {@link CommandMessage} to send.
-     * @return A command result success and failure hooks can be registered. The
-     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
+     * @param command the command payload or {@link CommandMessage} to send
+     * @return a command result to which success and failure hooks can be registered; the
+     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response
      * @see CommandGateway#send(Object, Metadata, ProcessingContext)
      */
-        default CommandResult send(Object command) {
+    default CommandResult send(Object command) {
         return send(command, Metadata.emptyInstance(), null);
     }
 
@@ -111,20 +111,20 @@ public interface CommandGateway extends DescribableComponent {
      * {@code CommandMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param command The command payload or {@link CommandMessage} to send.
-     * @param context The processing context, if any, to dispatch the given {@code command} in.
-     * @return A command result success and failure hooks can be registered. The
-     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
+     * @param command the command payload or {@link CommandMessage} to send
+     * @param context the processing context, if any, to dispatch the given {@code command} in
+     * @return a command result to which success and failure hooks can be registered; the
+     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response
      * @see CommandGateway#send(Object, Metadata, ProcessingContext)
      */
-        default CommandResult send(Object command,
+    default CommandResult send(Object command,
                                @Nullable ProcessingContext context) {
         return send(command, Metadata.emptyInstance(), context);
     }
 
     /**
-     * Sends the given {@code command} with the given {@code metadata} in the provided {@code context} (if available)
-     * and returns a {@link CommandResult} immediately, without waiting for the command to execute.
+     * Sends the given {@code command} with the given {@code metadata} and returns a {@link CommandResult} immediately,
+     * without waiting for the command to execute.
      * <p>
      * The caller will therefore not receive any immediate feedback on the {@code command's} execution. Instead, hooks
      * <em>can</em> be added to the returned {@code CommandResult} to react on success or failure of command
@@ -137,17 +137,17 @@ public interface CommandGateway extends DescribableComponent {
      * The given {@code command} and {@code metadata} are wrapped as the payload of the
      * {@link CommandMessage} that is eventually posted on the
      * {@link CommandBus}, unless the {@code command} already implements
-     * {@link org.axonframework.messaging.core.Message}. In that case, a {@code CommandMessage} is constructed from that
-     * message's payload and {@link org.axonframework.messaging.core.Metadata}. The provided {@code metadata} is attached
+     * {@link Message}. In that case, a {@code CommandMessage} is constructed from that
+     * message's payload and {@link Metadata}. The provided {@code metadata} is attached
      * afterward in this case.
      *
-     * @param command  The command payload or {@link CommandMessage} to send.
-     * @param metadata Meta-data that must be registered with the {@code command}.
-     * @return A command result success and failure hooks can be registered. The
-     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response.
+     * @param command  the command payload or {@link CommandMessage} to send
+     * @param metadata the metadata to register with the {@code command}
+     * @return a command result to which success and failure hooks can be registered; the
+     * {@link CommandResult#getResultMessage()} serves as a shorthand to retrieve the response
      * @see CommandGateway#send(Object, Metadata, ProcessingContext)
      */
-        default CommandResult send(Object command,
+    default CommandResult send(Object command,
                                Metadata metadata) {
         return send(command, metadata, null);
     }
@@ -168,16 +168,16 @@ public interface CommandGateway extends DescribableComponent {
      * {@code CommandMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param <R>        The generic type of the expected response.
-     * @param command    The command payload or {@link CommandMessage} to send.
-     * @param resultType The class representing the type of the expected command result.
-     * @return A {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
-     * command execution result.
+     * @param <R>        the generic type of the expected response
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @return a {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
+     * command execution result
      * @see CommandGateway#send(Object, Class, ProcessingContext)
      */
     default <R> CompletableFuture<R> send(Object command,
                                           Class<R> resultType) {
-        return send(command, resultType, null);
+        return send(command, resultType, Metadata.emptyInstance(), null);
     }
 
     /**
@@ -196,18 +196,50 @@ public interface CommandGateway extends DescribableComponent {
      * {@code CommandMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param <R>        The generic type of the expected response.
-     * @param command    The command payload or {@link CommandMessage} to send.
-     * @param resultType The class representing the type of the expected command result.
-     * @param context    The processing context, if any, to dispatch the given {@code command} in.
-     * @return A {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
-     * command execution result.
-     * @see CommandGateway#send(Object, ProcessingContext)
+     * @param <R>        the generic type of the expected response
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @param context    the processing context, if any, to dispatch the given {@code command} in
+     * @return a {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
+     * command execution result
+     * @see CommandGateway#send(Object, Class, Metadata, ProcessingContext)
      */
     default <R> CompletableFuture<R> send(Object command,
                                           Class<R> resultType,
                                           @Nullable ProcessingContext context) {
-        return send(command, context).resultAs(resultType);
+        return send(command, resultType, Metadata.emptyInstance(), context);
+    }
+
+    /**
+     * Sends the given {@code command} with the given {@code metadata} in the provided {@code context} (if available)
+     * and returns a {@link CompletableFuture} immediately, without waiting for the command to execute.
+     * <p>
+     * The caller will therefore not receive any immediate feedback on the {@code command's} execution. Instead, hooks
+     * <em>can</em> be added to the returned {@code CompletableFuture} to react on success or failure of command
+     * execution.
+     * <p>
+     * Note that this operation expects the {@link CommandBus} to use new threads for
+     * command execution.
+     * <p/>
+     * The given {@code command} and {@code metadata} are wrapped as the payload of the {@link CommandMessage} that is
+     * eventually posted on the {@code CommandBus}, unless the {@code command} already implements {@link Message}. In
+     * that case, a {@code CommandMessage} is constructed from that message's payload and {@link Metadata}. The provided
+     * {@code metadata} is attached afterward in this case.
+     *
+     * @param <R>        the generic type of the expected response
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @param metadata   the metadata to register with the {@code command}
+     * @param context    the processing context, if any, to dispatch the given {@code command} in
+     * @return a {@link CompletableFuture} that will be resolved successfully or exceptionally based on the eventual
+     * command execution result
+     * @since 5.3.0
+     */
+    default <R> CompletableFuture<R> send(Object command,
+                                          Class<R> resultType,
+                                          Metadata metadata,
+                                          @Nullable ProcessingContext context) {
+        return send(command, metadata, context).resultAs(resultType);
     }
 
     /**
@@ -220,9 +252,9 @@ public interface CommandGateway extends DescribableComponent {
      * If the result is needed, use {@link #sendAndWait(Object, Class)} instead, as it allows for type conversion of the
      * result payload.
      *
-     * @param command The command payload or {@link CommandMessage} to send.
-     * @return The payload of the result message, or {@code null} when none is present.
-     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     * @param command the command payload or {@link CommandMessage} to send
+     * @return the payload of the result message, or {@code null} when none is present
+     * @throws CommandExecutionException when a checked exception occurs while handling the command
      * @see CommandGateway#sendAndWait(Object, Class)
      */
     @Nullable
@@ -240,10 +272,10 @@ public interface CommandGateway extends DescribableComponent {
      * If the result is needed, use {@link #sendAndWait(Object, Class)} instead, as it allows for type conversion of the
      * result payload.
      *
-     * @param command The command payload or {@link CommandMessage} to send.
-     * @param context The processing context, if any, to dispatch the given {@code command} in.
-     * @return The payload of the result message, or {@code null} when none is present.
-     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     * @param command the command payload or {@link CommandMessage} to send
+     * @param context the processing context, if any, to dispatch the given {@code command} in
+     * @return the payload of the result message, or {@code null} when none is present
+     * @throws CommandExecutionException when a checked exception occurs while handling the command
      * @see CommandGateway#sendAndWait(Object, Class, ProcessingContext)
      */
     @Nullable
@@ -259,17 +291,17 @@ public interface CommandGateway extends DescribableComponent {
      * it was unsuccessful or conversion failed, an exception is thrown. Any checked exceptions that may occur as the
      * result of running the command will be wrapped in a {@link CommandExecutionException}.
      *
-     * @param command    The command payload or {@link CommandMessage} to send.
-     * @param resultType The class representing the type of the expected command result.
-     * @param <R>        The generic type of the expected response.
-     * @return The payload of the result message of type {@code R}, or {@code null} when none is present.
-     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @param <R>        the generic type of the expected response
+     * @return the payload of the result message of type {@code R}, or {@code null} when none is present
+     * @throws CommandExecutionException when a checked exception occurs while handling the command
      * @see CommandGateway#sendAndWait(Object, Class, ProcessingContext)
      */
     @Nullable
     default <R> R sendAndWait(Object command,
                               Class<R> resultType) {
-        return sendAndWait(command, resultType, null);
+        return sendAndWait(command, resultType, Metadata.emptyInstance(), null);
     }
 
     /**
@@ -279,17 +311,43 @@ public interface CommandGateway extends DescribableComponent {
      * it was unsuccessful or conversion failed, an exception is thrown. Any checked exceptions that may occur as the
      * result of running the command will be wrapped in a {@link CommandExecutionException}.
      *
-     * @param command    The command payload or {@link CommandMessage} to send.
-     * @param resultType The class representing the type of the expected command result.
-     * @param context    The processing context, if any, to dispatch the given {@code command} in.
-     * @param <R>        The generic type of the expected response.
-     * @return The payload of the result message of type {@code R}, or {@code null} when none is present.
-     * @throws CommandExecutionException When a checked exception occurs while handling the command.
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @param context    the processing context, if any, to dispatch the given {@code command} in
+     * @param <R>        the generic type of the expected response
+     * @return the payload of the result message of type {@code R}, or {@code null} when none is present
+     * @throws CommandExecutionException when a checked exception occurs while handling the command
+     * @see CommandGateway#sendAndWait(Object, Class, Metadata, ProcessingContext)
      */
     @Nullable
     default <R> R sendAndWait(Object command,
                               Class<R> resultType,
                               @Nullable ProcessingContext context) {
-        return send(command, context).wait(resultType);
+        return sendAndWait(command, resultType, Metadata.emptyInstance(), context);
+    }
+
+    /**
+     * Send the given {@code command} with the given {@code metadata} in the provided {@code context} (if available) and
+     * waits for the result converted to the {@code resultType}.
+     * <p>
+     * If the command was successful, its result will be converted to the specified {@code returnType} and returned. If
+     * it was unsuccessful or conversion failed, an exception is thrown. Any checked exceptions that may occur as the
+     * result of running the command will be wrapped in a {@link CommandExecutionException}.
+     *
+     * @param command    the command payload or {@link CommandMessage} to send
+     * @param resultType the class representing the type of the expected command result
+     * @param metadata   the metadata to register with the {@code command}
+     * @param context    the processing context, if any, to dispatch the given {@code command} in
+     * @param <R>        the generic type of the expected response
+     * @return the payload of the result message of type {@code R}, or {@code null} when none is present
+     * @throws CommandExecutionException when a checked exception occurs while handling the command
+     * @since 5.3.0
+     */
+    @Nullable
+    default <R> R sendAndWait(Object command,
+                              Class<R> resultType,
+                              Metadata metadata,
+                              @Nullable ProcessingContext context) {
+        return send(command, metadata, context).wait(resultType);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGateway.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -57,12 +58,12 @@ public class DefaultQueryGateway implements QueryGateway {
      * The {@link QualifiedName names} for {@link QueryMessage QueryMessages} are resolved
      * through the given {@code nameResolver}.
      *
-     * @param queryBus            The {@link QueryBus} to send queries on.
-     * @param messageTypeResolver The {@link MessageTypeResolver} resolving the
+     * @param queryBus            the {@link QueryBus} to send queries on
+     * @param messageTypeResolver the {@link MessageTypeResolver} resolving the
      *                            {@link QualifiedName names} for
-     *                            {@link QueryMessage QueryMessages} being dispatched on the {@code queryBus}.
-     * @param priorityCalculator  The {@link QueryPriorityCalculator} determining the priority of queries.
-     * @param converter           The converter to use for converting the result of query handling.
+     *                            {@link QueryMessage QueryMessages} being dispatched on the {@code queryBus}
+     * @param priorityCalculator  the {@link QueryPriorityCalculator} determining the priority of queries
+     * @param converter           the converter to use for converting the result of query handling
      */
     public DefaultQueryGateway(QueryBus queryBus,
                                MessageTypeResolver messageTypeResolver,
@@ -80,7 +81,15 @@ public class DefaultQueryGateway implements QueryGateway {
     public <R> CompletableFuture<R> query(Object query,
                                           Class<R> responseType,
                                           @Nullable ProcessingContext context) {
-        QueryMessage queryMessage = asQueryMessage(query);
+        return query(query, responseType, Metadata.emptyInstance(), context);
+    }
+
+    @Override
+    public <R> CompletableFuture<R> query(Object query,
+                                          Class<R> responseType,
+                                          Metadata metadata,
+                                          @Nullable ProcessingContext context) {
+        QueryMessage queryMessage = asQueryMessage(query, metadata);
         MessageStream<QueryResponseMessage> resultStream = queryBus.query(queryMessage, context);
         CompletableFuture<R> resultFuture =
                 resultStream.first()
@@ -104,7 +113,15 @@ public class DefaultQueryGateway implements QueryGateway {
     public <R> CompletableFuture<List<R>> queryMany(Object query,
                                                     Class<R> responseType,
                                                     @Nullable ProcessingContext context) {
-        QueryMessage queryMessage = asQueryMessage(query);
+        return queryMany(query, responseType, Metadata.emptyInstance(), context);
+    }
+
+    @Override
+    public <R> CompletableFuture<List<R>> queryMany(Object query,
+                                                    Class<R> responseType,
+                                                    Metadata metadata,
+                                                    @Nullable ProcessingContext context) {
+        QueryMessage queryMessage = asQueryMessage(query, metadata);
         MessageStream<QueryResponseMessage> resultStream = queryBus.query(queryMessage, context);
         CompletableFuture<List<R>> resultFuture =
                 resultStream.collect(ArrayList::new, (list, message) -> list.add(message.payloadAs(responseType, converter)));
@@ -121,7 +138,15 @@ public class DefaultQueryGateway implements QueryGateway {
     public <R> Publisher<R> streamingQuery(Object query,
                                            Class<R> responseType,
                                            @Nullable ProcessingContext context) {
-        return Mono.fromSupplier(() -> asQueryMessage(query))
+        return streamingQuery(query, responseType, Metadata.emptyInstance(), context);
+    }
+
+    @Override
+    public <R> Publisher<R> streamingQuery(Object query,
+                                           Class<R> responseType,
+                                           Metadata metadata,
+                                           @Nullable ProcessingContext context) {
+        return Mono.fromSupplier(() -> asQueryMessage(query, metadata))
                    .flatMapMany(queryMessage -> FluxUtils.of(queryBus.query(queryMessage, context)))
                    .map(MessageStream.Entry::message)
                    .mapNotNull(m -> m.payloadAs(responseType, converter));
@@ -137,7 +162,16 @@ public class DefaultQueryGateway implements QueryGateway {
                                               Class<R> responseType,
                                               @Nullable ProcessingContext context,
                                               int updateBufferSize) {
-        return subscriptionQuery(query,
+        return subscriptionQuery(query, responseType, Metadata.emptyInstance(), context, updateBufferSize);
+    }
+
+    @Override
+    public <R> Publisher<R> subscriptionQuery(Object query,
+                                              Class<R> responseType,
+                                              Metadata metadata,
+                                              @Nullable ProcessingContext context,
+                                              int updateBufferSize) {
+        return subscriptionQuery(asQueryMessage(query, metadata),
                                  responseType,
                                  m -> m.payloadAs(responseType, converter),
                                  context,
@@ -176,6 +210,10 @@ public class DefaultQueryGateway implements QueryGateway {
         return query instanceof Message message
                 ? new GenericQueryMessage(message)
                 : new GenericQueryMessage(resolveTypeFor(query), query);
+    }
+
+    private QueryMessage asQueryMessage(Object query, Metadata metadata) {
+        return asQueryMessage(query).andMetadata(metadata);
     }
 
     private MessageType resolveTypeFor(Object payload) {

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/QueryGateway.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/gateway/QueryGateway.java
@@ -55,11 +55,11 @@ public interface QueryGateway extends DescribableComponent {
      * {@code QueryMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@code Class} describing the desired response type.
-     * @param context      The processing context, if any, to dispatch the given {@code query} in.
-     * @param <R>          The generic type of the expected response.
-     * @return A {@code CompletableFuture} containing a single query response of type {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response
+     * @return a {@code CompletableFuture} containing a single query response of type {@code responseType}
      */
     <R> CompletableFuture<R> query(Object query,
                                    Class<R> responseType,
@@ -76,15 +76,46 @@ public interface QueryGateway extends DescribableComponent {
      * {@code QueryMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@code Class} describing the desired response type.
-     * @param <R>          The generic type of the expected response.
-     * @return A {@code CompletableFuture} containing a single query response of type {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param <R>          the generic type of the expected response
+     * @return a {@code CompletableFuture} containing a single query response of type {@code responseType}
      * @see #query(Object, Class, ProcessingContext)
      */
     default <R> CompletableFuture<R> query(Object query,
                                            Class<R> responseType) {
         return query(query, responseType, null);
+    }
+
+    /**
+     * Sends given {@code query} with the given {@code metadata} in the provided {@code context} (if available) over the
+     * {@link QueryBus}, expecting a single response with the given {@code responseType} from a single source.
+     * <p>
+     * Execution may be asynchronous, depending on the {@code QueryBus} implementation.
+     * <p>
+     * The given {@code query} and {@code metadata} are wrapped as the payload of the {@link QueryMessage} that is
+     * eventually posted on the {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that
+     * case, a {@code QueryMessage} is constructed from that message's payload and {@link Metadata}. The provided
+     * {@code metadata} is attached afterward in this case.
+     * <p>
+     * Implementations must override this method to support attaching the given {@code metadata}; the default
+     * implementation throws an {@link UnsupportedOperationException}.
+     *
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param metadata     the metadata to attach to the {@code query}
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response
+     * @return a {@code CompletableFuture} containing a single query response of type {@code responseType}
+     * @since 5.3.0
+     */
+    default <R> CompletableFuture<R> query(Object query,
+                                           Class<R> responseType,
+                                           Metadata metadata,
+                                           @Nullable ProcessingContext context) {
+        throw new UnsupportedOperationException(
+                "This QueryGateway does not support attaching metadata to a query."
+        );
     }
 
     /**
@@ -98,11 +129,11 @@ public interface QueryGateway extends DescribableComponent {
      * {@code QueryMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@code Class} describing the desired response type.
-     * @param context      The processing context, if any, to dispatch the given {@code query} in.
-     * @param <R>          The generic type of the expected response(s).
-     * @return A {@code CompletableFuture} containing a list of query responses of type {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@code CompletableFuture} containing a list of query responses of type {@code responseType}
      */
     <R> CompletableFuture<List<R>> queryMany(Object query,
                                              Class<R> responseType,
@@ -119,15 +150,46 @@ public interface QueryGateway extends DescribableComponent {
      * {@code QueryMessage} is constructed from that message's payload and
      * {@link Metadata}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@code Class} describing the desired response type.
-     * @param <R>          The generic type of the expected response(s).
-     * @return A {@code CompletableFuture} containing a list of query responses of type {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@code CompletableFuture} containing a list of query responses of type {@code responseType}
      * @see #queryMany(Object, Class, ProcessingContext)
      */
     default <R> CompletableFuture<List<R>> queryMany(Object query,
                                                      Class<R> responseType) {
         return queryMany(query, responseType, null);
+    }
+
+    /**
+     * Sends given {@code query} with the given {@code metadata} in the provided {@code context} (if available) over the
+     * {@link QueryBus}, expecting multiple responses in the form of {@code responseType} from a single source.
+     * <p>
+     * Execution may be asynchronous, depending on the {@code QueryBus} implementation.
+     * <p>
+     * The given {@code query} and {@code metadata} are wrapped as the payload of the {@link QueryMessage} that is
+     * eventually posted on the {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that
+     * case, a {@code QueryMessage} is constructed from that message's payload and {@link Metadata}. The provided
+     * {@code metadata} is attached afterward in this case.
+     * <p>
+     * Implementations must override this method to support attaching the given {@code metadata}; the default
+     * implementation throws an {@link UnsupportedOperationException}.
+     *
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@code Class} describing the desired response type
+     * @param metadata     the metadata to attach to the {@code query}
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@code CompletableFuture} containing a list of query responses of type {@code responseType}
+     * @since 5.3.0
+     */
+    default <R> CompletableFuture<List<R>> queryMany(Object query,
+                                                     Class<R> responseType,
+                                                     Metadata metadata,
+                                                     @Nullable ProcessingContext context) {
+        throw new UnsupportedOperationException(
+                "This QueryGateway does not support attaching metadata to a query."
+        );
     }
 
     /**
@@ -147,12 +209,12 @@ public interface QueryGateway extends DescribableComponent {
      * Project Reactor on class path. Check <a href="https://docs.axoniq.io/reference-guide/extensions/reactor">Reactor
      * Extension</a> for native Flux type and more. Use {@code Flux.from(publisher)} to convert to Flux stream.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@link java.lang.Class} describing the desired response type.
-     * @param context      The processing context, if any, to dispatch the given {@code query} in.
-     * @param <R>          The generic type of the expected response(s).
-     * @return A {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
-     * {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@link java.lang.Class} describing the desired response type
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
      */
     <R> Publisher<R> streamingQuery(Object query,
                                     Class<R> responseType,
@@ -175,11 +237,11 @@ public interface QueryGateway extends DescribableComponent {
      * Project Reactor on class path. Check <a href="https://docs.axoniq.io/reference-guide/extensions/reactor">Reactor
      * Extension</a> for native Flux type and more. Use {@code Flux.from(publisher)} to convert to Flux stream.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType A {@link java.lang.Class} describing the desired response type.
-     * @param <R>          The generic type of the expected response(s).
-     * @return A {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
-     * {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@link java.lang.Class} describing the desired response type
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
      * @see #streamingQuery(Object, Class, ProcessingContext)
      */
     default <R> Publisher<R> streamingQuery(Object query,
@@ -188,72 +250,43 @@ public interface QueryGateway extends DescribableComponent {
     }
 
     /**
-     * Sends given {@code query} over the {@link QueryBus} as a subscription query, combining the initial result and
-     * emitted update as a {@link Publisher} of the given {@code responseType}.
+     * Sends given {@code query} with the given {@code metadata} in the provided {@code context} (if available) over the
+     * {@link QueryBus}, expecting a response as a {@link org.reactivestreams.Publisher} of {@code responseType}.
      * <p>
-     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, update are received at the
-     * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
+     * The {@code query} is sent once the {@code Publisher} is subscribed to. See
+     * {@link #streamingQuery(Object, Class)} for the streaming semantics and Project Reactor requirements.
      * <p>
-     * The given {@code query} is wrapped as the payload of the {@link QueryMessage} that is eventually posted on the
-     * {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that case, a
-     * {@code QueryMessage} is constructed from that message's payload and
-     * {@link Metadata}.
+     * The given {@code query} and {@code metadata} are wrapped as the payload of the {@link QueryMessage} that is
+     * eventually posted on the {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that
+     * case, a {@code QueryMessage} is constructed from that message's payload and {@link Metadata}. The provided
+     * {@code metadata} is attached afterward in this case.
      * <p>
-     * Note that any {@code null} results, on the initial result or the update, wil lbe filtered out by the gateway. If
-     * you require the {@code null} to be returned for the initial and update results, we suggest using the
-     * {@code QueryBus} instead.
-     * <p>
-     * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
-     * full, any attempt to add an update will complete the stream with an exception.
+     * Implementations must override this method to support attaching the given {@code metadata}; the default
+     * implementation throws an {@link UnsupportedOperationException}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType The response type returned by this query as the initial result and the update.
-     * @param context      The processing context, if any, to dispatch the given {@code query} in.
-     * @param <R>          The type of all the responses.
-     * @return A {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
-     * {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType a {@link java.lang.Class} describing the desired response type
+     * @param metadata     the metadata to attach to the {@code query}
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the generic type of the expected response(s)
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
+     * @since 5.3.0
      */
-    default <R> Publisher<R> subscriptionQuery(Object query,
-                                               Class<R> responseType,
-                                               @Nullable ProcessingContext context) {
-        return subscriptionQuery(query, responseType, context, Queues.SMALL_BUFFER_SIZE);
+    default <R> Publisher<R> streamingQuery(Object query,
+                                            Class<R> responseType,
+                                            Metadata metadata,
+                                            @Nullable ProcessingContext context) {
+        throw new UnsupportedOperationException(
+                "This QueryGateway does not support attaching metadata to a query."
+        );
     }
 
     /**
      * Sends given {@code query} over the {@link QueryBus} as a subscription query, combining the initial result and
      * emitted update as a {@link Publisher} of the given {@code responseType}.
      * <p>
-     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, update are received at the
-     * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
-     * <p>
-     * The given {@code query} is wrapped as the payload of the {@link QueryMessage} that is eventually posted on the
-     * {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that case, a
-     * {@code QueryMessage} is constructed from that message's payload and
-     * {@link Metadata}.
-     * <p>
-     * Note that any {@code null} results, on the initial result or the update, wil lbe filtered out by the gateway. If
-     * you require the {@code null} to be returned for the initial and update results, we suggest using the
-     * {@code QueryBus} instead.
-     * <p>
-     * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
-     * full, any attempt to add an update will complete the stream with an exception.
-     *
-     * @param query        The {@code query} to be sent.
-     * @param responseType The response type returned by this query as the initial result and the update.
-     * @param <R>          The type of all the responses.
-     * @return A {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
-     * {@code responseType}.
-     */
-    default <R> Publisher<R> subscriptionQuery(Object query,
-                                               Class<R> responseType) {
-        return subscriptionQuery(query, responseType, (ProcessingContext) null);
-    }
-
-    /**
-     * Sends given {@code query} over the {@link QueryBus} as a subscription query, combining the initial result and
-     * emitted update as a {@link Publisher} of the given {@code responseType}.
-     * <p>
-     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, update are received at the
+     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, updates are received at the
      * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
      * <p>
      * The given {@code query} is wrapped as the payload of the {@link QueryMessage} that is eventually posted on the
@@ -268,19 +301,124 @@ public interface QueryGateway extends DescribableComponent {
      * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
      * full, any attempt to add an update will complete the stream with an exception.
      *
-     * @param query            The {@code query} to be sent.
-     * @param responseType     The response type returned by this query as the initial result and the update.
-     * @param context          The processing context, if any, to dispatch the given {@code query} in.
-     * @param updateBufferSize The size of buffer which accumulates update before a subscription to the {@code Flux} is
-     *                         made.
-     * @param <R>              The type of all the responses.
-     * @return A {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
-     * {@code responseType}.
+     * @param query        the {@code query} to be sent
+     * @param responseType the response type returned by this query as the initial result and the update
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the type of all the responses
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
+     */
+    default <R> Publisher<R> subscriptionQuery(Object query,
+                                               Class<R> responseType,
+                                               @Nullable ProcessingContext context) {
+        return subscriptionQuery(query, responseType, context, Queues.SMALL_BUFFER_SIZE);
+    }
+
+    /**
+     * Sends given {@code query} over the {@link QueryBus} as a subscription query, combining the initial result and
+     * emitted update as a {@link Publisher} of the given {@code responseType}.
+     * <p>
+     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, updates are received at the
+     * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
+     * <p>
+     * The given {@code query} is wrapped as the payload of the {@link QueryMessage} that is eventually posted on the
+     * {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that case, a
+     * {@code QueryMessage} is constructed from that message's payload and
+     * {@link Metadata}.
+     * <p>
+     * Note that any {@code null} results, on the initial result or the update, will be filtered out by the gateway. If
+     * you require the {@code null} to be returned for the initial and update results, we suggest using the
+     * {@code QueryBus} instead.
+     * <p>
+     * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
+     * full, any attempt to add an update will complete the stream with an exception.
+     *
+     * @param query        the {@code query} to be sent
+     * @param responseType the response type returned by this query as the initial result and the update
+     * @param <R>          the type of all the responses
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
+     */
+    default <R> Publisher<R> subscriptionQuery(Object query,
+                                               Class<R> responseType) {
+        return subscriptionQuery(query, responseType, (ProcessingContext) null);
+    }
+
+    /**
+     * Sends given {@code query} over the {@link QueryBus} as a subscription query, combining the initial result and
+     * emitted update as a {@link Publisher} of the given {@code responseType}.
+     * <p>
+     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, updates are received at the
+     * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
+     * <p>
+     * The given {@code query} is wrapped as the payload of the {@link QueryMessage} that is eventually posted on the
+     * {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that case, a
+     * {@code QueryMessage} is constructed from that message's payload and
+     * {@link Metadata}.
+     * <p>
+     * Note that any {@code null} results, on the initial result or the update, will be filtered out by the gateway. If
+     * you require the {@code null} to be returned for the initial and update results, we suggest using the
+     * {@code QueryBus} instead.
+     * <p>
+     * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
+     * full, any attempt to add an update will complete the stream with an exception.
+     *
+     * @param query            the {@code query} to be sent
+     * @param responseType     the response type returned by this query as the initial result and the update
+     * @param context          the processing context, if any, to dispatch the given {@code query} in
+     * @param updateBufferSize the size of buffer which accumulates updates before a subscription to the {@code Flux} is
+     *                         made
+     * @param <R>              the type of all the responses
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
      */
     <R> Publisher<R> subscriptionQuery(Object query,
                                        Class<R> responseType,
                                        @Nullable ProcessingContext context,
                                        int updateBufferSize);
+
+    /**
+     * Sends given {@code query} with the given {@code metadata} over the {@link QueryBus} as a subscription query,
+     * combining the initial result and emitted update as a {@link Publisher} of the given {@code responseType}.
+     * <p>
+     * The {@code query} is sent once the {@code Publisher} is subscribed to. Furthermore, updates are received at the
+     * moment the query is sent, and until it is cancelled by the caller or closed by the emitting side.
+     * <p>
+     * The given {@code query} and {@code metadata} are wrapped as the payload of the {@link QueryMessage} that is
+     * eventually posted on the {@code QueryBus}, unless the {@code query} already implements {@link Message}. In that
+     * case, a {@code QueryMessage} is constructed from that message's payload and {@link Metadata}. The provided
+     * {@code metadata} is attached afterward in this case.
+     * <p>
+     * Implementations must override this method to support attaching the given {@code metadata}; the default
+     * implementation throws an {@link UnsupportedOperationException}.
+     * <p>
+     * Note that any {@code null} results, on the initial result or the update, will be filtered out by the gateway. If
+     * you require the {@code null} to be returned for the initial and update results, we suggest using the
+     * {@code QueryBus} instead.
+     * <p>
+     * The returned Publisher must be subscribed to and consumed from before the buffer fills up. Once the buffer is
+     * full, any attempt to add an update will complete the stream with an exception.
+     *
+     * @param query            the {@code query} to be sent
+     * @param responseType     the response type returned by this query as the initial result and the update
+     * @param metadata         the metadata to attach to the {@code query}
+     * @param context          the processing context, if any, to dispatch the given {@code query} in
+     * @param updateBufferSize the size of buffer which accumulates updates before a subscription to the {@code Flux} is
+     *                         made
+     * @param <R>              the type of all the responses
+     * @return a {@link org.reactivestreams.Publisher} streaming the results as dictated by the given
+     * {@code responseType}
+     * @since 5.3.0
+     */
+    default <R> Publisher<R> subscriptionQuery(Object query,
+                                               Class<R> responseType,
+                                               Metadata metadata,
+                                               @Nullable ProcessingContext context,
+                                               int updateBufferSize) {
+        throw new UnsupportedOperationException(
+                "This QueryGateway does not support attaching metadata to a query."
+        );
+    }
 
     /**
      * Sends given {@code query} over the {@link QueryBus} and returns a {@link Publisher} supplying the initial update
@@ -289,7 +427,7 @@ public interface QueryGateway extends DescribableComponent {
      * whether the given {@code responseMessage} is an instance of {@link SubscriptionQueryUpdateMessage}. In that case
      * the message is considered an update, otherwise it is considered the initial result.
      * <p>
-     * The {@code query} is sent upon invocation of this method. Furthermore, update are received at the moment the
+     * The {@code query} is sent upon invocation of this method. Furthermore, updates are received at the moment the
      * query is sent, and until the subscription to the Publisher is canceled by the caller or closed by the emitting
      * side.
      * <p>
@@ -306,12 +444,12 @@ public interface QueryGateway extends DescribableComponent {
      * full, any attempt to add an update will complete the stream with an exception. To control the buffer size, use
      * {@link #subscriptionQuery(Object, Class, Function, ProcessingContext, int)}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType The response type returned by this query as the initial result
-     * @param mapper       A {@link Function} that maps the {@link QueryResponseMessage} to the desired response
-     * @param context      The processing context, if any, to dispatch the given {@code query} in.
-     * @param <R>          The type payload to map the responses to.
-     * @return Registration which can be used to cancel receiving update.
+     * @param query        the {@code query} to be sent
+     * @param responseType the response type returned by this query as the initial result
+     * @param mapper       a {@link Function} that maps the {@link QueryResponseMessage} to the desired response
+     * @param context      the processing context, if any, to dispatch the given {@code query} in
+     * @param <R>          the type payload to map the responses to
+     * @return a {@link Publisher} which can be used to cancel receiving update
      * @see #subscriptionQuery(Object, Class, Function, ProcessingContext, int)
      */
     default <R> Publisher<R> subscriptionQuery(Object query,
@@ -328,7 +466,7 @@ public interface QueryGateway extends DescribableComponent {
      * whether the given {@code responseMessage} is an instance of {@link SubscriptionQueryUpdateMessage}. In that case
      * the message is considered an update, otherwise it is considered the initial result.
      * <p>
-     * The {@code query} is sent upon invocation of this method. Furthermore, update are received at the moment the
+     * The {@code query} is sent upon invocation of this method. Furthermore, updates are received at the moment the
      * query is sent, and until the subscription to the Publisher is canceled by the caller or closed by the emitting
      * side.
      * <p>
@@ -345,11 +483,11 @@ public interface QueryGateway extends DescribableComponent {
      * full, any attempt to add an update will complete the stream with an exception. To control the buffer size, use
      * {@link #subscriptionQuery(Object, Class, Function, ProcessingContext, int)}.
      *
-     * @param query        The {@code query} to be sent.
-     * @param responseType The response type returned by this query as the initial result
-     * @param mapper       A {@link Function} that maps the {@link QueryResponseMessage} to the desired response
-     * @param <R>          The type payload to map the responses to.
-     * @return Registration which can be used to cancel receiving update.
+     * @param query        the {@code query} to be sent
+     * @param responseType the response type returned by this query as the initial result
+     * @param mapper       a {@link Function} that maps the {@link QueryResponseMessage} to the desired response
+     * @param <R>          the type payload to map the responses to
+     * @return a {@link Publisher} which can be used to cancel receiving update
      * @see #subscriptionQuery(Object, Class, Function, ProcessingContext, int)
      */
     default <R> Publisher<R> subscriptionQuery(Object query,
@@ -365,7 +503,7 @@ public interface QueryGateway extends DescribableComponent {
      * whether the given {@code responseMessage} is an instance of {@link SubscriptionQueryUpdateMessage}. In that case
      * the message is considered an update, otherwise it is considered the initial result.
      * <p>
-     * The {@code query} is sent upon invocation of this method. Furthermore, update are received at the moment the
+     * The {@code query} is sent upon invocation of this method. Furthermore, updates are received at the moment the
      * query is sent, and until the subscription to the Publisher is canceled by the caller or closed by the emitting
      * side.
      * <p>
@@ -378,11 +516,11 @@ public interface QueryGateway extends DescribableComponent {
      * you require the {@code null} to be returned for the initial and update results, we suggest using the
      * {@code QueryBus} instead.
      *
-     * @param query            The {@code query} to be sent.
-     * @param responseType     The response type returned by this query as the initial result
-     * @param updateBufferSize The size of the buffer which accumulates update to be processed.
-     * @param <R>              The type payload to map the responses to.
-     * @return Registration which can be used to cancel receiving update.
+     * @param query            the {@code query} to be sent
+     * @param responseType     the response type returned by this query as the initial result
+     * @param updateBufferSize the size of the buffer which accumulates updates to be processed
+     * @param <R>              the type payload to map the responses to
+     * @return a {@link Publisher} which can be used to cancel receiving update
      * @see #subscriptionQuery(Object, Class, Function, ProcessingContext, int)
      */
     default <R> Publisher<R> subscriptionQuery(Object query,
@@ -398,7 +536,7 @@ public interface QueryGateway extends DescribableComponent {
      * whether the given {@code responseMessage} is an instance of {@link SubscriptionQueryUpdateMessage}. In that case
      * the message is considered an update, otherwise it is considered the initial result.
      * <p>
-     * The {@code query} is sent upon invocation of this method. Furthermore, update are received at the moment the
+     * The {@code query} is sent upon invocation of this method. Furthermore, updates are received at the moment the
      * query is sent, and until the subscription to the Publisher is canceled by the caller or closed by the emitting
      * side.
      * <p>
@@ -411,14 +549,14 @@ public interface QueryGateway extends DescribableComponent {
      * you require the {@code null} to be returned for the initial and update results, we suggest using the
      * {@code QueryBus} instead.
      *
-     * @param query            The {@code query} to be sent.
-     * @param responseType     The response type returned by this query as the initial result
-     * @param mapper           A {@link Function} that maps the {@link QueryResponseMessage} to the desired response.
-     *                         Messages for which the mapper returns a {@code null} value are filtered out.
-     * @param context          The processing context, if any, to dispatch the given {@code query} in.
-     * @param updateBufferSize The size of the buffer which accumulates update to be processed.
-     * @param <R>              The type payload to map the responses to.
-     * @return Registration which can be used to cancel receiving update.
+     * @param query            the {@code query} to be sent
+     * @param responseType     the response type returned by this query as the initial result
+     * @param mapper           a {@link Function} that maps the {@link QueryResponseMessage} to the desired response;
+     *                         messages for which the mapper returns a {@code null} value are filtered out
+     * @param context          the processing context, if any, to dispatch the given {@code query} in
+     * @param updateBufferSize the size of the buffer which accumulates updates to be processed
+     * @param <R>              the type payload to map the responses to
+     * @return a {@link Publisher} which can be used to cancel receiving update
      * @see QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int)
      */
     <R> Publisher<R> subscriptionQuery(Object query,
@@ -434,7 +572,7 @@ public interface QueryGateway extends DescribableComponent {
      * whether the given {@code responseMessage} is an instance of {@link SubscriptionQueryUpdateMessage}. In that case
      * the message is considered an update, otherwise it is considered the initial result.
      * <p>
-     * The {@code query} is sent upon invocation of this method. Furthermore, update are received at the moment the
+     * The {@code query} is sent upon invocation of this method. Furthermore, updates are received at the moment the
      * query is sent, and until the subscription to the Publisher is canceled by the caller or closed by the emitting
      * side.
      * <p>
@@ -447,13 +585,13 @@ public interface QueryGateway extends DescribableComponent {
      * you require the {@code null} to be returned for the initial and update results, we suggest using the
      * {@code QueryBus} instead.
      *
-     * @param query            The {@code query} to be sent.
-     * @param responseType     The response type returned by this query as the initial result
-     * @param mapper           A {@link Function} that maps the {@link QueryResponseMessage} to the desired response.
-     *                         Messages for which the mapper returns a {@code null} value are filtered out.
-     * @param updateBufferSize The size of the buffer which accumulates update to be processed.
-     * @param <R>              The type payload to map the responses to.
-     * @return Registration which can be used to cancel receiving update.
+     * @param query            the {@code query} to be sent
+     * @param responseType     the response type returned by this query as the initial result
+     * @param mapper           a {@link Function} that maps the {@link QueryResponseMessage} to the desired response;
+     *                         messages for which the mapper returns a {@code null} value are filtered out
+     * @param updateBufferSize the size of the buffer which accumulates updates to be processed
+     * @param <R>              the type payload to map the responses to
+     * @return a {@link Publisher} which can be used to cancel receiving update
      * @see #subscriptionQuery(Object, Class, Function, ProcessingContext, int)
      */
     default <R> Publisher<R> subscriptionQuery(Object query,

--- a/messaging/src/test/java/org/axonframework/messaging/commandhandling/gateway/DefaultCommandGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/commandhandling/gateway/DefaultCommandGatewayTest.java
@@ -28,6 +28,7 @@ import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.common.util.MockException;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
@@ -49,6 +50,8 @@ class DefaultCommandGatewayTest {
 
     private static final MessageTypeResolver TEST_MESSAGE_NAME_RESOLVER =
             payloadType -> Optional.of(new MessageType(payloadType.getSimpleName()));
+
+    private static final Metadata TEST_METADATA = Metadata.with("key", "value");
 
     private CommandBus mockCommandBus;
 
@@ -252,6 +255,147 @@ class DefaultCommandGatewayTest {
         TestPayload payload = new TestPayload();
         // when/then...
         assertThatThrownBy(() -> testSubject.sendAndWait(payload, String.class)).isInstanceOf(MockException.class);
+    }
+
+    @Nested
+    class SendWithMetadata {
+
+        @Test
+        void sendWithMetadataAttachesMetadataToDispatchedCommand() {
+            // given
+            TestPayload payload = new TestPayload();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            testSubject.send(payload, TEST_METADATA);
+
+            // then
+            assertDispatchedWithMetadata(payload, null);
+        }
+
+        @Test
+        void sendWithMetadataAndContextAttachesMetadataAndPassesAlongContext() {
+            // given
+            TestPayload payload = new TestPayload();
+            ProcessingContext testContext = new StubProcessingContext();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            testSubject.send(payload, TEST_METADATA, testContext);
+
+            // then
+            assertDispatchedWithMetadata(payload, testContext);
+        }
+
+        @Test
+        void sendForResultTypeWithMetadataAttachesMetadataToDispatchedCommand() throws Exception {
+            // given
+            TestPayload payload = new TestPayload();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            CompletableFuture<String> result = testSubject.send(payload, String.class, TEST_METADATA, null);
+
+            // then
+            assertThat(result.get()).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, null);
+        }
+
+        @Test
+        void sendForResultTypeWithMetadataAndContextAttachesMetadataAndPassesAlongContext() throws Exception {
+            // given
+            TestPayload payload = new TestPayload();
+            ProcessingContext testContext = new StubProcessingContext();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            CompletableFuture<String> result = testSubject.send(payload, String.class, TEST_METADATA, testContext);
+
+            // then
+            assertThat(result.get()).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, testContext);
+        }
+    }
+
+    @Nested
+    class SendAndWaitWithMetadata {
+
+        @Test
+        void sendAndWaitWithMetadataAttachesMetadataAndReturnsExpectedResult() {
+            // given
+            TestPayload payload = new TestPayload();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            Object result = testSubject.sendAndWait(payload, Object.class, TEST_METADATA, null);
+
+            // then
+            assertThat(result).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, null);
+        }
+
+        @Test
+        void sendAndWaitWithMetadataAndContextAttachesMetadataAndPassesAlongContext() {
+            // given
+            TestPayload payload = new TestPayload();
+            ProcessingContext testContext = new StubProcessingContext();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            Object result = testSubject.sendAndWait(payload, Object.class, TEST_METADATA, testContext);
+
+            // then
+            assertThat(result).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, testContext);
+        }
+
+        @Test
+        void sendAndWaitForResultTypeWithMetadataAttachesMetadataAndReturnsExpectedResult() {
+            // given
+            TestPayload payload = new TestPayload();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            String result = testSubject.sendAndWait(payload, String.class, TEST_METADATA, null);
+
+            // then
+            assertThat(result).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, null);
+        }
+
+        @Test
+        void sendAndWaitForResultTypeWithMetadataAndContextAttachesMetadataAndPassesAlongContext() {
+            // given
+            TestPayload payload = new TestPayload();
+            ProcessingContext testContext = new StubProcessingContext();
+            arrangeSuccessfulDispatch("OK");
+
+            // when
+            String result = testSubject.sendAndWait(payload, String.class, TEST_METADATA, testContext);
+
+            // then
+            assertThat(result).isEqualTo("OK");
+            assertDispatchedWithMetadata(payload, testContext);
+        }
+    }
+
+    private void arrangeSuccessfulDispatch(String expectedResult) {
+        when(mockCommandBus.dispatch(any(), any())).thenAnswer(i -> CompletableFuture.completedFuture(
+                new GenericCommandResultMessage(new MessageType("result"), expectedResult)
+        ));
+    }
+
+    /**
+     * Verifies a single command was dispatched carrying the given {@code payload} and the shared test metadata, with
+     * the given {@code expectedContext} (or {@code null} for none).
+     */
+    private void assertDispatchedWithMetadata(TestPayload payload, @Nullable ProcessingContext expectedContext) {
+        ArgumentCaptor<CommandMessage> commandCaptor = ArgumentCaptor.forClass(CommandMessage.class);
+        verify(mockCommandBus).dispatch(commandCaptor.capture(),
+                                        expectedContext == null ? isNull() : eq(expectedContext));
+        CommandMessage dispatched = commandCaptor.getValue();
+        assertThat(dispatched.payload()).isEqualTo(payload);
+        assertThat(dispatched.metadata().get("key")).isEqualTo("value");
     }
 
     private static class TestPayload {

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGatewayTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/gateway/DefaultQueryGatewayTest.java
@@ -23,6 +23,8 @@ import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.conversion.DelegatingMessageConverter;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.queryhandling.GenericQueryMessage;
 import org.axonframework.messaging.queryhandling.GenericQueryResponseMessage;
 import org.axonframework.messaging.queryhandling.GenericSubscriptionQueryUpdateMessage;
@@ -40,8 +42,10 @@ import reactor.util.concurrent.Queues;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 /**
@@ -123,6 +127,25 @@ class DefaultQueryGatewayTest {
             Metadata resultMetadata = resultMessage.metadata();
             assertThat(resultMetadata).containsKey(expectedKey);
             assertThat(resultMetadata).containsValue(expectedValue);
+        }
+
+        @Test
+        void queryWithMetadataParameterAttachesMetadataToPlainPayload() throws Exception {
+            // given...
+            QueryResponseMessage testResponse = new GenericQueryResponseMessage(RESPONSE_TYPE, RESPONSE_PAYLOAD);
+            when(queryBus.query(any(), eq(null))).thenReturn(MessageStream.just(testResponse));
+            Metadata testMetadata = Metadata.with("key", "value");
+            // when...
+            CompletableFuture<String> result = testSubject.query(QUERY_PAYLOAD, String.class, testMetadata, null);
+            // then...
+            assertThat(result).isDone();
+            assertThat(result.get()).isEqualTo(RESPONSE_PAYLOAD);
+
+            verify(queryBus).query(queryCaptor.capture(), eq(null));
+
+            QueryMessage resultMessage = queryCaptor.getValue();
+            assertThat(resultMessage.payload()).isEqualTo(QUERY_PAYLOAD);
+            assertThat(resultMessage.metadata()).containsKey("key").containsValue("value");
         }
 
         @Test
@@ -238,6 +261,25 @@ class DefaultQueryGatewayTest {
         }
 
         @Test
+        void queryManyWithMetadataParameterAttachesMetadataToPlainPayload() throws Exception {
+            // given...
+            QueryResponseMessage testResponse = new GenericQueryResponseMessage(RESPONSE_TYPE, RESPONSE_PAYLOAD);
+            when(queryBus.query(any(), eq(null))).thenReturn(MessageStream.fromIterable(List.of(testResponse)));
+            Metadata testMetadata = Metadata.with("key", "value");
+            // when...
+            CompletableFuture<List<String>> result = testSubject.queryMany(QUERY_PAYLOAD, String.class, testMetadata, null);
+            // then...
+            assertThat(result).isDone();
+            assertThat(result.get()).containsExactly(RESPONSE_PAYLOAD);
+
+            verify(queryBus).query(queryCaptor.capture(), eq(null));
+
+            QueryMessage resultMessage = queryCaptor.getValue();
+            assertThat(resultMessage.payload()).isEqualTo(QUERY_PAYLOAD);
+            assertThat(resultMessage.metadata()).containsKey("key").containsValue("value");
+        }
+
+        @Test
         void queryManyReturningFailedMessageStreamReturnsExceptionalCompletableFuture() {
             // given...
             Throwable expected = new Throwable("oops");
@@ -333,6 +375,24 @@ class DefaultQueryGatewayTest {
         }
 
         @Test
+        void streamingQueryWithMetadataParameterAttachesMetadataToPlainPayload() {
+            // given...
+            QueryResponseMessage testResponse = new GenericQueryResponseMessage(RESPONSE_TYPE, RESPONSE_PAYLOAD);
+            when(queryBus.query(any(), eq(null))).thenReturn(MessageStream.just(testResponse));
+            Metadata testMetadata = Metadata.with("key", "value");
+            // when...
+            StepVerifier.create(testSubject.streamingQuery(QUERY_PAYLOAD, String.class, testMetadata, null))
+                        .expectNext(RESPONSE_PAYLOAD)
+                        .verifyComplete();
+            // then...
+            verify(queryBus).query(streamingQueryCaptor.capture(), eq(null));
+
+            QueryMessage resultMessage = streamingQueryCaptor.getValue();
+            assertThat(resultMessage.payload()).isEqualTo(QUERY_PAYLOAD);
+            assertThat(resultMessage.metadata()).containsKey("key").containsValue("value");
+        }
+
+        @Test
         void streamingQueryIsLazy() {
             // given...
             MessageStream<QueryResponseMessage> response = MessageStream.fromItems(
@@ -419,6 +479,29 @@ class DefaultQueryGatewayTest {
             Metadata resultMetadata = resultMessage.metadata();
             assertThat(resultMetadata).containsKey(expectedKey);
             assertThat(resultMetadata).containsValue(expectedValue);
+        }
+
+        @Test
+        void subscriptionQueryWithMetadataParameterAttachesMetadataToPlainPayload() {
+            // given...
+            when(queryBus.subscriptionQuery(any(), eq(null), eq(Queues.SMALL_BUFFER_SIZE)))
+                    .thenReturn(MessageStream.fromItems(new GenericQueryResponseMessage(QUERY_TYPE, "a"),
+                                                        new GenericSubscriptionQueryUpdateMessage(UPDATE_TYPE, "1")));
+            Metadata testMetadata = Metadata.with("key", "value");
+            // when/then ...
+            StepVerifier.create(testSubject.subscriptionQuery(QUERY_PAYLOAD,
+                                                              String.class,
+                                                              testMetadata,
+                                                              null,
+                                                              Queues.SMALL_BUFFER_SIZE))
+                        .expectNext("a", "1")
+                        .verifyComplete();
+            verify(queryBus).subscriptionQuery(
+                    queryCaptor.capture(), eq(null), eq(Queues.SMALL_BUFFER_SIZE)
+            );
+            QueryMessage resultMessage = queryCaptor.getValue();
+            assertThat(resultMessage.payload()).isEqualTo(QUERY_PAYLOAD);
+            assertThat(resultMessage.metadata()).containsKey("key").containsValue("value");
         }
 
         @Test
@@ -554,6 +637,76 @@ class DefaultQueryGatewayTest {
             StepVerifier.create(result)
                         .expectNext("a", "b")
                         .verifyComplete();
+        }
+    }
+
+    @Nested
+    class MetadataDefaultsWithoutOverride {
+
+        // A QueryGateway that implements only the non-metadata terminals, leaving the metadata-carrying defaults in
+        // place. The default implementations must signal that metadata is unsupported rather than silently dropping it.
+        private final QueryGateway gatewayWithoutMetadataSupport = new QueryGateway() {
+            @Override
+            public <R> CompletableFuture<R> query(Object query, Class<R> responseType, ProcessingContext context) {
+                return null;
+            }
+
+            @Override
+            public <R> CompletableFuture<List<R>> queryMany(Object query, Class<R> responseType,
+                                                            ProcessingContext context) {
+                return null;
+            }
+
+            @Override
+            public <R> Publisher<R> streamingQuery(Object query, Class<R> responseType, ProcessingContext context) {
+                return null;
+            }
+
+            @Override
+            public <R> Publisher<R> subscriptionQuery(Object query, Class<R> responseType, ProcessingContext context,
+                                                      int updateBufferSize) {
+                return null;
+            }
+
+            @Override
+            public <R> Publisher<R> subscriptionQuery(Object query, Class<R> responseType,
+                                                      Function<QueryResponseMessage, R> mapper,
+                                                      ProcessingContext context, int updateBufferSize) {
+                return null;
+            }
+
+            @Override
+            public void describeTo(ComponentDescriptor descriptor) {
+                // no-op
+            }
+        };
+
+        @Test
+        void queryWithMetadataThrowsUnsupportedOperation() {
+            assertThatThrownBy(() -> gatewayWithoutMetadataSupport.query(
+                    QUERY_PAYLOAD, String.class, Metadata.with("key", "value"), null
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void queryManyWithMetadataThrowsUnsupportedOperation() {
+            assertThatThrownBy(() -> gatewayWithoutMetadataSupport.queryMany(
+                    QUERY_PAYLOAD, String.class, Metadata.with("key", "value"), null
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void streamingQueryWithMetadataThrowsUnsupportedOperation() {
+            assertThatThrownBy(() -> gatewayWithoutMetadataSupport.streamingQuery(
+                    QUERY_PAYLOAD, String.class, Metadata.with("key", "value"), null
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void subscriptionQueryWithMetadataThrowsUnsupportedOperation() {
+            assertThatThrownBy(() -> gatewayWithoutMetadataSupport.subscriptionQuery(
+                    QUERY_PAYLOAD, String.class, Metadata.with("key", "value"), null, Queues.SMALL_BUFFER_SIZE
+            )).isInstanceOf(UnsupportedOperationException.class);
         }
     }
 }


### PR DESCRIPTION
## Why

The gateways had inconsistent, and in places absent, support for attaching `Metadata` when dispatching:

- **`CommandGateway`**: metadata could only be set on the `CommandResult`-returning `send(...)` family. The typed `CompletableFuture` `send(...)` and every `sendAndWait(...)` overload dropped metadata entirely.
- **`QueryGateway`**: no operation accepted metadata at all - callers had to hand-wrap the payload into a `QueryMessage` first.

This is an **enabler for the multi-tenancy support** being developed under AxonIQ/axoniq-framework#176, which by default resolves the target tenant from message **metadata**. For that to work through the normal dispatch APIs, a caller must be able to attach tenant metadata directly on any `send` / `sendAndWait` / `query` / `queryMany` / `streamingQuery` / `subscriptionQuery` call. These changes close those gaps.

## What

Both gateways now accept metadata **only through the richest terminal** of each operation, keeping the surface small and free of overload ambiguity. Metadata-without-context is expressed by passing a `null` `ProcessingContext`.

**`CommandGateway`**
- `send(command, resultType, metadata, context)` and `sendAndWait(command, resultType, metadata, context)`.
- All existing overloads funnel through the single pre-existing metadata terminal `send(Object, Metadata, ProcessingContext)`; additions are `default` methods only - no implementation or decorator changes.

**`QueryGateway`**
- `query`, `queryMany`, `streamingQuery` gain `(query, responseType, metadata, context)`; `subscriptionQuery` gains `(query, responseType, metadata, context, updateBufferSize)` (mapper-less path).
- `DefaultQueryGateway` overrides all four with the real dispatch body; metadata handling is confined to a single private `asQueryMessage(query, metadata)` helper, with the existing non-metadata terminals delegating to the metadata ones.

## Design notes / trade-offs

**Why the query defaults throw while the command defaults work.** This is a deliberate consequence of the two gateways' starting points, chosen to stay non-breaking for external implementors:

- `CommandGateway` already had an abstract terminal that carries metadata (`send(Object, Metadata, ProcessingContext)`). Every metadata overload can therefore be a working `default` funnelling into it - no new abstract method, nothing an implementor must implement.
- `QueryGateway` had **no** metadata terminal at all. Adding one as an `abstract` method would be a compiler-breaking change for every existing implementor. The metadata terminals are therefore added as `default` methods that throw `UnsupportedOperationException`, signalling that an implementation must override them to support metadata (as `DefaultQueryGateway` does). This keeps existing implementors compiling while making the "unsupported" case explicit rather than silently dropping metadata - which would be dangerous for tenant routing.

**No new overload ambiguity.** A narrower `(query, responseType, metadata)` / `(command, resultType, metadata)` convenience would collide with the existing `(…, responseType/resultType, context)` overload on a literal `null`, source-breaking the widespread `query(x, Type.class, null)` call pattern (37 internal call sites plus external callers). Such conveniences are therefore **omitted on both gateways**, and the command-side variants that had introduced this ambiguity were removed. Only new (unreleased) methods were dropped; no released API changed. Metadata-without-context is written as `query(q, rt, metadata, null)` / `send(cmd, rt, metadata, null)`.

Changes are additive and non-breaking (source and binary). Javadoc across both gateway interfaces was normalized to fragment style while touching them.

## Testing

- New unit tests in `DefaultCommandGatewayTest` and `DefaultQueryGatewayTest` verifying metadata (and context) reach the dispatched message across the new overloads.
- New tests asserting the `QueryGateway` metadata defaults throw `UnsupportedOperationException` when an implementation does not override them.
- Full-reactor `test-compile` clean; targeted gateway suites green.
