### PR TITLE
[#4791] Extract snapshot sourcing composition into its own enhancer

### DIFF
--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -250,3 +250,31 @@ Only the events that occurred after that position are applied to bring the entit
 
 If a snapshot cannot be used, the full event stream is replayed and a new snapshot may be created after sourcing completes, depending on the configured `SnapshotPolicy`.
 This new snapshot replaces the previous one according to the current storage behavior.
+
+=== Snapshot sourcing composition
+
+An `EventStorageEngine` reads snapshots in one of two ways.
+An engine that supports the snapshot sourcing strategy natively serves the snapshot and the events following it in a single call.
+Any other engine is decorated with a `SnapshotCapableEventStorageEngine`, which loads the snapshot from the configured `SnapshotStore` first and then sources the events that follow it.
+
+That decoration is applied by the `SnapshotSourcingConfigurationEnhancer`, which the event sourcing defaults register for you.
+The engine is left as is when no `SnapshotStore` is configured, and when the engine is the configured `SnapshotStore` itself.
+
+A storage topology that composes snapshot sourcing itself disables that enhancer and takes over the responsibility:
+
+[source,java]
+----
+configurer.componentRegistry(
+        registry -> registry.disableEnhancer(SnapshotSourcingConfigurationEnhancer.class)
+);
+----
+
+An engine routing sourcing to one engine per shard, tenant, or region is the case this exists for.
+The target is only known once a message is inspected, so decorating the routing engine would read snapshots before then, and the engines it routes to would never receive the snapshot sourcing strategy.
+Such a topology composes each of its engines with that engine's own snapshot store instead, using `SnapshotCapableEventStorageEngine.decorate(engine, snapshotStore)`.
+
+[NOTE]
+====
+Disabling the enhancer without composing snapshot sourcing elsewhere leaves snapshots being written while never being read.
+Sourcing then replays an entity's full event history, which is correct but forfeits the optimization.
+====

--- a/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
+++ b/docs/reference-guide/modules/tuning/pages/snapshotting.adoc
@@ -253,9 +253,10 @@ This new snapshot replaces the previous one according to the current storage beh
 
 === Snapshot sourcing composition
 
-An `EventStorageEngine` reads snapshots in one of two ways.
-An engine that supports the snapshot sourcing strategy natively serves the snapshot and the events following it in a single call.
-Any other engine is decorated with a `SnapshotCapableEventStorageEngine`, which loads the snapshot from the configured `SnapshotStore` first and then sources the events that follow it.
+An `EventStorageEngine` reads snapshots in one of two ways:
+
+* An engine that supports the snapshot sourcing strategy natively serves the snapshot and the events following it in a single call.
+* Any other engine is decorated with a `SnapshotCapableEventStorageEngine`, which loads the snapshot from the configured `SnapshotStore` first and then sources the events that follow it.
 
 That decoration is applied by the `SnapshotSourcingConfigurationEnhancer`, which the event sourcing defaults register for you.
 The engine is left as is when no `SnapshotStore` is configured, and when the engine is the configured `SnapshotStore` itself.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaults.java
@@ -23,11 +23,9 @@ import org.axonframework.eventsourcing.eventstore.AnnotationBasedTagResolver;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.eventsourcing.eventstore.InterceptingEventStore;
-import org.axonframework.eventsourcing.eventstore.SnapshotCapableEventStorageEngine;
 import org.axonframework.eventsourcing.eventstore.StorageEngineBackedEventStore;
 import org.axonframework.eventsourcing.eventstore.TagResolver;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
-import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.MessageDispatchInterceptor;
 import org.axonframework.messaging.core.configuration.MessagingConfigurationDefaults;
 import org.axonframework.messaging.core.interception.DispatchInterceptorRegistry;
@@ -52,13 +50,13 @@ import java.util.List;
  * </ul>
  * Furthermore, this enhancer will decorate the:
  * <ul>
- *     <li>The {@link EventStorageEngine} in a {@link SnapshotCapableEventStorageEngine} <b>if</b> a
- *     {@link SnapshotStore} is present and it is not the same instance as the engine. When the engine and the
- *     snapshot store are the same instance, the engine handles snapshots natively (potentially in a single
- *     round-trip) and wrapping it would degrade performance.</li>
  *     <li>The {@link EventStore} in a {@link InterceptingEventStore} <b>if</b> there are any
  *     {@link MessageDispatchInterceptor MessageDispatchInterceptors} present in the {@link DispatchInterceptorRegistry}.</li>
  * </ul>
+ * It also registers the {@link SnapshotSourcingConfigurationEnhancer}, which decorates the
+ * {@link EventStorageEngine} to support the {@link org.axonframework.eventsourcing.eventstore.SourcingStrategy.Snapshot
+ * snapshot sourcing strategy}. Registering it here rather than through the {@link java.util.ServiceLoader} means
+ * applications registering {@code this} enhancer manually receive it as well.
  *
  * @author Steven van Beelen
  * @author John Hendrikx
@@ -85,16 +83,7 @@ public class EventSourcingConfigurationDefaults implements ConfigurationEnhancer
                 .registerIfNotPresent(EventStorageEngine.class,
                                       EventSourcingConfigurationDefaults::defaultEventStorageEngine)
                 .registerIfNotPresent(EventStore.class, EventSourcingConfigurationDefaults::simpleEventStore);
-        registry.registerDecorator(
-                EventStorageEngine.class,
-                SnapshotCapableEventStorageEngine.DECORATION_ORDER,
-                (config, name, engine) -> {
-                    SnapshotStore snapshotStore = config.getOptionalComponent(SnapshotStore.class).orElse(null);
-                    return snapshotStore == null || snapshotStore == engine
-                            ? engine
-                            : new SnapshotCapableEventStorageEngine(engine, snapshotStore);
-                }
-        );
+        registry.registerEnhancer(new SnapshotSourcingConfigurationEnhancer());
         registry.registerDecorator(
                 EventStore.class,
                 InterceptingEventStore.DECORATION_ORDER,

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SnapshotSourcingConfigurationEnhancer.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/configuration/SnapshotSourcingConfigurationEnhancer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.configuration;
+
+import org.axonframework.common.annotation.RegistrationScope;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.SnapshotCapableEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.SourcingStrategy;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+
+/**
+ * A {@link ConfigurationEnhancer} making the {@link EventStorageEngine} support the
+ * {@link SourcingStrategy.Snapshot snapshot sourcing strategy}, by decorating it with the configured
+ * {@link SnapshotStore} through {@link SnapshotCapableEventStorageEngine#decorate(EventStorageEngine, SnapshotStore)}.
+ * <p>
+ * The engine is left as is when no {@code SnapshotStore} is configured, and when it is the configured
+ * {@code SnapshotStore} itself. The latter resolves the snapshot within its own {@code source} call, in a single round
+ * trip, which decorating would undo.
+ * <p>
+ * Registered by {@link EventSourcingConfigurationDefaults}, so applications registering those defaults manually receive
+ * it as well. It is deliberately not contributed through the {@link java.util.ServiceLoader}, unlike its sibling
+ * enhancers, to keep that single registration channel. Registered for the {@link RegistrationScope.Scope#CURRENT
+ * current} registry only, since the defaults registering it are copied into every module registry and would otherwise
+ * register it there a second time.
+ * <p>
+ * A storage topology composing snapshot sourcing itself disables this enhancer, taking over that responsibility:
+ * <pre>{@code
+ * configurer.componentRegistry(
+ *         registry -> registry.disableEnhancer(SnapshotSourcingConfigurationEnhancer.class)
+ * );
+ * }</pre>
+ * An engine routing {@code source} to one engine per shard, tenant, or region is the case this exists for: the shard is
+ * only known once a message is inspected, so decorating the routing engine would resolve snapshots before then, and the
+ * engines it routes to would never receive the snapshot sourcing strategy. Such a topology composes each of its engines
+ * with that engine's own snapshot store instead, through the same
+ * {@link SnapshotCapableEventStorageEngine#decorate(EventStorageEngine, SnapshotStore) decorate} operation.
+ * <p>
+ * Disabling this enhancer without composing snapshot sourcing elsewhere leaves snapshots being written while never
+ * being read: sourcing then replays an entity's full event history.
+ *
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+@RegistrationScope(scope = RegistrationScope.Scope.CURRENT)
+public class SnapshotSourcingConfigurationEnhancer implements ConfigurationEnhancer {
+
+    /**
+     * The order of {@code this} enhancer compared to others, equal to 10 positions after
+     * {@link EventSourcingConfigurationDefaults} (thus,
+     * {@link EventSourcingConfigurationDefaults#ENHANCER_ORDER} + 10).
+     * <p>
+     * What this order governs is the window in which {@code this} enhancer can still be disabled: a disable is only
+     * recorded while the enhancer has not been invoked yet, and is otherwise reported as having no effect. Running late
+     * therefore leaves every earlier-ordered enhancer free to take over snapshot composition.
+     */
+    public static final int ENHANCER_ORDER = EventSourcingConfigurationDefaults.ENHANCER_ORDER + 10;
+
+    @Override
+    public int order() {
+        return ENHANCER_ORDER;
+    }
+
+    @Override
+    public void enhance(ComponentRegistry registry) {
+        registry.registerDecorator(
+                EventStorageEngine.class,
+                SnapshotCapableEventStorageEngine.DECORATION_ORDER,
+                (config, name, engine) -> config
+                        .getOptionalComponent(SnapshotStore.class)
+                        .map(snapshotStore -> SnapshotCapableEventStorageEngine.decorate(engine, snapshotStore))
+                        .orElse(engine)
+        );
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
@@ -84,7 +84,7 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
      * The given {@code engine} is returned as is when it is the given {@code snapshotStore} itself. Such an engine
      * resolves the snapshot within its own {@link #source(SourcingCondition, ProcessingContext) source} call, serving
      * the snapshot and the events following it in a single round trip. Decorating it would resolve the snapshot
-     * separately and pass an {@link SourcingStrategy.Absolute absolute strategy} inward, costing that optimization.
+     * separately and pass an {@link SourcingStrategy.Absolute absolute strategy} inward, disabling that optimization.
      * <p>
      * An {@code engine} that is already decorated is returned as is too, so composing twice is harmless. It keeps
      * resolving snapshots from the store it was decorated with, and the given {@code snapshotStore} is ignored for it.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
@@ -77,6 +77,36 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
         this.snapshotStore = Objects.requireNonNull(snapshotStore, "The snapshotStore parameter cannot be null.");
     }
 
+    /**
+     * Returns an {@link EventStorageEngine} that supports the {@link SourcingStrategy.Snapshot} sourcing strategy,
+     * given the {@code engine} to source events from and the {@code snapshotStore} holding its snapshots.
+     * <p>
+     * The given {@code engine} is returned as is when it is the given {@code snapshotStore} itself. Such an engine
+     * resolves the snapshot within its own {@link #source(SourcingCondition, ProcessingContext) source} call, serving
+     * the snapshot and the events following it in a single round trip. Decorating it would resolve the snapshot
+     * separately and pass an {@link SourcingStrategy.Absolute absolute strategy} inward, costing that optimization.
+     * <p>
+     * An {@code engine} that is already decorated is returned as is too, so composing twice is harmless. It keeps
+     * resolving snapshots from the store it was decorated with, and the given {@code snapshotStore} is ignored for it.
+     * Decorating again would put the given store in front of that one instead of adding anything.
+     * <p>
+     * Any other {@code engine} is decorated, resolving the snapshot from the {@code snapshotStore} before sourcing the
+     * events that follow it.
+     *
+     * @param engine        the engine to source events from
+     * @param snapshotStore the store holding the snapshots of the given {@code engine}
+     * @return an event storage engine supporting the snapshot sourcing strategy
+     * @throws NullPointerException if the given {@code engine} or {@code snapshotStore} is {@code null}
+     * @since 5.3.0
+     */
+    public static EventStorageEngine decorate(EventStorageEngine engine, SnapshotStore snapshotStore) {
+        Objects.requireNonNull(engine, "The engine parameter cannot be null.");
+        Objects.requireNonNull(snapshotStore, "The snapshotStore parameter cannot be null.");
+        return engine == snapshotStore || engine instanceof SnapshotCapableEventStorageEngine
+                ? engine
+                : new SnapshotCapableEventStorageEngine(engine, snapshotStore);
+    }
+
     @Override
     public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
         if (condition.strategy() instanceof SourcingStrategy.Snapshot s) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SnapshotSourcingConfigurationEnhancerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/SnapshotSourcingConfigurationEnhancerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.configuration;
+
+import org.axonframework.common.configuration.ApplicationConfigurer;
+import org.axonframework.common.configuration.BaseModule;
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.SnapshotCapableEventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link SnapshotSourcingConfigurationEnhancer}.
+ *
+ * @author Laura Devriendt
+ */
+class SnapshotSourcingConfigurationEnhancerTest {
+
+    private final SnapshotSourcingConfigurationEnhancer testSubject = new SnapshotSourcingConfigurationEnhancer();
+
+    @Test
+    void orderEqualsEnhancerOrderConstant() {
+        assertThat(testSubject.order()).isEqualTo(SnapshotSourcingConfigurationEnhancer.ENHANCER_ORDER);
+    }
+
+    // The defaults register this enhancer while they are themselves being invoked, and an enhancer registered that way
+    // is invoked in its order relative to the enhancers that have not run yet. A lower order would place it before
+    // enhancers that already ran.
+    @Test
+    void orderExceedsTheEventSourcingDefaults() {
+        assertThat(SnapshotSourcingConfigurationEnhancer.ENHANCER_ORDER)
+                .isGreaterThan(EventSourcingConfigurationDefaults.ENHANCER_ORDER);
+    }
+
+    @Test
+    void decoratesTheEventStorageEngineWhenASnapshotStoreIsPresent() {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        configurer.componentRegistry(cr -> cr.registerComponent(SnapshotStore.class, c -> new InMemorySnapshotStore()));
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStorageEngine.class))
+                .isInstanceOf(SnapshotCapableEventStorageEngine.class);
+    }
+
+    // Registering the event sourcing defaults by hand must yield the same decoration as EventSourcingConfigurer does,
+    // since those defaults are what register this enhancer.
+    @Test
+    void decoratesTheEventStorageEngineWhenTheEventSourcingDefaultsAreRegisteredManually() {
+        ApplicationConfigurer configurer = MessagingConfigurer.create();
+        configurer.componentRegistry(cr -> cr.registerEnhancer(new EventSourcingConfigurationDefaults())
+                                             .registerComponent(SnapshotStore.class,
+                                                                c -> new InMemorySnapshotStore()));
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStorageEngine.class))
+                .isInstanceOf(SnapshotCapableEventStorageEngine.class);
+    }
+
+    // The supported opt-out for a storage topology composing snapshot sourcing itself.
+    @Test
+    void leavesTheEventStorageEngineUndecoratedWhenDisabled() {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        InMemoryEventStorageEngine composedEngine = new InMemoryEventStorageEngine();
+        configurer.componentRegistry(
+                cr -> cr.registerComponent(SnapshotStore.class, c -> new InMemorySnapshotStore())
+                        .registerComponent(EventStorageEngine.class, c -> composedEngine)
+                        .disableEnhancer(SnapshotSourcingConfigurationEnhancer.class)
+        );
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStorageEngine.class)).isSameAs(composedEngine);
+    }
+
+    // A storage topology switches this off from its own enhancer, which is the cross-repo opt-out. That only works while
+    // this enhancer has not run yet, so the disabling enhancer has to be ordered before it.
+    @Test
+    void leavesTheEventStorageEngineUndecoratedWhenDisabledByAnEarlierEnhancer() {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        InMemoryEventStorageEngine composedEngine = new InMemoryEventStorageEngine();
+        configurer.componentRegistry(
+                cr -> cr.registerComponent(SnapshotStore.class, config -> new InMemorySnapshotStore())
+                        .registerComponent(EventStorageEngine.class, config -> composedEngine)
+                        .registerEnhancer(new ComposesSnapshotSourcingItself())
+        );
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStorageEngine.class)).isSameAs(composedEngine);
+    }
+
+    // A module registry receives the parent's decorator definitions by copy, so the snapshot decorator is applied a
+    // second time to a module registering its own engine and snapshot store. The redundant decoration is not observable
+    // through snapshot loads, since the outer decoration rewrites the condition to an absolute one before delegating and
+    // the inner one then passes it through, so the nesting itself is what has to be asserted.
+    @Test
+    void decoratesAModulesOwnEventStorageEngineExactlyOnce() {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+        configurer.componentRegistry(parentRegistry -> parentRegistry.registerModule(
+                new EventSourcingModule("snapshot-module").componentRegistry(
+                        moduleRegistry -> moduleRegistry
+                                .registerComponent(SnapshotStore.class, config -> new InMemorySnapshotStore())
+                                .registerComponent(EventStorageEngine.class,
+                                                   config -> new InMemoryEventStorageEngine())
+                )
+        ));
+
+        Configuration moduleConfig = configurer.build().getModuleConfiguration("snapshot-module").orElseThrow();
+
+        EventStorageEngine engine = moduleConfig.getComponent(EventStorageEngine.class);
+        assertThat(engine).isInstanceOf(SnapshotCapableEventStorageEngine.class);
+        assertThat(engine).extracting("delegate").isNotInstanceOf(SnapshotCapableEventStorageEngine.class);
+    }
+
+    @Test
+    void leavesTheEventStorageEngineUndecoratedWhenNoSnapshotStoreIsPresent() {
+        ApplicationConfigurer configurer = EventSourcingConfigurer.create();
+
+        Configuration resultConfig = configurer.build();
+
+        assertThat(resultConfig.getComponent(EventStorageEngine.class))
+                .isNotInstanceOf(SnapshotCapableEventStorageEngine.class);
+    }
+
+    private static class EventSourcingModule extends BaseModule<EventSourcingModule> {
+
+        private EventSourcingModule(String name) {
+            super(name);
+        }
+    }
+
+    // Stands in for a storage topology composing snapshot sourcing per shard, tenant, or region. Ordered before the
+    // enhancer it disables, since a disable is only recorded while that enhancer has not run yet.
+    private static class ComposesSnapshotSourcingItself implements ConfigurationEnhancer {
+
+        @Override
+        public void enhance(@NonNull ComponentRegistry registry) {
+            registry.disableEnhancer(SnapshotSourcingConfigurationEnhancer.class);
+        }
+
+        @Override
+        public int order() {
+            return SnapshotSourcingConfigurationEnhancer.ENHANCER_ORDER - 1;
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
 
 /**
@@ -164,6 +165,67 @@ class SnapshotCapableEventStorageEngineTest {
                 return list;
             })
             .join();
+    }
+
+    @Nested
+    class Decorate {
+
+        @Test
+        void decoratesAnEngineThatIsNotTheSnapshotStore() {
+            EventStorageEngine result = SnapshotCapableEventStorageEngine.decorate(delegate, snapshotStore);
+
+            assertThat(result).isInstanceOf(SnapshotCapableEventStorageEngine.class);
+        }
+
+        // Such an engine resolves the snapshot within its own source call, so decorating costs it a round trip.
+        @Test
+        void returnsAnEngineThatIsTheSnapshotStoreAsIs() {
+            SnapshotResolvingEngine snapshotResolvingEngine = new SnapshotResolvingEngine();
+
+            EventStorageEngine result =
+                    SnapshotCapableEventStorageEngine.decorate(snapshotResolvingEngine, snapshotResolvingEngine);
+
+            assertThat(result).isSameAs(snapshotResolvingEngine);
+        }
+
+        // A module registry receives the copied decorator definition and re-runs the enhancer that registers it, so the
+        // same engine is composed twice. The second composition must not add a second snapshot load.
+        @Test
+        void returnsAnAlreadyDecoratedEngineAsIs() {
+            EventStorageEngine once = SnapshotCapableEventStorageEngine.decorate(delegate, snapshotStore);
+
+            EventStorageEngine twice = SnapshotCapableEventStorageEngine.decorate(once, new InMemorySnapshotStore());
+
+            assertThat(twice).isSameAs(once);
+        }
+
+        @Test
+        void rejectsANullEngine() {
+            assertThatThrownBy(() -> SnapshotCapableEventStorageEngine.decorate(null, snapshotStore))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("The engine parameter cannot be null.");
+        }
+
+        @Test
+        void rejectsANullSnapshotStore() {
+            assertThatThrownBy(() -> SnapshotCapableEventStorageEngine.decorate(delegate, null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("The snapshotStore parameter cannot be null.");
+        }
+    }
+
+    // An engine that is its own snapshot store, as PostgresqlEventStorageEngine is.
+    private static class SnapshotResolvingEngine extends InMemoryEventStorageEngine implements SnapshotStore {
+
+        @Override
+        public CompletableFuture<Void> store(QualifiedName qn, Object id, Snapshot s, ProcessingContext context) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Snapshot> load(QualifiedName qn, Object id, ProcessingContext context) {
+            return CompletableFuture.completedFuture(null);
+        }
     }
 
     private static SnapshotStore failingSnapshotStore() {


### PR DESCRIPTION
Fixes #4791

Supersedes #4788, which added a `handlesSnapshotSourcing()` capability method to `EventStorageEngine`. That approach left two signals meaning "do not decorate this engine" with opposite precedence against a configured `SnapshotStore`, and let an engine silently override an explicitly registered one. This replaces it: the identity comparison stays the only signal, and the decision moves to the configuration layer, where a topology can take it over.

## What changes

**The snapshot-composition decorator moves into its own enhancer.** `SnapshotSourcingConfigurationEnhancer` registers that one decorator and nothing else. `EventSourcingConfigurationDefaults` registers it during its own `enhance(ComponentRegistry)`, so applications registering those defaults manually receive it too. It is deliberately not contributed through the `ServiceLoader`, keeping a single registration channel and avoiding a duplicate-registration warning on every module build.

**The composition rule moves to a static factory.** `SnapshotCapableEventStorageEngine.decorate(engine, snapshotStore)` returns the engine as is when it is the snapshot store itself, and decorates it otherwise. One home for the rule, reusable by a topology composing per shard, tenant, or region.

**Disabling the enhancer becomes the supported opt-out.** Documented on the enhancer and on the snapshotting page, with the consequence of disabling it without composing elsewhere spelled out: snapshots keep being written while never being read.

## Bug fixed along the way

`decorate(...)` also returns an already-decorated engine as is, which fixes a defect on `main`. `DefaultComponentRegistry.copyWithDecoratorsAndEnhancers()` copies the parent's decorator definitions into a module registry, and that registry re-runs the copied enhancers, registering the same decorator a second time. The identity check passes for the second application, because the already-decorated engine is not the registered store, so a module registering its own `EventStorageEngine` and `SnapshotStore` got an engine decorated twice.

That redundant decoration costs a layer and a stream hop per sourcing, and silently ignores the second decoration's snapshot store. It does not cause a second snapshot read: the outer decoration rewrites the condition to an absolute one before delegating, so the inner one passes it through. A snapshot is therefore still read exactly once, which is why `decoratesAModulesOwnEventStorageEngineExactlyOnce` asserts the nesting rather than a load count. I first wrote it as a load-count assertion and it passed with the guard removed, so it would have proven nothing. The structural version fails with the guard removed, and only it fails.

The new enhancer carries `@RegistrationScope(scope = CURRENT)`, so the defaults being copied into module registries do not register it again. Without it, every module build logs a `Duplicate Configuration Enhancer registration` warning: 41 of them in one `eventsourcing` test run.

## Behaviour

No behaviour change for existing applications, and no `EventStorageEngine` API added. All ten pre-existing `EventSourcingConfigurationDefaultsTest` cases pass **unchanged**, including `decoratesEventStorageEngineWhenSnapshotStoreIsDifferentInstance_evenIfEngineImplementsSnapshotStore` — a separately configured `SnapshotStore` still wins, since implementing `SnapshotStore` still does not opt an engine out.

The new enhancer is deliberately public rather than `@Internal`: its class literal is the opt-out contract, so renaming it in a minor would break callers at compile time.

## Motivation

A routing event storage engine that fans out to one engine per context, each composed with that context's own snapshot store. Decorating the routing engine consumes the snapshot sourcing strategy before any context is known, so the composed engines never receive it. Tracked internally as `axoniq-framework#263`.

## Testing

`SnapshotSourcingConfigurationEnhancerTest` covers order relative to the defaults, decoration with a snapshot store present, the manual-defaults-registration path, the disable opt-out both through the registry and from an earlier-ordered enhancer (the cross-repo path, and the order-sensitive one), single decoration in a module registry, and no decoration without a snapshot store. `SnapshotCapableEventStorageEngineTest.Decorate` covers all three factory branches plus the null contracts. Full `eventsourcing` module: 542 tests, no failures.
