### PR TITLE
[#4799] Align the autoconfigured JPA gap defaults with the core defaults

### DIFF
--- a/docs/reference-guide/modules/migration/examples/migration/paths/eventstore/jpastorageengine/customconfig/AxonConfig.java
+++ b/docs/reference-guide/modules/migration/examples/migration/paths/eventstore/jpastorageengine/customconfig/AxonConfig.java
@@ -37,9 +37,9 @@ public class AxonConfig {
                         engineConfig -> engineConfig
                                 .batchSize(100)
                                 .gapCleaningThreshold(250)
-                                .gapTimeout(10000)
+                                .gapTimeout(60000)
                                 .lowestGlobalSequence(1)
-                                .maxGapOffset(60000)
+                                .maxGapOffset(10000)
                                 .persistenceExceptionResolver(
                                         config.getComponent(PersistenceExceptionResolver.class)
                                 )

--- a/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/event-store.adoc
@@ -450,12 +450,12 @@ If you had customized the `JpaEventStorageEngine` in Axon Framework 4 to, for ex
 axon.eventstorage.jpa.batch-size=100
 # Threshold for gap cleanup (default: 250)
 axon.eventstorage.jpa.gap-cleaning-threshold=250
-# Gap timeout in milliseconds (default: 10000)
-axon.eventstorage.jpa.gap-timeout=10000
+# Gap timeout in milliseconds (default: 60000)
+axon.eventstorage.jpa.gap-timeout=60000
 # Minimum global index value (default: 1)
 axon.eventstorage.jpa.lowest-global-sequence=1
-# Max gap distance from highest index (default: 60000)
-axon.eventstorage.jpa.max-gap-offset=60000
+# Max gap distance from highest index (default: 10000)
+axon.eventstorage.jpa.max-gap-offset=10000
 # Polling interval in ms for new events (default: 1000)
 axon.eventstorage.jpa.polling-interval=1000
 ----

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationProperties.java
@@ -41,9 +41,9 @@ public class JpaEventStorageEngineConfigurationProperties {
     public JpaEventStorageEngineConfigurationProperties(
         @DefaultValue("100") int batchSize,
         @DefaultValue("250") int gapCleaningThreshold,
-        @DefaultValue("10000") int gapTimeout,
+        @DefaultValue("60000") int gapTimeout,
         @DefaultValue("1") long lowestGlobalSequence,
-        @DefaultValue("60000") int maxGapOffset,
+        @DefaultValue("10000") int maxGapOffset,
         @DefaultValue("1000") long pollingInterval
     ) {
         this.batchSize = batchSize;
@@ -75,7 +75,7 @@ public class JpaEventStorageEngineConfigurationProperties {
     /**
      * Retrieves the time until a gap in global index is considered as timed out.
      *
-     * @return The time until a gap in global index is considered as timed out.
+     * @return The time until a gap in global index is considered as timed out. Defaults to 60000 ms.
      */
     public int gapTimeout() {
         return gapTimeout;
@@ -94,6 +94,7 @@ public class JpaEventStorageEngineConfigurationProperties {
      * Retrieves the maximum distance in sequence numbers between a gap and the event with the highest known index.
      *
      * @return The maximum distance in sequence numbers between a gap and the event with the highest known index.
+     * Defaults to 10000.
      */
     public int maxGapOffset() {
         return maxGapOffset;

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationPropertiesTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/JpaEventStorageEngineConfigurationPropertiesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot;
+
+import org.axonframework.eventsourcing.eventstore.jpa.AggregateBasedJpaEventStorageEngineConfiguration;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the {@link JpaEventStorageEngineConfigurationProperties} binding, verifying that an application that sets no
+ * {@code axon.eventstorage.jpa.*} property is configured exactly as one that uses
+ * {@link AggregateBasedJpaEventStorageEngineConfiguration#DEFAULT} directly.
+ *
+ * @author Stefan Dragisic
+ */
+class JpaEventStorageEngineConfigurationPropertiesTest {
+
+    private static final AggregateBasedJpaEventStorageEngineConfiguration CORE_DEFAULTS =
+            AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT;
+
+    private static JpaEventStorageEngineConfigurationProperties bindWithoutAnyProperty() {
+        return new Binder(new MapConfigurationPropertySource(Map.of()))
+                .bindOrCreate("axon.eventstorage.jpa", JpaEventStorageEngineConfigurationProperties.class);
+    }
+
+    @Nested
+    class DefaultsMatchTheCoreConfiguration {
+
+        @Test
+        void gapTimeoutDefaultsToTheCoreDefault() {
+            // given no axon.eventstorage.jpa property is set
+            // when
+            JpaEventStorageEngineConfigurationProperties properties = bindWithoutAnyProperty();
+
+            // then the gap timeout is not shortened relative to the core default, which would risk losing events
+            assertThat(properties.gapTimeout()).isEqualTo(CORE_DEFAULTS.gapTimeout());
+        }
+
+        @Test
+        void maxGapOffsetDefaultsToTheCoreDefault() {
+            // given no axon.eventstorage.jpa property is set
+            // when
+            JpaEventStorageEngineConfigurationProperties properties = bindWithoutAnyProperty();
+
+            // then
+            assertThat(properties.maxGapOffset()).isEqualTo(CORE_DEFAULTS.maxGapOffset());
+        }
+
+        @Test
+        void everySharedSettingDefaultsToTheCoreDefault() {
+            // given no axon.eventstorage.jpa property is set
+            // when
+            JpaEventStorageEngineConfigurationProperties properties = bindWithoutAnyProperty();
+
+            // then every setting the two configuration paths share agrees, so neither path silently drifts
+            assertThat(properties.batchSize()).isEqualTo(CORE_DEFAULTS.batchSize());
+            assertThat(properties.gapCleaningThreshold()).isEqualTo(CORE_DEFAULTS.gapCleaningThreshold());
+            assertThat(properties.gapTimeout()).isEqualTo(CORE_DEFAULTS.gapTimeout());
+            assertThat(properties.lowestGlobalSequence()).isEqualTo(CORE_DEFAULTS.lowestGlobalSequence());
+            assertThat(properties.maxGapOffset()).isEqualTo(CORE_DEFAULTS.maxGapOffset());
+        }
+    }
+
+    @Nested
+    class ExplicitPropertiesOverrideTheDefaults {
+
+        @Test
+        void gapTimeoutAndMaxGapOffsetAreBoundToTheirOwnProperty() {
+            // given
+            MapConfigurationPropertySource source = new MapConfigurationPropertySource(Map.of(
+                    "axon.eventstorage.jpa.gap-timeout", "1234",
+                    "axon.eventstorage.jpa.max-gap-offset", "4321"
+            ));
+
+            // when
+            JpaEventStorageEngineConfigurationProperties properties = new Binder(source)
+                    .bindOrCreate("axon.eventstorage.jpa", JpaEventStorageEngineConfigurationProperties.class);
+
+            // then
+            assertThat(properties.gapTimeout()).isEqualTo(1234);
+            assertThat(properties.maxGapOffset()).isEqualTo(4321);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4799

## What changed

The two `@DefaultValue` annotations on `JpaEventStorageEngineConfigurationProperties` carried each other's value:

| Setting | Was autoconfigured | Core default |
|---|---|---|
| `gapTimeout` | 10000 ms | 60000 ms |
| `maxGapOffset` | 60000 | 10000 |

The short timeout is the harmful direction. It is the window a not-yet-committed event has to become visible before a streaming consumer gives up on it, and nearly every production JPA application reaches the engine through Spring Boot.

The swap always won: `JpaEventStoreAutoConfiguration.AggregateBasedJpaEventStorageEngineConfigurationEnhancer:103-110` copies every property onto the core configuration unconditionally, so an application could not fall through to the correct core default even by setting nothing.

## Docs are in the commit on purpose

The same swapped pair is published as the documented defaults:

- `migration/pages/paths/event-store.adoc:453,458` states `gap-timeout=10000` and `max-gap-offset=60000` as "the default".
- The included sample `customconfig/AxonConfig.java:37,40` repeats those numbers against the **core** builder, where they are not the defaults either.

## Tests

`JpaEventStorageEngineConfigurationPropertiesTest`, 4 testcases, 0 failures. Plus `JpaAutoConfigurationTest` (2), the class that exercises the autoconfig path.

Reverting just the two `@DefaultValue` swaps fails with `expected: 60000 but was: 10000` and `expected: 10000 but was: 60000`.

The test asserts against `AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT` rather than literals, so the two paths cannot drift apart again silently, and a third case covers all five shared settings.

## For the reviewer

The effective default moves for every Spring Boot JPA application that never set these properties: tokens get smaller and gaps live longer. Worth checking whether any downstream test or benchmark depended on the 10000 ms timeout.

No behaviour change for anyone who set either property explicitly, which the new test also pins.

Related: this is the same `gapTimeout` mechanism as the event-skipping problem, so the two interact.



## Not a pure safety win in both directions

`gapTimeout` 10000 to 60000 is safer: gaps survive longer, so fewer committed events are skipped. It costs bigger tracking tokens and more gap re-querying.

`maxGapOffset` 60000 to 10000 is **less** forgiving: a token now abandons gaps more than 10000 behind the highest index instead of 60000. Aligning with the core record is still the right call, but only one half of this change is strictly safer.

This is an upgrade-time behaviour change for every Spring Boot JPA application that never set these properties, so it needs a release note.
