### PR TITLE
[#4828] Append at the end of the aggregate stream when no consistency condition is given

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -113,6 +113,10 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
             WHERE e.aggregateIdentifier = :id \
             AND e.aggregateSequenceNumber >= :seq \
             ORDER BY e.aggregateSequenceNumber ASC""";
+    private static final String LAST_SEQUENCE_NUMBER_QUERY = """
+            SELECT MAX(e.aggregateSequenceNumber) \
+            FROM AggregateEventEntry e \
+            WHERE e.aggregateIdentifier = :id""";
     private static final String EVENTS_BY_TOKEN_QUERY = """
             SELECT e \
             FROM AggregateEventEntry e \
@@ -199,7 +203,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         }
 
         return entityManagerExecutor(processingContext).apply(em -> {
-            AggregateBasedConsistencyMarker preCommitConsistencyMarker = AggregateBasedConsistencyMarker.from(condition);
+            AggregateBasedConsistencyMarker preCommitConsistencyMarker = markerFor(condition, events, em);
 
             try {
                 AggregateSequencer sequencer = preCommitConsistencyMarker.createSequencer();
@@ -235,6 +239,48 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                     .translateConflictException(preCommitConsistencyMarker, e, isConflictException);
             }
         });
+    }
+
+    /**
+     * Derives the {@link AggregateBasedConsistencyMarker} the given {@code events} should be sequenced from, based on
+     * the given {@code condition}.
+     * <p>
+     * For an unconditional append the marker is anchored at the end of the stream of every aggregate the {@code events}
+     * are tagged for. {@link AppendCondition#none()} carries the {@link ConsistencyMarker#INFINITY} marker, which holds
+     * no position for any aggregate, so without this step the sequencer would start every aggregate at sequence zero.
+     * The append would then collide with the events an aggregate already holds and be reported as a conflict, even
+     * though the caller asked for no consistency check at all. Resolving the highest stored sequence number per
+     * aggregate lets the append take the next sequence instead. Conditional appends are left as they are, so
+     * {@link ConsistencyMarker#ORIGIN} keeps meaning "the aggregate must still be empty".
+     *
+     * @param condition the condition the given {@code events} are appended under
+     * @param events    the events about to be appended
+     * @param em        the {@link EntityManager} to resolve the stored sequence numbers with
+     * @return the marker to sequence the given {@code events} from, never {@code null}
+     */
+    private static AggregateBasedConsistencyMarker markerFor(AppendCondition condition,
+                                                             List<TaggedEventMessage<?>> events,
+                                                             EntityManager em) {
+        AggregateBasedConsistencyMarker marker = AggregateBasedConsistencyMarker.from(condition);
+        if (condition.consistencyMarker() != ConsistencyMarker.INFINITY) {
+            return marker;
+        }
+
+        for (String aggregateIdentifier : events.stream()
+                                                .map(taggedEvent -> resolveAggregateIdentifier(taggedEvent.tags()))
+                                                .filter(Objects::nonNull)
+                                                .distinct()
+                                                .toList()) {
+            Long lastSequenceNumber = em.createQuery(LAST_SEQUENCE_NUMBER_QUERY, Long.class)
+                                        .setParameter("id", aggregateIdentifier)
+                                        .getSingleResult();
+            if (lastSequenceNumber != null) {
+                marker = marker.doUpperBound(
+                        new AggregateBasedConsistencyMarker(aggregateIdentifier, lastSequenceNumber)
+                );
+            }
+        }
+        return marker;
     }
 
     private static AggregateEventEntry mapToEntry(TaggedEventMessage<?> taggedEvent,

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -392,6 +392,30 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     }
 
     @Test
