### PR TITLE
[#4797] Fall back to the event identifier when a sequencing policy resolves nothing

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponent.java
@@ -23,6 +23,7 @@ import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.sequencing.HierarchicalSequencingPolicy;
+import org.axonframework.messaging.core.sequencing.NoOpSequencingPolicy;
 import org.axonframework.messaging.core.sequencing.SequencingPolicy;
 import org.axonframework.messaging.core.sequencing.SequentialPerAggregatePolicy;
 import org.axonframework.messaging.core.sequencing.SequentialPolicy;
@@ -34,12 +35,17 @@ import org.axonframework.messaging.eventhandling.replay.ReplayStatusChangedHandl
 import org.axonframework.messaging.eventhandling.replay.ResetContext;
 import org.axonframework.messaging.eventhandling.replay.ResetHandler;
 import org.axonframework.messaging.eventhandling.replay.ResetHandlerRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Simple implementation of the {@link EventHandlingComponent}, {@link EventHandlerRegistry}, and
@@ -58,6 +64,8 @@ public class SimpleEventHandlingComponent implements
         ResetHandlerRegistry<SimpleEventHandlingComponent>,
         ReplayStatusChangedHandlerRegistry<SimpleEventHandlingComponent> {
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static final SequencingPolicy<? super EventMessage> DEFAULT_SEQUENCING_POLICY = new HierarchicalSequencingPolicy<>(
             SequentialPerAggregatePolicy.INSTANCE,
             SequentialPolicy.INSTANCE
@@ -68,6 +76,7 @@ public class SimpleEventHandlingComponent implements
     private final SequencingPolicy<? super EventMessage> sequencingPolicy;
     private final Set<ResetHandler> resetHandlers = ConcurrentHashMap.newKeySet();
     private final Set<ReplayStatusChangedHandler> replayStatusChangedHandlers = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean loggedSequencingFallback = new AtomicBoolean();
 
     /**
      * Instantiates a simple {@link EventHandlingComponent} that is able to handle events and delegate them to
@@ -161,19 +170,24 @@ public class SimpleEventHandlingComponent implements
      *         safest default option.</li>
      * </ul>
      * <p>
+     * Whenever the configured {@link SequencingPolicy} cannot determine a sequence identifier, the
+     * {@link EventMessage#identifier() event's identifier} is used instead, so the events carry no sequencing
+     * requirements relative to one another. For a {@link NoOpSequencingPolicy} that is the configured intent. For any
+     * other policy it is a downgrade from the sequencing that was asked for, so the first such fallback is logged at
+     * warn level, once per component.
+     * <p>
      * Override this method to provide custom sequencing behavior. Or use a
      * {@link SequenceOverridingEventHandlingComponent} if you cannot inherit from a certain
      * {@code EventHandlingComponent} implementation.
      * <p>
      */
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Override
     public Object sequenceIdentifierFor(EventMessage event, ProcessingContext context) {
         var qualifiedName = event.type().qualifiedName();
         List<EventHandler> handlers = eventHandlers.get(qualifiedName);
 
         if (handlers == null || handlers.isEmpty()) {
-            return sequencingPolicy.sequenceIdentifierFor(event, context).get();
+            return policySequenceIdentifierFor(event, context);
         }
 
         return handlers.stream()
@@ -181,7 +195,21 @@ public class SimpleEventHandlingComponent implements
                        .map(EventHandlingComponent.class::cast)
                        .findFirst()
                        .map(component -> component.sequenceIdentifierFor(event, context))
-                       .orElse(sequencingPolicy.sequenceIdentifierFor(event, context).get());
+                       .orElseGet(() -> policySequenceIdentifierFor(event, context));
+    }
+
+    private Object policySequenceIdentifierFor(EventMessage event, ProcessingContext context) {
+        Optional<Object> sequenceIdentifier = sequencingPolicy.sequenceIdentifierFor(event, context);
+        if (sequenceIdentifier.isEmpty()
+                && !(sequencingPolicy instanceof NoOpSequencingPolicy)
+                && loggedSequencingFallback.compareAndSet(false, true)) {
+            logger.warn("Sequencing policy [{}] of event handling component [{}] resolved no sequence identifier. "
+                                + "Falling back to the event identifier, so these events are handled concurrently "
+                                + "instead of in sequence. Logged once per component.",
+                        sequencingPolicy.getClass().getName(),
+                        name);
+        }
+        return sequenceIdentifier.orElseGet(event::identifier);
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponentSequencingPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponentSequencingPolicyTest.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.jspecify.annotations.NonNull;
 import org.axonframework.conversion.Converter;
 import org.axonframework.conversion.PassThroughConverter;
 import org.axonframework.messaging.core.LegacyResources;
@@ -39,6 +38,7 @@ import org.axonframework.messaging.core.sequencing.SequentialPerAggregatePolicy;
 import org.axonframework.messaging.core.sequencing.SequentialPolicy;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.*;
 
 import java.util.Optional;
@@ -63,7 +63,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
     class DefaultSequencingPolicy {
 
         @Test
-        void should_use_default_hierarchical_sequencing_when_no_policy_specified() {
+        void shouldUseDefaultHierarchicalSequencingWhenNoPolicySpecified() {
             // given
             var component = SimpleEventHandlingComponent.create("test");
             var event = EventTestUtils.asEventMessage("test-event");
@@ -81,7 +81,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
     class ComponentLevelSequencingPolicy {
 
         @Test
-        void should_use_sequential_policy_when_set_on_component() {
+        void shouldUseSequentialPolicyWhenSetOnComponent() {
             // given
             var component = SimpleEventHandlingComponent.create("test", SequentialPolicy.INSTANCE);
             var event = EventTestUtils.asEventMessage("test-event");
@@ -95,7 +95,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_full_concurrency_policy_when_set_on_component() {
+        void shouldUseFullConcurrencyPolicyWhenSetOnComponent() {
             // given
             var component = SimpleEventHandlingComponent.create("test", FullConcurrencyPolicy.INSTANCE);
             var event = EventTestUtils.asEventMessage("test-event");
@@ -109,7 +109,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_metadata_sequencing_policy_when_set_on_component() {
+        void shouldUseMetadataSequencingPolicyWhenSetOnComponent() {
             // given
             var component = SimpleEventHandlingComponent.create("test", new MetadataSequencingPolicy("userId"));
             var metadata = Metadata.with("userId", "user123");
@@ -124,7 +124,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_metadata_sequencing_policy_fallback_to_event_identifier() {
+        void shouldUseMetadataSequencingPolicyFallbackToEventIdentifier() {
             // given
             var component = SimpleEventHandlingComponent.create(
                     "test",
@@ -144,7 +144,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_property_sequencing_policy_when_set_on_component() {
+        void shouldUsePropertySequencingPolicyWhenSetOnComponent() {
             // given
             var component = SimpleEventHandlingComponent.create(
                     "test",
@@ -162,7 +162,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_sequential_per_aggregate_policy_when_set_on_component() {
+        void shouldUseSequentialPerAggregatePolicyWhenSetOnComponent() {
             // given
             var component = SimpleEventHandlingComponent.create("test", SequentialPerAggregatePolicy.INSTANCE);
             var event = EventTestUtils.asEventMessage("test-event");
@@ -180,7 +180,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
     class NestedComponentOverridesPolicy {
 
         @Test
-        void should_use_nested_component_over_main_component_policy() {
+        void shouldUseNestedComponentOverMainComponentPolicy() {
             // given
             var mainComponent = SimpleEventHandlingComponent.create("test", FullConcurrencyPolicy.INSTANCE);
 
@@ -206,7 +206,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
     class MainComponentPolicyWhenNoNestedComponent {
 
         @Test
-        void should_use_main_component_policy_when_no_nested_component() {
+        void shouldUseMainComponentPolicyWhenNoNestedComponent() {
             // given
             var mainComponent = SimpleEventHandlingComponent.create("main", SequentialPolicy.INSTANCE);
             var plainEventHandler = new PlainEventHandler();
@@ -224,7 +224,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_use_main_component_policy_when_mixed_handlers() {
+        void shouldUseMainComponentPolicyWhenMixedHandlers() {
             // given
             var mainComponent = SimpleEventHandlingComponent.create(
                     "main", new PropertySequencingPolicy<>(OrderEvent.class, "orderId")
@@ -252,7 +252,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
     class PolicyCannotDetermineAnIdentifier {
 
         @Test
-        void should_fall_back_to_event_identifier_for_no_op_policy() {
+        void shouldFallBackToEventIdentifierForNoOpPolicy() {
             // given a policy that imposes no sequencing at all, so it never resolves an identifier
             var component = SimpleEventHandlingComponent.create("test", NoOpSequencingPolicy.INSTANCE);
             var event = EventTestUtils.asEventMessage("test-event");
@@ -266,7 +266,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_fall_back_to_event_identifier_when_no_aggregate_identifier_is_present() {
+        void shouldFallBackToEventIdentifierWhenNoAggregateIdentifierIsPresent() {
             // given a per-aggregate policy on a store that populates no aggregate identifier resource
             var component = SimpleEventHandlingComponent.create("test", SequentialPerAggregatePolicy.INSTANCE);
             var event = EventTestUtils.asEventMessage("test-event");
@@ -280,7 +280,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_fall_back_to_event_identifier_when_only_plain_handlers_are_subscribed() {
+        void shouldFallBackToEventIdentifierWhenOnlyPlainHandlersAreSubscribed() {
             // given the shape of an annotated projection: plain handlers, no nested component, no sequencing
             var component = SimpleEventHandlingComponent.create("test", NoOpSequencingPolicy.INSTANCE);
             component.subscribe(new QualifiedName("java.lang", "String"), new PlainEventHandler());
@@ -295,7 +295,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_not_consult_the_component_policy_when_a_nested_component_resolved_an_identifier() {
+        void shouldNotConsultTheComponentPolicyWhenANestedComponentResolvedAnIdentifier() {
             // given a main component whose own policy never resolves an identifier
             var mainComponent = SimpleEventHandlingComponent.create("main", NoOpSequencingPolicy.INSTANCE);
             mainComponent.subscribe(
@@ -341,7 +341,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_warn_once_naming_the_policy_however_many_events_fall_back() {
+        void shouldWarnOnceNamingThePolicyHoweverManyEventsFallBack() {
             // given a per-aggregate policy on a store that populates no aggregate identifier resource, so the
             // per-aggregate ordering that was asked for is silently not delivered
             var component = SimpleEventHandlingComponent.create("projection", SequentialPerAggregatePolicy.INSTANCE);
@@ -363,7 +363,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_not_warn_for_the_no_op_sequencing_policy() {
+        void shouldNotWarnForTheNoOpSequencingPolicy() {
             // given a policy whose empty result is the configured intent rather than a downgrade
             var component = SimpleEventHandlingComponent.create("projection", NoOpSequencingPolicy.INSTANCE);
             component.subscribe(new QualifiedName("java.lang", "String"), new PlainEventHandler());
@@ -379,7 +379,7 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
 
         @Test
-        void should_not_warn_for_the_default_sequencing_policy() {
+        void shouldNotWarnForTheDefaultSequencingPolicy() {
             // given the default hierarchical policy, which always resolves an identifier
             var component = SimpleEventHandlingComponent.create("test");
             var aggregateEvent = EventTestUtils.asEventMessage("test-event");

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponentSequencingPolicyTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponentSequencingPolicyTest.java
@@ -16,6 +16,11 @@
 
 package org.axonframework.messaging.eventhandling;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.jspecify.annotations.NonNull;
 import org.axonframework.conversion.Converter;
 import org.axonframework.conversion.PassThroughConverter;
@@ -28,6 +33,7 @@ import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.sequencing.FullConcurrencyPolicy;
 import org.axonframework.messaging.core.sequencing.HierarchicalSequencingPolicy;
 import org.axonframework.messaging.core.sequencing.MetadataSequencingPolicy;
+import org.axonframework.messaging.core.sequencing.NoOpSequencingPolicy;
 import org.axonframework.messaging.core.sequencing.PropertySequencingPolicy;
 import org.axonframework.messaging.core.sequencing.SequentialPerAggregatePolicy;
 import org.axonframework.messaging.core.sequencing.SequentialPolicy;
@@ -242,6 +248,152 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
         }
     }
 
+    @Nested
+    class PolicyCannotDetermineAnIdentifier {
+
+        @Test
+        void should_fall_back_to_event_identifier_for_no_op_policy() {
+            // given a policy that imposes no sequencing at all, so it never resolves an identifier
+            var component = SimpleEventHandlingComponent.create("test", NoOpSequencingPolicy.INSTANCE);
+            var event = EventTestUtils.asEventMessage("test-event");
+            var context = messageProcessingContext(event);
+
+            // when
+            var sequenceIdentifier = component.sequenceIdentifierFor(event, context);
+
+            // then every event gets its own identifier, imposing no sequencing between events
+            assertThat(sequenceIdentifier).isEqualTo(event.identifier());
+        }
+
+        @Test
+        void should_fall_back_to_event_identifier_when_no_aggregate_identifier_is_present() {
+            // given a per-aggregate policy on a store that populates no aggregate identifier resource
+            var component = SimpleEventHandlingComponent.create("test", SequentialPerAggregatePolicy.INSTANCE);
+            var event = EventTestUtils.asEventMessage("test-event");
+            var context = contextWithoutAggregateIdentifier(event);
+
+            // when
+            var sequenceIdentifier = component.sequenceIdentifierFor(event, context);
+
+            // then
+            assertThat(sequenceIdentifier).isEqualTo(event.identifier());
+        }
+
+        @Test
+        void should_fall_back_to_event_identifier_when_only_plain_handlers_are_subscribed() {
+            // given the shape of an annotated projection: plain handlers, no nested component, no sequencing
+            var component = SimpleEventHandlingComponent.create("test", NoOpSequencingPolicy.INSTANCE);
+            component.subscribe(new QualifiedName("java.lang", "String"), new PlainEventHandler());
+            var event = EventTestUtils.asEventMessage("test-event");
+            var context = messageProcessingContext(event);
+
+            // when
+            var sequenceIdentifier = component.sequenceIdentifierFor(event, context);
+
+            // then
+            assertThat(sequenceIdentifier).isEqualTo(event.identifier());
+        }
+
+        @Test
+        void should_not_consult_the_component_policy_when_a_nested_component_resolved_an_identifier() {
+            // given a main component whose own policy never resolves an identifier
+            var mainComponent = SimpleEventHandlingComponent.create("main", NoOpSequencingPolicy.INSTANCE);
+            mainComponent.subscribe(
+                    new QualifiedName("java.lang", "String"),
+                    SimpleEventHandlingComponent.create("nested", SequentialPolicy.INSTANCE)
+                                                .subscribe(new QualifiedName("java.lang", "String"),
+                                                           new PlainEventHandler())
+            );
+            var event = EventTestUtils.asEventMessage("test-event");
+            var context = messageProcessingContext(event);
+
+            // when
+            var sequenceIdentifier = mainComponent.sequenceIdentifierFor(event, context);
+
+            // then the nested component's answer is used, and the component policy is never resolved
+            assertThat(sequenceIdentifier).isEqualTo(FULL_SEQUENTIAL_POLICY);
+        }
+    }
+
+    @Nested
+    class FallbackToEventIdentifierIsLogged {
+
+        private ListAppender appender;
+        private Logger componentLogger;
+        private boolean previousAdditive;
+
+        @BeforeEach
+        void attachAppender() {
+            appender = new ListAppender("SequencingFallbackTestAppender");
+            appender.start();
+
+            componentLogger = (Logger) LogManager.getLogger(SimpleEventHandlingComponent.class);
+            previousAdditive = componentLogger.isAdditive();
+            componentLogger.setAdditive(false);
+            componentLogger.addAppender(appender);
+        }
+
+        @AfterEach
+        void detachAppender() {
+            componentLogger.removeAppender(appender);
+            componentLogger.setAdditive(previousAdditive);
+            appender.stop();
+        }
+
+        @Test
+        void should_warn_once_naming_the_policy_however_many_events_fall_back() {
+            // given a per-aggregate policy on a store that populates no aggregate identifier resource, so the
+            // per-aggregate ordering that was asked for is silently not delivered
+            var component = SimpleEventHandlingComponent.create("projection", SequentialPerAggregatePolicy.INSTANCE);
+            component.subscribe(new QualifiedName("java.lang", "String"), new PlainEventHandler());
+
+            // when five events in a row fall back
+            for (int i = 0; i < 5; i++) {
+                var event = EventTestUtils.asEventMessage("test-event");
+                component.sequenceIdentifierFor(event, contextWithoutAggregateIdentifier(event));
+            }
+
+            // then a single warning names both the policy and the component, rather than one per event
+            assertThat(appender.getEvents()).hasSize(1);
+            LogEvent warning = appender.getEvents().getFirst();
+            assertThat(warning.getLevel()).isEqualTo(Level.WARN);
+            assertThat(warning.getMessage().getFormattedMessage())
+                    .contains(SequentialPerAggregatePolicy.class.getName())
+                    .contains("projection");
+        }
+
+        @Test
+        void should_not_warn_for_the_no_op_sequencing_policy() {
+            // given a policy whose empty result is the configured intent rather than a downgrade
+            var component = SimpleEventHandlingComponent.create("projection", NoOpSequencingPolicy.INSTANCE);
+            component.subscribe(new QualifiedName("java.lang", "String"), new PlainEventHandler());
+
+            // when five events in a row fall back to the event identifier
+            for (int i = 0; i < 5; i++) {
+                var event = EventTestUtils.asEventMessage("test-event");
+                component.sequenceIdentifierFor(event, messageProcessingContext(event));
+            }
+
+            // then nothing is logged, as asking for no sequencing and getting none is not a degradation
+            assertThat(appender.getEvents()).isEmpty();
+        }
+
+        @Test
+        void should_not_warn_for_the_default_sequencing_policy() {
+            // given the default hierarchical policy, which always resolves an identifier
+            var component = SimpleEventHandlingComponent.create("test");
+            var aggregateEvent = EventTestUtils.asEventMessage("test-event");
+            var plainEvent = EventTestUtils.asEventMessage("test-event");
+
+            // when asked both with and without an aggregate identifier in the context
+            component.sequenceIdentifierFor(aggregateEvent, messageProcessingContext(aggregateEvent));
+            component.sequenceIdentifierFor(plainEvent, contextWithoutAggregateIdentifier(plainEvent));
+
+            // then nothing is logged, as the secondary SequentialPolicy answers when the primary policy cannot
+            assertThat(appender.getEvents()).isEmpty();
+        }
+    }
+
     private static EventHandler createEventHandlerFromComponent(EventHandlingComponent component) {
         return component;
     }
@@ -265,5 +417,11 @@ class SimpleEventHandlingComponentSequencingPolicyTest {
                 .withResource(LegacyResources.AGGREGATE_TYPE_KEY, AGGREGATE_TYPE)
                 .withResource(LegacyResources.AGGREGATE_IDENTIFIER_KEY, AGGREGATE_IDENTIFIER)
                 .withResource(LegacyResources.AGGREGATE_SEQUENCE_NUMBER_KEY, 0L);
+    }
+
+    private static ProcessingContext contextWithoutAggregateIdentifier(EventMessage event) {
+        return StubProcessingContext
+                .withComponent(Converter.class, PassThroughConverter.INSTANCE)
+                .withMessage(event);
     }
 }


### PR DESCRIPTION
Fixes #4797

## What changed

`SequencingPolicy.sequenceIdentifierFor` documents an empty result as normal, but `SimpleEventHandlingComponent` unwrapped it with `Optional.get()`, under a `@SuppressWarnings("OptionalGetWithoutIsPresent")`. Both call sites now fall back to the event identifier.

Two shipped policies legitimately answer empty, so they threw `NoSuchElementException` on every event and the processor delivered nothing at all, for ever: `NoOpSequencingPolicy`, and `SequentialPerAggregatePolicy` on any store that does not set the legacy aggregate identifier.

The old behaviour was **not** silent: `DefaultWorkPackageEventFilter` catches, `PropagatingErrorHandler` rethrows, and `WorkPackage.canHandle:321` logs `"Error while detecting whether event can be handled in Work Package ... Aborting Work Package"` with the `Optional.get` stack trace, then aborts. The permanent stall is the defect; the silence is not.

## Why this fallback

`FullConcurrencyPolicy` already returns `Optional.of(message.identifier())`. A per-event identifier *is* how the framework encodes "no sequencing", so falling back to it makes an empty `Optional` mean the same thing as the policy that explicitly asks for no sequencing.

## A warning when the fallback fires

`SimpleEventHandlingComponent` now warns once per component, naming the policy class, when a policy resolves no identifier and the fallback is used. Without it, explicitly configuring `SequentialPerAggregatePolicy` on a DCB store goes from a loud abort to silently getting one sequence per event -- the user asked for per-aggregate ordering and gets none.

`NoOpSequencingPolicy` is exempt: an empty answer there is the user's deliberate declaration that they want no sequencing, and a warning that fires on correct configuration gets muted wholesale, burying the case it exists for. Recognising it by type follows `MessagingConfigurationDefaults:345`, which already does `!(commandSequencingPolicy instanceof NoOpSequencingPolicy)` for the same reason, and `NoOpSequencingPolicy`'s own Javadoc sanctions it: "Infrastructure components may decide upon this sequencing policy being present bypassing sequencing infrastructure at all."

The wired default never returns empty, so it never warns -- asserted by a test, not just reasoned.

## Tests

`PolicyCannotDetermineAnIdentifier` covers all three branches, including a plain-`EventHandler` component, the shape a real annotated projection takes. `FallbackToEventIdentifierIsLogged` covers the warning: fires once for `SequentialPerAggregatePolicy` with no aggregate identifier, silent for `NoOpSequencingPolicy`, silent for the wired default.

Against the true pre-fix production file: **6 errors**, all `NoSuchElementException: No value present`. The default-policy test correctly stays green in both directions, as a regression guard should.

One detail worth knowing if anyone tries to shrink the diff: the `orElse` to `orElseGet` change is load-bearing on its own. `Optional.orElse` evaluates its argument eagerly, so the old code threw even when a nested component had already answered.

Targeted run, no failures:

| Class | tests |
|---|---|
| `SimpleEventHandlingComponentSequencingPolicyTest` | 13 |
| `SimpleEventHandlingComponentTest` | 7 |
| `SegmentMatcherTest` | 3 |
| `SequentialPerAggregatePolicyTest` | 3 |

No existing test needed updating; nothing had encoded the old throwing behaviour.

## For the reviewer

The behaviour change worth a second opinion: per-event identifiers mean "no sequencing", so events under `NoOpSequencingPolicy` may now be handled concurrently and spread across segments, where before they were handled not at all. A total read-side stall is not a contract worth preserving, but the chosen default is a judgement call.

This does **not** fix the separate problem that `SequentialPerAggregatePolicy` resolves nothing on a DCB store. With this change it degrades quietly to per-event identifiers instead of throwing. That degradation is #4803.

## Merge note

`bug/4803/default-sequencing-policy-dcb-degradation-docs` touches the same two files in different regions. Both derive from the same base blobs off `origin/main`, so no conflict is expected, but merge one before rebasing the other.
