### PR TITLE
Add 5.2.2 Release Notes

### DIFF
--- a/docs/reference-guide/modules/release-notes/pages/minor-releases.adoc
+++ b/docs/reference-guide/modules/release-notes/pages/minor-releases.adoc
@@ -6,6 +6,18 @@ Any patch release made for an Axon project is tailored towards resolving bugs. T
 [#release_5_2]
 == Release 5.2
 
+=== Release 5.2.2
+
+==== Bug fixes
+
+- Reopen the event stream when its source completed it link:https://github.com/AxonIQ/AxonFramework/pull/4785[#4785]
+
+==== Contributors
+
+A heartfelt thank you to all contributors who worked on this section:
+
+- link:https://github.com/abuijze[@abuijze]
+
 === Release 5.2.1
 
 ==== Bug fixes


### PR DESCRIPTION
This pull request adds the release notes for 5.2.2 to `axon-5.2.x`. A port towards `main` will follow once this is merged.