+    void unconditionalAppendContinuesAnAggregateThatAlreadyHoldsEvents() {
+        // given an aggregate that already holds one event
+        appendEvents(
+                AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                taggedEventMessage("event-0", TEST_AGGREGATE_TAGS)
+        );
+
+        // when appending to that same aggregate without any consistency condition
+        ConsistencyMarker result = appendEvents(
+                AppendCondition.none(),
+                taggedEventMessage("event-1", TEST_AGGREGATE_TAGS)
+        );
+
+        // then the append lands after the events already stored, instead of being rejected as a conflict for a
+        // condition that asked for no consistency check at all
+        assertThat(result).isEqualTo(new AggregateBasedConsistencyMarker(TEST_AGGREGATE_ID, 1));
+        StepVerifier.create(FluxUtils.of(testSubject.source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA))))
+                    .expectNextMatches(entryWithAggregateEvent("event-0", 0))
+                    .expectNextMatches(entryWithAggregateEvent("event-1", 1))
+                    .expectNextMatches(AggregateBasedStorageEngineTestSuite::assertMarkerEntry)
+                    .verifyComplete();
+    }
+
+    @Test
     void sourcingFromTwoAggregateStreamsReturnsACombinedStream() {
         var appendMarker = appendEvents(
                 AppendCondition.none(),


### PR DESCRIPTION
Fixes #4828

## What changed

`AggregateBasedConsistencyMarker.from` returns an empty position map for `ORIGIN` and `INFINITY` alike, and the sequencer defaults a missing aggregate to `0`. So an append made with `AppendCondition.none()` always asked for aggregate sequence 0.

That succeeded exactly once per aggregate and then hit the unique index on `(aggregateIdentifier, aggregateSequenceNumber)` for ever after -- reported as `AppendEventsTransactionRejectedException`, the framework's "you conflicted, source again and retry" answer, where the retry re-derived sequence 0 and failed identically.

The pre-commit marker now comes from one helper. A conditional append keeps `from(condition)` unchanged, so `ORIGIN` still means "the aggregate must be empty". An `INFINITY` marker resolves `MAX(aggregateSequenceNumber)` per distinct tagged aggregate and folds it in, so the append takes the next sequence.

Cost: one `SELECT MAX(...)` per distinct tagged aggregate, on unconditional appends only. Conditional appends issue no extra query.

## This does NOT close the residual race

Two concurrent unconditional appends to the same aggregate can both read the same `MAX`, and one still loses the unique-index race and is rejected as a conflict. **The difference is that a retry now re-reads `MAX` and succeeds, instead of failing for ever.**

That is ordinary optimistic concurrency on a per-aggregate sequence column, and retry converges: 8 concurrent writers on one populated aggregate needed at most 7 attempts, ending with contiguous sequences and no lost write.

The same check also fires on the **Axon Server** arm, so "an unconditional append is never rejected" is not absolutely honoured by any store under contention. The residual violations are plausibly a different root cause: the same checker is documented firing 18 times purely from partition-window misclassification, which this fix cannot address.

Closing it fully needs row locking, or a rejection shaped differently from a conflict. That is a design decision beyond this fix.

## Tests

`AggregateBasedStorageEngineTestSuite` gains `unconditionalAppendContinuesAnAggregateThatAlreadyHoldsEvents`, so every aggregate-store implementation inherits it. On unfixed code:

```
AppendEventsTransactionRejectedException: Event matching append criteria have been detected beyond
provided consistency marker: AggregateBasedConsistencyMarker{aggregatePositions={}}
  Suppressed: ConstraintViolationException: unique constraint or index violation ... AGGREGATEEVENTENTRY
```

`AggregateBasedJpaEventStorageEngineIT`: 34 testcases, 0 failures, new case passing.

Note: the IT exercising the shared suite lives in `extensions/spring/spring-boot-autoconfigure`, not `eventsourcing`, and needs `-Pintegration-test`. `-pl eventsourcing` alone never runs the new test.

## No conflict with #4819

That branch touches only `AggregateBasedConsistencyMarker` and its test, to add `doLowerBound`. This commit touches neither. Zero file overlap, so the two can land in either order.


## The conflation stays in place

The shared root cause is untouched: `AggregateBasedConsistencyMarker.from()` returns an empty position map for `ORIGIN` and `INFINITY` alike, and `AggregateSequencer.positionOf()` defaults to 0. This change compensates in a private helper inside the JPA engine instead.

Safe today, since `from()` and `createSequencer()` have exactly one production consumer. But a future aggregate-based engine, or a port from `stash/`, inherits the original bug and must re-implement the compensation.
