### PR TITLE
[#4796] Resolve the reset converter only when there is a reset context

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -322,11 +322,15 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
             @Nullable R resetContext,
             ProcessingContext processingContext
     ) {
+        byte[] convertedResetContext = convertedResetContext(resetContext, processingContext);
         return tokenStore.fetchSegments(name, processingContext)
                          .thenCompose(segments -> {
                              var tokenFutures = segments.stream()
                                                         .map(segment -> fetchTokenForSegment(
-                                                                segment, processingContext, startPosition, resetContext
+                                                                segment,
+                                                                processingContext,
+                                                                startPosition,
+                                                                convertedResetContext
                                                         ))
                                                         .toList();
                              return CompletableFuture.allOf(tokenFutures.toArray(CompletableFuture[]::new))
@@ -336,27 +340,31 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
                          });
     }
 
-    private <R> CompletableFuture<SegmentToken> fetchTokenForSegment(
+    private CompletableFuture<SegmentToken> fetchTokenForSegment(
             Segment segment,
             ProcessingContext processingContext,
             TrackingToken startPosition,
-            @Nullable R resetContext
+            byte[] convertedResetContext
     ) {
         return tokenStore.fetchToken(name, segment.getSegmentId(), processingContext)
                          .thenApply(token -> new SegmentToken(
                                  segment,
-                                 ReplayToken.createReplayToken(
-                                         token,
-                                         startPosition,
-                                         convertedResetContext(
-                                                 resetContext,
-                                                 processingContext.component(GeneralConverter.class)
-                                         )
-                                 )
+                                 ReplayToken.createReplayToken(token, startPosition, convertedResetContext)
                          ));
     }
 
-    private <R> byte[] convertedResetContext(@Nullable R resetContext, Converter converter) {
+    /**
+     * Converts the given {@code resetContext} to a {@code byte[]}, once for the entire reset.
+     * <p>
+     * A {@code null} reset context needs no conversion, so no {@link GeneralConverter} is resolved from the
+     * {@code processingContext} in that case. This keeps a reset without a context working on processors whose
+     * {@link org.axonframework.messaging.core.unitofwork.UnitOfWorkFactory} provides no components.
+     */
+    private <R> byte[] convertedResetContext(@Nullable R resetContext, ProcessingContext processingContext) {
+        if (resetContext == null) {
+            return new byte[0];
+        }
+        Converter converter = processingContext.component(GeneralConverter.class);
         byte[] convertedResetContext = converter.convert(resetContext, byte[].class);
         return convertedResetContext == null ? new byte[0] : convertedResetContext;
     }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -28,6 +28,7 @@ import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.commandhandling.gateway.CommandResult;
 import org.axonframework.messaging.core.ApplicationContext;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
@@ -2127,6 +2128,41 @@ class PooledStreamingEventProcessorTest {
 
             var thrown = assertThrows(IllegalStateException.class, () -> joinAndUnwrap(testSubject.resetTokens()));
             assertEquals("The Processor must be shut down before triggering a reset.", thrown.getMessage());
+        }
+
+        @Test
+        void resetTokensWithoutResetContextDoesNotRequireAConverter() {
+            // given - a processor whose unit of work provides no components at all, as is the default
+            TrackingToken initialToken = new GlobalSequenceTrackingToken(42);
+            int expectedSegmentCount = 2;
+            // given - the absent reset context is stored as an empty byte[], needing no conversion
+            TrackingToken expectedToken = ReplayToken.createReplayToken(initialToken, initialToken, new byte[0]);
+            simpleEhc.subscribe((ResetHandler) (resetContext, ctx) -> MessageStream.empty());
+            withTestSubject(
+                    List.of(),
+                    c -> c.initialSegmentCount(expectedSegmentCount)
+                          .initialToken(source -> completedFuture(initialToken))
+                          .unitOfWorkFactory(new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE))
+            );
+            // given - an initialized token per segment to reset
+            joinAndUnwrap(tokenStore.initializeTokenSegments(PROCESSOR_NAME,
+                                                             expectedSegmentCount,
+                                                             initialToken,
+                                                             null));
+
+            // when - resetting without a reset context, so there is nothing to convert
+            joinAndUnwrap(testSubject.resetTokens());
+
+            // then - every segment gets the same token, carrying the single empty reset context
+            List<Segment> segments = joinAndUnwrap(tokenStore.fetchSegments(PROCESSOR_NAME, null));
+            assertThat(segments).hasSize(expectedSegmentCount);
+            for (Segment segment : segments) {
+                TrackingToken token = joinAndUnwrap(
+                        tokenStore.fetchToken(PROCESSOR_NAME, segment.getSegmentId(), null)
+                );
+                assertThat(token).isEqualTo(expectedToken);
+                assertThat(ReplayToken.isReplay(token)).isTrue();
+            }
         }
 
         @Test


### PR DESCRIPTION
Fixes #4796

## What changed

`resetTokens()` resolved a `GeneralConverter` from the processing context unconditionally, once per segment, so a processor whose unit-of-work factory supplies no components could not be reset at all. It failed with `UnsupportedOperationException: EmptyApplicationContext does not provide any components`, an error naming neither resets nor converters.

The converter is now resolved once, and only when a reset context actually needs converting. `convertedResetContext` returns an empty array immediately for a `null` reset context, and the resulting `byte[]` is computed once in `fetchSegmentsWithTokens` and passed down.

## Tests

New: `PooledStreamingEventProcessorTest.ResetSupportTest.resetTokensWithoutResetContextDoesNotRequireAConverter`, using `SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE)`. It fails on unfixed code with the exception above. Full `messaging` module: green.

## For the reviewer

Two effects of one change. Hoisting the conversion out of the per-segment lambda means a genuine missing-converter failure now surfaces once per reset instead of once per segment. Short-circuiting on a null reset context means the component lookup never happens at all for the common `resetTokens()` case. `fetchTokenForSegment` consequently loses its `<R>` type parameter and takes the already-converted `byte[]`.

For a reset that carries a context the produced bytes are unchanged: every in-tree converter returns null for a null input, so the old `null ? new byte[0]` produced exactly what the short-circuit produces.

**One behaviour does change, on zero initialized segments.** Because the conversion moved ahead of `fetchSegments`, it now runs even when the per-segment lambda never would. A context-carrying reset on a processor whose tokens were never initialized used to succeed and invoke reset handlers; it now fails. Generalises to any `ConversionException` on an unserializable context with zero segments. Fail-fast is the better behaviour -- a reset that cannot serialize its context should not report success -- but it is a change, not a no-op.

Second effect: one `byte[]` instance is now shared by every segment's `ReplayToken`. Bytes are equal, so equality, storage and serialization are unaffected, but `ReplayToken.resetContext():352` hands out the internal array, so a caller mutating it perturbs every segment's token in that reset rather than one. Pre-existing leak, newly wider; no mutation site exists in the tree.
