### PR TITLE
[#4808] Document that merging segments redelivers events

### DIFF
--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -918,6 +918,22 @@ To change the number of segments at runtime, the _split and merge_ operations sh
 Splitting and merging allow you to control the number of segments dynamically.
 There are roughly three approaches to do this.
 
+[WARNING]
+.A merge redelivers events
+====
+A split is free of redelivery: both halves start from the position their parent had reached.
+A merge is not.
+The two segments being merged are rarely at the same position, and the surviving segment resumes from the *lower* of the two.
+Resuming from the higher position would skip the events the further-behind segment never reached, losing them, so the framework deliberately resumes from the lower one.
+The events between the two positions that belong to the further-ahead segment are therefore handled a second time.
+
+This holds no matter which of the three approaches below performs the merge, and no matter how the `TokenStore` is deployed.
+It happens on a healthy cluster that never lost a token claim and never crashed.
+Redelivery ends once the further-behind half catches up, at which point the two positions collapse into one.
+
+Make your event handlers idempotent before you merge segments, for the same reasons and by the same means as described under <<token_stealing,token stealing>>.
+====
+
 ==== Axoniq Platform
 
 Through xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform]'s processor detail page, where you can scale the segments manually, or configure your segments to scale automatically with the number of your application's replicas.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/StreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/StreamingEventProcessor.java
@@ -126,6 +126,13 @@ public interface StreamingEventProcessor extends EventProcessor {
      * <p>
      * The processor must currently be actively processing the segment with given {@code segmentId}.
      * <p>
+     * <b>A merge redelivers events.</b> The two halves rarely sit at the same position, and the merged segment resumes
+     * from the <em>lower</em> of the two positions, because resuming from the higher one would skip the events the
+     * further-behind half never reached. Every event between the two positions that belongs to the further-ahead half
+     * is therefore handled a second time. Handlers must be idempotent across a merge, regardless of how the
+     * {@link TokenStore} is deployed and even on a cluster that never lost a claim and never crashed. Redelivery stops
+     * once the further-behind half catches up, at which point the two positions collapse into one.
+     * <p>
      * Use {@link #releaseSegment(int)} to force this processor to release any claims with tokens required to merge the
      * segments.
      * <p>

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/MergeTask.java
@@ -107,6 +107,11 @@ class MergeTask extends CoordinatorTask {
      * Performs a {@link Segment} merge. Will succeed if either the given {@code workPackages} contain the
      * {@link WorkPackage}s corresponding to the given {@code segmentId} and the identifier to merge with. Or, if the
      * {@link TrackingToken}(s) for the segments can be claimed.
+     * <p>
+     * The surviving segment is given a {@link MergedTrackingToken} over both halves' tokens, whose position is the
+     * <em>lower</em> of the two. Taking the higher position would skip the events the further-behind half never
+     * reached, so instead the events the further-ahead half already handled are redelivered until the further-behind
+     * half catches up. Handlers must be idempotent across a merge.
      */
     @Override
     protected CompletableFuture<Boolean> task() {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/MergedTrackingToken.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/MergedTrackingToken.java
@@ -31,6 +31,14 @@ import java.util.OptionalLong;
  * Special Wrapped Token implementation that keeps track of two separate tokens, of which the streams have been merged
  * into a single one. This token keeps track of the progress of the two original "halves", by advancing each
  * individually, until both halves represent the same position.
+ * <p>
+ * Because the halves are rarely at the same position when they are merged, {@link #position()} reports the
+ * <em>lower</em> of the two. The merged segment consequently resumes behind the further-ahead half, and
+ * {@link #covers(TrackingToken)} reports {@code false} for every position in between, so the events the further-ahead
+ * half already handled are handled a second time. This is deliberate: reporting the higher position would skip the
+ * events the further-behind half never reached, losing them. Handlers must therefore be idempotent across a merge.
+ * Once the further-behind half catches up, both halves hold the same position, the wrapper collapses into a single
+ * token, and the redelivery ends.
  *
  * @author Allard Buijze
  * @since 4.1


### PR DESCRIPTION
Fixes #4808

## What changed

Documentation only. 36 added lines across three Javadoc blocks and one AsciiDoc admonition, zero behaviour change.

A merge gives the surviving segment the lower of the two halves' positions, so every event the further-ahead half had already handled is delivered again. That is the right choice, since resuming from the further-ahead position would silently skip events the other half never reached. But `redeliver` appeared zero times in `MergedTrackingToken`, `MergeTask`, `StreamingEventProcessor` and the streaming reference guide.

The contract now says so at the public entry point (`StreamingEventProcessor.mergeSegment`), at the class that computes the lower position, at the task that performs the merge, and in the reference guide.

## For the reviewer

Every claim was re-verified against the code on `main`: `MergedTrackingToken.position()` returns `Math.min` of the two halves, and `covers()` requires both halves to cover, so it is false for every position in between.

The AsciiDoc block also records the contrasting fact that a **split does not** redeliver: `SplitTask` initialises both halves from the one fetched parent token. It cross-references the existing `[[token_stealing]]` anchor for idempotency advice rather than repeating it.

No new test, deliberately: `MergedTrackingTokenTest.positionReportsLowestSegment` and `mergedTokenCoversOriginal` already pin both facts. `Merge*`, `Split*`, `Segment*` and `*TrackingToken*` tests are green, as is the full `messaging` module.
