### PR TITLE
Validate return- and parameter-type in `FieldChildEntityFieldDefinition`

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/entity/child/FieldChildEntityFieldDefinition.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/child/FieldChildEntityFieldDefinition.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.entity.child;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.infra.DescribableComponent;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -41,7 +42,9 @@ public class FieldChildEntityFieldDefinition<P, F> implements ChildEntityFieldDe
     private final Field field;
     private final Class<P> parentClass;
     private final String fieldName;
+    @Nullable
     private Method optionalGetter;
+    @Nullable
     private Method optionalSetter;
 
     /**
@@ -69,12 +72,15 @@ public class FieldChildEntityFieldDefinition<P, F> implements ChildEntityFieldDe
     }
 
     /**
-     * Detects the optional getter for the given field. It will look for a method with the same name as the field, or a
-     * method with the name "get" + the field name.
+     * Detects the optional getter for the given field.
+     * <p>
+     * It will look for a method with the same name as the field, or a method with the name "get" + the field name, as
+     * well as matching the return type to the field type.
      */
     private void detectOptionalGetter(Class<P> parentClass, Field field) {
         this.optionalGetter = StreamSupport.stream(ReflectionUtils.methodsOf(parentClass).spliterator(), false)
                                            .filter(m -> m.getParameterCount() == 0)
+                                           .filter(m -> field.getType().isAssignableFrom(m.getReturnType()))
                                            .filter(m -> m.getName().equals(field.getName())
                                                    || m.getName().equals("get" + capitalize(field.getName())))
                                            .findFirst()
@@ -85,12 +91,15 @@ public class FieldChildEntityFieldDefinition<P, F> implements ChildEntityFieldDe
     }
 
     /**
-     * Detects the optional setter for the given field. It will look for a method with the same name as the field, the
-     * name "set" + the field name, or the name "evolve" + the field name.
+     * Detects the optional setter for the given field.
+     * <p>
+     * It will look for a method with the same name as the field, the name "set" + the field name, or the name "evolve"
+     * + the field name, as well as matching the field type against the parameter type.
      */
     private void detectOptionalSetter(Class<P> parentClass, Field field) {
         this.optionalSetter = StreamSupport.stream(ReflectionUtils.methodsOf(parentClass).spliterator(), false)
                                            .filter(m -> m.getParameterCount() == 1)
+                                           .filter(m -> m.getParameterTypes()[0].isAssignableFrom(field.getType()))
                                            .filter(m -> m.getName().equals(field.getName())
                                                    || m.getName().equals("set" + capitalize(field.getName()))
                                                    || m.getName().equals("evolve" + capitalize(field.getName())))

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/FluentOptionalAccessorEntityMemberTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/FluentOptionalAccessorEntityMemberTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.junit.jupiter.api.*;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that an {@link EntityMember}-annotated field whose owning class also declares a same-named fluent accessor
+ * returning {@code Optional<Child>} (rather than {@code Child} itself) is still evolved correctly by
+ * {@link AnnotatedEntityMetamodel}. Such an accessor is name-compatible but type-incompatible with the field, and must
+ * not be mistaken for a usable getter/setter by
+ * {@link org.axonframework.modelling.entity.child.FieldChildEntityFieldDefinition}.
+ *
+ * @author Steven van Beelen
+ */
+class FluentOptionalAccessorEntityMemberTest
+        extends AbstractAnnotatedEntityMetamodelTest<FluentOptionalAccessorEntityMemberTest.FluentOwner> {
+
+    @Override
+    protected AnnotatedEntityMetamodel<FluentOwner> getMetamodel() {
+        return AnnotatedEntityMetamodel.forConcreteType(
+                FluentOwner.class, parameterResolverFactory, messageTypeResolver, messageConverter, eventConverter
+        );
+    }
+
+    @Test
+    void eventSourcingHandlerCreatesChildDespiteIncompatibleFluentOptionalAccessor() {
+        entityState = new FluentOwner();
+
+        dispatchInstanceCommand(new CreateChild("new-name"));
+
+        assertThat(entityState.child()).isPresent();
+        assertThat(entityState.child().get().getName()).isEqualTo("new-name");
+    }
+
+    static class FluentOwner {
+
+        @EntityMember
+        private FluentChild child;
+
+        @CommandHandler
+        public void handle(CreateChild command, EventAppender appender) {
+            appender.append(new ChildCreated(command.name()));
+        }
+
+        @EventHandler
+        public void on(ChildCreated event) {
+            this.child = new FluentChild(event.name());
+        }
+
+        // Fluent-style accessor: same name as the field, no "get" prefix, wraps the value in Optional.
+        // Not annotated with @EntityMember, and not type-compatible with the field.
+        public Optional<FluentChild> child() {
+            return Optional.ofNullable(child);
+        }
+    }
+
+    static class FluentChild {
+
+        private final String name;
+
+        FluentChild(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    record CreateChild(String name) {
+
+    }
+
+    record ChildCreated(String name) {
+
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/child/FieldChildEntityFieldDefinitionTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/child/FieldChildEntityFieldDefinitionTest.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.entity.child;
 import org.axonframework.modelling.entity.child.mock.RecordingChildEntity;
 import org.junit.jupiter.api.*;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -108,8 +109,15 @@ class FieldChildEntityFieldDefinitionTest {
         assertTrue(evolvedParentEntity.evolved);
     }
 
+    @Test
+    void fallsBackToFieldWhenSameNamedAccessorHasIncompatibleReturnType() {
+        ParentEntityWithIncompatibleGetter parentEntity = new ParentEntityWithIncompatibleGetter();
 
+        FieldChildEntityFieldDefinition<ParentEntityWithIncompatibleGetter, RecordingChildEntity> testSubject =
+                new FieldChildEntityFieldDefinition<>(ParentEntityWithIncompatibleGetter.class, "childEntity");
 
+        assertNull(testSubject.getChildValue(parentEntity));
+    }
 
     private static class ParentEntityWithOnlyField {
         private final RecordingChildEntity childEntity;
@@ -146,6 +154,17 @@ class FieldChildEntityFieldDefinitionTest {
 
         public ParentEntityWithEvolveMethod evolveChildEntity(RecordingChildEntity childEntity) {
             return new ParentEntityWithEvolveMethod(childEntity, true);
+        }
+    }
+
+    private static class ParentEntityWithIncompatibleGetter {
+
+        private RecordingChildEntity childEntity;
+
+        // Fluent-style, same name as the field, but wraps the value in Optional -- must not be
+        // mistaken for a same-typed getter.
+        public Optional<RecordingChildEntity> childEntity() {
+            return Optional.ofNullable(childEntity);
         }
     }
 


### PR DESCRIPTION
This PR adjusts the `FieldChildEntityFieldDefinition` slightly, by having it check if the field's type matches the return type of a getter and parameter type of a setter. 
Not doing this will cause the `FieldChildEntityFieldDefinition` to wrongfully pick a getter/setter purely based on the name of the field, while the type differs. 

A concrete example noted at a user is an `@EntityMember` annotated field like  paired with an identically named getter that returns an `Optional` of the (thus) nullable entity member. 
This exact scenario is covered in the `FluentOptionalAccessorEntityMemberTest`.