### PR TITLE
[#4798] Clear the re-claim block when a split or merge fails

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTask.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -33,6 +34,22 @@ import java.util.concurrent.CompletableFuture;
  * @since 4.5
  */
 abstract class CoordinatorTask {
+
+    /**
+     * Ceiling on the re-claim block a {@link SplitTask} or {@link MergeTask} installs for the segment(s) whose
+     * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken} it is about to
+     * rewrite.
+     * <p>
+     * The block stops the {@link Coordinator} running the task from claiming a segment while that segment's token is
+     * being deleted and re-initialized. Every task clears its own block once its {@link #task()} completes, whether it
+     * succeeded, failed, or threw before its completion handler was attached, so this ceiling is only reached by a task
+     * whose future never completes at all. Even then it is not permanent: the {@code Coordinator} drops the entry the
+     * first time it evaluates a segment whose deadline has passed, so the block expires without anyone clearing it.
+     * <p>
+     * The block is scoped to a single {@code Coordinator}: it stops <em>this</em> processor instance from re-claiming
+     * the segment, and does not stop another instance from claiming it mid-split or mid-merge.
+     */
+    static final Duration RECLAIM_BLOCK_TIMEOUT = Duration.ofSeconds(60);
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.ClockUtils;
+import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
@@ -124,22 +125,31 @@ class MergeTask extends CoordinatorTask {
 
             return unitOfWorkFactory.create().executeWithResult(
                     context -> tokenStore.fetchSegment(name, thisSegment.mergeableSegmentId(), context)
-            ).thenCompose(thatSegment -> {
+            ).thenCompose(thatSegment -> FutureUtils.runFailing(() -> {
+                // runFailing turns a synchronous throw (an abort rejected by a saturated worker executor, for
+                // instance) into a failed future, so the handler below observes it too rather than being skipped along
+                // with the rest of the chain -- leaking whichever blocks tokenFor already installed.
                 CompletableFuture<TrackingToken> thisTokenFuture = tokenFor(thisSegment.getSegmentId());
                 CompletableFuture<TrackingToken> thatTokenFuture = tokenFor(thatSegment.getSegmentId());
                 return thisTokenFuture
                         .thenCombine(thatTokenFuture,
                                      (thisToken, thatToken) -> mergeSegments(thisSegment, thisToken, thatSegment, thatToken))
                         .thenCompose(Function.identity());
-            });
+            })
+            // Lift the block on both segments however the merge ends. Clearing it only on the paths that reach the
+            // token rewrite would leave a failed abort or a failed token fetch of either half blocking re-claim of
+            // both until the ceiling expires.
+            .whenComplete((result, throwable) -> {
+                releasesDeadlines.remove(thisSegment.getSegmentId());
+                releasesDeadlines.remove(thatSegment.getSegmentId());
+            }));
         });
     }
 
     private CompletableFuture<TrackingToken> tokenFor(int segmentId) {
         // Block the segment from being claimed by the Coordinator while we perform the merge.
         // This prevents a race condition where the Coordinator might claim a segment that's being merged.
-        releasesDeadlines.put(segmentId,
-                              clock.instant().plusSeconds(60)); // Block for 1 minute (will be cleared after merge)
+        releasesDeadlines.put(segmentId, clock.instant().plus(RECLAIM_BLOCK_TIMEOUT));
 
         // Remove WorkPackage so that the CoordinatorTask cannot find it to release its claim upon impending abortion.
         WorkPackage workPackage = workPackages.remove(segmentId);
@@ -173,9 +183,6 @@ class MergeTask extends CoordinatorTask {
                                              name, thisSegment, thatSegment, mergedSegment);
                                  return true;
                              });
-        }).whenComplete((result, throwable) -> {
-            releasesDeadlines.remove(thisSegment.getSegmentId());
-            releasesDeadlines.remove(thatSegment.getSegmentId());
         });
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTask.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
 import org.axonframework.common.ClockUtils;
