### PR TITLE
Add `FutureUtils#allOrEmpty`

### DIFF
--- a/common/src/main/java/org/axonframework/common/FutureUtils.java
+++ b/common/src/main/java/org/axonframework/common/FutureUtils.java
@@ -19,6 +19,7 @@ package org.axonframework.common;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -71,6 +72,29 @@ public final class FutureUtils {
      */
     public static <T> CompletableFuture<T> emptyCompletedFuture() {
         return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Combines the given {@code futures} into a single {@link CompletableFuture} that completes once all of them
+     * complete, returning an already completed future when {@code futures} is empty.
+     * <p>
+     * This is a drop-in alternative to {@link CompletableFuture#allOf(CompletableFuture[])} for code paths that
+     * routinely deal with empty collections, such as fan-out over a dynamic set of handlers, subscribers, or segments.
+     * It avoids allocating an array and a dependent future for a combination that has nothing to wait for.
+     * <p>
+     * The returned future completes exceptionally with a {@link CompletionException} as soon as any of the given
+     * {@code futures} completes exceptionally, matching the behavior of
+     * {@link CompletableFuture#allOf(CompletableFuture[])}.
+     *
+     * @param futures the futures to combine
+     * @return a future that completes once every future in {@code futures} completes, or a completed future if
+     * {@code futures} is empty
+     * @since 5.3.0
+     */
+    public static CompletableFuture<Void> allOrEmpty(List<CompletableFuture<Void>> futures) {
+        return futures.isEmpty()
+                ? emptyCompletedFuture()
+                : CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
     /**

--- a/common/src/test/java/org/axonframework/common/FutureUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/FutureUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -123,6 +124,68 @@ class FutureUtilsTest {
 
             // then
             assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    class AllOrEmpty {
+
+        @Test
+        void emptyListResultsInCompletedFuture() {
+            // given
+            List<CompletableFuture<Void>> futures = List.of();
+
+            // when
+            CompletableFuture<Void> result = FutureUtils.allOrEmpty(futures);
+
+            // then
+            assertThat(result).isCompletedWithValue(null);
+        }
+
+        @Test
+        void completesOnlyAfterEveryFutureCompleted() {
+            // given
+            CompletableFuture<Void> first = new CompletableFuture<>();
+            CompletableFuture<Void> second = new CompletableFuture<>();
+
+            // when
+            CompletableFuture<Void> result = FutureUtils.allOrEmpty(List.of(first, second));
+
+            // then
+            assertThat(result).isNotDone();
+            first.complete(null);
+            assertThat(result).isNotDone();
+            second.complete(null);
+            assertThat(result).isCompletedWithValue(null);
+        }
+
+        @Test
+        void completedFuturesResultInCompletedFuture() {
+            // given
+            List<CompletableFuture<Void>> futures = List.of(FutureUtils.emptyCompletedFuture(),
+                                                           FutureUtils.emptyCompletedFuture());
+
+            // when
+            CompletableFuture<Void> result = FutureUtils.allOrEmpty(futures);
+
+            // then
+            assertThat(result).isCompletedWithValue(null);
+        }
+
+        @Test
+        void failingFutureResultsInExceptionallyCompletedFuture() {
+            // given
+            IllegalStateException expected = new IllegalStateException("first failed");
+            CompletableFuture<Void> failing = CompletableFuture.failedFuture(expected);
+            CompletableFuture<Void> succeeding = FutureUtils.emptyCompletedFuture();
+
+            // when
+            CompletableFuture<Void> result = FutureUtils.allOrEmpty(List.of(failing, succeeding));
+
+            // then
+            assertThat(result).isCompletedExceptionally();
+            assertThatThrownBy(() -> FutureUtils.joinAndUnwrap(result, Duration.ofSeconds(1)))
+                    .isSameAs(expected);
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
@@ -170,7 +170,7 @@ public class SimpleEventBus implements EventBus {
             futures.add(processor.apply(newMessages, context));
         }
 
-        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+        return FutureUtils.allOrEmpty(futures);
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessor.java
@@ -394,11 +394,11 @@ public class PooledStreamingEventProcessor implements StreamingEventProcessor {
                                                 processingContext
                                         ))
                                         .toList();
-        return CompletableFuture.allOf(storeFutures.toArray(CompletableFuture[]::new))
-                                .thenRun(() -> logger.info(
-                                        "Processor [{}] successfully reset tokens for segments [{}].",
-                                        name, segments
-                                ));
+        return FutureUtils.allOrEmpty(storeFutures)
+                          .thenRun(() -> logger.info(
+                                  "Processor [{}] successfully reset tokens for segments [{}].",
+                                  name, segments
+                          ));
     }
 
     private record SegmentToken(Segment segment, @Nullable TrackingToken token) {


### PR DESCRIPTION
This PR adds a small utility for combining a dynamically sized, possibly empty list of futures:

```java
public static CompletableFuture<Void> allOrEmpty(List<CompletableFuture<Void>> futures) {
    return futures.isEmpty()
            ? emptyCompletedFuture()
            : CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
}
```

`CompletableFuture#allOf` on an empty collection still allocates an array and a dependent future to wait for nothing, so
fan-out code paths end up duplicating the `isEmpty()` guard - or omitting it. Second commit migrates the two existing
call sites that did the latter: `SimpleEventBus#processEventsInPhase` (no subscribers) and
`PooledStreamingEventProcessor#storeReplayTokens` (no segments). Non-empty behaviour is unchanged, since it still
delegates to `allOf`.

Originates from https://github.com/AxonIQ/axoniq-framework/pull/281#discussion_r3656074139, where the same helper was
added privately for per-tenant fan-out.

Covered by a new nested `AllOrEmpty` class in `FutureUtilsTest` (empty, pending, completed, and failing inputs).
`FutureUtilsTest` and the two migrated classes' suites pass; `checkstyle:check` clean on `common` and `messaging`.

## Follow-up

`PooledStreamingEventProcessor#fetchSegmentsWithTokens` combines a possibly empty list too, but its futures carry a
result (`CompletableFuture<SegmentToken>`), so it needs a separate, result-preserving sibling rather than this method:

```java
public static <T> CompletableFuture<List<T>> allResults(List<CompletableFuture<T>> futures)
```

Keeping the two apart preserves what the `Void` signature asserts - that collapsing these futures discards nothing - and
lets `PooledStreamingEventProcessor#fetchSegmentsWithTokens` drop its hand-rolled
`allOf(...).thenApply(stream.map(join).toList())` idiom, including the per-element `join()` calls. Note the two cannot be
overloads, since they share the erasure `(List)`.
