### PR TITLE
[#4800] Recognise the broadcast sentinel by identity instead of by value

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/sequencing/SequencingPolicy.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/sequencing/SequencingPolicy.java
@@ -59,16 +59,35 @@ public interface SequencingPolicy<M extends Message> {
      * Well-known sentinel sequence identifier signaling that a message should be handled by <b>every</b> handler
      * eligible for it, rather than being routed to a single one based on its sequence identifier.
      * <p>
-     * When the sequence identifier resolved for a message equals {@code BROADCAST}, that message is
-     * delivered to every eligible handler instead of only the one its identifier would otherwise select. Such messages
-     * remain sequenced relative to one another wherever sequencing applies.
+     * When the sequence identifier resolved for a message <b>is this exact instance</b>, that message is delivered to
+     * every eligible handler instead of only the one its identifier would otherwise select. Such messages remain
+     * sequenced relative to one another wherever sequencing applies.
      * <p>
-     * Note: This uses a String constant to provide consistent {@link Object#hashCode()} and
-     * {@link Object#equals(Object)} behaviour across JVM restarts.
+     * Note: this is a unique instance recognized by identity, not by value. A policy requests a broadcast only by
+     * returning {@code SequencingPolicy.BROADCAST} itself. Sequence identifiers extracted from a message - a metadata
+     * value, a payload property, or an entity identifier - can never request a broadcast by accident, whatever their
+     * value.
+     * <p>
+     * Equality is identity, while {@link Object#hashCode()} is deliberately a fixed value rather than the identity
+     * hash. Identity equality is what makes an accidental broadcast impossible. The fixed hash is only a safety net:
+     * every recognition site skips segment routing for this instance, but a site that hashed the sentinel into a
+     * segment regardless would then pick the same segment on every run instead of a different arbitrary one after each
+     * restart. Sharing a hash bucket with the {@code String} {@code "BROADCAST"} is harmless, since identity equality
+     * still keeps the two apart wherever sequence identifiers are collected or keyed.
      *
      * @since 5.3.0
      */
-    Object BROADCAST = "BROADCAST";
+    Object BROADCAST = new Object() {
+        @Override
+        public int hashCode() {
+            return "BROADCAST".hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "BROADCAST";
+        }
+    };
 
     /**
      * Returns the sequence identifier for the given {@code message}. When two messages have the same identifier (as

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -113,8 +113,9 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * <p>
      * When a {@link Segment} is attached to the {@code context} (as done by a segmented processor), a component only
      * handles an event when the component's sequence identifier hashes into that segment, ensuring each event is handled
-     * exactly once per component across all segments. Without a {@link Segment} in the {@code context}, every supporting
-     * component handles the event.
+     * exactly once per component across all segments. The one exception is a component whose sequence identifier is
+     * {@link SequencingPolicy#BROADCAST}, which handles the event in every segment. Without a {@link Segment} in the
+     * {@code context}, every supporting component handles the event.
      *
      * @param entries the batch of message stream entries to be processed
      * @param context the processing context in which the event messages are processed
@@ -173,9 +174,10 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
      * {@link org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor}), handling is
      * not segmented and the component always handles the event.
      * <p>
-     * When the component's sequence identifier equals {@link SequencingPolicy#BROADCAST}, segment
+     * When the component's sequence identifier is the {@link SequencingPolicy#BROADCAST} instance itself, segment
      * matching is skipped and the component handles the event in every segment, mirroring the admission decision made
-     * while scheduling.
+     * while scheduling. The comparison is by identity, so a sequence identifier that merely carries the same value as
+     * data is routed to a single segment like any other.
      *
      * @param segment   the {@link Segment} currently handling the event, or {@code null} when handling is not segmented
      * @param component the component that would handle the event
@@ -191,7 +193,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
             return true;
         }
         Object sequenceIdentifier = component.sequenceIdentifierFor(event, context);
-        if (SequencingPolicy.BROADCAST.equals(sequenceIdentifier)) {
+        if (sequenceIdentifier == SequencingPolicy.BROADCAST) {
             return true;
         }
         return new SegmentMatcher((e, ctx) -> Optional.of(sequenceIdentifier))

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
@@ -72,8 +72,10 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
      * <p>
      * This implementation will delegate the decision to the {@link EventHandlingComponent}.
      * <p>
-     * When any of the components returns the {@link SequencingPolicy#BROADCAST} sequence identifier
-     * for the given {@code eventMessage}, segment matching is skipped and the event is handled by every segment.
+     * When any of the components returns the {@link SequencingPolicy#BROADCAST} instance itself as the sequence
+     * identifier for the given {@code eventMessage}, segment matching is skipped and the event is handled by every
+     * segment. The comparison is by identity, so an identifier that merely carries the same value as data is matched
+     * against the segment like any other.
      *
      * @param eventMessage The message for which to identify if the processor can handle it.
      * @param segment      The segment for which the event should be processed.
@@ -108,6 +110,8 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
             }
 
             var sequenceIdentifiers = eventHandlingComponents.sequenceIdentifiersFor(eventMessage, context);
+            // The sentinel inherits Object's identity equals, so this lookup resolves by identity: a sequence
+            // identifier that merely reads "BROADCAST" as data shares the sentinel's hash bucket but never matches it.
             if (sequenceIdentifiers.contains(SequencingPolicy.BROADCAST)) {
                 return true;
             }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponentsTest.java
@@ -274,6 +274,51 @@ class ProcessorEventHandlingComponentsTest {
         }
 
         @Test
+        void componentCarryingTheBroadcastSentinelsValueAsDataHandlesInASingleSegment() {
+            // given a component sequenced by a value taken off the event that happens to read "BROADCAST", which any
+            // value-extracting policy (metadata, property, extraction, per-aggregate) can produce. Spelled as a
+            // literal rather than derived from the sentinel, so this stays a value a user could write even if
+            // toString() changes.
+            RecordingEventHandlingComponent component =
+                    recordingComponent("data-carrying", EVENT_NAME, "BROADCAST");
+            testSubject = new ProcessorEventHandlingComponents(List.of(component));
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+
+            // when the same event is handled in every segment
+            handleInSegment(event, segments[0]);
+            handleInSegment(event, segments[1]);
+
+            // then it was handled once in total, not once per segment
+            assertThat(component.recorded()).containsExactly(event);
+        }
+
+        @Test
+        void sequenceIdentifiersForKeepsTheSentinelApartFromAnIdenticallyValuedIdentifier() {
+            // given one component requesting a broadcast and one sequenced by a value that happens to read
+            // "BROADCAST". The two hash into the same bucket of the resolved set, so only identity equality keeps
+            // them from collapsing into a single element and losing one component's identifier.
+            EventMessage event = EventTestUtils.asEventMessage("payload");
+            ProcessorEventHandlingComponents subject = new ProcessorEventHandlingComponents(List.of(
+                    recordingComponent("broadcast", EVENT_NAME, SequencingPolicy.BROADCAST),
+                    recordingComponent("data-carrying", EVENT_NAME, "BROADCAST")
+            ));
+            AtomicReference<Set<Object>> capturedIdentifiers = new AtomicReference<>();
+
+            // when
+            UnitOfWorkTestUtils.aUnitOfWork()
+                               .executeWithResult(ctx -> {
+                                   capturedIdentifiers.set(subject.sequenceIdentifiersFor(event, ctx));
+                                   return CompletableFuture.completedFuture(null);
+                               })
+                               .orTimeout(2, java.util.concurrent.TimeUnit.SECONDS)
+                               .join();
+
+            // then both survive as separate elements
+            assertThat(capturedIdentifiers.get())
+                    .containsExactlyInAnyOrder(SequencingPolicy.BROADCAST, "BROADCAST");
+        }
+
+        @Test
         void sequenceIdentifiersForExcludesNonSupportingComponents() {
             // given a component that supports the event and one that does not
             EventMessage event = EventTestUtils.asEventMessage("payload");

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilterTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilterTest.java
@@ -29,6 +29,7 @@ import org.axonframework.messaging.eventhandling.processing.errorhandling.Propag
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.junit.jupiter.api.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,6 +81,33 @@ class DefaultWorkPackageEventFilterTest {
     }
 
     @Test
+    void broadcastSentinelIsNeverHashedAgainstASegment() throws Exception {
+        // given a segment that records every hash tested against it. Were the sentinel ever hashed against a segment
+        // it would route every broadcast event to a single segment instead of all of them, so admission must
+        // short-circuit before that hash is taken.
+        List<Integer> testedHashes = new ArrayList<>();
+        Segment recordingSegment = new Segment(0, 3) {
+            @Override
+            public boolean matches(int value) {
+                // Both SegmentMatcher and Segment.matches(Object) funnel through this overload.
+                testedHashes.add(value);
+                return super.matches(value);
+            }
+        };
+        DefaultWorkPackageEventFilter testSubject = testSubjectWith(
+                componentWithSequenceIdentifier(STRING_EVENT_NAME, SequencingPolicy.BROADCAST)
+        );
+        EventMessage testEvent = EventTestUtils.asEventMessage("test-payload");
+
+        // when
+        boolean result = testSubject.canHandle(testEvent, new StubProcessingContext(), recordingSegment);
+
+        // then the event is admitted, and admitted without the sentinel ever being hashed against the segment
+        assertThat(result).isTrue();
+        assertThat(testedHashes).isEmpty();
+    }
+
+    @Test
     void regularSequenceIdentifierMatchesOnlyTheSegmentItHashesInto() throws Exception {
         //given
         Object sequenceIdentifier = "sample-identifier";
@@ -112,6 +140,49 @@ class DefaultWorkPackageEventFilterTest {
             boolean result = testSubject.canHandle(testEvent, new StubProcessingContext(), segment);
 
             //then
+            assertThat(result).as("segment [%s]", segment).isTrue();
+        }
+    }
+
+    @Test
+    void sequenceIdentifierCarryingTheSentinelsValueAsDataIsRoutedToASingleSegment() throws Exception {
+        // given a component sequenced by a value taken off the event that happens to read "BROADCAST", which any
+        // value-extracting policy (metadata, property, extraction, per-aggregate) can produce. Spelled as a literal
+        // rather than derived from the sentinel, so this stays a value a user could write even if toString() changes.
+        Object sequenceIdentifier = "BROADCAST";
+        DefaultWorkPackageEventFilter testSubject = testSubjectWith(
+                componentWithSequenceIdentifier(STRING_EVENT_NAME, sequenceIdentifier)
+        );
+        EventMessage testEvent = EventTestUtils.asEventMessage("test-payload");
+
+        // when the event is offered to every segment
+        int matchingSegments = 0;
+        for (Segment segment : ALL_SEGMENTS) {
+            if (testSubject.canHandle(testEvent, new StubProcessingContext(), segment)) {
+                matchingSegments++;
+            }
+        }
+
+        // then it is admitted by the one segment its hash routes to, not by all of them
+        assertThat(matchingSegments).isOne();
+    }
+
+    @Test
+    void broadcastMatchesEverySegmentEvenWhenAnotherComponentCarriesTheSentinelsValueAsData() throws Exception {
+        // given one component requesting a broadcast and one sequenced by a value that happens to read "BROADCAST".
+        // The two share a hash bucket in the resolved set of identifiers, so finding the sentinel in it relies on
+        // identity equality telling the colliding entries apart.
+        DefaultWorkPackageEventFilter testSubject = testSubjectWith(
+                componentWithSequenceIdentifier(STRING_EVENT_NAME, "BROADCAST"),
+                componentWithSequenceIdentifier(STRING_EVENT_NAME, SequencingPolicy.BROADCAST)
+        );
+        EventMessage testEvent = EventTestUtils.asEventMessage("test-payload");
+
+        for (Segment segment : ALL_SEGMENTS) {
+            // when
+            boolean result = testSubject.canHandle(testEvent, new StubProcessingContext(), segment);
+
+            // then
             assertThat(result).as("segment [%s]", segment).isTrue();
         }
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SequencingEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SequencingEventHandlingComponentTest.java
@@ -20,15 +20,18 @@ import org.jspecify.annotations.NonNull;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.sequencing.SequencingPolicy;
 import org.axonframework.messaging.eventhandling.*;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -192,6 +195,47 @@ class SequencingEventHandlingComponentTest {
                 .havingCause()
                 .isInstanceOf(RuntimeException.class)
                 .withMessage("Test exception");
+    }
+
+    @Test
+    void broadcastSentinelAndAnIdenticallyValuedIdentifierAreSequencedIndependently() {
+        // given a policy returning the broadcast sentinel for one event and the String "BROADCAST" for another. The
+        // two hash into the same bucket of the invocation map, so only identity equality keeps them apart as keys;
+        // were they one key, the second event's handling would be chained behind the first's.
+        EventMessage sentinelSequenced = testEvent("sentinel-sequenced");
+        EventMessage dataSequenced = testEvent("data-sequenced");
+        CompletableFuture<EventMessage> firstHandlingStillRunning = new CompletableFuture<>();
+        List<EventMessage> invocations = new CopyOnWriteArrayList<>();
+        handlerRegistry.subscribe(new QualifiedName(TestPayload.class), (event, context) -> {
+            invocations.add(event);
+            if (event.equals(sentinelSequenced)) {
+                return MessageStream.fromFuture(firstHandlingStillRunning).ignoreEntries().cast();
+            }
+            return MessageStream.empty();
+        });
+        EventHandlingComponent eventHandlingComponent = new SequencingEventHandlingComponent(
+                new SequenceOverridingEventHandlingComponent(
+                        (event, context) -> Optional.of(event.equals(sentinelSequenced)
+                                                                ? SequencingPolicy.BROADCAST
+                                                                : "BROADCAST"),
+                        handlerRegistry
+                )
+        );
+
+        // when both events are handled in one processing context, while the first one's handling has not completed
+        List<EventMessage> invokedWhileFirstStillRunning = new ArrayList<>();
+        aUnitOfWork().executeWithResult(ctx -> {
+                         var firstResult = eventHandlingComponent.handle(sentinelSequenced, ctx).asCompletableFuture();
+                         var secondResult = eventHandlingComponent.handle(dataSequenced, ctx).asCompletableFuture();
+                         invokedWhileFirstStillRunning.addAll(invocations);
+                         firstHandlingStillRunning.complete(null);
+                         return CompletableFuture.allOf(firstResult, secondResult);
+                     })
+                     .orTimeout(2, TimeUnit.SECONDS)
+                     .join();
+
+        // then the second event was handled without waiting for the first, so the two were distinct keys
+        assertThat(invokedWhileFirstStillRunning).containsExactly(sentinelSequenced, dataSequenced);
     }
 
     static @NonNull EventMessage testEvent(String payload) {


### PR DESCRIPTION
Fixes #4800

## What changed

`SequencingPolicy.BROADCAST` was the plain string `"BROADCAST"`, matched by value. Every shipped sequencing policy takes its value from the event, so an ordinary tenant, topic, channel or entity identifier that happened to read `BROADCAST` was treated as a broadcast request and handled **once per live segment** -- 16 times by default, with the multiplier changing on every split or merge.

The sentinel is now a unique instance with identity equality, so the collision is impossible by construction rather than merely unlikely.

**Equality is identity; `hashCode()` is deliberately fixed** to `"BROADCAST".hashCode()`. Identity equality makes an accidental broadcast impossible; the fixed hash is a safety net. Should a future refactor drop one of the two short-circuits, an identity hash would route broadcast events to a segment **that changes on every JVM restart**; a fixed hash gives one consistent segment -- still wrong, but diagnosable.

## Only the sentinel change is load-bearing

The sentinel change alone makes the suite green, with or without the call-site edits, which shrinks what a reviewer has to trust. `Object.equals` already *is* identity and `HashSet.contains` resolves by hash plus identity equals, so both edits are behavioural no-ops. `==` is kept in `ProcessorEventHandlingComponents` because it states the intent; `contains()` is kept in `DefaultWorkPackageEventFilter` rather than `stream().anyMatch()`, which is O(n) plus an allocation on the per-event admission path.

## Where the sentinel is hashed, and why that is safe

Three sites, all safe:

| Site | Role | Safe because |
|---|---|---|
| `ProcessorEventHandlingComponents:239` | `Collectors.toSet()` element | per-`ProcessingContext`, ephemeral |
| `SequencingEventHandlingComponent:82` | `ConcurrentHashMap` key | same |
| `SequenceCachingEventHandlingComponent:79` | cached **value**, keyed by event id | hash never used |

`SegmentMatcher:65` is the one place identity semantics would change routing; both production call sites short-circuit before it.

## Tests

Five new cases. Against the true pre-fix production files, exactly four fail and nothing else:

- a component whose data equals `"BROADCAST"` is handled in a single segment
- the same through the work-package filter -- `expected: 1 but was: 4`
- the sentinel and an identically-valued identifier stay **separate elements** in the `Collectors.toSet()` set
- the sentinel and an identically-valued identifier are **sequenced independently** in the `ConcurrentHashMap`

Plus two that guard the mechanism rather than the outcome:

- `broadcastSentinelIsNeverHashedAgainstASegment` asserts no hash of the sentinel is ever tested against a segment. It goes red when the short-circuit is deleted, where an outcome assertion is a coin flip per segment.
- broadcast still matches every segment when another component carries the sentinel's value as data, the only place `contains(sentinel)` runs against a set holding a hash-colliding element.

127 testcases green across the sequencing and processing classes. Real broadcast still fans out: `broadcastComponentHandlesEventInEverySegmentWhileRegularComponentHandlesOnlyInItsOwn` passes.

## No migration note is owed

`BROADCAST` was added on 2026-07-13 for `5.3.0-SNAPSHOT`, and appears in **zero release tags** (5.2.0, 5.2.1, 5.2.2) and zero maintenance branches, so nobody could have hardcoded the literal from a released artifact.

## Two intended side effects, previously unstated

The sentinel and a data value `"BROADCAST"` are now two distinct elements where they collapsed to one, and a component returning the literal no longer shares a sequencing chain with a real broadcast component. Both are the point of the change. This also corrects the public `handle` contract, which claimed "exactly once per component across all segments" with no mention of broadcast.