+import org.axonframework.common.FutureUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -110,13 +111,18 @@ class SplitTask extends CoordinatorTask {
     protected CompletableFuture<Boolean> task() {
         // Block the segment from being claimed by the Coordinator while we perform the split.
         // This prevents a race condition where the Coordinator might claim a segment that's being split.
-        releasesDeadlines.put(segmentId,
-                              clock.instant().plusSeconds(60)); // Block for 1 minute (will be cleared after split)
+        releasesDeadlines.put(segmentId, clock.instant().plus(RECLAIM_BLOCK_TIMEOUT));
 
         logger.debug("Processor [{}] will perform split instruction for segment {}.", name, segmentId);
         // Remove WorkPackage so that the CoordinatorTask cannot find it to release its claim upon impending abortion.
         WorkPackage workPackage = workPackages.remove(segmentId);
-        return workPackage != null ? abortAndSplit(workPackage) : fetchSegmentAndSplit(segmentId);
+        // runFailing turns a synchronous throw (an abort rejected by a saturated worker executor, say) into a failed
+        // future, so the handler below observes it rather than being skipped along with the rest of the chain.
+        return FutureUtils
+                .runFailing(() -> workPackage != null ? abortAndSplit(workPackage) : fetchSegmentAndSplit(segmentId))
+                // Lift the block however the split ends. Clearing it only on the paths that reach the token rewrite
+                // would leave a failed abort or segment fetch blocking re-claim until the ceiling expires.
+                .whenComplete((result, throwable) -> releasesDeadlines.remove(segmentId));
     }
 
     private CompletableFuture<Boolean> abortAndSplit(WorkPackage workPackage) {
@@ -138,10 +144,7 @@ class SplitTask extends CoordinatorTask {
                         context -> tokenStore.fetchToken(name, segmentToSplit.getSegmentId(), context)
                                              .thenApply(tokenToSplit -> TrackerStatus.split(segmentToSplit, tokenToSplit))
                                              .thenCompose(splitStatuses -> splitAndRelease(splitStatuses, segmentToSplit, context))
-                )).whenComplete((result, throwable) ->
-                        // Remove the segment from the releases deadlines to allow the Coordinator to claim the split segments
-                        releasesDeadlines.remove(segmentToSplit.getSegmentId())
-                );
+                ));
     }
 
     private CompletableFuture<Boolean> splitAndRelease(TrackerStatus[] splitStatuses,

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTaskTest.java
@@ -31,9 +31,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -353,6 +358,92 @@ class MergeTaskTest {
             // then - the result is exceptionally completed, and both release deadlines are removed
             assertThat(result).isDone();
             assertThat(result.isCompletedExceptionally()).isTrue();
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runClearsReleasesDeadlinesOfBothHalvesWhenAHalfsTokenCannotBeFetched() {
+            // given - the segment to be merged with is owned elsewhere, so no token is rewritten at all
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                    .thenReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("owned elsewhere")));
+
+            // when
+            testSubject.run();
+
+            // then - a merge that never happened must not keep either half unclaimable
+            assertThat(result).isCompletedExceptionally();
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runClearsReleasesDeadlinesWhenAbortingAWorkPackageFails() {
+            // given
+            workPackages.put(SEGMENT_TO_MERGE, workPackageOne);
+            when(workPackageOne.segment()).thenReturn(SEGMENT_ZERO);
+            when(workPackageOne.abort(null))
+                    .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("abort failed")));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThat(releasesDeadlines).isEmpty();
+        }
+    }
+
+    @Nested
+    class WhenMergeSegmentsSucceeds {
+
+        @Test
+        void runClearsReleasesDeadlinesOfBothHalves() {
+            // given
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+            when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenReturn(FutureUtils.emptyCompletedFuture());
+            when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                    .thenReturn(FutureUtils.emptyCompletedFuture());
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isCompletedWithValue(true);
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runKeepsBothHalvesBlockedForEveryTokenStoreWriteOfTheMerge() {
+            // given - the block only prevents the Coordinator re-claiming a half-merged segment if it outlives the
+            // token rewrite, so record which halves were still blocked on each write the merge performs
+            List<Set<Integer>> blockedSegmentsPerTokenWrite = new ArrayList<>();
+            Answer<CompletableFuture<Void>> recordBlockedSegments = invocation -> {
+                blockedSegmentsPerTokenWrite.add(new HashSet<>(releasesDeadlines.keySet()));
+                return FutureUtils.emptyCompletedFuture();
+            };
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_MERGE), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_TO_BE_MERGED), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(1)));
+            when(tokenStore.deleteToken(anyString(), anyInt(), any())).thenAnswer(recordBlockedSegments);
+            when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), eq(new Segment(0, 0)), any()))
+                    .thenAnswer(recordBlockedSegments);
+
+            // when
+            testSubject.run();
+
+            // then - three writes (delete both halves, initialize the merged segment), each with both halves blocked
+            assertThat(result).isCompletedWithValue(true);
+            assertThat(blockedSegmentsPerTokenWrite)
+                    .containsExactly(Set.of(SEGMENT_TO_MERGE, SEGMENT_TO_BE_MERGED),
+                                     Set.of(SEGMENT_TO_MERGE, SEGMENT_TO_BE_MERGED),
+                                     Set.of(SEGMENT_TO_MERGE, SEGMENT_TO_BE_MERGED));
             assertThat(releasesDeadlines).isEmpty();
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/SplitTaskTest.java
@@ -26,13 +26,17 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.axonframework.messaging.core.unitofwork.UnitOfWorkTestUtils;
 import org.junit.jupiter.api.*;
 import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
 import static org.junit.jupiter.api.Assertions.*;
