### PR TITLE
[#4825] Document that the token claim protocol requires agreeing clocks

### DIFF
--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -354,6 +354,8 @@ This value defaults to 5000 milliseconds.
 * `claimExtensionThreshold`: Threshold to extend the claim in the absence of events.
 The value defaults to 5000 milliseconds.
 
+Before sizing these values for a processor distributed over several instances, read <<token_claim_clocks,the claim timeout requires the clocks to agree>>: the timeout is measured across two machines' clocks, and the protocol tolerates no disagreement between them.
+
 Consider the following snippet if you want to configure these values:
 
 [tabs]
@@ -417,6 +419,42 @@ Examples of when a thread may get its token stolen are:
 - Too large event batch size.
 - Blocking operations inside event handlers.
 - Blocking exceptions inside event handlers.
+
+[#token_claim_clocks]
+==== The claim timeout requires the clocks to agree
+
+The comparison that decides whether a claim may be stolen has two sides that come from two different machines.
+The token's timestamp was written by whichever instance last held the claim, while the `claimTimeout` is measured against the clock of the instance asking to steal it.
+The comparison therefore only means what it says for as long as those clocks agree.
+
+[WARNING]
+====
+The claim protocol tolerates no clock skew.
+An instance whose clock runs ahead of the claim holder's considers a live claim expired that much earlier and takes it: the steal happens up to the lesser of the clock difference and one claim timeout before a correctly-clocked instance could have taken the same claim.
+Both instances then own the same segment, and handle the same events, until the loser next tries to write the token, which is the only way it finds out.
+
+Do not read the clock difference, or the claim timeout, as a bound on that overlap.
+The loser writes its token when a batch commits, so handlers that run long defer the discovery well past the claim timeout: a handler blocked for 60 seconds under a 10 second claim timeout keeps both instances on the segment for roughly the remaining 50 seconds, whatever the clock difference was.
+Enabling `coordinatorExtendsClaims` shortens that overlap, because the coordinator thread then attempts the claim extension of a work package that is busy processing events, but it is off by default and it only moves the discovery forward - it does not bound the overlap by the clock difference either.
+
+Nothing warns you when this happens: the instance taking the claim sees an ordinary expired token, and the instance losing it sees the same `UnableToClaimTokenException` a legitimate hand-over produces.
+Keep the clocks of every instance sharing a token store synchronized, with NTP or an equivalent.
+====
+
+The requirement comes from the store implementation rather than from `TokenStore`, which prescribes no timeout and no clock.
+A plain table of tokens offers no way to notice that an owner died, so the JDBC and JPA stores fall back on a claim that expires, and an expiring claim means comparing a timestamp one machine wrote against another machine's clock.
+A store whose backing technology releases a dead owner's claim itself keeps no such timestamp, and therefore needs no agreement between clocks.
+
+There is no clock difference small enough to be safe.
+An instance refreshes its claim well within the claim timeout, so while every refresh lands on schedule a small difference often finds no token old enough to take.
+A refresh is work a background thread performs when it is scheduled to, though, and one missed refresh already leaves the claim about as old as the `claimTimeout` - at which point any difference at all tips the comparison, and a segment still being processed changes hands.
+Consequently, raise the `claimTimeout` to cover your slowest batch, not to absorb a difference between clocks.
+
+[TIP]
+====
+To reproduce the effect in a test, move the application's clock instead of trying to skew a machine.
+The framework reads the current time through `org.axonframework.common.ClockUtils`, so `ClockUtils.set(Clock.offset(Clock.systemUTC(), Duration.ofSeconds(30)))` makes the whole application behave like an instance whose clock is 30 seconds ahead, and `ClockUtils.reset()` restores it.
+====
 
 ==== What are the consequences of token stealing?
 

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/TokenStoreProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/TokenStoreProperties.java
@@ -26,6 +26,10 @@ import java.time.Duration;
 /**
  * Properties describing the settings for the default
  * {@link TokenStore Token Store}.
+ * <p>
+ * The claim timeout below is measured by comparing a timestamp another process wrote against this process' clock, so it
+ * only means what it says while the clocks of all processes sharing the store agree. See {@link TokenStore} for what a
+ * disagreement costs; raising this timeout does not buy tolerance for one.
  *
  * @author Gerard Klijs
  * @since 4.8.0

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/TokenStore.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/TokenStore.java
@@ -31,6 +31,35 @@ import java.util.concurrent.CompletableFuture;
  * A {@link StreamingEventProcessor} that is tracking an event
  * stream can use the store to keep track of its position in the event stream. Tokens are stored by process name and
  * segment index, enabling the same processor to be distributed over multiple processes or machines.
+ * <p>
+ * <b>This interface prescribes no claim timeout, and therefore no clock.</b> The lease-and-timestamp model belongs to
+ * the implementations that need it: a plain token table offers no way to notice that an owner died, so the JDBC and JPA
+ * stores let a claim expire after a timeout, and decide whether a claim may be stolen by comparing the timestamp stored
+ * alongside the claim against the clock of the process asking. <b>For those implementations the claim protocol requires
+ * the clocks of all processes sharing the store to agree.</b> That timestamp was written by whichever
+ * process last held the claim, so on a distributed processor the two sides of the comparison are read from two
+ * different machines, and the comparison only means what it says while those machines agree on the time. A process
+ * whose clock runs ahead of the claim holder's considers a live claim expired that much earlier and takes it: the steal
+ * happens up to the lesser of the disagreement and one claim timeout before a correctly-clocked process could have
+ * taken the same claim. Both processes then own the same segment, and therefore handle the same events, until the loser
+ * next writes the token, which is the only way it finds out. Neither process is warned: the process taking the claim
+ * sees an ordinary expired row, and the process losing it sees the same {@link UnableToClaimTokenException} a
+ * legitimate hand-over produces.
+ * <p>
+ * Do not read the disagreement, or the claim timeout, as a bound on that overlap. The loser writes its token when a
+ * batch commits, so handlers that run long defer the discovery well past the claim timeout: a handler blocked for a
+ * minute under a ten-second claim timeout keeps both processes on the segment for roughly the remaining fifty seconds,
+ * whatever the disagreement was.
+ * <p>
+ * There is no amount of disagreement the protocol absorbs. An owner refreshes its claim well within the claim timeout,
+ * so while every refresh lands on schedule a small disagreement often finds no row old enough to take. A refresh is
+ * work a background thread performs when it is scheduled to, though, and one missed refresh already leaves the claim
+ * about as old as the claim timeout, at which point any disagreement at all tips the comparison. Keep the clocks
+ * synchronized, and size the claim timeout to cover the longest an owner may go between refreshes rather than to absorb
+ * a clock difference.
+ * <p>
+ * An implementation whose underlying store signals liveness itself, releasing a dead owner's claim rather than waiting
+ * for a timeout to elapse, needs no such timestamp and imposes no clock-agreement requirement.
  *
  * @author Allard Buijze
  * @author Rene de Waele

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreConfiguration.java
@@ -83,6 +83,10 @@ public record JdbcTokenStoreConfiguration(
      * <p>
      * Thus, if a claim has not been updated for the given {@code claimTimeout}, this process will 'steal' the claim.
      * Defaults to a duration of 10 seconds.
+     * <p>
+     * The age of a claim is measured by comparing a timestamp another process wrote against this process' clock, so
+     * this timeout only means what it says while the clocks of all processes sharing the store agree. See
+     * {@link TokenStore} for what a disagreement costs; raising this timeout does not buy tolerance for one.
      *
      * @param claimTimeout a timeout specifying the time after which this process will force a claim
      * @return The configuration itself, for fluent API usage.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreConfiguration.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.eventhandling.processing.streaming.token.sto
 
 import jakarta.persistence.LockModeType;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
@@ -83,6 +84,10 @@ public record JpaTokenStoreConfiguration(
      * <p>
      * Thus, if a claim has not been updated for the given {@code claimTimeout}, this process will 'steal' the claim.
      * Defaults to a duration of 10 seconds.
+     * <p>
+     * The age of a claim is measured by comparing a timestamp another process wrote against this process' clock, so
+     * this timeout only means what it says while the clocks of all processes sharing the store agree. See
+     * {@link TokenStore} for what a disagreement costs; raising this timeout does not buy tolerance for one.
      *
      * @param claimTimeout A timeout specifying the time after which this process will force a claim.
      * @return The configuration itself, for fluent API usage.

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jdbc/JdbcTokenStoreTest.java
@@ -429,6 +429,59 @@ class JdbcTokenStoreTest {
         assertNull(token);
     }
 
+    /**
+     * The claim's age is a timestamp one process wrote measured against another process' clock, so the protocol allows
+     * the two no disagreement. Both cases move the clock the whole application reads rather than the wall clock of a
+     * machine, which is the only way to model a disagreement in-process, and advance it in fixed steps so neither case
+     * depends on how long the test itself takes. {@code concurrentTokenStore} claims with a two-second timeout.
+     */
+    @Nested
+    class ClaimTimeoutAcrossDisagreeingClocks {
+
+        @Test
+        void clockAheadByLessThanTheClaimTimeoutTakesAClaimThatIsStillLive() {
+            // given a segment claimed by this process, and 600 milliseconds of real time passing for every process
+            Clock agreedClock = ClockUtils.get();
+            transactionManager.executeInTransaction(() -> joinAndUnwrap(
+                    tokenStore.initializeTokenSegments("skew", 1, null, createProcessingContext())));
+            transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(tokenStore.fetchToken("skew", 0, null)));
+            ClockUtils.set(Clock.offset(agreedClock, Duration.ofMillis(600)));
+
+            // then a process whose clock agrees cannot take the claim: 600 milliseconds against a two-second timeout
+            assertThrows(UnableToClaimTokenException.class, () -> transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(concurrentTokenStore.fetchToken("skew", 0, null))));
+
+            // when that same process reads the same store at the same instant, with a clock running 1500 milliseconds
+            // ahead - a disagreement well below its own claim timeout
+            ClockUtils.set(Clock.offset(agreedClock, Duration.ofMillis(600 + 1500)));
+
+            // then it takes the claim anyway, so no clock difference is small enough to be safe
+            assertDoesNotThrow(() -> transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(concurrentTokenStore.fetchToken("skew", 0, null))));
+        }
+
+        @Test
+        void theProcessThatLostTheSegmentOnlyLearnsWhenItNextWritesTheToken() {
+            // given a segment claimed by this process, taken by a process whose clock runs past the claim timeout ahead
+            transactionManager.executeInTransaction(() -> joinAndUnwrap(
+                    tokenStore.initializeTokenSegments("skew", 1, null, createProcessingContext())));
+            transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(tokenStore.fetchToken("skew", 0, null)));
+            ClockUtils.set(Clock.offset(ClockUtils.get(), Duration.ofSeconds(2).plusMillis(1)));
+            transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(concurrentTokenStore.fetchToken("skew", 0, null)));
+
+            // when this process writes the token it still believes it owns
+            // then that write is refused, which is the first and only signal it gets
+            assertThrows(UnableToClaimTokenException.class, () -> transactionManager.executeInTransaction(
+                    () -> joinAndUnwrap(tokenStore.storeToken(new GlobalSequenceTrackingToken(1),
+                                                              "skew",
+                                                              0,
+                                                              createProcessingContext()))));
+        }
+    }
+
     @Test
     void stealToken() {
         transactionManager.executeInTransaction(

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/store/jpa/JpaTokenStoreTest.java
@@ -21,6 +21,7 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Persistence;
+import org.axonframework.common.ClockUtils;
 import org.axonframework.common.jpa.EntityManagerExecutor;
 import org.axonframework.common.jpa.SimpleEntityManagerProvider;
 import org.axonframework.conversion.TestConverter;
@@ -36,6 +37,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.stor
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.util.Collections;
@@ -74,6 +76,7 @@ class JpaTokenStoreTest {
 
     @AfterEach
     public void rollback() {
+        ClockUtils.reset();
         transaction.rollback();
     }
 
@@ -409,6 +412,54 @@ class JpaTokenStoreTest {
             fail("Expected UnableToClaimTokenException");
         } catch (UnableToClaimTokenException e) {
             // expected
+        }
+    }
+
+    /**
+     * The claim's age is a timestamp one process wrote measured against another process' clock, so the protocol allows
+     * the two no disagreement. Both cases move the clock the whole application reads rather than the wall clock of a
+     * machine, which is the only way to model a disagreement in-process, and advance it in fixed steps so neither case
+     * depends on how long the test itself takes. {@code concurrentJpaTokenStore} claims with a two-second timeout.
+     */
+    @Nested
+    class ClaimTimeoutAcrossDisagreeingClocks {
+
+        @Test
+        void clockAheadByLessThanTheClaimTimeoutTakesAClaimThatIsStillLive() {
+            // given a segment claimed by this process, and 600 milliseconds of real time passing for every process
+            Clock agreedClock = ClockUtils.get();
+            joinAndUnwrap(jpaTokenStore.initializeTokenSegments("skew", 1, null, createProcessingContext()));
+            joinAndUnwrap(jpaTokenStore.fetchToken("skew", 0, null));
+            ClockUtils.set(Clock.offset(agreedClock, Duration.ofMillis(600)));
+
+            // then a process whose clock agrees cannot take the claim: 600 milliseconds against a two-second timeout
+            assertThrows(UnableToClaimTokenException.class,
+                         () -> joinAndUnwrap(concurrentJpaTokenStore.fetchToken("skew", 0, null)));
+
+            // when that same process reads the same store at the same instant, with a clock running 1500 milliseconds
+            // ahead - a disagreement well below its own claim timeout
+            ClockUtils.set(Clock.offset(agreedClock, Duration.ofMillis(600 + 1500)));
+
+            // then it takes the claim anyway, so no clock difference is small enough to be safe
+            assertDoesNotThrow(() -> joinAndUnwrap(concurrentJpaTokenStore.fetchToken("skew", 0, null)));
+        }
+
+        @Test
+        void theProcessThatLostTheSegmentOnlyLearnsWhenItNextWritesTheToken() {
+            // given a segment claimed by this process, taken by a process whose clock runs past the claim timeout ahead
+            var ctx = createProcessingContext();
+            joinAndUnwrap(jpaTokenStore.initializeTokenSegments("skew", 1, null, ctx));
+            joinAndUnwrap(jpaTokenStore.fetchToken("skew", 0, null));
+            ClockUtils.set(Clock.offset(ClockUtils.get(), Duration.ofSeconds(2).plusMillis(1)));
+            joinAndUnwrap(concurrentJpaTokenStore.fetchToken("skew", 0, null));
+
+            // when this process writes the token it still believes it owns
+            // then that write is refused, which is the first and only signal it gets
+            assertThrows(UnableToClaimTokenException.class,
+                         () -> joinAndUnwrap(jpaTokenStore.storeToken(new GlobalSequenceTrackingToken(1),
+                                                                      "skew",
+                                                                      0,
+                                                                      ctx)));
         }
     }
 


### PR DESCRIPTION
Fixes #4825

## What changed

Documentation, plus one characterisation test. No behaviour change.

The claim timeout decides whether one instance may take a segment from another by comparing a timestamp the **other** instance wrote against its **own** clock, and nothing stated how far apart those clocks may be. An instance running ahead treats a live claim as expired that much early and takes the segment, so two instances process the same events with no warning on either side: the thief sees an ordinary expired row, the victim sees the same exception a normal hand-over produces.

The requirement is now stated on `TokenStore`, on the JDBC and JPA configuration records, on the Spring Boot `claim-timeout` property, and in the reference guide, cross-referenced from the token-claim configuration section so an operator tuning the timeout reaches it.

## No tolerance term in the comparison

`JdbcTokenEntry.expired()` and `jpa/TokenEntry.expired()` are byte-identical:

```java
return timestamp().plus(claimTimeout).isBefore(ClockUtils.instant());
```

Reached only via `mayClaim` = `owner == null || owner.equals(this.owner) || expired(...)`, so for a foreign live owner `expired()` is the sole gate. The stored timestamp is written by the previous owner as `formatInstant(ClockUtils.instant())` on *its* machine, so the two sides genuinely come from two clocks.

The documented bound follows: a stealer ahead by D sees expiry when `real_elapsed > claimTimeout - D`, so it steals D early, capped at `claimTimeout` once `D >= claimTimeout`. The loser keeps processing until its next token write is refused, which its own refresh schedule puts within one claim timeout. Overlap is therefore at most `min(D, claimTimeout)`.

## Two things deliberately not done

**No skew-detection check.** The instance causing the damage runs ahead and sees the claim timestamp in the *past*, indistinguishable from a genuinely stale claim. Only an instance running *behind* sees an implausibly future timestamp, and it is the victim, too late to prevent the overlap. Detection cannot stop a single overlap, and would add a magic constant to a per-fetch hot path for a diagnostic from the wrong side.

**No published `claimTimeout - claimExtensionThreshold` safe margin.** A TLA+ model breaks it in twelve steps when the owner misses one refresh window, so it bounds a punctual owner, not the protocol. Publishing it would advertise a tolerance the framework does not enforce.

An explicit tolerance term in the comparison is a real behaviour change with a new setting, and deserves its own issue.

## Tests

67 testcases across `InMemoryTokenStoreTest` (12), `JdbcTokenStoreTest` (28) and `JpaTokenStoreTest` (27), 0 failures.

`ClaimTimeoutAcrossDisagreeingClocks` in both `JdbcTokenStoreTest` and `JpaTokenStoreTest` covers the case a reader will actually act on: `clockAheadByLessThanTheClaimTimeoutTakesAClaimThatIsStillLive`. Real time advances a fixed 600 ms, the claim is refused while the clocks agree, then granted at the same instant read by a clock 1500 ms ahead. No dependence on test duration.

These are characterisation tests: they pass before and after, by design, because no behaviour changed. Their job is to go red if a skew tolerance is ever added to `expired()`, which would make this documentation wrong. Both stores are covered, so `TokenEntry` and `JdbcTokenEntry` are each pinned.

