### PR TITLE
[#4832] Commit the append transaction before the context transaction

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -22,6 +22,8 @@ import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.core.Context.ResourceKey;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
@@ -208,7 +210,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
                     return eventStorageEngine.appendEvents(appendCondition, processingContext, eventQueue)
                                              .thenApply(DefaultEventStoreTransaction::castTransaction)
                                              .thenAccept(tx -> {
-                                                 processingContext.onCommit(c -> tx.commit()
+                                                 processingContext.on(AppendPhase.APPEND_COMMIT, c -> tx.commit()
                                                      .thenAccept(v -> processingContext.onAfterCommit(c2 -> doAfterCommit(c2, tx, v)))
                                                  );
                                                  processingContext.onError((c, p, e) -> tx.rollback());
@@ -276,5 +278,27 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
     @SuppressWarnings("unchecked")
     private static AppendTransaction<Object> castTransaction(AppendTransaction<?> at) {
         return (AppendTransaction<Object>) at;
+    }
+
+    /**
+     * The {@link ProcessingLifecycle.Phase phase} committing the {@link AppendTransaction}, ordered strictly before
+     * {@link DefaultPhases#COMMIT}.
+     * <p>
+     * Actions within a single phase have no order relative to one another and may run in parallel. A
+     * {@link org.axonframework.messaging.core.unitofwork.transaction.TransactionManager TransactionManager} bound to
+     * the {@link ProcessingContext} commits its {@code Transaction} in the {@code COMMIT} phase, so committing the
+     * {@code AppendTransaction} in that same phase would leave the moment the appended events become durable
+     * undefined: it could occur before, during or after {@link AppendTransaction#commit()}. Committing one phase
+     * earlier guarantees the {@code AppendTransaction} completes while that surrounding transaction is still open,
+     * making {@code commit()} the last point at which an append can still be refused.
+     */
+    private enum AppendPhase implements ProcessingLifecycle.Phase {
+
+        APPEND_COMMIT;
+
+        @Override
+        public int order() {
+            return DefaultPhases.COMMIT.order() - 1;
+        }
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -281,8 +281,8 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
     }
 
     /**
-     * The {@link ProcessingLifecycle.Phase phase} committing the {@link AppendTransaction}, ordered strictly before
-     * {@link DefaultPhases#COMMIT}.
+     * The {@link ProcessingLifecycle.Phase phase} in which a {@code DefaultEventStoreTransaction} commits its
+     * {@link AppendTransaction}, ordered strictly before {@link DefaultPhases#COMMIT}.
      * <p>
      * Actions within a single phase have no order relative to one another and may run in parallel. A
      * {@link org.axonframework.messaging.core.unitofwork.transaction.TransactionManager TransactionManager} bound to
@@ -291,9 +291,23 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
      * undefined: it could occur before, during or after {@link AppendTransaction#commit()}. Committing one phase
      * earlier guarantees the {@code AppendTransaction} completes while that surrounding transaction is still open,
      * making {@code commit()} the last point at which an append can still be refused.
+     * <p>
+     * Anything observing the phase an action runs in sees this phase alongside the {@link DefaultPhases}, which is why
+     * it is published rather than kept internal. Most notably, an
+     * {@link ProcessingLifecycle.ErrorHandler ErrorHandler} registered through
+     * {@link ProcessingLifecycle#onError(ProcessingLifecycle.ErrorHandler) onError} is handed {@code APPEND_COMMIT},
+     * and not {@code COMMIT}, when the append commit is the action that failed. Match on this constant to recognize
+     * the append commit; a comparison against {@code COMMIT} alone does not cover it.
+     * <p>
+     * Note that a {@code ProcessingLifecycle} groups actions by {@link ProcessingLifecycle.Phase#order() order} rather
+     * than by phase identity. A separately defined phase sharing this phase's order is therefore indistinguishable
+     * from it, and its actions run together with the append commit.
      */
-    private enum AppendPhase implements ProcessingLifecycle.Phase {
+    public enum AppendPhase implements ProcessingLifecycle.Phase {
 
+        /**
+         * Commits the {@link AppendTransaction}, one order before {@link DefaultPhases#COMMIT}.
+         */
         APPEND_COMMIT;
 
         @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -193,10 +193,12 @@ public interface EventStorageEngine extends DescribableComponent {
         /**
          * Commit any underlying transactions to make the appended events visible to consumers.
          * <p>
-         * Called strictly before the
+         * Called in the {@link DefaultEventStoreTransaction.AppendPhase#APPEND_COMMIT APPEND_COMMIT} phase, which is
+         * ordered strictly before the
          * {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#COMMIT COMMIT} phase,
          * so that this invocation completes while a transaction bound to the {@link ProcessingContext} - which commits
-         * in the {@code COMMIT} phase - is still open.
+         * in the {@code COMMIT} phase - is still open. Being a phase of its own, it is observable: a failure of this
+         * method is attributed to {@code APPEND_COMMIT} rather than to {@code COMMIT}.
          * <p>
          * Note that an implementation relying on such a context-bound transaction may do no work here at all. On those
          * implementations the appended events become durable when that surrounding transaction commits, which is after

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -193,7 +193,15 @@ public interface EventStorageEngine extends DescribableComponent {
         /**
          * Commit any underlying transactions to make the appended events visible to consumers.
          * <p>
-         * Called during the {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#COMMIT COMMIT} phase.
+         * Called strictly before the
+         * {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#COMMIT COMMIT} phase,
+         * so that this invocation completes while a transaction bound to the {@link ProcessingContext} - which commits
+         * in the {@code COMMIT} phase - is still open.
+         * <p>
+         * Note that an implementation relying on such a context-bound transaction may do no work here at all. On those
+         * implementations the appended events become durable when that surrounding transaction commits, which is after
+         * this method returns; a successful return is therefore not a durability guarantee. What this method does
+         * guarantee, on every implementation, is that the events are not visible to consumers before it is invoked.
          *
          * @return A {@code CompletableFuture} to complete the commit asynchrously, returning a value
          *     for {@link #afterCommit(Object) afterCommit}.

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -658,6 +658,67 @@ class DefaultEventStoreTransactionTest {
             assertThat(commits).containsExactly("appendTransaction", "contextTransaction");
         }
 
+        @Test
+        void aFailedAppendCommitLeavesTheTransactionBoundToTheProcessingContextUncommitted() {
+            // given a store whose append commit refuses the append
+            RuntimeException appendFailure = new RuntimeException("Append refused.");
+            InMemoryEventStorageEngine refusingEngine = new InMemoryEventStorageEngine() {
+                @Override
+                public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                            ProcessingContext context,
+                                                                            List<TaggedEventMessage<?>> events) {
+                    return super.appendEvents(condition, context, events)
+                                .<AppendTransaction<?>>thenApply(tx -> failingCommit(tx, appendFailure));
+                }
+            };
+            // and a transaction attached to the processing context, recording what it is asked to do
+            List<String> transactionCalls = new CopyOnWriteArrayList<>();
+            TransactionManager transactionManager = () -> new Transaction() {
+                @Override
+                public void commit() {
+                    transactionCalls.add("commit");
+                }
+
+                @Override
+                public void rollback() {
+                    transactionCalls.add("rollback");
+                }
+            };
+
+            // when appending an event within a unit of work carrying that transaction
+            var uow = aUnitOfWork();
+            transactionManager.attachToProcessingLifecycle(uow);
+            uow.runOnInvocation(context -> new DefaultEventStoreTransaction(
+                    refusingEngine, context, event -> new GenericTaggedEventMessage<>(event, Set.of(AGGREGATE_ID_TAG))
+            ).appendEvent(eventMessage(0)));
+            CompletableFuture<Void> result = uow.execute();
+
+            // then the unit of work failed with the refusal
+            assertThatThrownBy(() -> awaitExceptionalCompletion(result)).hasRootCause(appendFailure);
+            // and the context-bound transaction rolled back without ever committing, because the COMMIT phase in
+            // which it would have committed is ordered after the phase that failed and therefore never ran
+            assertThat(transactionCalls).containsExactly("rollback");
+        }
+
+        private <R> AppendTransaction<R> failingCommit(AppendTransaction<R> delegate, Throwable failure) {
+            return new AppendTransaction<>() {
+                @Override
+                public CompletableFuture<R> commit() {
+                    return CompletableFuture.failedFuture(failure);
+                }
+
+                @Override
+                public void rollback() {
+                    delegate.rollback();
+                }
+
+                @Override
+                public CompletableFuture<ConsistencyMarker> afterCommit(R commitResult) {
+                    return delegate.afterCommit(commitResult);
+                }
+            };
+        }
+
         private <R> AppendTransaction<R> recordingCommit(AppendTransaction<R> delegate, List<String> commits) {
             return new AppendTransaction<>() {
                 @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -23,6 +23,8 @@ import org.axonframework.messaging.core.FluxUtils;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
+import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
@@ -33,10 +35,13 @@ import org.junit.jupiter.api.*;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -609,6 +614,72 @@ class DefaultEventStoreTransactionTest {
                         .isInstanceOf(NullPointerException.class);
             });
             awaitSuccessfulCompletion(uow.execute());
+        }
+    }
+
+    @Nested
+    class CommitOrdering {
+
+        @Test
+        void appendTransactionCommitsBeforeTheTransactionBoundToTheProcessingContext() {
+            // given a store recording its commit, completing it asynchronously as a remote store would
+            List<String> commits = new CopyOnWriteArrayList<>();
+            InMemoryEventStorageEngine recordingEngine = new InMemoryEventStorageEngine() {
+                @Override
+                public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                            ProcessingContext context,
+                                                                            List<TaggedEventMessage<?>> events) {
+                    return super.appendEvents(condition, context, events)
+                                .<AppendTransaction<?>>thenApply(tx -> recordingCommit(tx, commits));
+                }
+            };
+            // and a transaction attached to the processing context, recording its commit as well
+            TransactionManager transactionManager = () -> new Transaction() {
+                @Override
+                public void commit() {
+                    commits.add("contextTransaction");
+                }
+
+                @Override
+                public void rollback() {
+                    // No rollback expected in this test.
+                }
+            };
+
+            // when appending an event within a unit of work carrying that transaction
+            var uow = aUnitOfWork();
+            transactionManager.attachToProcessingLifecycle(uow);
+            uow.runOnInvocation(context -> new DefaultEventStoreTransaction(
+                    recordingEngine, context, event -> new GenericTaggedEventMessage<>(event, Set.of(AGGREGATE_ID_TAG))
+            ).appendEvent(eventMessage(0)));
+            awaitSuccessfulCompletion(uow.execute());
+
+            // then the append transaction committed while the context-bound transaction was still open
+            assertThat(commits).containsExactly("appendTransaction", "contextTransaction");
+        }
+
+        private <R> AppendTransaction<R> recordingCommit(AppendTransaction<R> delegate, List<String> commits) {
+            return new AppendTransaction<>() {
+                @Override
+                public CompletableFuture<R> commit() {
+                    return CompletableFuture.supplyAsync(() -> null)
+                                            .thenCompose(ignored -> delegate.commit())
+                                            .thenApply(result -> {
+                                                commits.add("appendTransaction");
+                                                return result;
+                                            });
+                }
+
+                @Override
+                public void rollback() {
+                    delegate.rollback();
+                }
+
+                @Override
+                public CompletableFuture<ConsistencyMarker> afterCommit(R commitResult) {
+                    return delegate.afterCommit(commitResult);
+                }
+            };
         }
     }
 


### PR DESCRIPTION
Fixes #4832

**Draft on purpose: this reopens #3704.** That issue, closed 2026-01-16, described the identical race and resolved it deliberately by convention -- document what an engine may do per phase, and expect engines to do nothing in `commit()`. Adding a phase was raised there and not taken. This PR asks for that to be revisited, so it should not merge on my say-so.

## What changed

The append transaction's `commit()` was registered in `DefaultPhases.COMMIT`, the same phase in which the context-bound `TransactionManager` commits its `Transaction`. `UnitOfWork` runs same-order actions with `allOf`, so the two were unordered by construction and appended events could become durable and readable before, during or after `commit()`. Measured: readable **1877 ms before** `commit()` was entered.

The append commit now runs in a private `AppendPhase` ordered at `DefaultPhases.COMMIT.order() - 1`. Phases with distinct orders run strictly sequentially, so `commit()` always completes while the context-bound transaction is still open -- making it the last point at which an append can be refused. Not a new public phase, so no SPI surface changes.

`AppendTransaction.commit()`'s Javadoc now states which phase it is called in and that a successful return is not a durability guarantee on an engine relying on a context-bound transaction.

## Two arguments against, both from #3704

1. It chose convention deliberately, and the current no-op engines satisfy it.
2. Its closing note is the real objection: appending earlier means holding locks longer, so a slow transaction can block faster ones during `PREPARE_COMMIT`. Ordering the phases makes that structural rather than incidental.

The Javadoc half is uncontroversial and could land alone if the ordering is rejected.

## Tests

`CommitOrdering.appendTransactionCommitsBeforeTheTransactionBoundToTheProcessingContext`, deterministic. On unfixed code:

```
Expecting actual:   ["contextTransaction", "appendTransaction"]
to contain exactly (and in same order):
                    ["appendTransaction", "contextTransaction"]
```

`eventsourcing` event-store transaction tests: 20 testcases, 0 failures. `test` module `AxonTestFixture*Test`: 57 testcases, 0 failures.

## Merge order matters

| Branch | Result |
|---|---|
| #4820 `no-rollback-after-successful-commit` | **Conflict** in `DefaultEventStoreTransaction.java` only. Both rewrite the same `onCommit(...)` line: #4820 wraps the body to set an `AtomicBoolean committed`, this changes the registration to `on(AppendPhase.APPEND_COMMIT, ...)`. Resolution is keep both: `processingContext.on(AppendPhase.APPEND_COMMIT, c -> tx.commit().thenAccept(v -> { committed.set(true); ... }))`. Its `rollback()` Javadoc edit merges clean. |
| #4826 `in-memory-store-atomic-batch-visibility` | Clean. |

Worth noting the coupling with #4826: its added sentence, that a reader observes none of an invocation's events or all of them, is **false today on a transaction-managed store**, and this ordering change is what would make it true. The two decisions reinforce each other.



## The phase is published, not hidden

An earlier revision claimed "not a new public phase, so no SPI change". That was wrong at runtime. `UnitOfWork.phaseActions` is keyed by `Phase::order` and `runNextPhase()` hands the key to `ProcessingLifecycle.ErrorHandler.handle`, which is public. `ProcessingLifecycleInterceptor.interceptPhase` is `@Internal`, so the extra invocation there is not a public break -- but an `ErrorHandler` registered through the public `onError(...)` receives the instance and could not name, compare or switch on it.

So `AppendPhase` is now **public**. `AppendTransaction#commit()` links `APPEND_COMMIT` and states that append-commit failures are attributed to it rather than to `COMMIT`, and the enum's own Javadoc says to match on the constant because comparing against `COMMIT` alone does not cover it. The order-collision caveat is documented too: the lifecycle groups by `order()`, not phase identity, so a separately defined phase at the same order is indistinguishable.

**A decision for reviewers:** the constant currently lives on `DefaultEventStoreTransaction`, which is the implementation that registers it. Hoisting it to the `EventStoreTransaction` interface would overclaim for other implementations, and dropping it back to private plus documentation is also viable. One line either way.

## A failing append commit is now covered

`aFailedAppendCommitLeavesTheTransactionBoundToTheProcessingContextUncommitted` is red 2 of 2 on reverted production code. In one shared phase both actions are dispatched, so the database transaction commits anyway; with the ordering, `COMMIT` is never reached and only the rollback runs. 21 of 21 testcases green.

## On #3704's lock objection

It does not survive contact with the engines. `appendEvents()` already ran in `PREPARE_COMMIT` before and after this change; only `AppendTransaction.commit()` moved. The JPA engine flushes in `PREPARE_COMMIT` and its `commit()` is a documented no-op, and the Axoniq PostgreSQL engine appends inside `appendEvents()`. Lock hold time is unchanged for every in-tree engine. Only a remote store does real work in `commit()`, which is the point of the change.
