### PR TITLE
[#4802] Adopt a concurrently created config token instead of failing to start

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStore.java
@@ -39,6 +39,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Savepoint;
 import java.time.temporal.TemporalAmount;
 import java.util.Collections;
 import java.util.List;
@@ -158,6 +159,14 @@ public class JdbcTokenStore implements TokenStore {
         });
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The identifier lives in a row of the token table, created the first time any process asks for it. When several
+     * processes ask at the same instant, they all try to create that row and only one of them can; the others adopt the
+     * identifier the winner stored instead of failing, so that starting several processors together against a fresh
+     * token table brings all of them up.
+     */
     @Override
     public CompletableFuture<String> retrieveStorageIdentifier(@Nullable ProcessingContext context) {
         return connectionExecutor(context).apply(connection -> {
@@ -182,6 +191,7 @@ public class JdbcTokenStore implements TokenStore {
     }
 
     private ConfigToken initializeConfigToken(Connection connection) {
+        Savepoint beforeInsert = savepointOrNull(connection);
         try {
             return (ConfigToken) insertTokenEntry(connection,
                                                   new ConfigToken(Collections.singletonMap("id",
@@ -190,9 +200,48 @@ public class JdbcTokenStore implements TokenStore {
                                                   CONFIG_TOKEN_ID,
                                                   CONFIG_SEGMENT);
         } catch (SQLException e) {
+            ConfigToken concurrentlyInitialized = readConfigTokenAfterFailedInsert(connection, beforeInsert);
+            if (concurrentlyInitialized != null) {
+                return concurrentlyInitialized;
+            }
             throw new UnableToRetrieveIdentifierException(
-                    "Exception while attempting to initialize the config token. It may have been concurrently initialized.",
+                    "Exception while attempting to initialize the config token.",
                     e);
+        }
+    }
+
+    /**
+     * Marks the connection so a failed config-token insert can be undone without losing the surrounding transaction.
+     * <p>
+     * Returns {@code null} when the connection auto-commits, in which case a failed insert does not affect any other
+     * statement, and when the driver does not support savepoints.
+     */
+    @Nullable
+    private Savepoint savepointOrNull(Connection connection) {
+        try {
+            return connection.getAutoCommit() ? null : connection.setSavepoint();
+        } catch (SQLException e) {
+            logger.debug("Could not set a savepoint before initializing the config token.", e);
+            return null;
+        }
+    }
+
+    /**
+     * Reads the config token another process inserted first, returning {@code null} when there is none to read.
+     * <p>
+     * Rolls the connection back to {@code beforeInsert} first, because databases that abort the entire transaction on a
+     * constraint violation would otherwise refuse the read.
+     */
+    @Nullable
+    private ConfigToken readConfigTokenAfterFailedInsert(Connection connection, @Nullable Savepoint beforeInsert) {
+        try {
+            if (beforeInsert != null) {
+                connection.rollback(beforeInsert);
+            }
+            return retrieveConfigToken(connection);
+        } catch (SQLException | UnableToRetrieveIdentifierException e) {
+            logger.debug("Could not re-read the config token after the insert failed.", e);
+            return null;
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
@@ -49,8 +49,13 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -592,6 +597,44 @@ class JdbcTokenStoreTest {
             TrackingToken actual = joinAndUnwrap(tokenStore.fetchToken("multi", 0, null));
             assertEquals(new GlobalSequenceTrackingToken(1), actual);
         });
+    }
+
+    @Nested
+    class ConcurrentIdentifierInitialization {
+
+        @Test
+        void everyProcessResolvesTheSameIdentifierWhenTheyAskTogether() throws Exception {
+            // given four processes about to ask an empty token table for its identifier at the same instant
+            int processCount = 4;
+            CyclicBarrier release = new CyclicBarrier(processCount);
+            CountDownLatch done = new CountDownLatch(processCount);
+            List<String> identifiers = Collections.synchronizedList(new ArrayList<>());
+            List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+            for (int process = 0; process < processCount; process++) {
+                Thread thread = new Thread(() -> {
+                    try {
+                        release.await(30, TimeUnit.SECONDS);
+                        identifiers.add(transactionManager.fetchInTransaction(
+                                () -> joinAndUnwrap(tokenStore.retrieveStorageIdentifier(createProcessingContext()))
+                        ));
+                    } catch (Throwable failure) {
+                        failures.add(failure);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                thread.setDaemon(true);
+                thread.start();
+            }
+
+            // when they have all been released and have all answered
+            assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+
+            // then none of them failed, and they agree on the single identifier the table now holds
+            assertThat(failures).isEmpty();
+            assertThat(identifiers).hasSize(processCount);
+            assertThat(Set.copyOf(identifiers)).hasSize(1);
+        }
     }
 
     private ProcessingContext createProcessingContext() {


### PR DESCRIPTION
Fixes #4802

## What changed

`initializeConfigToken` rethrew the insert's primary-key violation as `UnableToRetrieveIdentifierException` without re-reading the row the winning instance had just committed. Several instances starting at once against a fresh token table therefore left all but one unable to start. Measured at three failures in four.

The insert is now wrapped in a JDBC savepoint. On failure it rolls back to the savepoint, re-reads the config token, and adopts the winner's identifier, rethrowing with the original cause only when there is genuinely no row. The savepoint is what makes the re-read legal on databases such as PostgreSQL that abort the whole transaction on a constraint violation.

## Tests

New: `JdbcTokenStoreTest.ConcurrentIdentifierInitialization`, a four-thread barrier race. Green on 5 consecutive runs; with `JdbcTokenStore.java` reverted it fails 3 of 3, 3 of 4 threads throwing `UnableToRetrieveIdentifierException` -- the three-in-four rate reported on the issue.

Full `messaging` module: green. No existing test needed changing.

## The fix only works at READ COMMITTED

Measured across four HSQLDB configurations, same 4-thread race:

| tx mode | isolation | succeeded | failed |
|---|---|---|---|
| mvcc | READ_COMMITTED | 4 | 0 |
| locks | READ_COMMITTED | 4 | 0 |
| mvcc | SERIALIZABLE | 1 | 3 |
| locks | SERIALIZABLE | 1 | 3 |

At SERIALIZABLE the cause is `SQLTransactionRollbackException: transaction rollback: serialization failure` -- the whole transaction is dead before the savepoint rollback runs, so the re-read never happens and 3 of 4 processors still fail to start. The same reasoning applies to PostgreSQL REPEATABLE READ and SERIALIZABLE, and to **MySQL and MariaDB, whose default is REPEATABLE READ**: a consistent read pins the snapshot at the first read, so a plain non-`FOR UPDATE` re-read cannot see the winner.

Not a regression, and not a correctness hazard -- a `40001` serialization failure is exactly what a caller retries as a whole transaction. But it is a real limit on where this helps.

## For the reviewer

The savepoint is deliberately optional: `savepointOrNull` returns null when the connection auto-commits, where a failed statement poisons nothing, and when the driver rejects `setSavepoint`. The re-read is still attempted, so both degrade to today's behaviour rather than breaking. The savepoint is never explicitly released, because `releaseSavepoint` is unsupported on some drivers.

The original `SQLException` is preserved as the cause and surfaces only when the re-read finds no row, so a genuine schema or connectivity fault still fails loudly instead of being swallowed as a lost race.

Two gaps worth naming. The savepoint half of the diff has **no test**: HSQLDB does not abort the transaction on a PK violation, so the adopt path works even with `setSavepoint` throwing, leaving the property claimed for the savepoint unverified here. And the test asserts no **landing evidence** -- if the barrier ever serialised so all four threads found the row on the first read, it would pass without exercising the catch block.

**Not covered here:** `JpaTokenStore.getConfig` has the same race. After a failed `em.flush()` the persistence context is rollback-only, so recovering there needs a fresh transaction rather than a re-read. Called out in #4802 as deserving its own issue rather than widened into this one.
