### PR TITLE
[#4801] Keep the work package's stored token monotonic from the first store of a claim

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -139,6 +139,10 @@ class WorkPackage implements SegmentProgressContext {
         this.segmentStatusUpdater = builder.segmentStatusUpdater;
         this.clock = builder.clock;
         this.lastConsumedToken = builder.initialToken;
+        // The claimed token is by definition the last position the token store accepted for this segment, so it is the
+        // reference the monotonicity guard in storeIfAdvanced must start from. Leaving it null would skip the guard on
+        // the first store of every claim cycle.
+        this.lastStoredToken = builder.initialToken;
         this.nextClaimExtension = new AtomicLong(now() + claimExtensionThreshold);
         this.processingEvents = new AtomicBoolean(false);
         this.schedulingProcessingContextProvider = builder.schedulingProcessingContextProvider;

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.progress.S
 import org.axonframework.messaging.eventhandling.processing.streaming.progress.TokenStoringProgressStrategy;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.MergedTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
@@ -467,10 +468,52 @@ class WorkPackageTest {
         assertEquals(new GlobalSequenceTrackingToken(600L), fetchStoredToken());
     }
 
+    @Test
+    void persistProgressIgnoresATokenBehindTheClaimedTokenOnTheFirstStoreOfAClaim() {
+        // given: a segment whose durable progress sits at position 5, freshly claimed by a new work package
+        TrackingToken claimedToken = new GlobalSequenceTrackingToken(5L);
+        persistProgressInUnitOfWork(claimedToken);
+        assertEquals(claimedToken, fetchStoredToken());
+        WorkPackage freshlyClaimed = testSubjectBuilder.initialToken(claimedToken).build();
+        clearInvocations(tokenStore);
+
+        // when: the very first progress offered after the claim is behind the claimed position
+        persistProgressInUnitOfWork(freshlyClaimed, new GlobalSequenceTrackingToken(3L));
+
+        // then: it is ignored, so the claimed progress survives the first store of the claim cycle
+        verify(tokenStore, never()).storeToken(
+                eq(new GlobalSequenceTrackingToken(3L)), eq(PROCESSOR_NAME), eq(segment.getSegmentId()),
+                any(ProcessingContext.class)
+        );
+        assertEquals(claimedToken, fetchStoredToken());
+    }
+
+    @Test
+    void persistProgressStoresTheFirstAdvanceOfAClaimThatHasNotConsumedAnythingYet() {
+        // given: a segment claimed right after a reset, so the claimed token describes no consumed position yet. The
+        // raw token type is the one a JPA-backed event store hands out; its covers(..) rejects a null argument.
+        TrackingToken tokenAtReset = GapAwareTrackingToken.newInstance(5L, Collections.emptyList());
+        TrackingToken claimedToken = ReplayToken.createReplayToken(tokenAtReset);
+        WorkPackage freshlyClaimed = testSubjectBuilder.initialToken(claimedToken).build();
+
+        // when: the first progress offered after the claim advances into the replay
+        TrackingToken advanced = ReplayToken.createReplayToken(
+                tokenAtReset, GapAwareTrackingToken.newInstance(1L, Collections.emptyList())
+        );
+        persistProgressInUnitOfWork(freshlyClaimed, advanced);
+
+        // then: the advance is stored; the monotonicity guard has no position to compare against, so it stays inert
+        assertEquals(advanced, fetchStoredToken());
+    }
+
     private void persistProgressInUnitOfWork(TrackingToken candidate) {
+        persistProgressInUnitOfWork(testSubject, candidate);
+    }
+
+    private void persistProgressInUnitOfWork(WorkPackage workPackage, TrackingToken candidate) {
         FutureUtils.joinAndUnwrap(
                 UnitOfWorkTestUtils.SIMPLE_FACTORY.create()
-                                                  .executeWithResult(ctx -> testSubject.persistProgress(candidate, ctx))
+                                                  .executeWithResult(ctx -> workPackage.persistProgress(candidate, ctx))
         );
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtilsTest.java
@@ -211,5 +211,17 @@ class TrackingTokenUtilsTest {
             // when / then -- there is no progress to regress from, so the candidate advances beyond it
             assertThat(TrackingTokenUtils.coversWhenUnwrapped(token(3), freshReset)).isTrue();
         }
+
+        @Test
+        void reportsAdvanceWhenTheReferenceHasNoPositionYetForARawTypeRejectingNull() {
+            // given -- a reset that has not consumed anything yet unwraps to no raw position at all. The raw token type
+            // used here rejects a null argument to covers(..), so the comparison must not reach it.
+            TrackingToken freshReset =
+                    ReplayToken.createReplayToken(GapAwareTrackingToken.newInstance(5L, emptyList()));
+
+            // when / then -- there is no position to regress from, so the candidate covers it
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(GapAwareTrackingToken.newInstance(1L, emptyList()),
+                                                              freshReset)).isTrue();
+        }
     }
 }


### PR DESCRIPTION
Fixes #4801

## What changed

`lastStoredToken` had no initialiser while `lastDeliveredToken` and `lastConsumedToken` were both seeded from `builder.initialToken`. The monotonicity guard is written `lastStoredToken != null && ...`, so it was skipped on the first store of every claim cycle, per segment. A progress strategy offering a low position at that moment durably rewound the segment with no warning, and the whole segment was redelivered on the next claim.

The claimed token is by definition the last position the token store accepted for that segment, so it is the reference the guard must start from.

```java
this.lastStoredToken = builder.initialToken;
```

## Why this is now a one-line fix

The original version of this PR also made `coversWhenUnwrapped` null-tolerant, because a seeded token can unwrap to no raw position at all (the default initial token is a `ReplayToken` with a null current token) and the helper dereferenced that null. #4881 has since landed on `main` and did that in a stronger form -- it guards both ends of a range, not just the upper bound. That half is dropped here.

What remains is the seed, plus one test that pins the null-tolerance for a token type the existing tests never paired with a pooled processor.

## Tests

Full `messaging` suite: 4330 tests, 0 failures.

The seed is load-bearing: removing it fails exactly one test, `persistProgressIgnoresATokenBehindTheClaimedTokenOnTheFirstStoreOfAClaim`.

`WorkPackageTest` gains two cases:
- the first store after a claim is behind the claimed position, so it must be ignored
- a segment claimed right after a reset, where the claimed token describes no consumed position yet, so the first advance must still store

`TrackingTokenUtilsTest` gains one case using `GapAwareTrackingToken`, the token type a JPA-backed event store hands out and the only one whose `covers(null)` throws. Every other test around the default replay initial token uses `GlobalSequenceTrackingToken`, which tolerates it, so nothing in the tree exercised that path.

## For the reviewer

The guard in `storeIfAdvanced` and the idle-upkeep gate are otherwise unchanged; they simply now have a non-null reference on the first store after a claim.

A second intended effect: the idle gate `Objects.equals(lastConsumedToken, lastStoredToken)` never held on a freshly claimed idle segment, contradicting its own Javadoc that an idle segment never drives a strategy with an unchanged position. Seeding makes it hold, so a freshly claimed idle segment stops invoking `onBatchCommit` until something is consumed. No strategy can be starved: `hasPendingWork()` routes an idle segment through a commit cycle before the upkeep gate. Claim extension is unaffected.
