### PR TITLE
[#4809] Leave the processor token-store name unset by default

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
@@ -34,6 +34,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -333,10 +334,11 @@ public class EventProcessorProperties {
         /**
          * Sets the name of the TokenStore bean.
          *
-         * @param tokenStore A name of the Spring Bean used for this processor, or {@code null} to leave it unset.
+         * @param tokenStore the name of the Spring Bean used for this processor; omitting the property, rather than
+         *                   binding it to {@code null}, is what leaves the name unset
          */
-        public void setTokenStore(@Nullable String tokenStore) {
-            this.tokenStore = tokenStore;
+        public void setTokenStore(String tokenStore) {
+            this.tokenStore = Objects.requireNonNull(tokenStore, "TokenStore cannot be null");
         }
 
         /**

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.StreamingE
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -33,7 +34,6 @@ import org.springframework.core.env.Environment;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -151,9 +151,14 @@ public class EventProcessorProperties {
         private int batchSize = 1;
 
         /**
-         * Name of the {@link TokenStore} bean used for this processor. Must not be null.
+         * Name of the {@link TokenStore} bean used for this processor.
+         * <p>
+         * Defaults to unset, in which case the bean named {@code tokenStore} is used, or otherwise the unique
+         * {@link TokenStore} bean of the application.
          */
-        private String tokenStore = "tokenStore";
+        @Nullable
+        private String tokenStore;
+
         /**
          * The name of the bean that represents the sequencing policy for processing events. If no name is specified,
          * the processor defaults to a {@link SequentialPerAggregatePolicy},
@@ -328,20 +333,20 @@ public class EventProcessorProperties {
         /**
          * Sets the name of the TokenStore bean.
          *
-         * @param tokenStore A name of the Spring Bean used for this processor.
+         * @param tokenStore A name of the Spring Bean used for this processor, or {@code null} to leave it unset.
          */
-        public void setTokenStore(String tokenStore) {
-            Objects.requireNonNull(tokenStore, "TokenStore cannot be null");
+        public void setTokenStore(@Nullable String tokenStore) {
             this.tokenStore = tokenStore;
         }
 
         /**
          * Retrieves the name of the TokenStore bean.
          *
-         * @return Name of the token store Spring Bean.
+         * @return name of the token store Spring Bean, or {@code null} when unset
          */
         @Override
-                public String tokenStore() {
+        @Nullable
+        public String tokenStore() {
             return tokenStore;
         }
 

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot;
+
+import org.axonframework.extension.spring.config.EventProcessorSettings;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.stereotype.Component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating how {@link EventProcessorProperties.ProcessorSettings} bound from application properties
+ * describe the {@link TokenStore} of a pooled processor.
+ *
+ * @author Stefan Dragisic
+ */
+class EventProcessorPropertiesTest {
+
+    private static final String PROCESSOR_NAME = "test-processor";
+    private static final String PROCESSOR_PREFIX = "axon.eventhandling.processors[" + PROCESSOR_NAME + "]";
+
+    @Nested
+    class UnsetTokenStoreProperty {
+
+        @Test
+        void bindingWithoutATokenStorePropertyLeavesTheTokenStoreNameUnset() {
+            // given - an application that configures a processor without naming a token store
+            Environment environment = environmentWith(PROCESSOR_PREFIX + ".mode", "pooled");
+
+            // when
+            EventProcessorSettings settings = EventProcessorProperties.getProcessors(environment).get(PROCESSOR_NAME);
+
+            // then - an unset name is what makes the token store optional while customizing the processor
+            assertThat(settings).isInstanceOf(EventProcessorSettings.PooledEventProcessorSettings.class);
+            assertThat(((EventProcessorSettings.PooledEventProcessorSettings) settings).tokenStore()).isNull();
+        }
+
+        @Test
+        void startsAnApplicationWhoseTokenStoreBeanIsNotNamedTokenStore() {
+            // given - the only TokenStore bean is named "customTokenStore", and no token-store property is set
+            // when / then - the unset name resolves the TokenStore by type instead of demanding a named bean
+            new ApplicationContextRunner()
+                    .withUserConfiguration(TestContext.class)
+                    .run(context -> assertThat(context).hasNotFailed());
+        }
+    }
+
+    @Nested
+    class ExplicitlySetTokenStoreProperty {
+
+        @Test
+        void bindingATokenStorePropertyKeepsTheConfiguredName() {
+            // given
+            Environment environment = environmentWith(PROCESSOR_PREFIX + ".mode", "pooled",
+                                                      PROCESSOR_PREFIX + ".token-store", "my-token-store");
+
+            // when
+            EventProcessorSettings settings = EventProcessorProperties.getProcessors(environment).get(PROCESSOR_NAME);
+
+            // then
+            assertThat(((EventProcessorSettings.PooledEventProcessorSettings) settings).tokenStore())
+                    .isEqualTo("my-token-store");
+        }
+
+        @Test
+        void failsToStartAnApplicationNamingAnUnknownTokenStore() {
+            // given / when / then - an explicitly named token store stays mandatory
+            new ApplicationContextRunner()
+                    .withUserConfiguration(TestContext.class)
+                    .withPropertyValues("axon.eventhandling.processors[..default].token-store=unknown-token-store")
+                    .run(context -> assertThat(context).hasFailed());
+        }
+    }
+
+    private static Environment environmentWith(String... keysAndValues) {
+        MockEnvironment environment = new MockEnvironment();
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            environment.setProperty(keysAndValues[i], keysAndValues[i + 1]);
+        }
+        return environment;
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class TestContext {
+
+        @Bean
+        public TokenStore customTokenStore() {
+            return new InMemoryTokenStore();
+        }
+
+        @SuppressWarnings("unused")
+        @Component
+        public static class EventHandlingComponent {
+
+            @SuppressWarnings("unused")
+            @EventHandler
+            public void on(String event) {
+                // a handler is required for a pooled processor to be constructed at all
+            }
+        }
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesTest.java
@@ -16,8 +16,10 @@
 
 package org.axonframework.extension.springboot;
 
+import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.extension.spring.config.EventProcessorSettings;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorConfiguration;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.junit.jupiter.api.*;
@@ -64,7 +66,30 @@ class EventProcessorPropertiesTest {
             // when / then - the unset name resolves the TokenStore by type instead of demanding a named bean
             new ApplicationContextRunner()
                     .withUserConfiguration(TestContext.class)
-                    .run(context -> assertThat(context).hasNotFailed());
+                    .run(context -> assertThat(selectedTokenStore(context.getBean(AxonConfiguration.class)))
+                            .isSameAs(context.getBean("customTokenStore", TokenStore.class)));
+        }
+
+        @Test
+        void prefersTheConventionallyNamedTokenStoreBeanWhenSeveralBeansExist() {
+            // given - two TokenStore beans, one of them named "tokenStore", and no token-store property is set
+            new ApplicationContextRunner()
+                    .withUserConfiguration(TestContext.class, ConventionalTokenStoreContext.class)
+                    // when / then - the conventional bean name wins over an ambiguous type-level lookup
+                    .run(context -> assertThat(selectedTokenStore(context.getBean(AxonConfiguration.class)))
+                            .isSameAs(context.getBean("tokenStore", TokenStore.class)));
+        }
+
+        @Test
+        void reportsTheLookedForBeanNameWhenNoTokenStoreCanBeResolved() {
+            // given - two TokenStore beans, neither named "tokenStore", and no token-store property is set
+            new ApplicationContextRunner()
+                    .withUserConfiguration(TestContext.class, SecondUnconventionalTokenStoreContext.class)
+                    // when / then - naming the bean that was looked for is what makes the failure actionable
+                    .run(context -> assertThat(context)
+                            .getFailure()
+                            .hasStackTraceContaining("Could not find a mandatory TokenStore with name 'tokenStore'")
+                            .hasStackTraceContaining("The TokenStore is a hard requirement"));
         }
     }
 
@@ -95,6 +120,21 @@ class EventProcessorPropertiesTest {
         }
     }
 
+    /**
+     * Returns the {@link TokenStore} the single pooled processor of the application was configured with.
+     */
+    private static TokenStore selectedTokenStore(AxonConfiguration axonConfiguration) {
+        var processorConfigurations =
+                axonConfiguration.getModuleConfigurations()
+                                 .stream()
+                                 .flatMap(module -> module
+                                         .getOptionalComponent(PooledStreamingEventProcessorConfiguration.class)
+                                         .stream())
+                                 .toList();
+        assertThat(processorConfigurations).hasSize(1);
+        return processorConfigurations.getFirst().tokenStore();
+    }
+
     private static Environment environmentWith(String... keysAndValues) {
         MockEnvironment environment = new MockEnvironment();
         for (int i = 0; i < keysAndValues.length; i += 2) {
@@ -121,6 +161,24 @@ class EventProcessorPropertiesTest {
             public void on(String event) {
                 // a handler is required for a pooled processor to be constructed at all
             }
+        }
+    }
+
+    @Configuration
+    static class ConventionalTokenStoreContext {
+
+        @Bean
+        public TokenStore tokenStore() {
+            return new InMemoryTokenStore();
+        }
+    }
+
+    @Configuration
+    static class SecondUnconventionalTokenStoreContext {
+
+        @Bean
+        public TokenStore anotherTokenStore() {
+            return new InMemoryTokenStore();
         }
     }
 }

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/DefaultProcessorModuleFactory.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/DefaultProcessorModuleFactory.java
@@ -144,6 +144,7 @@ public class DefaultProcessorModuleFactory implements ProcessorModuleFactory {
                                 for (var extension : extensionsCustomizations) {
                                     result = extension.apply(axonConfig, result);
                                 }
+                                SpringCustomizations.requireResolvedTokenStore(processorName, result);
                                 return result;
                             };
                     yield EventProcessorModule

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/EventProcessorSettings.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/EventProcessorSettings.java
@@ -131,10 +131,11 @@ public sealed interface EventProcessorSettings {
         int batchSize();
 
         /**
-         * Name of the token store of the bean.
+         * Name of the bean acting as token store for this pooled streaming processor.
          *
-         * @return Name of the bean acting as token store for this pooled streaming processor.
+         * @return only used if non-null.
          */
+        @Nullable
         String tokenStore();
     }
 }

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
@@ -131,8 +131,10 @@ interface SpringCustomizations {
      * {@link #CONVENTIONAL_TOKEN_STORE_BEAN_NAME conventional bean name} before that type-level lookup, so that
      * applications declaring several token stores keep resolving the same one. Otherwise, it leaves that part of the
      * configuration untouched, allowing customizations applied after this one, like an
-     * {@code EventProcessorDefinition}, to supply it. A still-missing source or token store is reported when the
-     * resulting {@link PooledStreamingEventProcessorConfiguration} is validated.
+     * {@code EventProcessorDefinition}, to supply it. A still-missing source is reported when the resulting
+     * {@link PooledStreamingEventProcessorConfiguration} is validated, a still-missing token store by
+     * {@link #requireResolvedTokenStore(String, PooledStreamingEventProcessorConfiguration)} once all customizations
+     * have been applied.
      */
     class SpringPooledStreamingEventProcessingModuleCustomization
             implements PooledStreamingEventProcessorModule.Customization {
@@ -197,6 +199,26 @@ interface SpringCustomizations {
 
             return result;
         }
+    }
+
+    /**
+     * Verifies a {@link TokenStore} ended up on the given {@code configuration} of the event processor with the given
+     * {@code name}, after every customization had the opportunity to supply one.
+     * <p>
+     * Names the {@link #CONVENTIONAL_TOKEN_STORE_BEAN_NAME bean that was looked for}, as that is the information
+     * needed to fix the configuration, and is no longer available once the
+     * {@link PooledStreamingEventProcessorConfiguration} itself reports the missing token store during validation.
+     *
+     * @param name          the name of the event processor the {@code configuration} belongs to
+     * @param configuration the event processor configuration with all customizations applied
+     */
+    static void requireResolvedTokenStore(String name, PooledStreamingEventProcessorConfiguration configuration) {
+        require(configuration.tokenStore() != null,
+                "Could not find a mandatory TokenStore with name '" + CONVENTIONAL_TOKEN_STORE_BEAN_NAME
+                        + "' for event processor '" + name + "'. The TokenStore is a hard requirement and should be "
+                        + "provided, either by naming a TokenStore bean '" + CONVENTIONAL_TOKEN_STORE_BEAN_NAME
+                        + "', by declaring a single TokenStore bean, or by setting the token-store property of this "
+                        + "event processor.");
     }
 
     /**

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
@@ -43,6 +43,15 @@ import java.util.function.Supplier;
 interface SpringCustomizations {
 
     /**
+     * The bean name a {@link TokenStore} is resolved under when the token-store setting is unset.
+     * <p>
+     * Both the JPA and JDBC auto configurations register their token store under this name, so preferring it keeps
+     * applications that declare several token stores resolving the same one they resolved before the setting became
+     * optional.
+     */
+    String CONVENTIONAL_TOKEN_STORE_BEAN_NAME = "tokenStore";
+
+    /**
      * Creates customizations for a pooled streaming event processing module.
      *
      * @param name     Module name.
@@ -118,10 +127,12 @@ interface SpringCustomizations {
      * {@link EventProcessorSettings#source() source} or
      * {@link EventProcessorSettings.PooledEventProcessorSettings#tokenStore() token-store} setting is explicitly set.
      * When a setting is unset (or empty), this customization falls back to resolving the unique, type-level component
-     * and only applies it when one is found. Otherwise, it leaves that part of the configuration untouched, allowing
-     * customizations applied after this one, like an {@code EventProcessorDefinition}, to supply it. A still-missing
-     * source or token store is reported when the resulting {@link PooledStreamingEventProcessorConfiguration} is
-     * validated.
+     * and only applies it when one is found. An unset token store prefers the
+     * {@link #CONVENTIONAL_TOKEN_STORE_BEAN_NAME conventional bean name} before that type-level lookup, so that
+     * applications declaring several token stores keep resolving the same one. Otherwise, it leaves that part of the
+     * configuration untouched, allowing customizations applied after this one, like an
+     * {@code EventProcessorDefinition}, to supply it. A still-missing source or token store is reported when the
+     * resulting {@link PooledStreamingEventProcessorConfiguration} is validated.
      */
     class SpringPooledStreamingEventProcessingModuleCustomization
             implements PooledStreamingEventProcessorModule.Customization {
@@ -169,10 +180,16 @@ interface SpringCustomizations {
             }
 
             String tokenStoreName = StringUtils.nonEmptyOrNull(settings.tokenStore()) ? settings.tokenStore() : null;
-            var tokenStore = getComponent(configuration, TokenStore.class, tokenStoreName, null);
+            TokenStore tokenStore;
             if (tokenStoreName != null) {
+                tokenStore = getComponent(configuration, TokenStore.class, tokenStoreName, null);
                 require(tokenStore != null, "Could not find a mandatory TokenStore with name '" + settings.tokenStore()
                         + "' for event processor '" + name + "'.");
+            } else {
+                tokenStore = getComponent(configuration,
+                                          TokenStore.class,
+                                          CONVENTIONAL_TOKEN_STORE_BEAN_NAME,
+                                          () -> getComponent(configuration, TokenStore.class, null, null));
             }
             if (tokenStore != null) {
                 result = result.tokenStore(tokenStore);

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
@@ -256,6 +256,24 @@ class SpringCustomizationsTest {
         }
 
         @Test
+        void prefersTheConventionallyNamedTokenStoreOverAnAmbiguousTypeLevelLookup() {
+            // given - two token stores, one of them under the conventional bean name
+            StreamableEventSource typeLevelSource = mock(StreamableEventSource.class);
+            TokenStore conventionalTokenStore = new InMemoryTokenStore();
+            var configuration = configuration(cr -> cr
+                    .registerComponent(StreamableEventSource.class, cfg -> typeLevelSource)
+                    .registerComponent(TokenStore.class, "tokenStore", cfg -> conventionalTokenStore)
+                    .registerComponent(TokenStore.class, "other-token-store", cfg -> new InMemoryTokenStore())
+            );
+
+            // when
+            var result = customizePooled(configuration, null, null);
+
+            // then
+            assertThat(result.tokenStore()).isSameAs(conventionalTokenStore);
+        }
+
+        @Test
         void leavesSourceAndTokenStoreUnsetWhenNoTypeLevelDefaultsArePresent() {
             // given - only named components are registered
             var configuration = configuration(cr -> cr


### PR DESCRIPTION
Fixes #4809

## What changed

The pooled processor's token store was made optional when the setting is unset, but `EventProcessorProperties` defaulted the setting to the literal `"tokenStore"`, so it was never unset and the optional branch was dead code. An application whose `TokenStore` bean carried any other name failed at startup with `Could not find a mandatory TokenStore with name 'tokenStore'` -- naming a bean it never declared.

The field now defaults to null, matching the already-nullable sibling `source`, and `PooledEventProcessorSettings#tokenStore()` is marked nullable to match.

## The part that needs review

Dropping the default to null **alone** would have regressed a different class of application, silently.

An app with several `TokenStore` beans previously resolved the one named `tokenStore`, because the property defaulted to that literal. A plain unique-type lookup fails on that ambiguity. So `SpringCustomizations` keeps `"tokenStore"` as a documented bean-name convention and only falls back to the type-level lookup when no bean carries that name. Existing applications resolve exactly what they resolved before.

Both the JPA and JDBC autoconfigurations register under that name, so the convention is worth preserving.

The alternative -- make ambiguity fatal and update the integration test -- is a legitimate choice a reviewer may prefer. It is the difference between a silent pick and a startup error.

## Tests

`EventProcessorPropertiesTest` (new, 4 cases), `SpringCustomizationsTest` (16) and `EventProcessorPropertiesAndDefinitionInteractionIT` (10), 0 failures. On unfixed code the new cases fail with `expected: null but was: "tokenStore"` and with the real startup failure.

The integration test is the regression guard: its context declares `store1`/`store2` plus a bean actually named `tokenStore`, which is exactly the ambiguity case. It needs `-Pintegration-test` but no container, only `ApplicationContextRunner` and `InMemoryTokenStore`.

Also added `prefersTheConventionallyNamedTokenStoreOverAnAmbiguousTypeLevelLookup` to `SpringCustomizationsTest`, because the conventional-name branch was otherwise covered only by the IT.



## The failure message names the bean again

It could not be restored inside `SpringCustomizations`: when the setting is unset, a missing token store must stay unset so a later `EventProcessorDefinition` or extension customization can still supply it, since `DefaultProcessorModuleFactory` applies base, then definition, then extensions. The check therefore moved to after that whole chain, as `SpringCustomizations.requireResolvedTokenStore(...)` called from `DefaultProcessorModuleFactory`:

```
Could not find a mandatory TokenStore with name 'tokenStore' for event processor 'X'. The TokenStore
is a hard requirement and should be provided, either by naming a TokenStore bean 'tokenStore', by
declaring a single TokenStore bean, or by setting the token-store property of this event processor.
```

Side effect: when source and token store are both missing, the token store is now reported first, ahead of the `StreamableEventSource` message. No test depends on that order.

`setTokenStore()` rejects null again. The binder never passes null -- it calls the setter only for a present property, and an empty value binds to `""` -- so the `requireNonNull` was dropped for no reason. The field and getter stay nullable.

## The conventional-name preference is now pinned on the real Spring path

The earlier test exercised `DefaultComponentRegistry`, which resolves names differently from `SpringComponentRegistry` (Spring falls back to an FQCN-named bean and to `getBean(type)` with `@Primary`). Three cases in `EventProcessorPropertiesTest` now assert on the real path, reading the selection through `AxonConfiguration.getModuleConfigurations()`: the conventionally named bean wins when several exist, a differently named single bean is selected, and the message above is produced when none can be resolved.

Verified: removing the conventional-name preference fails the first two; removing the new check fails the third. `EventProcessorPropertiesAndDefinitionInteractionIT` stays green, which is what proves definition-supplied configuration still works with the check in its new position.

## Upgrade note

`PooledEventProcessorSettings.tokenStore()` becomes `@Nullable`. Implementors are unaffected, since widening a return type's nullability is source- and binary-compatible. **Callers** must now handle null. It aligns with `EventProcessorSettings.source()`, which is already nullable, so this follows an existing pattern rather than introducing one.
