### PR TITLE
Only deduplicate fluent accessors for records

### DIFF
--- a/common/src/main/java/org/axonframework/common/ReflectionUtils.java
+++ b/common/src/main/java/org/axonframework/common/ReflectionUtils.java
@@ -601,7 +601,7 @@ public final class ReflectionUtils {
     public static List<? extends Member> collectMatchingMethodsAndFields(Class<?> type,
                                                                          Predicate<Member> filter) {
         List<Method> methods = stream(ReflectionUtils.methodsOf(type).spliterator(), false).toList();
-        var deduplicateFilter = deduplicateRecordFields(methods);
+        Predicate<Field> deduplicateFilter = type.isRecord() ? deduplicateRecordFields(methods) : field -> true;
 
         var fields = stream(ReflectionUtils.fieldsOf(type).spliterator(), false)
                 .filter(deduplicateFilter);

--- a/common/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -458,7 +458,7 @@ class ReflectionUtilsTest {
         }
 
         @Test
-        void nonRecordFieldIsNotDroppedForCollidingSameNamedAccessor() {
+        void nonRecordFieldIsKeptForCollidingSameNamedAccessor() {
             var members = collectMatchingMethodsAndFields(Baz.class, it -> it.getName().startsWith("x"));
             assertThat(members).hasSize(2);
             assertThat(members).extracting(Member::getName)

--- a/common/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/ReflectionUtilsTest.java
@@ -432,6 +432,15 @@ class ReflectionUtilsTest {
             }
         }
 
+        static class Baz {
+
+            private String xfield;
+
+            private String xfield() {
+                return xfield;
+            }
+        }
+
         @Test
         void findAllMethodsAndFieldsOnSimpleClass() {
             var members = collectMatchingMethodsAndFields(Foo.class, it -> it.getName().startsWith("x"));
@@ -446,6 +455,14 @@ class ReflectionUtilsTest {
             assertThat(members).hasSize(2);
             assertThat(members).extracting(Member::getName)
                     .containsExactlyInAnyOrder("xfield", "xmethod");
+        }
+
+        @Test
+        void nonRecordFieldIsNotDroppedForCollidingSameNamedAccessor() {
+            var members = collectMatchingMethodsAndFields(Baz.class, it -> it.getName().startsWith("x"));
+            assertThat(members).hasSize(2);
+            assertThat(members).extracting(Member::getName)
+                    .containsExactlyInAnyOrder("xfield", "xfield");
         }
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/FluentAccessorEntityMemberTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/FluentAccessorEntityMemberTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that an {@link EntityMember}-annotated field is still discovered by {@link AnnotatedEntityMetamodel} when the
+ * owning class also declares a fluent-style accessor method (same name as the field, no {@code get}/{@code is} prefix)
+ * that is not itself annotated with {@link EntityMember}.
+ * <p>
+ * Fluent accessors can be added manually by a user, but may enter unexpectedly when they use Lombok's
+ * {@code @Accessors(fluent = true)} annotation, which generates exactly such accessors.
+ *
+ * @author Steven van Beelen
+ */
+class FluentAccessorEntityMemberTest
+        extends AbstractAnnotatedEntityMetamodelTest<FluentAccessorEntityMemberTest.FluentOwner> {
+
+    @Override
+    protected AnnotatedEntityMetamodel<FluentOwner> getMetamodel() {
+        return AnnotatedEntityMetamodel.forConcreteType(FluentOwner.class,
+                                                        parameterResolverFactory,
+                                                        messageTypeResolver,
+                                                        messageConverter,
+                                                        eventConverter);
+    }
+
+    @Test
+    void eventHandlerOnEntityMemberIsInvokedDespiteCollidingFluentAccessor() {
+        entityState = new FluentOwner();
+
+        dispatchInstanceCommand(new RenameChild("new-name"));
+
+        assertThat(entityState.child().getName()).isEqualTo("new-name");
+    }
+
+    static class FluentOwner {
+
+        @EntityMember
+        private final FluentChild child = new FluentChild();
+
+        // Fluent-style accessor: same name as the field, no "get" prefix, not annotated with @EntityMember.
+        public FluentChild child() {
+            return child;
+        }
+    }
+
+    static class FluentChild {
+
+        private String name = "initial";
+
+        @CommandHandler
+        public void handle(RenameChild command, EventAppender appender) {
+            appender.append(new ChildRenamed(command.name()));
+        }
+
+        @EventHandler
+        public void on(ChildRenamed event) {
+            this.name = event.name();
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    record RenameChild(String name) {
+
+    }
+
+    record ChildRenamed(String name) {
+
+    }
+}


### PR DESCRIPTION
This pull request introduces a minor change to the `ReflectionUtils`.
Specifically the `collectMatchingMethodsAndFields` method, which has a deduplication flow for `record` classes specifically.
However, it deduplicated regardless of whether the given class was a `record`, hence it didn't upheld it's described contract.

This issue surfaced due to a user utilizing Lombok to automatically generate **fluent** accessors for all fields.
In doing so, the `@EntityMember` annotated field also received an accessors, identically named as the field due to the fact it's set to be fluent.
This predicament only occurred for annotated entities, as the `AnnotatedEntityMetamodel` kicked in and used `ReflectionUtils#collectMethodsAndFields` (which uses `collectMatchingMethodsAndFields`) to simply find all the `Members`.
Once all `Members` were found, it would check for annotations, like `@EntityMember`. 

Given the typical ordering of fields and getter, with fields coming first, an `@EntityMember` annotated field would be deduplicated (read: removed) because a fluent accessor exists.
By fixating the `ReflectionUtils#collectMatchingMethodsAndFields` to only deduplicate for a `record` we resolve this predicament.

One may think, "what about `record` entity members? Don't those fail now?" 
In short, no, as the annotation can still be discovered in that case.
The above solution is purely to not deduplicate during construction of the entity metamodel, making it so that the `@EntityMember` annotation can be found one (1) the field or (2) the getter.