### PR TITLE
[#4814] Do not roll back an append transaction that already committed

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -208,10 +209,21 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
                     return eventStorageEngine.appendEvents(appendCondition, processingContext, eventQueue)
                                              .thenApply(DefaultEventStoreTransaction::castTransaction)
                                              .thenAccept(tx -> {
+                                                 AtomicBoolean committed = new AtomicBoolean(false);
                                                  processingContext.onCommit(c -> tx.commit()
-                                                     .thenAccept(v -> processingContext.onAfterCommit(c2 -> doAfterCommit(c2, tx, v)))
+                                                     .thenAccept(v -> {
+                                                         committed.set(true);
+                                                         processingContext.onAfterCommit(
+                                                             c2 -> doAfterCommit(c2, tx, v));
+                                                     })
                                                  );
-                                                 processingContext.onError((c, p, e) -> tx.rollback());
+                                                 // Once the commit succeeded the events are visible to consumers and no
+                                                 // rollback can take them back, so later failures must not request one.
+                                                 processingContext.onError((c, p, e) -> {
+                                                     if (!committed.get()) {
+                                                         tx.rollback();
+                                                     }
+                                                 });
                                              });
                 }
         );

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -202,6 +202,10 @@ public interface EventStorageEngine extends DescribableComponent {
 
         /**
          * Rolls back any events that have been appended, permanently making them unavailable for consumers.
+         * <p>
+         * Only invoked while the appended events are still invisible to consumers, in other words before
+         * {@link #commit()} has completed successfully. Once a commit has succeeded the events are published and this
+         * method is not invoked anymore.
          */
         void rollback();
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -29,15 +29,19 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.Trac
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.entity.EntityMetamodel;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -405,6 +409,105 @@ class DefaultEventStoreTransactionTest {
             assertFalse(onAfterCommitExecuted.get(), "After commit step should not execute after an error");
             assertTrue(onPostInvocationExecuted.get(), "Post invocation step should be executed after an error");
         }
+
+        @Test
+        void rollbackIsNotRequestedWhenTheFailureArrivesAfterASuccessfulCommit() {
+            // given an engine recording every rollback request, and a failure strictly after the commit succeeded
+            var recordingEngine = new RollbackRecordingEventStorageEngine(false);
+            var event = eventMessage(0);
+
+            // when
+            var uow = aUnitOfWork();
+            uow.runOnPreInvocation(context -> {
+                   EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
+                   transaction.appendEvent(event);
+               })
+               .runOnAfterCommit(context -> {
+                   throw new IllegalStateException("Simulated failure after commit");
+               });
+            assertThrows(CompletionException.class, () -> awaitExceptionalCompletion(uow.execute()));
+
+            // then the committed batch cannot be taken back, so no rollback may be requested for it
+            assertThat(recordingEngine.rollbacks()).isZero();
+
+            var verificationUow = aUnitOfWork();
+            var committedEvents = new AtomicReference<MessageStream<? extends EventMessage>>();
+            verificationUow.runOnPreInvocation(context -> {
+                EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
+                committedEvents.set(transaction.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)));
+            });
+            awaitSuccessfulCompletion(verificationUow.execute());
+            StepVerifier.create(FluxUtils.of(committedEvents.get()))
+                        .assertNext(entry -> assertEvent(entry.message(), event))
+                        .verifyComplete();
+        }
+
+        @Test
+        void rollbackIsStillRequestedWhenTheCommitItselfFails() {
+            // given an engine whose commit refuses the batch
+            var recordingEngine = new RollbackRecordingEventStorageEngine(true);
+
+            // when
+            var uow = aUnitOfWork();
+            uow.runOnPreInvocation(context -> {
+                EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
+                transaction.appendEvent(eventMessage(0));
+            });
+            assertThrows(CompletionException.class, () -> awaitExceptionalCompletion(uow.execute()));
+
+            // then the batch was never made visible, so it must be rolled back
+            assertThat(recordingEngine.rollbacks()).isOne();
+        }
+    }
+
+    /**
+     * Counts the {@link AppendTransaction#rollback() rollbacks} the framework requests, and optionally refuses the
+     * commit so a rollback is warranted.
+     */
+    private static class RollbackRecordingEventStorageEngine extends InMemoryEventStorageEngine {
+
+        private final AtomicInteger rollbacks = new AtomicInteger();
+        private final boolean failCommit;
+
+        private RollbackRecordingEventStorageEngine(boolean failCommit) {
+            this.failCommit = failCommit;
+        }
+
+        private int rollbacks() {
+            return rollbacks.get();
+        }
+
+        @Override
+        public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                    @Nullable ProcessingContext processingContext,
+                                                                    List<TaggedEventMessage<?>> events) {
+            return super.appendEvents(condition, processingContext, events).thenApply(this::recording);
+        }
+
+        @SuppressWarnings("unchecked")
+        private AppendTransaction<?> recording(AppendTransaction<?> delegate) {
+            AppendTransaction<Object> typed = (AppendTransaction<Object>) delegate;
+            return new AppendTransaction<Object>() {
+
+                @Override
+                public CompletableFuture<Object> commit() {
+                    return failCommit
+                            ? CompletableFuture.failedFuture(new IllegalStateException("Simulated commit failure"))
+                            : typed.commit();
+                }
+
+                @Override
+                public void rollback() {
+                    rollbacks.incrementAndGet();
+                    typed.rollback();
+                }
+
+                @Override
+                public CompletableFuture<ConsistencyMarker> afterCommit(Object commitResult) {
+                    return typed.afterCommit(commitResult);
+                }
+            };
+        }
     }
 
     @Nested
