### PR TITLE
Reopen the event stream when its source completed it

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -755,7 +755,7 @@ class Coordinator {
         private final AtomicBoolean processingGate = new AtomicBoolean();
         private final AtomicBoolean scheduledGate = new AtomicBoolean();
         private final AtomicBoolean interruptibleScheduledGate = new AtomicBoolean();
-        private MessageStream<? extends EventMessage> eventStream;
+        private @Nullable MessageStream<? extends EventMessage> eventStream;
         private TrackingToken lastScheduledToken = NoToken.INSTANCE;
         private boolean availabilityCallbackSupported;
         private long unclaimedSegmentValidationThreshold;
@@ -863,7 +863,9 @@ class Coordinator {
             }
 
             CompletableFuture<Void> claimAndStreamFuture;
-            if (eventStream == null || unclaimedSegmentValidationThreshold <= clock.instant().toEpochMilli()) {
+            if (eventStream == null
+                    || eventStream.isCompleted()
+                    || unclaimedSegmentValidationThreshold <= clock.instant().toEpochMilli()) {
                 // Claim new segments, construct work packages per new segment, and open stream based on lowest segment
                 unclaimedSegmentValidationThreshold = clock.instant().toEpochMilli() + tokenClaimInterval;
                 TrackingToken streamStartPosition = lastScheduledToken;
@@ -1184,11 +1186,19 @@ class Coordinator {
         }
 
         private CompletableFuture<Void> ensureOpenStream(@Nullable TrackingToken trackingToken) {
-            // We already had a stream and the token differs the last scheduled token, thus we started new WorkPackages.
-            // Close old stream to start at the new position, if we have Work Packages left.
-            if (eventStream != null && !Objects.equals(trackingToken, lastScheduledToken)) {
-                logger.debug("Processor [{}] (Coordination Task [{}]) will close the current stream.",
-                             name, generation);
+            // Close the old stream when it can no longer be read from. Either it is completed, or the token differs from
+            // the last scheduled token, thus we started new WorkPackages and need to start at the new position.
+            if (eventStream != null
+                    && (eventStream.isCompleted() || !Objects.equals(trackingToken, lastScheduledToken))) {
+                if (eventStream.isCompleted()) {
+                    // The trailing argument is only logged when the source completed the stream with an error.
+                    logger.info("Processor [{}] (Coordination Task [{}]) will replace the stream its source completed "
+                                        + "by one starting at token [{}].",
+                                name, generation, trackingToken, eventStream.error().orElse(null));
+                } else {
+                    logger.debug("Processor [{}] (Coordination Task [{}]) will close the current stream.",
+                                 name, generation);
+                }
                 closeStreamQuietly();
                 eventStream = null;
                 lastScheduledToken = NoToken.INSTANCE;

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
@@ -190,6 +190,20 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
     }
 
     /**
+     * Completes every currently open stream as if this source terminated them, without reporting an error and without
+     * clearing the published events.
+     * <p>
+     * A completed stream reports {@link MessageStream#isCompleted()} as {@code true}, an empty
+     * {@link MessageStream#error()}, and never returns another event. This mirrors a source that ends an otherwise
+     * infinite stream, which {@link MessageStream#close()} cannot emulate here, as closing may clear the published
+     * events. Each completed stream's availability callback is invoked, matching the {@code MessageStream} contract
+     * that the callback fires on completion.
+     */
+    public void completeOpenStreams() {
+        openStreams.forEach(AsyncMessageStream::complete);
+    }
+
+    /**
      * Set a handler to be called whenever a stream is opened.
      *
      * @param onOpen the handler to call
@@ -246,9 +260,11 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                 // Start from the beginning
                 this.currentPosition = new AtomicLong(0);
             } else {
-                // Start from the position after the given token
+                // Events are published with a token one higher than their storage index, so a token's position is the
+                // index of the first event that has not been consumed yet. Matching the InMemoryEventStorageEngine,
+                // which opens a stream at condition.position() directly.
                 long tokenPosition = startToken.position().orElse(-1);
-                this.currentPosition = new AtomicLong(tokenPosition + 1);
+                this.currentPosition = new AtomicLong(Math.max(0, tokenPosition));
             }
         }
 
@@ -389,6 +405,17 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                 if (currentCallback != null) {
                     currentCallback.run();
                 }
+            }
+        }
+
+        private void complete() {
+            if (closed) {
+                return;
+            }
+            Runnable currentCallback = callback.get();
+            closed = true;
+            if (currentCallback != null) {
+                currentCallback.run();
             }
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -43,6 +45,7 @@ import org.axonframework.common.ReflectionUtils;
 import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.QueueMessageStream;
 import org.axonframework.messaging.core.SimpleEntry;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.SimpleUnitOfWorkFactory;
@@ -79,6 +82,7 @@ class CoordinatorTest {
     private final ScheduledThreadPoolExecutor executorService = mock(ScheduledThreadPoolExecutor.class);
     private final StreamableEventSource messageSource = mock(StreamableEventSource.class);
     private final WorkPackage workPackage = mock(WorkPackage.class);
+    private final ScheduledExecutorService delegateExecutor = Executors.newSingleThreadScheduledExecutor();
     private Coordinator testSubject;
 
     private static Context trackingTokenContext(TrackingToken token) {
@@ -95,6 +99,11 @@ class CoordinatorTest {
         when(messageSource.latestToken(null)).thenReturn(FutureUtils.emptyCompletedFuture());
         when(messageSource.firstToken(null)).thenReturn(FutureUtils.emptyCompletedFuture());
         testSubject = buildCoordinator();
+    }
+
+    @AfterEach
+    void tearDown() {
+        delegateExecutor.shutdownNow();
     }
 
     private Coordinator buildCoordinator() {
@@ -281,7 +290,7 @@ class CoordinatorTest {
             doReturn(false).when(workPackage).isAbortTriggered();
             doReturn(true).when(workPackage).hasRemainingCapacity();
             doReturn(false).when(workPackage).isDone();
-            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+            doAnswer(invocation -> openStreamWithoutEvents())
                     .when(messageSource).open(any(StreamingCondition.class), isNull());
 
             // when
@@ -344,6 +353,27 @@ class CoordinatorTest {
 
     private Answer<Future<Void>> runTaskAsync() {
         return invocationOnMock -> CompletableFuture.runAsync(invocationOnMock.getArgument(0));
+    }
+
+    /**
+     * Hands scheduled tasks to a real {@link ScheduledExecutorService}, so the coordinator keeps rescheduling itself as
+     * it would in production. Running them on the invoking thread instead would recurse without bound.
+     */
+    private Answer<?> scheduleTask() {
+        return invocationOnMock -> delegateExecutor.schedule(
+                (Runnable) invocationOnMock.getArgument(0),
+                invocationOnMock.getArgument(1),
+                invocationOnMock.getArgument(2)
+        );
+    }
+
+    /**
+     * Returns an open stream that has no events available, mimicking a {@link StreamableEventSource} that has nothing
+     * to hand out yet. Deliberately not a completed stream, as an event source hands out infinite streams that never
+     * complete on their own.
+     */
+    private static MessageStream<EventMessage> openStreamWithoutEvents() {
+        return new QueueMessageStream<>();
     }
 
     /**
@@ -515,7 +545,7 @@ class CoordinatorTest {
             doReturn(false).when(workPackage).isAbortTriggered();
             doReturn(true).when(workPackage).hasRemainingCapacity();
             doReturn(false).when(workPackage).isDone();
-            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+            doAnswer(invocation -> openStreamWithoutEvents())
                     .when(messageSource).open(any(StreamingCondition.class), isNull());
             doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
 
@@ -548,7 +578,7 @@ class CoordinatorTest {
             doReturn(false).when(workPackage).isAbortTriggered();
             doReturn(true).when(workPackage).hasRemainingCapacity();
             doReturn(false).when(workPackage).isDone();
-            doReturn(MessageStream.fromIterable(Collections.emptyList()))
+            doAnswer(invocation -> openStreamWithoutEvents())
                     .when(messageSource).open(any(StreamingCondition.class), isNull());
             doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
 
@@ -559,6 +589,44 @@ class CoordinatorTest {
             //        and the stream is subsequently opened from that resolved token
             verify(messageSource).firstToken(null);
             verify(messageSource).open(streamingFrom(resolvedFirstToken), null);
+        }
+
+        @Test
+        void opensNewStreamFromLastConsumedTokenWhenStreamIsCompletedByItsSource() {
+            // given - the first stream hands out a single event and is then completed by its source
+            GlobalSequenceTrackingToken initialToken = new GlobalSequenceTrackingToken(0);
+            GlobalSequenceTrackingToken eventToken = new GlobalSequenceTrackingToken(1);
+            QueueMessageStream<EventMessage> completingStream = new QueueMessageStream<>();
+            completingStream.offer(EventTestUtils.asEventMessage("event"), trackingTokenContext(eventToken));
+            completingStream.seal();
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(List.of(SEGMENT_ZERO))).when(tokenStore)
+                                                            .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(initialToken)).when(tokenStore)
+                                                   .fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ZERO), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(false).when(workPackage).isAbortTriggered();
+            doReturn(true).when(workPackage).hasRemainingCapacity();
+            doReturn(false).when(workPackage).isDone();
+            doReturn(true).when(workPackage).scheduleEvent(any());
+            doReturn(completingStream).doAnswer(invocation -> openStreamWithoutEvents())
+                                      .when(messageSource).open(any(StreamingCondition.class), isNull());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+            doAnswer(scheduleTask()).when(executorService)
+                                    .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+            // short intervals keep the coordination runs frequent, so the assertion does not rely on the availability
+            // callback winning the race with the run that is already in progress
+            Coordinator coordinator = buildCoordinatorWith(
+                    builder -> builder.claimExtensionThreshold(50).tokenClaimInterval(50)
+            );
+
+            // when
+            awaitStart(coordinator);
+
+            // then - the completed stream is replaced by one starting at the token of the last consumed event
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> verify(messageSource).open(streamingFrom(eventToken), null));
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -874,6 +875,160 @@ class PooledStreamingEventProcessorTest {
 
             // Unblock the WorkPackage after successful validation
             handleLatch.countDown();
+        }
+    }
+
+    @Nested
+    class StreamReopeningTest {
+
+        private RecordingEventHandlingComponent recordingComponent;
+
+        @BeforeEach
+        void setUpEventSourceRetainingEventsOnClose() {
+            // The events must survive the coordinator closing a stream, as a reopened stream has to resume on them.
+            stubMessageSource = spy(new AsyncInMemoryStreamableEventSource(true, false));
+            when(stubMessageSource.firstToken(null))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(-1)));
+            SimpleEventHandlingComponent component = SimpleEventHandlingComponent.create("test");
+            component.subscribe(new QualifiedName(String.class), (event, ctx) -> MessageStream.empty());
+            recordingComponent = new RecordingEventHandlingComponent(component);
+            withTestSubject(List.of(recordingComponent), c -> c.initialSegmentCount(1));
+        }
+
+        @Test
+        void reopensStreamWithoutWaitingForTheNextTokenClaim() {
+            // given - a token claim interval far beyond the assertion window, so only noticing the completed stream on
+            //         a coordination run can explain a timely reopen. The claim extension threshold keeps those runs
+            //         frequent, ruling out a lost availability callback as the reason for a slow reopen.
+            withTestSubject(List.of(recordingComponent),
+                            c -> c.initialSegmentCount(1).tokenClaimInterval(30_000).claimExtensionThreshold(100));
+            EventMessage eventOne = EventTestUtils.asEventMessage("event-1");
+            stubMessageSource.publishMessage(eventOne);
+            startEventProcessor();
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).containsExactly(eventOne));
+
+            // when
+            stubMessageSource.completeOpenStreams();
+            EventMessage eventTwo = EventTestUtils.asEventMessage("event-2");
+            stubMessageSource.publishMessage(eventTwo);
+
+            // then - handled long before the next token claim would have come around
+            await().atMost(3, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(eventTwo));
+        }
+
+        @Test
+        void reopensStreamAtTheLastHandledEventWhenTheSourceCompletesIt() {
+            // given
+            EventMessage eventOne = EventTestUtils.asEventMessage("event-1");
+            EventMessage eventTwo = EventTestUtils.asEventMessage("event-2");
+            stubMessageSource.publishMessage(eventOne);
+            stubMessageSource.publishMessage(eventTwo);
+            startEventProcessor();
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).containsExactly(eventOne, eventTwo));
+
+            // when - the source terminates the stream without reporting an error, as a broker ending a tailing stream
+            stubMessageSource.completeOpenStreams();
+            EventMessage eventThree = EventTestUtils.asEventMessage("event-3");
+            EventMessage eventFour = EventTestUtils.asEventMessage("event-4");
+            stubMessageSource.publishMessage(eventThree);
+            stubMessageSource.publishMessage(eventFour);
+
+            // then - a fresh stream resumes exactly where the completed one left off: no event is skipped or replayed
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded())
+                           .containsExactly(eventOne, eventTwo, eventThree, eventFour));
+            verify(stubMessageSource, atLeast(2)).open(any(), isNull());
+        }
+
+        @Test
+        void keepsSegmentClaimedAndReportsNoErrorWhenReopeningTheStream() {
+            // given
+            stubMessageSource.publishMessage(EventTestUtils.asEventMessage("event-1"));
+            startEventProcessor();
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(testSubject.processingStatus()).containsKey(0));
+            clearInvocations(stubMessageSource);
+
+            // when
+            stubMessageSource.completeOpenStreams();
+
+            // then - the coordinator replaces the stream without giving up the segment it holds
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> verify(stubMessageSource).open(any(), isNull()));
+            assertThat(testSubject.processingStatus()).containsKey(0);
+            assertThat(testSubject.isError()).isFalse();
+            verify(tokenStore, never()).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+
+            // then - and it continues processing on the reopened stream
+            EventMessage nextEvent = EventTestUtils.asEventMessage("event-2");
+            stubMessageSource.publishMessage(nextEvent);
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(nextEvent));
+        }
+
+        @Test
+        void doesNotSpinWhenTheSourceKeepsHandingOutCompletedStreams() throws InterruptedException {
+            // given - a source that only ever returns completed streams, so every reopen attempt is futile
+            AtomicInteger openCount = new AtomicInteger();
+            doAnswer(invocation -> {
+                openCount.incrementAndGet();
+                return MessageStream.empty();
+            }).when(stubMessageSource).open(any(), isNull());
+
+            // when
+            startEventProcessor();
+            Thread.sleep(500);
+
+            // then - reopening is paced by the coordination runs, rather than looping on itself
+            assertThat(openCount.get()).describedAs("streams opened in 500ms").isLessThan(15);
+        }
+
+        @Test
+        void reportsErrorWhenTheStreamTurnsOutToBeFailedWhileReadingIt() {
+            // given - a stream that reports its failure as soon as the coordinator reads from it
+            doReturn(MessageStream.failed(new IllegalStateException("Stream failed")))
+                    .doCallRealMethod()
+                    .when(stubMessageSource).open(any(), isNull());
+
+            // when
+            startEventProcessor();
+
+            // then - reading the stream surfaces the failure, which is reported through the retry logic
+            assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(testSubject.isError()));
+        }
+
+        @Test
+        void reopensStreamWhenItsSourceCompletesItWithAnErrorWhileTheCoordinatorIsIdle() {
+            // given - a stream reporting its terminal state without being read, as a stream fed by a remote source
+            //         does when that source signals a failure while the coordinator has nothing to read
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<Optional<Throwable>> streamError = new AtomicReference<>(Optional.empty());
+            //noinspection unchecked
+            MessageStream<EventMessage> remotelyFailingStream = mock(MessageStream.class);
+            when(remotelyFailingStream.isCompleted()).thenAnswer(invocation -> completed.get());
+            when(remotelyFailingStream.error()).thenAnswer(invocation -> streamError.get());
+            when(remotelyFailingStream.hasNextAvailable()).thenReturn(false);
+            when(remotelyFailingStream.next()).thenReturn(Optional.empty());
+            when(remotelyFailingStream.peek()).thenReturn(Optional.empty());
+            doReturn(remotelyFailingStream).doCallRealMethod().when(stubMessageSource).open(any(), isNull());
+
+            startEventProcessor();
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(testSubject.processingStatus()).containsKey(0));
+
+            // when - the source terminates the stream with an error, in between two coordination runs
+            streamError.set(Optional.of(new IllegalStateException("Stream failed remotely")));
+            completed.set(true);
+
+            // then - a closed stream cannot be read from regardless of why it closed, so it is replaced by a fresh one
+            EventMessage nextEvent = EventTestUtils.asEventMessage("event-1");
+            stubMessageSource.publishMessage(nextEvent);
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(nextEvent));
+            verify(stubMessageSource, atLeast(2)).open(any(), isNull());
         }
     }
 


### PR DESCRIPTION
## Problem

The `Coordinator` of the `PooledStreamingEventProcessor` inspected its event stream for errors only:

```java
var streamError = eventStream.error();
if (streamError.isPresent()) {
    throw new RuntimeException("Event stream has an error", streamError.get());
}
```

`MessageStream#isCompleted()` was never consulted anywhere in the pooled package. Per the `MessageStream` contract, a stream completed *without* an error reports an empty `error()` and `hasNextAvailable() == false` permanently, while the only reopen condition compared the requested start position against the last scheduled token, which matches on an idle run and therefore reopened nothing.

The processor consequently waited forever on a stream that would never produce another event: it reported every segment as caught up, kept extending its token claims so no other node could take the segments over, reported `isError() == false`, and logged nothing.

Axon Server closes a streaming connection without reporting an error under certain circumstances, which left a processor in this state until it was restarted. The connector surfaces that as `isClosed() == true` with an empty `getError()` (`AbstractBufferedStream#onCompleted`), which the framework's stream adapters map directly onto `isCompleted()` and `error()`.

## Change

`ensureOpenStream` replaces a stream it can no longer read from, instead of only one whose start position moved:

```java
if (eventStream != null
        && (eventStream.isCompleted() || !Objects.equals(trackingToken, lastScheduledToken))) {
```

Whether the source completed the stream normally or with an error affects only the log message, at `info` with the cause appended when there is one. A closed stream is unusable either way, so the replacement decision does not depend on it. Errors that surface while the stream is being read are unaffected and still travel the existing abort-and-retry path, which releases claims, applies back-off, and sets `isError()`.

A coordination run treats a completed stream as a reason to claim and open, so the stream's own completion callback drives the replacement immediately rather than waiting for the next token claim.

## Recovery characteristics

- **Immediate**, normally: the source's completion fires the availability callback that `ensureOpenStream` registered, waking the coordinator, whose next run replaces the stream.
- **At the latest at the next token claim**, if that wake-up is lost because it arrives while a coordination run holds the processing gate.
- **No events skipped or reprocessed**: the new stream starts at `lastScheduledToken`, the token of the last event handed to the work packages. The connector only reports a stream closed once its terminal marker reaches the head of the buffer, so everything already delivered is consumed first.
- **Token claims retained**, with no back-off and no error status, since reopening is a normal recovery rather than a failure.
- **Paced by the coordination runs**: a source returning a completed stream on every open opened five streams in 500ms in the accompanying test, rather than looping on itself.

## Test support

`AsyncInMemoryStreamableEventSource` gained `completeOpenStreams()`, which completes its open streams the way a source does (terminal state plus availability callback, no error) without clearing published events, since `close()` may clear them.

It also starts a stream at the position its condition carries, matching `InMemoryEventStorageEngine`. It previously started one position later, so it skipped an event whenever a stream was reopened part way through, which would have masked the behaviour under test.

## Verification

Full `messaging` module suite and the integration test suite pass on this branch. Each half of the change was verified by mutation: disabling the check in `ensureOpenStream` fails all four reopen tests, and removing it from the coordination run leaves the reopen working but no longer immediate, failing only `reopensStreamWithoutWaitingForTheNextTokenClaim`.