### PR TITLE
[#4812] Document that InMemoryTokenStore implements no claim arbitration

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStore.java
@@ -42,6 +42,28 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
  * Implementation of a {@link TokenStore} that stores tracking tokens in memory. This implementation is thread-safe.
+ * <p>
+ * <b>This store performs no claim or ownership arbitration.</b> It keeps no owner, no claim timestamp and no claim
+ * timeout, because its tokens live on the heap of a single JVM and can never be reached by another process. The
+ * claim-related guarantees of {@link TokenStore} therefore do <b>not</b> hold here:
+ * <ul>
+ *     <li>{@link #fetchToken(String, int, ProcessingContext)} does not claim the token, and never fails because
+ *     another process holds it. It fails only when the segment was never initialized.</li>
+ *     <li>{@link TokenStore#extendClaim(String, int, ProcessingContext)} never fails because the claim was lost, as
+ *     it delegates to {@code fetchToken}.</li>
+ *     <li>{@link #storeToken(TrackingToken, String, int, ProcessingContext)} never fails because the token is
+ *     claimed elsewhere. It fails only when the segment was never initialized.</li>
+ *     <li>{@link #deleteToken(String, int, ProcessingContext)} does not require ownership of the token.</li>
+ *     <li>{@link #releaseClaim(String, int, ProcessingContext)} is a no-op.</li>
+ *     <li>{@link #fetchAvailableSegments(String, ProcessingContext)} returns every known segment, because no segment
+ *     is ever claimed. It is equivalent to {@link #fetchSegments(String, ProcessingContext)}.</li>
+ * </ul>
+ * Anything depending on those guarantees - a multi-process deployment, or a test asserting that a claim is refused or
+ * stolen - must use a claim-capable store instead, such as the
+ * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.jdbc.JdbcTokenStore} or the
+ * {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.jpa.JpaTokenStore}. Switching
+ * store does not by itself arbitrate between two processors of the same name inside one JVM: a claim identifies the
+ * node, which defaults to the JVM, so both are the same owner unless each is given its own node identifier.
  *
  * @author Rene de Waele
  * @author Christophe Bouhier
@@ -122,6 +144,12 @@ public class InMemoryTokenStore implements TokenStore {
         return old != null;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation does <b>not</b> claim the token. The returned future fails only when no token was
+     * initialized for the given {@code processorName} and {@code segmentId}, never because another process owns it.
+     */
     @Override
     public CompletableFuture<TrackingToken> fetchToken(String processorName,
                                                        int segmentId,
@@ -136,6 +164,11 @@ public class InMemoryTokenStore implements TokenStore {
         return completedFuture(st.trackingToken);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is a no-op, as it holds no claims to release.
+     */
     @Override
     public CompletableFuture<Void> releaseClaim(String processorName,
                                                 int segment,
@@ -187,6 +220,12 @@ public class InMemoryTokenStore implements TokenStore {
         );
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * As this implementation never claims a segment, every known segment is reported as available. This method is
+     * equivalent to {@link #fetchSegments(String, ProcessingContext)}.
+     */
     @Override
     public CompletableFuture<List<Segment>> fetchAvailableSegments(String processorName, ProcessingContext context) {
         return fetchSegments(processorName, context);

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/inmemory/InMemoryTokenStoreTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -229,6 +230,100 @@ class InMemoryTokenStoreTest {
             assertThat(result.exceptionNow())
                     .isInstanceOf(UnableToInitializeTokenException.class)
                     .hasMessageContaining("Token was already present");
+        }
+    }
+
+    /**
+     * Pins the absence of claim and ownership arbitration in this store, as documented on the class. These are not
+     * guarantees of {@link org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore};
+     * they are the behaviour a caller gets from this implementation, and any of them changing means ownership was
+     * introduced and the class documentation no longer holds.
+     */
+    @Nested
+    class NoOwnershipArbitration {
+
+        @Test
+        void fetchTokenTwiceInARowNeverConflicts() {
+            // given
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 1, null, createProcessingContext()));
+
+            // when / then - a second fetch of an already-fetched token is not refused
+            assertThatCode(() -> {
+                joinAndUnwrap(testSubject.fetchToken("proc", 0, null));
+                joinAndUnwrap(testSubject.fetchToken("proc", 0, null));
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
+        void extendClaimNeverFailsOnAnInitializedSegment() {
+            // given
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 1, null, createProcessingContext()));
+
+            // when / then - the claim can never have been lost, as it was never taken
+            assertThatCode(() -> {
+                joinAndUnwrap(testSubject.extendClaim("proc", 0, null));
+                joinAndUnwrap(testSubject.extendClaim("proc", 0, null));
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
+        void storeTokenSucceedsWithoutEverFetchingTheToken() {
+            // given
+            ProcessingContext ctx = createProcessingContext();
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 1, null, ctx));
+
+            // when - no fetch, so no claim, yet the write is accepted
+            joinAndUnwrap(testSubject.storeToken(new GlobalSequenceTrackingToken(5), "proc", 0, ctx));
+
+            // then
+            assertThat(joinAndUnwrap(testSubject.fetchToken("proc", 0, null)))
+                    .isEqualTo(new GlobalSequenceTrackingToken(5));
+        }
+
+        @Test
+        void releaseClaimLeavesTheStoredTokenIntact() {
+            // given
+            ProcessingContext ctx = createProcessingContext();
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 1, null, ctx));
+            joinAndUnwrap(testSubject.storeToken(new GlobalSequenceTrackingToken(7), "proc", 0, ctx));
+
+            // when - releasing a claim that was never taken
+            joinAndUnwrap(testSubject.releaseClaim("proc", 0, null));
+
+            // then - the token, and the segment, are still there
+            assertThat(joinAndUnwrap(testSubject.fetchToken("proc", 0, null)))
+                    .isEqualTo(new GlobalSequenceTrackingToken(7));
+            assertThat(joinAndUnwrap(testSubject.fetchSegments("proc", null))).hasSize(1);
+        }
+
+        @Test
+        void everySegmentStaysAvailableAfterAllTokensAreFetched() {
+            // given
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 4, null, createProcessingContext()));
+            List<Segment> allSegments = joinAndUnwrap(testSubject.fetchSegments("proc", null));
+            for (Segment segment : allSegments) {
+                joinAndUnwrap(testSubject.fetchToken("proc", segment, null));
+            }
+
+            // when
+            List<Segment> available = joinAndUnwrap(testSubject.fetchAvailableSegments("proc", null));
+
+            // then - fetching claims nothing, so availability is unchanged
+            assertThat(available).containsExactlyInAnyOrderElementsOf(allSegments);
+        }
+
+        @Test
+        void deleteTokenSucceedsWithoutOwningTheToken() {
+            // given
+            joinAndUnwrap(testSubject.initializeTokenSegments("proc", 2, null, createProcessingContext()));
+
+            // when - deleting a token this caller never fetched, so never owned
+            joinAndUnwrap(testSubject.deleteToken("proc", 0, null));
+
+            // then
+            assertThat(joinAndUnwrap(testSubject.fetchSegments("proc", null)))
+                    .extracting(Segment::getSegmentId)
+                    .containsExactly(1);
         }
     }
 


### PR DESCRIPTION
Fixes #4812

## What changed

Documentation and tests only. No behaviour change.

`TokenStore` promises that a fetch claims the token, that a write or claim extension fails once another owner holds the entry, that deletion needs ownership, and that available segments exclude claimed ones. `InMemoryTokenStore` has no owner field, no claim timestamp and no claim timeout, and its class Javadoc said only that it is thread-safe.

The practical harm is silent: anyone asserting claim semantics against this store, which is the default in most setups, got a test that passes without exercising anything.

The class documentation now names each guarantee that does not hold, and points at `JdbcTokenStore` and `JpaTokenStore` for multi-process use.

## Each claim in the new Javadoc was verified against the code

| Documented as not holding | Interface promise | Implementation |
|---|---|---|
| `fetchToken` does not claim | "claimed by the current process", fails if claimed elsewhere | a `ConcurrentHashMap.get`; only failure is segment absent |
| `extendClaim` never fails on a lost claim | fails if "claimed by another process" | not overridden; default is `fetchToken(...).thenRun(() -> {})` |
| `storeToken` never fails because claimed elsewhere | fails if "claimed by another process" | only checks `containsKey` |
| `deleteToken` needs no ownership | token "**must** be owned by the current process" | bare `tokens.remove(...)`, no check |
| `releaseClaim` is a no-op | "release a claim" | returns a completed future |
| `fetchAvailableSegments` returns every segment | "not claimed by any other event processor" | delegates straight to `fetchSegments` |

## Why ownership is not implemented

A claim identifies the node, which defaults to the JVM, and these tokens never leave one JVM. Implementing arbitration would buy no safety while turning a call that currently cannot fail into one that can, on the store most tests in the repo use.

## Tests

`InMemoryTokenStoreTest` goes from 12 to 18 testcases; all six new `NoOwnershipArbitration` cases confirmed present in the surefire XML by `classname`.

They deliberately pass on unfixed code, because they pin what the store actually does. That is the point: they go red if ownership is ever added and this new documentation silently goes stale.

## Unrelated nit, not changed

`storeToken` declares `@Nullable ProcessingContext context` and then `requireNonNull`s it, so it can also fail with an NPE on a null context. The new list item is exhaustive for claim-related failures but not for that argument check.