@@ -187,6 +191,87 @@ class SplitTaskTest {
             .isInstanceOf(ExecutionException.class)
             .cause()
             .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Nested
+    class ReclaimBlock {
+
+        @Test
+        void runClearsTheBlockAfterASuccessfulSplit() {
+            // given
+            when(tokenStore.fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(completedFuture(Segment.ROOT_SEGMENT));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), any(), any()))
+                    .thenReturn(emptyCompletedFuture());
+            when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(emptyCompletedFuture());
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isCompletedWithValue(true);
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runKeepsTheBlockInPlaceForEveryTokenStoreWriteOfTheSplit() {
+            // given - the block only prevents the Coordinator re-claiming a half-split segment if it outlives the
+            // token rewrite, so record whether it was still installed on each write the split performs
+            List<Integer> blockedSegmentsPerTokenWrite = new ArrayList<>();
+            Answer<CompletableFuture<Void>> recordBlockedSegments = invocation -> {
+                blockedSegmentsPerTokenWrite.addAll(releasesDeadlines.keySet());
+                return emptyCompletedFuture();
+            };
+            when(tokenStore.fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(completedFuture(Segment.ROOT_SEGMENT));
+            when(tokenStore.fetchToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(completedFuture(new GlobalSequenceTrackingToken(0)));
+            when(tokenStore.initializeSegment(any(), eq(PROCESSOR_NAME), any(), any()))
+                    .thenAnswer(recordBlockedSegments);
+            when(tokenStore.deleteToken(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenAnswer(recordBlockedSegments);
+
+            // when
+            testSubject.run();
+
+            // then - three writes (initialize new half, delete original, re-initialize original), block held on each
+            assertThat(result).isCompletedWithValue(true);
+            assertThat(blockedSegmentsPerTokenWrite).containsExactly(SEGMENT_ID, SEGMENT_ID, SEGMENT_ID);
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runClearsTheBlockWhenTheSegmentCannotBeFetched() {
+            // given - the segment is owned elsewhere, so the split fails before any token is rewritten
+            when(tokenStore.fetchSegment(eq(PROCESSOR_NAME), eq(SEGMENT_ID), any()))
+                    .thenReturn(CompletableFuture.failedFuture(new UnableToClaimTokenException("owned elsewhere")));
+
+            // when
+            testSubject.run();
+
+            // then - a split that never happened must not keep the segment unclaimable
+            assertThat(result).isCompletedExceptionally();
+            assertThat(releasesDeadlines).isEmpty();
+        }
+
+        @Test
+        void runClearsTheBlockWhenAbortingTheWorkPackageFails() {
+            // given
+            workPackages.put(SEGMENT_ID, workPackage);
+            when(workPackage.segment()).thenReturn(Segment.ROOT_SEGMENT);
+            when(workPackage.abort(null))
+                    .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("abort failed")));
+
+            // when
+            testSubject.run();
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThat(releasesDeadlines).isEmpty();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #4798

## What changed

`SplitTask` and `MergeTask` marked a segment unclaimable for 60 seconds as their first action, but cleared the mark only on the path that rewrites the token. An ordinary `UnableToClaimTokenException` from the token fetch therefore stranded the segment -- both halves, for a merge -- for a full minute although nothing had changed.

Each clear now hangs off the point where every outcome of the instruction converges, so it also runs on the abort-failure and token-fetch-failure paths. (In `MergeTask` that point is inside the `thenCompose(thatSegment -> ...)` lambda, where both puts live, not the outermost chain.)

The block still covers the token rewrite: the new attachment point is strictly downstream of the old one, so the clear can only fire later than before, never earlier, and `Coordinator:832-842` awaits `task.run()` before releasing the processing gate that the claim scan runs inside.

A synchronous throw between the `put` and the handler attachment leaked too, and that one is reachable on a **healthy** processor: `workerExecutor` is user-supplied, so a bounded pool with the default abort policy throws `RejectedExecutionException` out of `WorkPackage.scheduleWorker()`. In `MergeTask` that leaked both ids when the second `tokenFor` threw after the first put. Both `task()` methods now build their chain inside the existing `FutureUtils.runFailing(...)`, so a synchronous throw becomes a failed future and the same `whenComplete` clear runs. It catches `Exception`, not `Error`, matching `CoordinatorTask.run()`.

Incidental: `SplitTask` put on `segmentId` but removed on `segmentToSplit.getSegmentId()`. The keys coincided in practice, so there was no live bug.

Because the 60-second deadline is no longer how the block normally ends, the literal is promoted to `CoordinatorTask.RECLAIM_BLOCK_TIMEOUT`, documented as a watchdog for a task whose future never completes. The entry self-purges: `isSegmentBlockedFromClaim` uses `compute` returning null past the deadline.

## Tests

New: `SplitTaskTest.ReclaimBlock` (3 cases) and `MergeTaskTest` (3 cases). Four of the six fail on unfixed code, for example `Expecting empty but was: {0=2026-07-29T10:54:51Z}`.

Two more pin the **ordering**, which nothing did before: `runKeepsTheBlockInPlaceForEveryTokenStoreWriteOfTheSplit` and `runKeepsBothHalvesBlockedForEveryTokenStoreWriteOfTheMerge` assert the block is still held at every token-store write of the rewrite. Without them, moving the `whenComplete` upstream would be caught by nothing.

Targeted run, whole classes: `SplitTaskTest` 10, `MergeTaskTest` 14, `CoordinatorTest` 22, `ClaimTaskTest` 5, `WorkPackageTest` 33, `PooledStreamingEventProcessorTest` 70 -- **155 testcases, 0 red**.

## For the reviewer

The Javadoc now records that the block is per-`Coordinator`, so it does not stop another processor instance from claiming the segment mid-split; the original inline comment implied broader protection than the code gives.

`releasesDeadlines.remove` is unconditional, so a split or merge still clobbers a longer user-requested `releaseUntil` deadline on the same segment. Unchanged by this PR, since the `put` already clobbered it.

Full `messaging` run hits a pre-existing `PooledStreamingEventProcessorTest` Awaitility timeout that reproduces identically on unmodified `origin/main`.
