### PR TITLE
Let an event storage engine report that it handles snapshot sourcing

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
@@ -55,7 +55,9 @@ import java.util.List;
  *     <li>The {@link EventStorageEngine} in a {@link SnapshotCapableEventStorageEngine} <b>if</b> a
  *     {@link SnapshotStore} is present and it is not the same instance as the engine. When the engine and the
  *     snapshot store are the same instance, the engine handles snapshots natively (potentially in a single
- *     round-trip) and wrapping it would degrade performance.</li>
+ *     round-trip) and wrapping it would degrade performance. An engine reporting
+ *     {@link EventStorageEngine#handlesSnapshotSourcing()} is left undecorated for the same reason, even when a
+ *     different {@link SnapshotStore} is present, since it resolves the snapshot sourcing strategy itself.</li>
  *     <li>The {@link EventStore} in a {@link InterceptingEventStore} <b>if</b> there are any
  *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry}.</li>
  * </ul>
@@ -89,6 +91,9 @@ public class EventSourcingConfigurationDefaults implements ConfigurationEnhancer
                 EventStorageEngine.class,
                 SnapshotCapableEventStorageEngine.DECORATION_ORDER,
                 (config, name, engine) -> {
+                    if (engine.handlesSnapshotSourcing()) {
+                        return engine;
+                    }
                     SnapshotStore snapshotStore = config.getOptionalComponent(SnapshotStore.class).orElse(null);
                     return snapshotStore == null || snapshotStore == engine
                             ? engine

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -137,6 +137,27 @@ public interface EventStorageEngine extends DescribableComponent {
     MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context);
 
     /**
+     * Indicates whether {@link #source(SourcingCondition, ProcessingContext) sourcing} resolves a
+     * {@link SourcingStrategy.Snapshot snapshot sourcing strategy} itself.
+     * <p>
+     * An engine that does can serve the snapshot and the events following it in a single round trip, so it is not
+     * complemented with a {@link SnapshotCapableEventStorageEngine}. Complementing it would resolve the snapshot
+     * separately and pass an {@link SourcingStrategy.Absolute absolute strategy} inward, costing that optimization.
+     * <p>
+     * Resolving the strategy by delegating counts. An engine routing {@code source} to other engines may return
+     * {@code true} provided every engine it routes to resolves the snapshot sourcing strategy.
+     * <p>
+     * Returning {@code true} while ignoring the {@link SourcingStrategy.Snapshot} strategy means snapshots are never
+     * applied, and entities are reconstructed from their full event history instead.
+     *
+     * @return {@code true} if this engine resolves a snapshot sourcing strategy itself, {@code false} when it needs to
+     * be complemented with a snapshot store to do so
+     */
+    default boolean handlesSnapshotSourcing() {
+        return false;
+    }
+
+    /**
      * Creates an <b>infinite</b> {@link MessageStream} of {@link EventMessage events} matching the given
      * {@code condition}.
      * <p>

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
@@ -77,6 +77,15 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
         this.snapshotStore = Objects.requireNonNull(snapshotStore, "The snapshotStore parameter cannot be null.");
     }
 
+    /**
+     * Always {@code true}: resolving the snapshot sourcing strategy from the snapshot store is what this engine adds to
+     * its delegate.
+     */
+    @Override
+    public boolean handlesSnapshotSourcing() {
+        return true;
+    }
+
     @Override
     public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
         if (condition.strategy() instanceof SourcingStrategy.Snapshot s) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -177,6 +177,21 @@ class EventSourcingConfigurationDefaultsTest {
     }
 
     @Test
+    void doesNotDecorateEventStorageEngineThatHandlesSnapshotSourcingItself() {
+        SnapshotResolvingEngine snapshotResolvingEngine = new SnapshotResolvingEngine();
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        configurer.componentRegistry(cr -> cr.registerComponent(EventStorageEngine.class,
+                                                                c -> snapshotResolvingEngine)
+                                             .registerComponent(SnapshotStore.class, c -> new InMemorySnapshotStore()));
+        Configuration resultConfig = configurer.build();
+
+        // the engine resolves snapshots while sourcing, so wrapping would cost it that single round-trip
+        assertThat(resultConfig.getComponent(EventStorageEngine.class))
+                .isNotInstanceOf(SnapshotCapableEventStorageEngine.class)
+                .isSameAs(snapshotResolvingEngine);
+    }
+
+    @Test
     void decoratorsEventStoreAsInterceptorEventStoreWhenDispatchInterceptorIsPresent(
             @Mock MessageDispatchInterceptor<Message> mockInterceptor) {
         ApplicationConfigurer configurer = EventSourcingConfigurer
@@ -192,6 +207,15 @@ class EventSourcingConfigurationDefaultsTest {
         @Override
         public @NonNull Set<Tag> resolve(@NonNull EventMessage event) {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    // An engine reporting it resolves the snapshot sourcing strategy itself, so it must be left undecorated.
+    private static class SnapshotResolvingEngine extends InMemoryEventStorageEngine {
+
+        @Override
+        public boolean handlesSnapshotSourcing() {
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Problem

`EventSourcingConfigurationDefaults` complements an `EventStorageEngine` with a `SnapshotCapableEventStorageEngine` unless the registered `SnapshotStore` is the *same instance* as the engine:

```java
SnapshotStore snapshotStore = config.getOptionalComponent(SnapshotStore.class).orElse(null);
return snapshotStore == null || snapshotStore == engine
        ? engine
        : new SnapshotCapableEventStorageEngine(engine, snapshotStore);
```

That identity comparison is the only way for an engine to say "I resolve the snapshot sourcing strategy myself, leave me alone". It works when the engine *is* the snapshot store, but it conflates two independent questions: *which component resolves snapshots while sourcing*, and *which component is the application's snapshot store*.

An engine that resolves snapshots in a single round trip is therefore forced to also be registered as the `SnapshotStore` to keep that optimization. That has consequences beyond taste:

- Registering one instance under two component types means two components, and `SpringComponentRegistry` creates one bean definition per component. Both beans then resolve to the same object implementing both interfaces, so injecting an `EventStorageEngine` becomes ambiguous once the `SnapshotStore` bean exists: `NoUniqueBeanDefinitionException ... expected single matching bean but found 2`. It is order dependent, since the ambiguity only appears after that second bean is instantiated. Marking one primary is not possible either, because component bean definitions are registered from `postProcessAfterInitialization`, after every `BeanFactoryPostProcessor` has run (#4575).
- Registering a single component under a type assignable to both does not work either: the decorator resolves the `SnapshotStore` while the engine is being resolved, so one component answering both lookups re-enters its own resolution and overflows the stack.

Deriving the capability from `engine instanceof SnapshotStore` is not an option, and is wrong on purpose: `decoratesEventStorageEngineWhenSnapshotStoreIsDifferentInstance_evenIfEngineImplementsSnapshotStore` asserts that a separately configured `SnapshotStore` must win, because snapshot reads then belong to that store rather than to the engine.

## Change

Adds one capability method to `EventStorageEngine`, next to the `source` contract it describes:

```java
default boolean handlesSnapshotSourcing() {
    return false;
}
```

and one clause honouring it:

```java
if (engine.handlesSnapshotSourcing()) {
    return engine;
}
```

`SnapshotCapableEventStorageEngine` overrides it to `true`, since resolving that strategy is exactly what it adds to its delegate.

An engine can now keep its single-round-trip path while the application's `SnapshotStore` is a separate component. Resolving the strategy by delegating counts, so an engine routing `source` to other engines may report `true` provided every engine it routes to resolves the strategy.

## Behaviour

Purely additive, no behaviour change for existing users. The default is `false`, so every existing engine is decorated exactly as before. The identity comparison and its test are untouched, and implementing `SnapshotStore` still does not opt an engine out. Because the clause is evaluated before the `SnapshotStore` lookup, it also removes the re-entrancy hazard described above.

## Motivation

Needed by the multi-tenant event storage engine in `axoniq-framework` (AxonIQ/axoniq-framework#263). It routes sourcing to a per-tenant engine and must not be complemented above that fan-out, since the tenant is not known until the message is inspected. Each per-tenant engine is composed with that tenant's own snapshot store, so both the single-round-trip and the two-round-trip path work per tenant. The application's `SnapshotStore` is a separate, tenant-routing component, which is what this change makes possible.

## Testing

`doesNotDecorateEventStorageEngineThatHandlesSnapshotSourcingItself` covers the new clause. Full `eventsourcing` module: 530 tests, no failures.