@@ -614,6 +717,18 @@ class DefaultEventStoreTransactionTest {
 
     private EventStoreTransaction defaultEventStoreTransactionFor(ProcessingContext processingContext) {
         return defaultEventStoreTransactionFor(processingContext, m -> Set.of(AGGREGATE_ID_TAG));
+    }
+
+    private EventStoreTransaction defaultEventStoreTransactionFor(ProcessingContext processingContext,
+                                                                  EventStorageEngine engine) {
+        return processingContext.computeResourceIfAbsent(
+                testEventStoreTransactionKey,
+                () -> new DefaultEventStoreTransaction(
+                        engine,
+                        processingContext,
+                        event -> new GenericTaggedEventMessage<>(event, Set.of(AGGREGATE_ID_TAG))
+                )
+        );
     }
 
     private EventStoreTransaction defaultEventStoreTransactionFor(ProcessingContext processingContext,

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -412,34 +412,44 @@ class DefaultEventStoreTransactionTest {
 
         @Test
         void rollbackIsNotRequestedWhenTheFailureArrivesAfterASuccessfulCommit() {
-            // given an engine recording every rollback request, and a failure strictly after the commit succeeded
+            // given an engine recording commits and rollbacks, and a failure strictly after the commit succeeded
             var recordingEngine = new RollbackRecordingEventStorageEngine(false);
-            var event = eventMessage(0);
 
             // when
             var uow = aUnitOfWork();
             uow.runOnPreInvocation(context -> {
                    EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
-                   transaction.appendEvent(event);
+                   transaction.appendEvent(eventMessage(0));
                })
                .runOnAfterCommit(context -> {
                    throw new IllegalStateException("Simulated failure after commit");
                });
             assertThrows(CompletionException.class, () -> awaitExceptionalCompletion(uow.execute()));
 
-            // then the committed batch cannot be taken back, so no rollback may be requested for it
+            // then the batch committed, and a committed batch cannot be taken back by a rollback
+            assertThat(recordingEngine.successfulCommits()).isOne();
             assertThat(recordingEngine.rollbacks()).isZero();
+        }
 
-            var verificationUow = aUnitOfWork();
-            var committedEvents = new AtomicReference<MessageStream<? extends EventMessage>>();
-            verificationUow.runOnPreInvocation(context -> {
-                EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
-                committedEvents.set(transaction.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA)));
-            });
-            awaitSuccessfulCompletion(verificationUow.execute());
-            StepVerifier.create(FluxUtils.of(committedEvents.get()))
-                        .assertNext(entry -> assertEvent(entry.message(), event))
-                        .verifyComplete();
+        @Test
+        void rollbackIsNotRequestedWhenAnotherCommitPhaseHandlerFails() {
+            // given an unrelated COMMIT phase handler that fails, registered before the append attaches its own
+            var recordingEngine = new RollbackRecordingEventStorageEngine(false);
+
+            // when
+            var uow = aUnitOfWork();
+            uow.runOnCommit(context -> {
+                   throw new IllegalStateException("Simulated failure of an unrelated commit handler");
+               })
+               .runOnPreInvocation(context -> {
+                   EventStoreTransaction transaction = defaultEventStoreTransactionFor(context, recordingEngine);
+                   transaction.appendEvent(eventMessage(0));
+               });
+            assertThrows(CompletionException.class, () -> awaitExceptionalCompletion(uow.execute()));
+
+            // then all handlers of a phase run, so this batch committed as well and must not be rolled back
+            assertThat(recordingEngine.successfulCommits()).isOne();
+            assertThat(recordingEngine.rollbacks()).isZero();
         }
 
         @Test
@@ -461,16 +471,22 @@ class DefaultEventStoreTransactionTest {
     }
 
     /**
-     * Counts the {@link AppendTransaction#rollback() rollbacks} the framework requests, and optionally refuses the
-     * commit so a rollback is warranted.
+     * Counts the successful {@link AppendTransaction#commit() commits} and the
+     * {@link AppendTransaction#rollback() rollbacks} the framework requests, and optionally refuses the commit so a
+     * rollback is warranted.
      */
     private static class RollbackRecordingEventStorageEngine extends InMemoryEventStorageEngine {
 
+        private final AtomicInteger successfulCommits = new AtomicInteger();
         private final AtomicInteger rollbacks = new AtomicInteger();
         private final boolean failCommit;
 
         private RollbackRecordingEventStorageEngine(boolean failCommit) {
             this.failCommit = failCommit;
+        }
+
+        private int successfulCommits() {
+            return successfulCommits.get();
         }
 
         private int rollbacks() {
@@ -493,7 +509,10 @@ class DefaultEventStoreTransactionTest {
                 public CompletableFuture<Object> commit() {
                     return failCommit
                             ? CompletableFuture.failedFuture(new IllegalStateException("Simulated commit failure"))
-                            : typed.commit();
+                            : typed.commit().thenApply(result -> {
+                                successfulCommits.incrementAndGet();
+                                return result;
+                            });
                 }
 
                 @Override


### PR DESCRIPTION
Fixes #4814

## What changed

A single `onError` handler called `AppendTransaction.rollback()` whatever phase the error arrived in, so a failure after a successful commit asked the storage engine to roll back a batch that was already published and visible.

The handler now skips the rollback once the commit has completed successfully, and `AppendTransaction.rollback()` states the matching contract: it is invoked only while the events are still invisible.

`TracingEventStorageEngine` was the shipped victim -- it closes its span scope in `afterCommit` on error, and the bogus `rollback()` closed it again. An engine that took the interface wording literally would have tried to delete delivered events.

## Why a guard rather than a documentation note

The wrong call is made in one place every storage engine routes through, so one guard fixes present and future engines, including third-party ones. Documenting it would have pushed the defence onto every implementor and left the bogus call in place.

## Can the guard skip a rollback that is still needed?

No. The flag is a per-append-transaction `AtomicBoolean`, created inside the per-transaction lambda so it cannot leak across transactions, and set only in the success continuation of `tx.commit()`. It flips exactly when the engine has reported the batch published (`EventStorageEngine.java:187`: "Events may only be visible to consumers after the invocation of `commit()`"). A failed commit, or an error arriving before the commit phase, leaves it false and the rollback still fires.

**One case the guard does not cover**, stated for honesty: a concurrent `onError` in the same COMMIT phase racing `commit()`'s success before the flag lands would still request a rollback for published events. That is identical to today's behaviour, so not a regression, and it is not reachable through the single-append path this class drives.

## Tests

Two new cases in `DefaultEventStoreTransactionTest.TransactionRollback`.

| case | with fix | guard reverted |
|---|---|---|
| `rollbackIsStillRequestedWhenTheCommitItselfFails` | pass | pass |
| `rollbackIsNotRequestedWhenTheFailureArrivesAfterASuccessfulCommit` | pass | **fail** |

The first is an over-suppression sentinel and passes either way: it constrains the guard rather than tracking it. The second re-sources the stream afterwards to prove the committed event survived, rather than only counting rollback calls.

Targeted run: 6 classes, 79 tests, 0 failures. No existing test encoded the old behaviour.



## Scope: this is an SPI-contract fix, not a data-loss fix

No engine in this repository loses data from the bug. `InMemoryEventStorageEngine.rollback()` is `finished.set(true)` and never removes events, and `AggregateBasedJpaEventStorageEngine.rollback()` is an explicit no-op because the entity-manager executor owns the transaction. What flips is the rollback call count, that is, compliance with the `AppendTransaction` contract.

Real data loss needs an engine that implements `rollback()` honestly: a custom engine, or the Axon Server DCB store, which is not in this repository. `TracingEventStorageEngine` is the in-tree victim, and its damage is a span scope closed twice rather than lost events.

The Javadoc change on `AppendTransaction.rollback()` is therefore the substantive half for third-party engine authors: it promises that rollback is never called after a successful commit.

The pre-existing race is untouched and not claimed: a concurrent COMMIT-phase handler throwing while `tx.commit()` is still in flight still sees the flag false and still requests a rollback.



## A second reachable instance of the same bug

`rollbackIsNotRequestedWhenAnotherCommitPhaseHandlerFails` covers it. An unrelated COMMIT-phase handler that throws does **not** stop the append's `onCommit`: `UnitOfWork.runNextPhase:461` maps every handler of the phase into one `allOf`, with no short-circuit. So the commit still succeeds and the guard must suppress the rollback. It fails without the guard.

## The visibility assertion was replaced, not kept

The original test asserted that events are still sourceable after the suppressed rollback. That assertion passed with or without the fix, because no in-tree engine discards on rollback. It is replaced by a `successfulCommits()` counter on the recording engine, which is what it was actually worth: without it, `rollbacks() == 0` passes vacuously if the fixture never appended.

Making the recording engine discard instead was rejected: its `eventStorage` is private with no delete API, so it would mean overriding `source()` to lie, and the only thing that fake could detect is "rollback was requested", which the counter already asserts. It would also contradict the contract this PR adds.

Not covered, deliberately: an exception thrown inside the success continuation itself. The only thing there that can throw is `onAfterCommit(...)`, and `UnitOfWorkProcessingContext.on()` throws only when the target phase order has passed -- which cannot happen, because COMMIT awaits the continuation's future. Forcing it would require asserting against a fake.
