### PR TITLE
[#209] Add per-tenant snapshotting to the multi-tenancy demo

### DIFF
--- a/examples/university-multi-tenancy-examples/README.md
+++ b/examples/university-multi-tenancy-examples/README.md
@@ -20,6 +20,13 @@ tenant's instance into each message handler, so a handler never resolves a tenan
   seats in another. Reading a tenant's events back as a stream, to rebuild the statistics as a projection
   instead of updating them in the handler, is added in a later step. In memory there is one shared event
   store, so this isolation is shown only against Axon Server.
+* **Per-tenant snapshotting** (Axon Server): the course carries a snapshot policy, and each tenant's
+  snapshots live in that tenant's own context, so the same course identifier in two tenants is two
+  unrelated snapshots. A snapshot is a performance optimization, so no behavior reveals which tenant's
+  store it landed in. The demo therefore reads the per-tenant snapshot stores directly: both tenants hold
+  their own snapshot of that identifier, and each holds only its own tenant's student. It compares snapshot
+  contents rather than snapshot envelopes, since two envelopes never compare equal. In memory every tenant
+  shares one snapshot store, so this isolation is not shown.
 * **Tenant-scoped injection on the read side too**: the statistics query handler is handed the querying
   tenant's own components, matched by type, with the tenant resolved from the message metadata.
 * **The tenant lifecycle**: tenants known at startup, a tenant added at runtime, an unknown tenant

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
@@ -22,6 +22,7 @@ org.axonframework.examples.demo.multitenancy
    |  +- DemoLifecycle                the tenant lifecycle the demos walk, top to bottom
    |  +- DemoOutcome                  what a run observed, asserted by the demos' tests
    |  +- EventStorageOutcome          what the per-tenant event-storage isolation observed, asserted by the tests
+   |  +- SnapshottingOutcome          what the per-tenant snapshot isolation observed, asserted by the tests
    |  +- TenantView                   renders one tenant's isolated view
    |  +- ProviderAmbiguityGuardrail   the configuration-time guardrail
    +- messaging                       drives the command and query gateways
@@ -30,6 +31,7 @@ org.axonframework.examples.demo.multitenancy
    |  +- RemoteExceptions             recognizes a handler failure whether raised as itself or reconstructed over Axon Server
    +- tenant                          supplies the tenants and their per-tenant components
    |  +- TenantProvisioning           in-memory vs Axon Server tenant provisioning (and whether it isolates event stores)
+   |  +- TenantSnapshots              reads one tenant's own snapshot store, to observe where a snapshot landed
    |  +- DemoTenantProvider           an in-memory TenantProvider (the declarative demo's default)
    |  +- AxonServerTenantContextManager  creates and deletes Axon Server contexts
    |  +- TenantComponents             the two TenantComponentProviders
@@ -48,10 +50,19 @@ application:
    identifier still accepts an enrollment in the other tenant, which proves each tenant's events live in
    its own store. In memory there is one shared event store, so the tenants use distinct identifiers and
    this isolation is not shown.
-2. Add a tenant at runtime, enroll into it, and show its components appear on first use.
-3. Send a command for an unknown tenant and confirm it is rejected.
-4. Remove a tenant and confirm its per-tenant instances are closed.
-5. Shut down and confirm every remaining tenant's instances are closed.
+2. Show where those snapshots ended up. The course carries a snapshot policy, so enrolling the second
+   student snapshots it, and the rejected third enrollment sources the course from that snapshot. Against
+   Axon Server both tenants end up with their own snapshot of the same course identifier, and each snapshot
+   holds only its own tenant's student, which is what proves neither tenant read the other's. It compares
+   the snapshots' contents, not the snapshot envelopes: two envelopes never compare equal, since each
+   carries its own write timestamp, so comparing envelopes would report a difference even if one tenant had
+   read the other's snapshot. A snapshot captures the state its triggering load sourced rather than the
+   state that command leaves behind, so each holds one student. In memory every tenant shares one snapshot
+   store, so this isolation is not shown.
+3. Add a tenant at runtime, enroll into it, and show its components appear on first use.
+4. Send a command for an unknown tenant and confirm it is rejected.
+5. Remove a tenant and confirm its per-tenant instances are closed.
+6. Shut down and confirm every remaining tenant's instances are closed.
 
 The configuration-time guardrail (`ProviderAmbiguityGuardrail`) is a separate, standalone check, since
 it is about configuration rather than the running lifecycle.
@@ -59,6 +70,15 @@ it is about configuration rather than the running lifecycle.
 The statistics the enrollment handler updates are an interim read model. Once per-tenant event streaming
 lands, they become a projection built from the stored events instead of being written in the command
 handler.
+
+The enroll-student slice's course entity is an immutable record whose event sourcing handlers return the
+evolved course, rather than a mutable class that changes itself. A snapshot is the entity handed to the
+`Converter`, and a record's components are exactly the state to capture, so it converts both ways without
+any converter-specific annotation. A mutable class whose private fields have no accessors converts to an
+empty document against the default converter, and the course then silently comes back blank, which is worth
+knowing before adding a snapshot policy to an entity of your own. `CourseSnapshotConversionTest` is what
+pins that round trip: the in-memory snapshot store keeps the entity instance as-is, so it never converts
+anything and cannot catch the problem.
 
 ## Running
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
@@ -23,9 +23,11 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.shared.messaging.Enrollments;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatistics;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudent;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
@@ -35,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -47,9 +51,10 @@ import java.util.function.BooleanSupplier;
  * {@link EnrollStudent} command and reading a tenant's statistics is a
  * {@link TenantStatisticsQueryHandler} query. Enrolling both appends to the tenant's own event store and
  * updates that tenant's {@link CourseStatisticsStore} and {@link AuditLog}, injected by type, so one
- * command shows per-tenant event storage and per-tenant component injection together. {@link #run} reads
- * top to bottom as the story: tenants known at startup, a tenant added at runtime, an unknown tenant
- * rejected, a tenant removed, and shutdown.
+ * command shows per-tenant event storage and per-tenant component injection together. Enrolling enough
+ * students also snapshots the course, into that same tenant's own snapshot store. {@link #run} reads top
+ * to bottom as the story: tenants known at startup, the course snapshotted per tenant, a tenant added at
+ * runtime, an unknown tenant rejected, a tenant removed, and shutdown.
  */
 public final class DemoLifecycle {
 
@@ -78,6 +83,13 @@ public final class DemoLifecycle {
     // The runtime-added tenant uses its own identifier as well.
     private static final String OGDENVILLE_COURSE_ID = "econ-300";
 
+    // A tenant's context and command bus connector are created asynchronously, so its first command waits.
+    private static final Duration TENANT_READY_TIMEOUT = Duration.ofSeconds(15);
+    // Storing a snapshot does not hold up the command that triggered it, so the lookup waits for it.
+    private static final Duration SNAPSHOT_LOOKUP_TIMEOUT = Duration.ofSeconds(15);
+    // Closing every tenant's instances happens as shutdown unwinds, so the check waits for it.
+    private static final Duration SHUTDOWN_CLEANUP_TIMEOUT = Duration.ofSeconds(5);
+
     private DemoLifecycle() {
         // Utility class, not meant to be instantiated.
     }
@@ -94,6 +106,8 @@ public final class DemoLifecycle {
      * @param auditProvider      the provider of the per-tenant audit logs
      * @param provisioning       how this run adds and removes tenants, and whether it has a per-tenant
      *                           event store (in memory or against Axon Server)
+     * @param snapshots          reads a single tenant's own snapshot store, to observe where the course's
+     *                           snapshot ended up
      * @param shutdown           shuts the started application down, which is where the framework closes
      *                           every remaining tenant's instances (the configuration or Spring context)
      * @return the observed outcome of the demo run
@@ -103,12 +117,14 @@ public final class DemoLifecycle {
                                   TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                                   TenantComponentProvider<AuditLog> auditProvider,
                                   TenantProvisioning provisioning,
+                                  TenantSnapshots<CourseSnapshot> snapshots,
                                   Runnable shutdown) {
         Objects.requireNonNull(commandGateway, "The command gateway must not be null");
         Objects.requireNonNull(queryGateway, "The query gateway must not be null");
         Objects.requireNonNull(statisticsProvider, "The course-statistics provider must not be null");
         Objects.requireNonNull(auditProvider, "The audit-log provider must not be null");
         Objects.requireNonNull(provisioning, "The tenant provisioning must not be null");
+        Objects.requireNonNull(snapshots, "The tenant snapshots must not be null");
         Objects.requireNonNull(shutdown, "The shutdown action must not be null");
 
         provisioning.prepareKnownTenants();
@@ -121,21 +137,28 @@ public final class DemoLifecycle {
         logTenantView("Springfield University", queryGateway, SPRINGFIELD);
         logTenantView("Shelbyville University", queryGateway, SHELBYVILLE);
 
-        // 2. Add a tenant at runtime. Its instances materialize on its first command, no config change.
+        // 2. Filling those courses snapshotted them. Each snapshot went to its own tenant's snapshot store,
+        // so the same course identifier yields two snapshots holding two different sets of students.
+        SnapshottingOutcome snapshottingOutcome = snapshots.hasPerTenantSnapshotStore()
+                ? proveSnapshotIsolation(snapshots)
+                : SnapshottingOutcome.notDemonstrated();
+
+        // 3. Add a tenant at runtime. Its instances materialize on its first command, no config change.
         provisioning.addTenant(OGDENVILLE);
         enrollWhenTenantReady(commandGateway);
         logTenantView("Ogdenville University (added at runtime)", queryGateway, OGDENVILLE);
 
-        // 3. A command for a tenant the application does not know is rejected.
+        // 4. A command for a tenant the application does not know is rejected.
         boolean unknownTenantRejected = unknownTenantIsRejected(commandGateway);
 
-        // 4. Removing a tenant closes its per-tenant instances.
+        // 5. Removing a tenant closes its per-tenant instances.
         boolean shelbyvilleClosedOnRemoval =
                 removingTenantClosesItsInstances(provisioning, statisticsProvider, auditProvider);
 
-        // 5. Shutting down closes every remaining tenant's instances.
+        // 6. Shutting down closes every remaining tenant's instances.
         return shutDownAndBuildOutcome(shutdown, queryGateway, statisticsProvider, auditProvider,
-                                       unknownTenantRejected, shelbyvilleClosedOnRemoval, eventStorage);
+                                       unknownTenantRejected, shelbyvilleClosedOnRemoval, eventStorage,
+                                       snapshottingOutcome);
     }
 
     /**
@@ -144,63 +167,135 @@ public final class DemoLifecycle {
      * event-sourced course it sources, and updates that tenant's {@link CourseStatisticsStore} and
      * {@link AuditLog}, injected by type.
      * <p>
-     * Springfield fills its course to capacity. Shelbyville enrolls into its own course. Against Axon
-     * Server that course carries the same identifier as Springfield's, so it demonstrates event-store
-     * isolation: Shelbyville's enrollment is accepted even though Springfield's identically-named course
-     * is full, and a further enrollment into Springfield's course is rejected as full. In memory there is
-     * no per-tenant event store, so Shelbyville uses a distinct identifier and this isolation is not shown.
+     * Both tenants fill their course to capacity, so a further enrollment is rejected as full, decided from
+     * that tenant's own events. Against Axon Server both courses carry the same identifier, so the two
+     * together demonstrate event-store isolation: Shelbyville's enrollments are accepted even though
+     * Springfield's identically-named course is already full. In memory there is no per-tenant event store,
+     * so Shelbyville uses a distinct identifier and this isolation is not shown, though both courses still
+     * fill up and reject.
+     * <p>
+     * Filling a course also crosses its snapshot threshold, so the framework snapshots it while the second
+     * student enrolls, and the rejected third enrollment sources the course from that snapshot.
      *
      * @param commandGateway           the gateway enrollments are sent on
      * @param hasPerTenantEventStore   whether each tenant has its own event store (only against Axon Server)
      * @return what the event-storage isolation showed, or {@link EventStorageOutcome#notDemonstrated()} in memory
      */
     private static EventStorageOutcome enrollStudents(CommandGateway commandGateway, boolean hasPerTenantEventStore) {
-        String shelbyvilleCourseId = hasPerTenantEventStore ? SHARED_COURSE_ID : SHELBYVILLE_COURSE_ID;
+        String shelbyvilleCourse = hasPerTenantEventStore ? SHARED_COURSE_ID : SHELBYVILLE_COURSE_ID;
 
-        Enrollments.openCourse(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, COURSE_CAPACITY);
-        Enrollments.enroll(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, "alice");
-        Enrollments.enroll(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, "bob");
+        // Springfield's course is fresh, so both enrollments are expected to land.
+        if (!fillCourse(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, "alice", "bob")) {
+            throw new IllegalStateException("Springfield's course did not accept both of its students");
+        }
+        boolean shelbyvilleAccepted = fillCourse(commandGateway, SHELBYVILLE, shelbyvilleCourse, "carol", "dave");
 
-        Enrollments.openCourse(commandGateway, SHELBYVILLE, shelbyvilleCourseId, COURSE_CAPACITY);
-        boolean shelbyvilleAccepted = Enrollments.tryEnroll(commandGateway, SHELBYVILLE, shelbyvilleCourseId, "carol");
+        // Both courses are full now, so this is rejected from that tenant's own events. It also sources the
+        // course once more, which is the load that reads the snapshot back.
+        boolean springfieldRejectedWhenFull =
+                !Enrollments.tryEnroll(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, "frank");
 
         return hasPerTenantEventStore
-                ? provePerTenantEventStoreIsolation(commandGateway, shelbyvilleAccepted)
+                ? EventStorageOutcome.demonstratedWith(springfieldRejectedWhenFull, shelbyvilleAccepted)
                 : EventStorageOutcome.notDemonstrated();
     }
 
     /**
-     * Proves per-tenant event-store isolation, only against Axon Server where each tenant has its own
-     * store. Springfield's course was just filled to capacity, so a further enrollment is rejected,
-     * decided from Springfield's own events, while Shelbyville's identically-named course still accepted
-     * its student. That the same course identifier behaves differently in the two tenants shows their
-     * event stores are isolated.
+     * Opens the given tenant's course and enrolls both students, filling it to capacity. The first command
+     * waits until the tenant accepts commands, and enrolling the second student crosses the course's
+     * snapshot threshold.
      *
-     * @param commandGateway                  the gateway enrollments are sent on
-     * @param shelbyvilleAcceptedSameCourseId whether Shelbyville accepted an enrollment into the same
-     *                                        course identifier Springfield filled
-     * @return the observed event-storage isolation outcome
+     * @param commandGateway the gateway enrollments are sent on
+     * @param tenant         the tenant whose course to fill
+     * @param courseId       the identifier of the course to open and fill
+     * @param firstStudent   the student enrolled first
+     * @param secondStudent  the student enrolled second, whose enrollment snapshots the course
+     * @return whether both students were accepted
      */
-    private static EventStorageOutcome provePerTenantEventStoreIsolation(CommandGateway commandGateway,
-                                                                        boolean shelbyvilleAcceptedSameCourseId) {
-        boolean springfieldRejectedWhenFull =
-                !Enrollments.tryEnroll(commandGateway, SPRINGFIELD, SHARED_COURSE_ID, "frank");
-        return EventStorageOutcome.demonstratedWith(springfieldRejectedWhenFull, shelbyvilleAcceptedSameCourseId);
+    private static boolean fillCourse(CommandGateway commandGateway,
+                                      TenantDescriptor tenant,
+                                      String courseId,
+                                      String firstStudent,
+                                      String secondStudent) {
+        whenTenantReady(tenant, () -> Enrollments.openCourse(commandGateway, tenant, courseId, COURSE_CAPACITY));
+        // Both attempts are sent, so a rejected first student does not skip the second.
+        boolean firstAccepted = Enrollments.tryEnroll(commandGateway, tenant, courseId, firstStudent);
+        boolean secondAccepted = Enrollments.tryEnroll(commandGateway, tenant, courseId, secondStudent);
+        return firstAccepted && secondAccepted;
     }
 
     /**
-     * Enrolls in a tenant added at runtime, retrying until it is ready. Creating a tenant's context and
-     * command bus connector is asynchronous, so the first command can arrive before the connector exists.
-     * A failed attempt fails at dispatch without enrolling, and opening and enrolling are idempotent, so
-     * the enrollment still lands exactly once.
+     * Proves per-tenant snapshot isolation, only against Axon Server where each tenant has its own snapshot
+     * store. Both tenants filled a course under the same identifier, so each store holds its own snapshot of
+     * that identifier, and each snapshot must hold only that tenant's own student.
+     * <p>
+     * A snapshot captures the state its triggering load sourced, not the state that command leaves behind,
+     * so each holds the one student enrolled before it.
+     * <p>
+     * Storing a snapshot does not hold up the command that triggered it, so this waits for both to appear.
+     *
+     * @param snapshots reads a single tenant's own snapshot store
+     * @return the observed snapshot isolation outcome
+     */
+    private static SnapshottingOutcome proveSnapshotIsolation(TenantSnapshots<CourseSnapshot> snapshots) {
+        AtomicReference<CourseSnapshot> springfieldSnapshot = new AtomicReference<>();
+        AtomicReference<CourseSnapshot> shelbyvilleSnapshot = new AtomicReference<>();
+        boolean bothTenantsHoldOwnSnapshot = holdsWithin(
+                "both tenants' snapshot stores hold course [" + SHARED_COURSE_ID + "]",
+                SNAPSHOT_LOOKUP_TIMEOUT,
+                () -> {
+                    springfieldSnapshot.set(snapshots.snapshotContentsOf(SPRINGFIELD, SHARED_COURSE_ID));
+                    shelbyvilleSnapshot.set(snapshots.snapshotContentsOf(SHELBYVILLE, SHARED_COURSE_ID));
+                    return springfieldSnapshot.get() != null && shelbyvilleSnapshot.get() != null;
+                });
+
+        boolean snapshotsHoldTheirOwnStudents = bothTenantsHoldOwnSnapshot
+                && springfieldSnapshot.get().enrolledStudents().equals(Set.of("alice"))
+                && shelbyvilleSnapshot.get().enrolledStudents().equals(Set.of("carol"));
+
+        logger.info("""
+                    Course [{}] is snapshotted in both tenants' own snapshot stores: {}. \
+                    Each snapshot holds only its own tenant's student, so neither read the other's: {}. \
+                    Springfield's snapshot holds {}, Shelbyville's holds {}""",
+                    SHARED_COURSE_ID,
+                    bothTenantsHoldOwnSnapshot,
+                    snapshotsHoldTheirOwnStudents,
+                    bothTenantsHoldOwnSnapshot ? springfieldSnapshot.get().enrolledStudents() : Set.of(),
+                    bothTenantsHoldOwnSnapshot ? shelbyvilleSnapshot.get().enrolledStudents() : Set.of());
+        return SnapshottingOutcome.demonstratedWith(bothTenantsHoldOwnSnapshot, snapshotsHoldTheirOwnStudents);
+    }
+
+    /**
+     * Enrolls in a tenant added at runtime, once that tenant accepts commands.
      */
     private static void enrollWhenTenantReady(CommandGateway commandGateway) {
-        Awaitility.await("tenant [" + DemoLifecycle.OGDENVILLE.tenantId() + "] ready for commands")
-                  .atMost(Duration.ofSeconds(15))
+        whenTenantReady(OGDENVILLE, () -> {
+            Enrollments.openCourse(commandGateway, OGDENVILLE, OGDENVILLE_COURSE_ID, COURSE_CAPACITY);
+            Enrollments.enroll(commandGateway, OGDENVILLE, OGDENVILLE_COURSE_ID, "dan");
+        });
+    }
+
+    /**
+     * Sends the given tenant's {@code firstCommands}, retrying until that tenant accepts them.
+     * <p>
+     * Creating a tenant's Axon Server context and command bus connector is asynchronous, and finishes after
+     * the tenant provider has discovered the tenant. A command sent in that window is rejected, as an
+     * unresolved tenant or as an unknown context, so the first command to any tenant has to tolerate it.
+     * That holds for the tenants known at startup as much as for one added at runtime: provisioning waits
+     * until the provider lists the tenant, which does not mean the server already routes to its context.
+     * <p>
+     * A rejected attempt fails at dispatch without appending anything, and opening a course and enrolling a
+     * student are both idempotent, so retrying lands the work exactly once.
+     *
+     * @param tenant        the tenant whose readiness to wait for
+     * @param firstCommands the commands to send, retried until the tenant accepts them
+     */
+    private static void whenTenantReady(TenantDescriptor tenant, Runnable firstCommands) {
+        Awaitility.await("tenant [" + tenant.tenantId() + "] ready for commands")
+                  .atMost(TENANT_READY_TIMEOUT)
                   .ignoreExceptionsMatching(Enrollments::causedByTenantNotReady)
                   .until(() -> {
-                      Enrollments.openCourse(commandGateway, OGDENVILLE, OGDENVILLE_COURSE_ID, COURSE_CAPACITY);
-                      Enrollments.enroll(commandGateway, OGDENVILLE, OGDENVILLE_COURSE_ID, "dan");
+                      firstCommands.run();
                       return true;
                   });
     }
@@ -258,7 +353,8 @@ public final class DemoLifecycle {
                                                        TenantComponentProvider<AuditLog> auditProvider,
                                                        boolean unknownTenantRejected,
                                                        boolean shelbyvilleClosedOnRemoval,
-                                                       EventStorageOutcome eventStorage) {
+                                                       EventStorageOutcome eventStorage,
+                                                       SnapshottingOutcome snapshotting) {
         // Read the totals through queries while the application is still running.
         TenantStatistics springfield = Enrollments.statistics(queryGateway, SPRINGFIELD);
         int ogdenvilleEnrollments = Enrollments.statistics(queryGateway, OGDENVILLE).totalEnrollments();
@@ -272,7 +368,7 @@ public final class DemoLifecycle {
                 auditProvider.componentFor(SPRINGFIELD),
                 auditProvider.componentFor(OGDENVILLE));
         shutdown.run();
-        boolean allClosedOnShutdown = awaitClosed(() ->
+        boolean allClosedOnShutdown = holdsWithin("shutdown cleanup", SHUTDOWN_CLEANUP_TIMEOUT, () ->
                 stores.stream().allMatch(CourseStatisticsStore::isClosed)
                         && auditLogs.stream().allMatch(AuditLog::isClosed));
         logger.info("Shutdown complete. All remaining tenant instances closed: {}", allClosedOnShutdown);
@@ -283,21 +379,30 @@ public final class DemoLifecycle {
                                unknownTenantRejected,
                                shelbyvilleClosedOnRemoval,
                                allClosedOnShutdown,
-                               eventStorage);
+                               eventStorage,
+                               snapshotting);
     }
 
     /**
-     * Waits until the given {@code closed} condition holds, returning whether it did within the timeout.
-     * Unlike a bare {@code await(...).until(...)}, this returns {@code false} on timeout rather than
-     * throwing, so the demo can report the cleanup outcome instead of failing opaquely.
+     * Waits until the given {@code condition} holds, returning whether it did within {@code atMost}. It
+     * returns {@code false} rather than throwing, so the demo reports what it observed and carries on to
+     * its remaining steps.
+     *
+     * @param description names the condition, so a failure says which observation did not hold
+     * @param atMost      how long to wait before giving up
+     * @param condition   the condition to wait for
+     * @return whether the condition held within {@code atMost}
      */
-    private static boolean awaitClosed(BooleanSupplier closed) {
+    private static boolean holdsWithin(String description, Duration atMost, BooleanSupplier condition) {
         try {
-            Awaitility.await("shutdown cleanup")
-                      .atMost(Duration.ofSeconds(5))
-                      .until(closed::getAsBoolean);
+            Awaitility.await(description)
+                      .atMost(atMost)
+                      // A failing lookup also counts as "did not hold".
+                      .ignoreExceptions()
+                      .until(condition::getAsBoolean);
             return true;
-        } catch (ConditionTimeoutException e) {
+        } catch (ConditionTimeoutException timeout) {
+            logger.info("Gave up waiting for {} after {}.", description, atMost);
             return false;
         }
     }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
@@ -28,6 +28,8 @@ package org.axonframework.examples.demo.multitenancy.shared.run;
  * @param allClosedOnShutdown        whether every remaining tenant's instances were closed on shutdown
  * @param eventStorage               what the per-tenant event-storage demonstration observed (only demonstrated
  *                                   against Axon Server)
+ * @param snapshotting               what the per-tenant snapshotting demonstration observed (only demonstrated
+ *                                   against Axon Server)
  */
 public record DemoOutcome(int springfieldEnrollments,
                           int springfieldAuditEntries,
@@ -35,6 +37,7 @@ public record DemoOutcome(int springfieldEnrollments,
                           boolean unknownTenantRejected,
                           boolean shelbyvilleClosedOnRemoval,
                           boolean allClosedOnShutdown,
-                          EventStorageOutcome eventStorage) {
+                          EventStorageOutcome eventStorage,
+                          SnapshottingOutcome snapshotting) {
 
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/EventStorageOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/EventStorageOutcome.java
@@ -24,7 +24,7 @@ package org.axonframework.examples.demo.multitenancy.shared.run;
  *
  * @param demonstrated                     whether the event-storage demonstration ran (only against Axon Server)
  * @param springfieldRejectedWhenFull      whether a further enrollment into Springfield's full course was rejected
- * @param shelbyvilleAcceptedSameCourseId  whether the same course identifier still accepted an enrollment in
+ * @param shelbyvilleAcceptedSameCourseId  whether the same course identifier still accepted its enrollments in
  *                                         Shelbyville, proving its event store did not see Springfield's events
  */
 public record EventStorageOutcome(boolean demonstrated,
@@ -35,7 +35,7 @@ public record EventStorageOutcome(boolean demonstrated,
      * The outcome of a run that exercised per-tenant event storage, carrying what it observed.
      *
      * @param springfieldRejectedWhenFull     whether a further enrollment into Springfield's full course was rejected
-     * @param shelbyvilleAcceptedSameCourseId whether the same course identifier still accepted an enrollment in
+     * @param shelbyvilleAcceptedSameCourseId whether the same course identifier still accepted its enrollments in
      *                                        Shelbyville
      * @return an outcome marked as demonstrated
      */

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/ProviderAmbiguityGuardrail.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/ProviderAmbiguityGuardrail.java
@@ -20,7 +20,7 @@ import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigur
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
-import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerMultiTenancyConfigurationDefaults;
+import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/SnapshottingOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/SnapshottingOutcome.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.run;
+
+/**
+ * What the per-tenant snapshotting demonstration observed. Per-tenant snapshot storage is a feature of Axon
+ * Server, where each tenant's snapshots live in its own context, so this demonstration only runs on the Axon
+ * Server paths. In memory every tenant shares one snapshot store, so it is {@link #notDemonstrated() not
+ * demonstrated} and {@link #demonstrated()} is {@code false}.
+ *
+ * @param demonstrated                   whether the snapshotting demonstration ran (only against Axon Server)
+ * @param bothTenantsHoldOwnSnapshot     whether both tenants' own stores hold a snapshot of the same course
+ * @param snapshotsHoldTheirOwnStudents  whether each snapshot holds only its own tenant's student, proving
+ *                                       neither tenant read the other's snapshot
+ */
+public record SnapshottingOutcome(boolean demonstrated,
+                                  boolean bothTenantsHoldOwnSnapshot,
+                                  boolean snapshotsHoldTheirOwnStudents) {
+
+    /**
+     * The outcome of a run that exercised per-tenant snapshotting, carrying what it observed.
+     *
+     * @param bothTenantsHoldOwnSnapshot    whether both tenants' own stores hold a snapshot of the same course
+     * @param snapshotsHoldTheirOwnStudents whether each snapshot holds only its own tenant's student
+     * @return an outcome marked as demonstrated
+     */
+    public static SnapshottingOutcome demonstratedWith(boolean bothTenantsHoldOwnSnapshot,
+                                                       boolean snapshotsHoldTheirOwnStudents) {
+        return new SnapshottingOutcome(true, bothTenantsHoldOwnSnapshot, snapshotsHoldTheirOwnStudents);
+    }
+
+    /**
+     * The outcome of a run that did not exercise per-tenant snapshotting, such as the in-memory demo.
+     *
+     * @return an outcome marked as not demonstrated
+     */
+    public static SnapshottingOutcome notDemonstrated() {
+        return new SnapshottingOutcome(false, false, false);
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantProvisioning.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantProvisioning.java
@@ -19,7 +19,7 @@ package org.axonframework.examples.demo.multitenancy.shared.tenant;
 import io.axoniq.framework.axonserver.connector.api.AxonServerConnectionManager;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
-import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
+import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
 import org.awaitility.Awaitility;
 import org.axonframework.common.configuration.AxonConfiguration;
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantSnapshots.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantSnapshots.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.tenant;
+
+import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
+import io.axoniq.framework.messaging.multitenancy.eventsourcing.TenantSnapshotStoreFactory;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.conversion.GeneralConverter;
+import org.axonframework.eventsourcing.snapshot.api.Snapshot;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+import org.axonframework.messaging.core.QualifiedName;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Reads what one tenant's own snapshot store captured for an entity, so the demo can observe where a
+ * snapshot ended up and what it holds.
+ * <p>
+ * Using snapshots needs none of this. The framework stores and reads a snapshot in the store of the tenant
+ * handling the command, without the application naming a tenant. Only this demo needs to look them up, and
+ * it needs to because a snapshot is a performance optimization. An entity behaves identically whether or
+ * not it was snapshotted, so no behavior reveals which tenant's store a snapshot landed in.
+ * <p>
+ * Get one through {@link #axonServer(AxonConfiguration, QualifiedName, Class)}, or {@link #inMemory()} for
+ * a backing where every tenant shares one store.
+ *
+ * @param <T> the type a stored snapshot's contents are read into
+ */
+public interface TenantSnapshots<T> {
+
+    /**
+     * Whether each tenant has its own snapshot store, which only Axon Server gives it.
+     *
+     * @return {@code true} against Axon Server, {@code false} in memory
+     */
+    boolean hasPerTenantSnapshotStore();
+
+    /**
+     * What the given {@code tenant}'s own store captured for the given entity, or {@code null} when it holds
+     * no snapshot of it.
+     *
+     * @param tenant     the tenant whose snapshot store to read
+     * @param identifier the identifier of the entity to look for
+     * @return that tenant's snapshot contents, or {@code null} when there is none
+     * @throws UnsupportedOperationException when this backing has no per-tenant snapshot stores
+     */
+    @Nullable
+    T snapshotContentsOf(TenantDescriptor tenant, String identifier);
+
+    /**
+     * Snapshot lookups over a backing that gives every tenant the same snapshot store, which is what the
+     * in-memory run does. There is no per-tenant store to read, so a lookup is refused.
+     *
+     * @param <T> the type a stored snapshot's contents would be read into
+     * @return snapshot lookups that report they are not per tenant
+     */
+    static <T> TenantSnapshots<T> inMemory() {
+        return new TenantSnapshots<>() {
+            @Override
+            public boolean hasPerTenantSnapshotStore() {
+                return false;
+            }
+
+            @Override
+            public T snapshotContentsOf(TenantDescriptor tenant, String identifier) {
+                throw new UnsupportedOperationException(
+                        "In memory every tenant shares one snapshot store, so there is no per-tenant store to read");
+            }
+        };
+    }
+
+    /**
+     * Snapshot lookups over Axon Server, where each tenant's snapshots live in that tenant's own context.
+     * It reads the same per-tenant store the framework writes through, converted with the application's own
+     * converter.
+     *
+     * @param configuration the started configuration to resolve the per-tenant stores and converter from
+     * @param snapshotName  the name the entity's snapshots are stored under
+     * @param contentsType  the type a stored snapshot's contents are read into
+     * @param <T>           the type a stored snapshot's contents are read into
+     * @return the Axon Server snapshot lookups
+     */
+    static <T> TenantSnapshots<T> axonServer(AxonConfiguration configuration,
+                                             QualifiedName snapshotName,
+                                             Class<T> contentsType) {
+        Objects.requireNonNull(configuration, "The configuration must not be null");
+        Objects.requireNonNull(snapshotName, "The snapshot name must not be null");
+        Objects.requireNonNull(contentsType, "The contents type must not be null");
+        TenantSnapshotStoreFactory snapshotStores = configuration.getComponent(TenantSnapshotStoreFactory.class);
+        GeneralConverter converter = configuration.getComponent(GeneralConverter.class);
+        // Bounded, so a stalled server does not hang the demo.
+        Duration lookupTimeout = Duration.ofSeconds(5);
+        return new TenantSnapshots<>() {
+            @Override
+            public boolean hasPerTenantSnapshotStore() {
+                return true;
+            }
+
+            @Override
+            public T snapshotContentsOf(TenantDescriptor tenant, String identifier) {
+                SnapshotStore tenantStore = snapshotStores.storeFor(tenant);
+                Snapshot snapshot = tenantStore.load(snapshotName, identifier, null)
+                                               .orTimeout(lookupTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                                               .join();
+                return snapshot == null ? null : converter.convert(snapshot.payload(), contentsType);
+            }
+        };
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/CourseSnapshot.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/CourseSnapshot.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.write.enrollstudent;
+
+import java.util.Set;
+
+/**
+ * A course as a stored snapshot captured it, for reading a snapshot back outside the framework.
+ * <p>
+ * It carries the same components under the same names as the course entity, which is what lets the
+ * application's {@code Converter} read a stored snapshot into it.
+ * <p>
+ * A snapshot captures the state the triggering load <em>sourced</em>, not the state the command that
+ * triggered it leaves behind, so the students here are those enrolled before that command's own event.
+ *
+ * @param open             whether the course was open
+ * @param capacity         how many seats the course offered
+ * @param enrolledStudents the students enrolled at the position the snapshot was taken
+ */
+public record CourseSnapshot(boolean open, int capacity, Set<String> enrolledStudents) {
+
+    public CourseSnapshot {
+        enrolledStudents = enrolledStudents == null ? Set.of() : Set.copyOf(enrolledStudents);
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
@@ -24,11 +24,13 @@ import org.axonframework.examples.demo.multitenancy.university.events.StudentEnr
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.Snapshotting;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
 import org.axonframework.messaging.eventhandling.gateway.EventAppender;
 import org.axonframework.modelling.annotation.InjectEntity;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,14 +82,14 @@ class EnrollStudentCommandHandler {
     }
 
     private List<StudentEnrolledInCourse> decide(EnrollStudent command, State state) {
-        if (!state.open) {
+        if (!state.open()) {
             throw new CourseNotOpenException(command.courseId());
         }
         if (state.isEnrolled(command.studentId())) {
             return List.of();
         }
         if (state.isFull()) {
-            throw new CourseFullException(command.courseId(), state.capacity);
+            throw new CourseFullException(command.courseId(), state.capacity());
         }
         return List.of(new StudentEnrolledInCourse(command.courseId(), command.studentId()));
     }
@@ -95,28 +97,51 @@ class EnrollStudentCommandHandler {
     /**
      * The slice's own view of a course: whether it is open, how many seats it offers, and who is already
      * enrolled, which is all this handler needs to decide on an enrollment.
+     * <p>
+     * The course is snapshotted, and a snapshot is the entity itself handed to the {@code Converter}, so
+     * this is an immutable record rather than a mutable class: each {@link EventSourcingHandler} returns
+     * the evolved course instead of changing this one. A record's components are exactly the state to
+     * capture, so it converts both ways without any converter-specific annotation. A mutable class whose
+     * private fields have no accessors converts to an empty document against the default converter, and the
+     * course then silently comes back blank.
+     * <p>
+     * Snapshots are per tenant. The framework stores each course's snapshot in the snapshot store of the
+     * tenant whose command triggered it, and reads it back from that same store when sourcing that
+     * tenant's course, so the same course identifier in two tenants is two unrelated snapshots.
+     * <p>
+     * {@link Snapshotting#afterEvents()} triggers once <em>more than</em> one event has been applied while
+     * sourcing. Opening a course applies none, enrolling the first student applies one, and enrolling the
+     * second applies two and so snapshots the course. The threshold is deliberately tiny to keep the demo
+     * short. A real system snapshots after hundreds of events.
      */
     @EventSourcedEntity(tagKey = UniversityTags.COURSE_ID)
-    static final class State {
+    @Snapshotting(afterEvents = 1)
+    record State(boolean open, int capacity, Set<String> enrolledStudents) {
 
-        private boolean open;
-        private int capacity;
-        private final Set<String> enrolledStudents = new LinkedHashSet<>();
+        State {
+            // Also covers the constructor a snapshot is converted back through, where the students may be
+            // absent.
+            enrolledStudents = enrolledStudents == null
+                    ? Set.of()
+                    : Collections.unmodifiableSet(new LinkedHashSet<>(enrolledStudents));
+        }
 
         @EntityCreator
         State() {
             // A fresh course, evolved from its own tenant's events before the command handler sees it.
+            this(false, 0, Set.of());
         }
 
         @EventSourcingHandler
-        void evolve(CourseOpened event) {
-            this.open = true;
-            this.capacity = event.capacity();
+        State evolve(CourseOpened event) {
+            return new State(true, event.capacity(), enrolledStudents);
         }
 
         @EventSourcingHandler
-        void evolve(StudentEnrolledInCourse event) {
-            this.enrolledStudents.add(event.studentId());
+        State evolve(StudentEnrolledInCourse event) {
+            Set<String> enrolled = new LinkedHashSet<>(enrolledStudents);
+            enrolled.add(event.studentId());
+            return new State(open, capacity, enrolled);
         }
 
         private boolean isEnrolled(String studentId) {

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentConfiguration.java
@@ -21,6 +21,10 @@ import org.axonframework.common.configuration.ModuleBuilder;
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
+
+import java.util.Objects;
 
 /**
  * Registers the enroll-student write slice. The declarative demo passes its {@link EventSourcingConfigurer}
@@ -62,6 +66,22 @@ public final class EnrollStudentConfiguration {
      */
     public static Module commandModule() {
         return commandModuleBuilder().build();
+    }
+
+    /**
+     * The name the framework stores and loads this slice's course snapshots under, resolved through the
+     * given {@code messageTypeResolver}. The course entity stays private to this slice, so its snapshot
+     * name is exposed here rather than the entity type itself.
+     * <p>
+     * This assumes the entity's repository resolves the name through the same resolver, which holds as long
+     * as the entity module inherits the application's {@code MessageTypeResolver}.
+     *
+     * @param messageTypeResolver the resolver deriving the message type of this slice's course entity
+     * @return the qualified name of this slice's course snapshots
+     */
+    public static QualifiedName courseSnapshotName(MessageTypeResolver messageTypeResolver) {
+        Objects.requireNonNull(messageTypeResolver, "The message type resolver must not be null");
+        return messageTypeResolver.resolveOrThrow(EnrollStudentCommandHandler.State.class).qualifiedName();
     }
 
     private static EventSourcedEntityModule<String, EnrollStudentCommandHandler.State> entityModuleBuilder() {

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
@@ -21,7 +21,7 @@ import io.axoniq.framework.messaging.multitenancy.api.MetadataBasedTenantResolve
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
-import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerMultiTenancyConfigurationDefaults;
+import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
@@ -25,6 +25,9 @@ import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerMultiTena
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.eventsourcing.snapshot.api.Snapshot;
+import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
@@ -34,9 +37,13 @@ import org.axonframework.examples.demo.multitenancy.university.UniversityModuleC
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseFullException;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseNotOpenException;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudent;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourse;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
+import org.axonframework.messaging.core.QualifiedName;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -62,6 +69,8 @@ class CourseEnrollmentCompositionTest {
     private static final int CAPACITY = 2;
     private static final long TIMEOUT_SECONDS = 5;
 
+    private final SnapshotStore snapshotStore = new InMemorySnapshotStore();
+
     private AxonConfiguration configuration;
     private CommandGateway commandGateway;
     private TenantComponentProvider<CourseStatisticsStore> statisticsProvider;
@@ -81,7 +90,10 @@ class CourseEnrollmentCompositionTest {
                     .disableEnhancer(AxonServerMultiTenancyConfigurationDefaults.class)
                     .registerComponent(TenantProvider.class, config -> tenantProvider)
                     .registerComponent(TenantComponentProvider.class, "courseStatistics", config -> statisticsProvider)
-                    .registerComponent(TenantComponentProvider.class, "auditLog", config -> auditProvider);
+                    .registerComponent(TenantComponentProvider.class, "auditLog", config -> auditProvider)
+                    // The course is snapshotted, so it needs a snapshot store. In memory that is one
+                    // shared store. Against Axon Server the multi-tenancy defaults give each tenant its own.
+                    .registerComponent(SnapshotStore.class, config -> snapshotStore);
         });
         configuration = configurer.build();
         configuration.start();
@@ -105,6 +117,24 @@ class CourseEnrollmentCompositionTest {
         assertThat(statisticsProvider.componentFor(TENANT).statistics())
                 .containsExactly(new CourseStatistics(COURSE_ID, 2));
         assertThat(auditProvider.componentFor(TENANT).entries()).hasSize(2);
+    }
+
+    @Test
+    void fillingTheCourseSnapshotsItAndTheSnapshotSourcesBackTheFullCourse() {
+        openCourse(COURSE_ID, CAPACITY);
+        enroll(COURSE_ID, "alice");
+        // Crosses the course's snapshot threshold, so this load snapshots the course.
+        enroll(COURSE_ID, "bob");
+
+        // The snapshot was really written, under the name the framework stores it with. Whether the entity
+        // survives conversion is a separate question, asserted by CourseSnapshotConversionTest: the
+        // in-memory store keeps the entity instance as-is, so this path never converts anything.
+        assertThat(storedCourseSnapshot()).isNotNull();
+
+        // And sourcing from that snapshot restores the full course rather than a blank one: a blank course
+        // would be rejected as not open instead of as full.
+        assertThatThrownBy(() -> enroll(COURSE_ID, "carol"))
+                .hasRootCauseInstanceOf(CourseFullException.class);
     }
 
     @Test
@@ -155,6 +185,17 @@ class CourseEnrollmentCompositionTest {
         // is appended and the component is not updated again.
         assertThat(statisticsProvider.componentFor(TENANT).statistics())
                 .containsExactly(new CourseStatistics(COURSE_ID, 1));
+    }
+
+    // Reads the snapshot straight from the store the configuration was given, under the same name the
+    // entity's repository stores it with.
+    @Nullable
+    private Snapshot storedCourseSnapshot() {
+        QualifiedName courseSnapshotName =
+                EnrollStudentConfiguration.courseSnapshotName(configuration.getComponent(MessageTypeResolver.class));
+        return snapshotStore.load(courseSnapshotName, COURSE_ID, null)
+                            .orTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                            .join();
     }
 
     private void openCourse(String courseId, int capacity) {

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/CourseSnapshotConversionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/CourseSnapshotConversionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.write.enrollstudent;
+
+import org.axonframework.conversion.jackson.JacksonConverter;
+import org.axonframework.examples.demo.multitenancy.university.events.CourseOpened;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that a snapshot of the course survives the round trip through the default converter.
+ * <p>
+ * A snapshot is the entity itself handed to the {@code Converter}. This is the assertion that decides
+ * whether the entity may carry a snapshot policy at all: a shape the converter cannot round-trip is stored
+ * as an empty document without failing, and the course then comes back blank, turning a full course into
+ * one that was never opened. The in-memory snapshot store keeps the entity instance as-is, so it never
+ * exercises this path, which is why this is asserted against the converter directly.
+ */
+class CourseSnapshotConversionTest {
+
+    private static final String COURSE_ID = "cs-101";
+
+    private final JacksonConverter converter = new JacksonConverter();
+
+    @Test
+    void theCourseSurvivesTheRoundTripThroughTheDefaultConverter() {
+        EnrollStudentCommandHandler.State course = filledCourse();
+
+        Object document = converter.convert(course, String.class);
+        EnrollStudentCommandHandler.State restored =
+                converter.convert(document, EnrollStudentCommandHandler.State.class);
+
+        assertThat(restored).isEqualTo(course);
+    }
+
+    // Reading a stored snapshot back outside the framework goes through CourseSnapshot, so the document the
+    // entity produces has to populate that view too.
+    @Test
+    void theStoredDocumentReadsBackIntoTheCourseSnapshotView() {
+        EnrollStudentCommandHandler.State course = filledCourse();
+
+        Object document = converter.convert(course, String.class);
+        CourseSnapshot view = converter.convert(document, CourseSnapshot.class);
+
+        assertThat(view.open()).isTrue();
+        assertThat(view.capacity()).isEqualTo(2);
+        assertThat(view.enrolledStudents()).containsExactlyInAnyOrder("alice", "bob");
+    }
+
+    // A document without the students, as an entity that cannot be converted would produce, must not come
+    // back looking like a valid course.
+    @Test
+    void anEmptyDocumentDoesNotReadBackAsAnOpenCourse() {
+        CourseSnapshot view = converter.convert("{}", CourseSnapshot.class);
+
+        assertThat(view.open()).isFalse();
+        assertThat(view.enrolledStudents()).isEmpty();
+    }
+
+    private static EnrollStudentCommandHandler.State filledCourse() {
+        return new EnrollStudentCommandHandler.State()
+                .evolve(new CourseOpened(COURSE_ID, 2))
+                .evolve(new StudentEnrolledInCourse(COURSE_ID, "alice"))
+                .evolve(new StudentEnrolledInCourse(COURSE_ID, "bob"));
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
@@ -26,6 +26,11 @@ or against Axon Server with the toggle, starts it, and hands the gateways and pr
 `DemoLifecycle`. In memory the event store is a single shared store; against Axon Server each tenant has
 its own.
 
+The course carries a snapshot policy, so a `SnapshotStore` is needed too. In memory `UniversityConfiguration`
+registers one shared `InMemorySnapshotStore`. Against Axon Server it registers none: the multi-tenancy
+defaults own that registration so each tenant's snapshots land in its own context, and a store the
+application registers itself is refused.
+
 ## Running
 
 From this module's directory:
@@ -74,6 +79,11 @@ The Axon Server run additionally shows per-tenant event storage, which the in-me
 it has one shared event store. The two known tenants open a course under the same identifier: one fills
 it and rejects a further enrollment as full, while the same identifier still accepts one in the other
 tenant, because each tenant's events are sourced from its own store.
+
+It also shows per-tenant snapshotting. Enrolling the second student crosses the course's snapshot
+threshold, and each tenant's snapshot goes to its own snapshot store. Both tenants therefore hold a
+snapshot of the same course identifier, and each holds only its own tenant's student. The in-memory run
+snapshots into one store shared by every tenant, so it cannot show the isolation.
 
 ## The same demo, wired by Spring Boot
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
@@ -25,9 +25,14 @@ import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProv
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +91,7 @@ public class MultiTenancyApplication {
                                  statisticsProvider,
                                  auditProvider,
                                  TenantProvisioning.inMemory(tenantProvider),
+                                 TenantSnapshots.<CourseSnapshot>inMemory(),
                                  configuration::shutdown);
     }
 
@@ -106,11 +112,15 @@ public class MultiTenancyApplication {
         AxonConfiguration configuration = configurer.build();
         configuration.start();
 
+        QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
+                configuration.getComponent(MessageTypeResolver.class));
+
         return DemoLifecycle.run(configuration.getComponent(CommandGateway.class),
                                  configuration.getComponent(QueryGateway.class),
                                  statisticsProvider,
                                  auditProvider,
                                  TenantProvisioning.axonServer(configuration, DemoLifecycle.KNOWN_TENANTS),
+                                 TenantSnapshots.axonServer(configuration, courseSnapshots, CourseSnapshot.class),
                                  configuration::shutdown);
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -19,7 +19,7 @@ package org.axonframework.examples.demo.multitenancy;
 import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
-import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerMultiTenancyConfigurationDefaults;
+import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -23,6 +23,8 @@ import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerMultiTena
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
@@ -51,7 +53,10 @@ public final class UniversityConfiguration {
      * <p>
      * The Axon Server configuration enhancer is disabled and the {@code tenantProvider} is registered
      * explicitly, so the demo runs fully in memory, on a single shared in-memory event store rather than
-     * one per tenant.
+     * one per tenant. The course is snapshotted, so this path also needs a {@link SnapshotStore}, and in
+     * memory that is one shared store rather than one per tenant. Against Axon Server the application
+     * registers none: the multi-tenancy defaults own that registration so every tenant's snapshots land
+     * in its own context, and an application-registered store is refused.
      *
      * @param configurer         the configurer to extend
      * @param tenantProvider     the provider of the application's tenants
@@ -68,7 +73,9 @@ public final class UniversityConfiguration {
                                          // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
                                          registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
                                                  .disableEnhancer(AxonServerMultiTenancyConfigurationDefaults.class)
-                                                 .registerComponent(TenantProvider.class, config -> tenantProvider);
+                                                 .registerComponent(TenantProvider.class, config -> tenantProvider)
+                                                 .registerComponent(SnapshotStore.class,
+                                                                    config -> new InMemorySnapshotStore());
                                          registerTenantComponents(registry, statisticsProvider, auditProvider);
                                      });
     }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -52,6 +52,10 @@ class MultiTenancyDemoTest {
         // and the per-tenant event-storage demonstration did not run, as it needs each tenant's own Axon Server
         // event store, which the in-memory demo does not have
         assertThat(outcome.eventStorage().demonstrated()).isFalse();
+        // and the per-tenant snapshotting demonstration did not run either, as in memory every tenant
+        // shares one snapshot store. CourseEnrollmentCompositionTest covers the snapshot round trip
+        // against that shared store
+        assertThat(outcome.snapshotting().demonstrated()).isFalse();
     }
 
     @Test

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
@@ -17,7 +17,7 @@ application and its beans:
 ```
 org.axonframework.examples.demo.multitenancy
 +- MultiTenancyApplication   the @SpringBootApplication, no multi-tenancy wiring of its own
-+- UniversityConfiguration   the beans: the two per-tenant providers, the query handler, and the course modules
++- UniversityConfiguration   the beans: the two per-tenant providers, the query handler, the course modules, and a snapshot store for when multi-tenancy is off
 +- DemoRunner                a CommandLineRunner that runs the lifecycle, then stops
 ```
 
@@ -27,9 +27,9 @@ enrollment command handler is registered with the course, so there is no separat
 The starter's multi-tenancy auto-configuration picks the provider beans up, subscribes them to the tenant
 lifecycle, installs the tenant parameter resolver and interceptor, and registers the default
 auto-discovering `AxonServerTenantProvider`. The starter also registers the course module beans, so the
-course is sourced from and appended to its tenant's own event store. There is no manual multi-tenancy
-wiring at all: the tenants are discovered from Axon Server's contexts (with `_admin` filtered out),
-exactly as in the declarative demo's Axon Server path.
+course is sourced from and appended to its tenant's own event store, and snapshotted into that tenant's own
+snapshot store. There is no manual multi-tenancy wiring at all: the tenants are discovered from Axon
+Server's contexts (with `_admin` filtered out), exactly as in the declarative demo's Axon Server path.
 
 ## Requires Axon Server
 
@@ -62,7 +62,9 @@ declarative demo, this time proving the auto-configuration path. It also asserts
 context, which exists on the server, is filtered out of the discovered tenants. Because it runs against a
 real Axon Server, it also asserts the per-tenant event-storage demonstration: the same course identifier fills
 to capacity and rejects a further enrollment in one tenant, while still accepting one in another,
-sourced from that tenant's own event store.
+sourced from that tenant's own event store. It asserts the per-tenant snapshot demonstration for the same
+reason: both tenants hold their own snapshot of that same course identifier, and each holds only its own
+tenant's student.
 
 Because hosting several tenant contexts needs a licensed Enterprise Edition server, the test licenses
 the container in one of two ways, checked in that order:
@@ -87,4 +89,7 @@ container). Run it with `mvn verify` (it runs at the `verify` phase).
 `MultiTenancyDisabledTest` proves the disable toggle. With `axon.multitenancy.enabled=false`, the
 auto-configuration installs no tenant resolution, so dispatching a tenant-scoped enrollment fails because
 its tenant is never resolved. That failure is the observable proof that the feature is fully off. The
-test disables Axon Server as well, so it needs none and runs as an ordinary unit test.
+test disables Axon Server as well, so it needs none and runs as an ordinary unit test. Because the course
+carries a snapshot policy, `UniversityConfiguration` contributes one shared `SnapshotStore` while
+multi-tenancy is off, which is what keeps that configuration runnable: with the feature on, the defaults
+supply one per tenant and a store the application registers itself is refused.

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/DemoRunner.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/DemoRunner.java
@@ -22,9 +22,14 @@ import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +68,8 @@ public class DemoRunner implements CommandLineRunner {
      * @param queryGateway       the gateway statistics are read on
      * @param statisticsProvider the provider of the per-tenant course-statistics stores
      * @param auditProvider      the provider of the per-tenant audit logs
-     * @param axonConfiguration  the Axon configuration, to resolve the Axon Server tenant provider from
+     * @param axonConfiguration  the Axon configuration, to resolve the Axon Server tenant provider and the
+     *                           per-tenant snapshot stores from
      * @param applicationContext the context to close when the demo has finished, triggering cleanup
      */
     public DemoRunner(CommandGateway commandGateway,
@@ -82,6 +88,8 @@ public class DemoRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
+        QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
+                axonConfiguration.getComponent(MessageTypeResolver.class));
         logger.info("Two providers for one component type are rejected at configuration time: {}",
                     ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType());
         DemoOutcome outcome = DemoLifecycle.run(commandGateway,
@@ -90,6 +98,9 @@ public class DemoRunner implements CommandLineRunner {
                                                 auditProvider,
                                                 TenantProvisioning.axonServer(axonConfiguration,
                                                                               DemoLifecycle.KNOWN_TENANTS),
+                                                TenantSnapshots.axonServer(axonConfiguration,
+                                                                           courseSnapshots,
+                                                                           CourseSnapshot.class),
                                                 applicationContext::close);
         logger.info("Demo finished. Outcome: {}", outcome);
     }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -19,12 +19,15 @@ package org.axonframework.examples.demo.multitenancy;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
 import org.axonframework.common.configuration.Module;
+import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
+import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourseConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -62,6 +65,27 @@ public class UniversityConfiguration {
     @Bean
     public TenantComponentProvider<AuditLog> auditLogProvider() {
         return TenantComponents.auditLogProvider();
+    }
+
+    /**
+     * A single shared {@link SnapshotStore}, for runs where multi-tenancy is switched off.
+     * <p>
+     * The course carries a snapshot policy, so a snapshot store has to be present or the configuration
+     * fails to start. While multi-tenancy is active the defaults supply one per tenant, so this bean must
+     * not exist then: a store the application registers itself is refused.
+     * <p>
+     * Tenants are Axon Server contexts, so the feature is inactive whenever either
+     * {@code axon.multitenancy.enabled} or {@code axon.axonserver.enabled} is off, and this bean covers both.
+     * The condition has to be property-based rather than {@code @ConditionalOnMissingBean}, because the
+     * per-tenant registration happens in Axon's component registry rather than in the bean factory, so no
+     * bean exists for Spring to find.
+     *
+     * @return one snapshot store shared by the whole application
+     */
+    @Bean
+    @ConditionalOnExpression("!${axon.multitenancy.enabled:true} or !${axon.axonserver.enabled:true}")
+    public SnapshotStore snapshotStore() {
+        return new InMemorySnapshotStore();
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -17,7 +17,7 @@
 package org.axonframework.examples.demo.multitenancy;
 
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
-import io.axoniq.framework.messaging.multitenancy.axonserver.AxonServerTenantProvider;
+import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
@@ -28,10 +28,16 @@ import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.EventStorageOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
+import org.axonframework.examples.demo.multitenancy.shared.run.SnapshottingOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -167,6 +173,8 @@ class MultiTenancyDemoIT {
                 .run()) {
 
             AxonConfiguration configuration = context.getBean(AxonConfiguration.class);
+            QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
+                    configuration.getComponent(MessageTypeResolver.class));
             TenantProvider tenantProvider = configuration.getComponent(TenantProvider.class);
             AxonServerTenantContextManager serverContexts =
                     new AxonServerTenantContextManager(configuration.getComponent(AxonServerConnectionManager.class));
@@ -185,6 +193,9 @@ class MultiTenancyDemoIT {
                                                     auditProvider(context),
                                                     TenantProvisioning.axonServer(configuration,
                                                                                   DemoLifecycle.KNOWN_TENANTS),
+                                                    TenantSnapshots.axonServer(configuration,
+                                                                               courseSnapshots,
+                                                                               CourseSnapshot.class),
                                                     context::close);
 
             // then both of Springfield's components saw only its own two enrollments, matched by type
@@ -207,6 +218,14 @@ class MultiTenancyDemoIT {
             assertThat(eventStorage.demonstrated()).isTrue();
             assertThat(eventStorage.springfieldRejectedWhenFull()).isTrue();
             assertThat(eventStorage.shelbyvilleAcceptedSameCourseId()).isTrue();
+
+            // and per-tenant snapshotting kept the same course identifier isolated too: both tenants' own
+            // stores hold a snapshot of that identifier, and each holds only its own tenant's student, so
+            // neither tenant read the other's snapshot
+            SnapshottingOutcome snapshotting = outcome.snapshotting();
+            assertThat(snapshotting.demonstrated()).isTrue();
+            assertThat(snapshotting.bothTenantsHoldOwnSnapshot()).isTrue();
+            assertThat(snapshotting.snapshotsHoldTheirOwnStudents()).isTrue();
 
             // and registering two providers for one component type is rejected at configuration time
             assertThat(ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType()).isTrue();


### PR DESCRIPTION
Adds per-tenant snapshotting to the multi-tenancy demo, the half of [axoniq-framework#263](https://github.com/AxonIQ/axoniq-framework/pull/263) the demo did not yet cover. Tracked by [axoniq-framework#209](https://github.com/AxonIQ/axoniq-framework/issues/209), which is what the `#209` in the title refers to rather than anything in this repository.

## What it adds

A new step 2 in `DemoLifecycle.run`. Both known tenants fill a course under the same identifier, so each tenant's own snapshot store ends up holding its own snapshot of that identifier. The run logs:

```
Course [cs-101] is snapshotted in both tenants' own snapshot stores: true.
Each snapshot holds only its own tenant's student, so neither read the other's: true.
Springfield's snapshot holds [alice], Shelbyville's holds [carol]
```

Snapshot isolation cannot be shown behaviourally, because a snapshot changes no behaviour. The demo therefore reads the two per-tenant stores through a new `TenantSnapshots` seam and compares snapshot **contents**. Comparing the framework's snapshot envelopes would prove nothing, since each envelope carries its own write timestamp and never compares equal to another, even if one tenant had read the other's snapshot.

## Also included

`MultiTenancyDemoIT` failed about one run in four with `CANCELLED: Unknown Context springfield` on its first command. Provisioning waits until the tenant provider lists a tenant, which does not mean Axon Server routes to its context yet. The existing `Enrollments.causedByTenantNotReady` retry now covers every tenant's first command, not only the runtime-added one.

## Depends on axoniq-framework#263

`TenantSnapshotStoreFactory` exists only on that branch, so examples CI fails here until it merges. Verified locally against `feature/176/209_eventStore` at `cfa9839b92`, where the 12 core tests, the declarative smoke test, and the Axon Server integration test all pass.
