### PR TITLE
[#4829] Do not decide gap recording from an event's message timestamp

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -61,20 +61,15 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -138,8 +133,6 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
     private final Predicate<List<? extends AggregateEventEntry>> finalBatchPredicate;
     private final int batchSize;
     private final int gapCleaningThreshold;
-    private final int maxGapOffset;
-    private final long lowestGlobalSequence;
     private final EventTypeResolver eventTypeResolver;
 
     private final GapAwareTrackingTokenOperations tokenOperations;
@@ -174,11 +167,12 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         this.finalBatchPredicate = config.finalBatchPredicate();
         this.batchSize = config.batchSize();
         this.gapCleaningThreshold = config.gapCleaningThreshold();
-        this.lowestGlobalSequence = config.lowestGlobalSequence();
-        this.maxGapOffset = config.maxGapOffset();
         this.eventTypeResolver = config.eventTypeResolver();
 
-        this.tokenOperations = new GapAwareTrackingTokenOperations(config.gapTimeout(), logger);
+        this.tokenOperations = new GapAwareTrackingTokenOperations(config.gapTimeout(),
+                                                                  config.maxGapOffset(),
+                                                                  config.lowestGlobalSequence(),
+                                                                  logger);
         this.eventCoordinatorHandle = config.eventCoordinator().startCoordination(this::onAppendDetected);
         this.isConflictException = t -> persistenceExceptionResolver != null
             && t instanceof Exception ex
@@ -373,7 +367,6 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
             List<AggregateEventEntry> events = queryEventsBy(em, cleanedToken);
 
             GapAwareTrackingToken token = cleanedToken;
-            Instant gapTimeoutThreshold = tokenOperations.gapTimeoutThreshold();
 
             for (AggregateEventEntry event : events) {
                 String type = event.aggregateType();
@@ -383,7 +376,7 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
                 Set<Tag> tags = type == null || identifier == null ? Set.of() : Set.of(new Tag(type, identifier));
 
                 // Always advance the cursor past every scanned event, regardless of match:
-                token = calculateToken(token, event.globalIndex(), event.timestamp(), gapTimeoutThreshold);
+                token = tokenOperations.advance(token, event.globalIndex());
                 cursorRef.set(token);
 
                 if (condition.matches(new QualifiedName(event.type()), tags)) {
@@ -418,24 +411,6 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
         return eventsByTokenQuery.setParameter("token", token == null ? -1L : token.getIndex())
                                  .setMaxResults(batchSize)
                                  .getResultList();
-    }
-
-    private GapAwareTrackingToken calculateToken(@Nullable GapAwareTrackingToken token,
-                                                 long globalIndex,
-                                                 Instant timestamp,
-                                                 Instant gapTimeoutThreshold) {
-        boolean allowGaps = timestamp.isAfter(gapTimeoutThreshold);
-        return token == null
-                ? GapAwareTrackingToken.newInstance(globalIndex, calculateGaps(globalIndex, allowGaps))
-                : token.advanceTo(globalIndex, allowGaps ? maxGapOffset : 0);
-    }
-
-    private Collection<Long> calculateGaps(long globalIndex, boolean allowGaps) {
-        return allowGaps
-                ? LongStream.range(Math.min(lowestGlobalSequence, globalIndex), globalIndex)
-                            .boxed()
-                            .collect(Collectors.toCollection(TreeSet::new))
-                : Collections.emptySortedSet();
     }
 
     private GenericEventMessage convertToEventMessage(AggregateEventEntry event) {

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
@@ -236,7 +236,10 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * event with the highest known index.
      * <p>
      * If the gap is bigger it is assumed that the missing event will not be committed to the store anymore. This event
-     * storage engine will no longer look for those events the next time a batch is fetched.
+     * storage engine will no longer look for those events the next time a batch is fetched. That assumption is the one
+     * point at which a streaming reader gives up on an index: an event whose transaction commits after its index has
+     * fallen this far behind is never handed to that reader, even though the append succeeded. Raise this value for
+     * deployments with long-running append transactions.
      * <p>
      * Defaults to {@code 10000}.
      *

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfiguration.java
@@ -108,7 +108,10 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
         requireNonNull(eventCoordinator, "The eventCoordinator must not be null.");
         assertStrictPositive(batchSize, "The batchSize must be a positive number.");
         assertPositive(gapCleaningThreshold, "gapCleaningThreshold");
-        assertPositive(maxGapOffset, "The maxGapOffset must be a positive number.");
+        assertStrictPositive(maxGapOffset,
+                             "The maxGapOffset must be greater than zero; a maxGapOffset of 0 records no gaps at all, "
+                                     + "which loses every event whose transaction commits after a later index became "
+                                     + "visible.");
         assertPositive(lowestGlobalSequence, "The lowestGlobalSequence must be a positive number.");
         assertPositive(gapTimeout, "gapTimeout");
         requireNonNull(eventTypeResolver, "The eventTypeResolver must not be null.");
@@ -213,6 +216,16 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
     /**
      * Sets the threshold of number of gaps in a token before an attempt to clean gaps up is taken.
      * <p>
+     * Because every hole a reader discovers is recorded as a gap, a store that contains permanent holes - deleted
+     * rows, rolled back appends, a sequence that is not gapless - crosses this threshold as a matter of course rather
+     * than exceptionally. Simulating a 10% permanent-hole rate over 400 batches crosses the default threshold on 375
+     * of them, peaking at 940 outstanding gaps. Each crossing runs a cleaning query over the whole span between the
+     * lowest and highest gap, and that query is not limited to a batch. Lower this value to clean more eagerly at the
+     * cost of running that query more often, raise it to carry more gaps in the token instead.
+     * <p>
+     * The same applies to a replay: it starts below every hole the table has ever had, so it fetches its batches with
+     * the gap-aware query and pays for cleaning on top, where a stream at the head of the store pays for neither.
+     * <p>
      * Defaults to {@code 250}.
      *
      * @param gapCleaningThreshold an {@code int} specifying the threshold of number of gaps in a token before an
@@ -238,10 +251,17 @@ public record AggregateBasedJpaEventStorageEngineConfiguration(
      * If the gap is bigger it is assumed that the missing event will not be committed to the store anymore. This event
      * storage engine will no longer look for those events the next time a batch is fetched. That assumption is the one
      * point at which a streaming reader gives up on an index: an event whose transaction commits after its index has
-     * fallen this far behind is never handed to that reader, even though the append succeeded. Raise this value for
-     * deployments with long-running append transactions.
+     * fallen this far behind is never handed to that reader, even though the append succeeded.
      * <p>
-     * Defaults to {@code 10000}.
+     * Raising this value is not free, because a token carries its outstanding gaps and is written on every batch. A
+     * gap costs roughly nine bytes serialized, so a token holding the full offset measures about 88 KB at
+     * {@code 10000} and about 527 KB at {@code 60000} - the value the Spring Boot starter configures. Every gap is
+     * also listed individually in the {@code IN} clause of the query that fetches the next batch, which exceeds
+     * Oracle's limit of 1000 expressions per list ({@code ORA-01795}) far below either of those figures. Treat a
+     * deployment that routinely fills this offset as one that needs shorter append transactions, not a larger offset.
+     * <p>
+     * Defaults to {@code 10000}, and must be greater than zero: at {@code 0} no gap is ever recorded, so every event
+     * whose transaction commits after a higher index became visible is skipped for good.
      *
      * @param maxGapOffset an {@code int} specifying the maximum distance in sequence numbers between a missing event
      *                     and the event with the highest known index

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -20,25 +20,67 @@ import org.axonframework.common.ClockUtils;
 import org.axonframework.common.DateTimeUtils;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 /**
  * Contains operations that are used to interact with {@link GapAwareTrackingToken} used in Aggregate based JPA event
  * store implementation.
  *
+ * @param gapTimeout           the amount of time in milliseconds until a gap may be considered timed out and thus ready
+ *                             for removal by {@link #withGapsCleaned(GapAwareTrackingToken, List)}
+ * @param maxGapOffset         the maximum distance in global indices between a gap and the highest index a token has
+ *                             seen; gaps further behind than this are dropped from the token
+ * @param lowestGlobalSequence the first global index the backing table is expected to contain
+ * @param logger               the logger to report an unparsable stored timestamp on
  * @author Mateusz Nowak
  * @since 5.0.0
  */
 record GapAwareTrackingTokenOperations(
         int gapTimeout,
+        int maxGapOffset,
+        long lowestGlobalSequence,
         Logger logger
 ) {
+
+    /**
+     * Advances the given {@code token} to the given {@code globalIndex}, recording every index in between as a gap.
+     * <p>
+     * Every hole below {@code globalIndex} is recorded, without exception. A hole exists precisely because that index
+     * was taken from the database sequence by a transaction that has not committed yet, and nothing about the rows a
+     * reader can see tells it whether that transaction is still going to commit. Choosing not to record the gap
+     * therefore drops the event for good once the transaction does commit: the token has moved past the index and holds
+     * nothing that would ever bring the reader back to it.
+     * <p>
+     * The cost of recording is bounded by the {@code maxGapOffset}, which drops gaps that have fallen further than that
+     * many indices behind the token, and by {@link #withGapsCleaned(GapAwareTrackingToken, List)}.
+     *
+     * @param token       the token to advance, or {@code null} when the reader has not established one yet
+     * @param globalIndex the global index of the event that was just read
+     * @return the given {@code token} advanced to {@code globalIndex}
+     */
+    GapAwareTrackingToken advance(@Nullable GapAwareTrackingToken token, long globalIndex) {
+        return token == null
+                ? GapAwareTrackingToken.newInstance(globalIndex, initialGaps(globalIndex))
+                : token.advanceTo(globalIndex, maxGapOffset);
+    }
+
+    private Collection<Long> initialGaps(long globalIndex) {
+        long lowestGap = Math.max(Math.min(lowestGlobalSequence, globalIndex), globalIndex - maxGapOffset);
+        return LongStream.range(lowestGap, globalIndex)
+                         .boxed()
+                         .collect(Collectors.toCollection(TreeSet::new));
+    }
 
     GapAwareTrackingToken withGapsCleaned(GapAwareTrackingToken token, List<Object[]> indexAndTimestampBetweenGaps) {
         Instant gapTimeoutThreshold = gapTimeoutThreshold();
@@ -80,7 +122,7 @@ record GapAwareTrackingTokenOperations(
         }
     }
 
-    Instant gapTimeoutThreshold() {
+    private Instant gapTimeoutThreshold() {
         return ClockUtils.instant().minus(gapTimeout, ChronoUnit.MILLIS);
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperations.java
@@ -82,6 +82,25 @@ record GapAwareTrackingTokenOperations(
                          .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    /**
+     * Drops the leading gaps of the given {@code token} that are old enough to be considered permanent holes.
+     * <p>
+     * A gap is dropped once the row above it exists and carries a stored timestamp older than {@code gapTimeout}. That
+     * comparison has the same weakness as deciding gap recording from a timestamp had: the stored timestamp is the
+     * moment the event was created, not the moment its transaction committed, and the distance between the two is
+     * unbounded. A gap can therefore still be dropped while the transaction that holds it is about to commit. The
+     * window is {@code gapTimeout} wide instead of unbounded, and cleaning only starts above
+     * {@code gapCleaningThreshold} gaps, but it is a mitigation rather than a proof.
+     * <p>
+     * Recording every hole makes that threshold easy to reach: with permanent holes in the table, cleaning becomes the
+     * normal path rather than the exception, so this comparison runs far more often than it did when holes below
+     * seemingly old events were dropped outright.
+     *
+     * @param token                        the token whose gaps to clean
+     * @param indexAndTimestampBetweenGaps the {@code globalIndex} and stored {@code timestamp} of every row between the
+     *                                     lowest and the highest gap of the {@code token}, in index order
+     * @return the given {@code token} with its timed-out leading gaps removed
+     */
     GapAwareTrackingToken withGapsCleaned(GapAwareTrackingToken token, List<Object[]> indexAndTimestampBetweenGaps) {
         Instant gapTimeoutThreshold = gapTimeoutThreshold();
         GapAwareTrackingToken cleanedToken = token;

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
@@ -82,6 +82,11 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
      * - To immediately trigger a notification when onEventsAppended is called.
      * - To terminate the polling thread when terminate is invoked.
      *
+     * The interrupt is only an accelerator for the second case, never the condition itself: the
+     * callback runs arbitrary code that may consume the interrupt before the loop observes it. The
+     * terminated flag is therefore checked on every iteration, so a swallowed interrupt costs one
+     * more poll rather than leaving terminate blocked on join forever.
+     *
      * The COUNT(*) query is intentionally used for the JPA variant as it does not
      * have a gapless monotonic index that can be relied on.
      *
@@ -96,7 +101,7 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
         Thread pollingThread = THREAD_FACTORY.newThread(() -> {
             long lastTotalEvents = 0;
 
-            for (;;) {
+            while (!terminated.get()) {
                 try {
                     Thread.sleep(pollingInterval);
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinator.java
@@ -53,6 +53,16 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
         SELECT COUNT(*) FROM AggregateEventEntry
         """;
 
+    /**
+     * The bound on how long {@link Handle#terminate()} waits for the polling thread to return.
+     * <p>
+     * A poll blocks in a JDBC call that does not respond to an interrupt, so waiting without a deadline hands the
+     * caller of {@code terminate()} - a shutdown sequence, or a test tearing down its context - the same unbounded
+     * wait as the query it happens to have caught. The polling thread is a daemon, so giving up on it costs nothing
+     * beyond the query it is still running.
+     */
+    private static final Duration TERMINATION_TIMEOUT = Duration.ofSeconds(5);
+
     private final EntityManagerProvider entityManagerProvider;
     private final Duration pollingInterval;
 
@@ -83,9 +93,10 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
      * - To terminate the polling thread when terminate is invoked.
      *
      * The interrupt is only an accelerator for the second case, never the condition itself: the
-     * callback runs arbitrary code that may consume the interrupt before the loop observes it. The
-     * terminated flag is therefore checked on every iteration, so a swallowed interrupt costs one
-     * more poll rather than leaving terminate blocked on join forever.
+     * callback runs arbitrary code that may consume the interrupt before the loop observes it, and a
+     * poll blocked in JDBC does not observe it at all. The terminated flag is therefore checked on
+     * every iteration, and terminate waits for the thread only up to TERMINATION_TIMEOUT, so neither
+     * a swallowed interrupt nor a slow query can leave terminate blocked forever.
      *
      * The COUNT(*) query is intentionally used for the JPA variant as it does not
      * have a gapless monotonic index that can be relied on.
@@ -123,6 +134,10 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
                     LOGGER.warn("Exception while polling AggregateEventEntry, retrying next poll interval", e);
                 }
 
+                if (terminated.get()) {
+                    break;  // do not call back into a component that is being shut down
+                }
+
                 onAppendDetected.run();  // if this throws an exception, terminates the coordination
             }
 
@@ -146,7 +161,13 @@ public class JpaPollingEventCoordinator implements EventCoordinator {
                 pollingThread.interrupt();
 
                 try {
-                    pollingThread.join();
+                    if (!pollingThread.join(TERMINATION_TIMEOUT)) {
+                        LOGGER.warn(
+                            "Polling thread {} did not stop within {}, most likely blocked in a query that does not "
+                                + "respond to an interrupt. Leaving it to exit on its own; it is a daemon thread.",
+                            pollingThread.getName(), TERMINATION_TIMEOUT
+                        );
+                    }
                 } catch (InterruptedException e) {
                     // Best effort, tried waiting, but got interrupted, restore flag and ignore:
                     Thread.currentThread().interrupt();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineConfigurationTest.java
@@ -62,6 +62,15 @@ class AggregateBasedJpaEventStorageEngineConfigurationTest {
     }
 
     @Test
+    void zeroMaxGapOffsetThrowsException() {
+        // A maxGapOffset of 0 records no gap at all, which skips every event whose transaction commits
+        // after a higher global index became visible.
+        assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.maxGapOffset(0))
+                .isInstanceOf(AxonConfigurationException.class)
+                .hasMessageContaining("maxGapOffset");
+    }
+
+    @Test
     void negativeLowestGlobalSequenceThrowsException() {
         assertThatThrownBy(() -> AggregateBasedJpaEventStorageEngineConfiguration.DEFAULT.lowestGlobalSequence(-1))
                 .isInstanceOf(AxonConfigurationException.class);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperationsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/GapAwareTrackingTokenOperationsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import org.axonframework.messaging.eventhandling.processing.streaming.token.GapAwareTrackingToken;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the token advance rules of the {@link GapAwareTrackingTokenOperations}.
+ *
+ * @author Stefan Dragisic
+ */
+class GapAwareTrackingTokenOperationsTest {
+
+    private static final int GAP_TIMEOUT = 60_000;
+    private static final int MAX_GAP_OFFSET = 10_000;
+    private static final long LOWEST_GLOBAL_SEQUENCE = 1L;
+
+    private final GapAwareTrackingTokenOperations testSubject = operationsWith(MAX_GAP_OFFSET);
+
+    private static GapAwareTrackingTokenOperations operationsWith(int maxGapOffset) {
+        return new GapAwareTrackingTokenOperations(
+                GAP_TIMEOUT,
+                maxGapOffset,
+                LOWEST_GLOBAL_SEQUENCE,
+                LoggerFactory.getLogger(GapAwareTrackingTokenOperationsTest.class)
+        );
+    }
+
+    @Nested
+    class Advance {
+
+        @Test
+        void recordsEveryHoleBelowTheIndexThatWasRead() {
+            // given a reader that has seen global index 5
+            GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(5L, List.of());
+
+            // when the next row it reads is index 8, leaving 6 and 7 taken by transactions it cannot see
+            GapAwareTrackingToken result = testSubject.advance(token, 8L);
+
+            // then both holes are recorded, so the reader returns for them once those transactions commit
+            assertThat(result.getIndex()).isEqualTo(8L);
+            assertThat(result.getGaps()).containsExactly(6L, 7L);
+        }
+
+        @Test
+        void recordsAHoleThatSpansAWholeBatchOfIndices() {
+            // given a reader at the very start of the store
+            GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(0L, List.of());
+
+            // when a single row far ahead of it becomes visible first
+            GapAwareTrackingToken result = testSubject.advance(token, 100L);
+
+            // then every index in between is recorded rather than skipped
+            assertThat(result.getGaps()).hasSize(99);
+            assertThat(result.getGaps().first()).isEqualTo(1L);
+            assertThat(result.getGaps().last()).isEqualTo(99L);
+        }
+
+        @Test
+        void keepsRemainingHolesWhenOneOfThemIsFilled() {
+            // given a token whose gaps 6 and 7 are still outstanding below index 8
+            GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(8L, List.of(6L, 7L));
+
+            // when the transaction holding index 6 commits and the row is read
+            GapAwareTrackingToken result = testSubject.advance(token, 6L);
+
+            // then the token stays at 8 and index 7 is still outstanding
+            assertThat(result.getIndex()).isEqualTo(8L);
+            assertThat(result.getGaps()).containsExactly(7L);
+        }
+
+        @Test
+        void boundsRecordedHolesByTheConfiguredMaxGapOffset() {
+            // given a store configured to look no further than three indices behind the token
+            GapAwareTrackingTokenOperations narrow = operationsWith(3);
+            GapAwareTrackingToken token = GapAwareTrackingToken.newInstance(10L, List.of());
+
+            // when a row twenty indices ahead becomes visible
+            GapAwareTrackingToken result = narrow.advance(token, 30L);
+
+            // then only the holes within that distance of the new index are carried
+            assertThat(result.getIndex()).isEqualTo(30L);
+            assertThat(result.getGaps()).containsExactly(27L, 28L, 29L);
+        }
+
+        @Test
+        void boundsTheFirstTokensHolesByTheConfiguredMaxGapOffset() {
+            // given a reader with no token yet, against a store whose lowest surviving index is far above the
+            // configured lowest global sequence
+            GapAwareTrackingTokenOperations narrow = operationsWith(3);
+
+            // when its first visible row is index 1000
+            GapAwareTrackingToken result = narrow.advance(null, 1000L);
+
+            // then the token it starts from does not enumerate every index the table never held
+            assertThat(result.getIndex()).isEqualTo(1000L);
+            assertThat(result.getGaps()).containsExactly(997L, 998L, 999L);
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinatorTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinatorTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,6 +69,43 @@ class JpaPollingEventCoordinatorTest {
 
             // then it still stops, because the polling loop does not rely on the interrupt surviving
             assertThat(termination).succeedsWithin(Duration.ofSeconds(10));
+        }
+
+        @Test
+        void returnsWhileAPollIsStillBlockedInsideTheCountQuery() throws InterruptedException {
+            // given a poll that has entered the count query and is blocked there, not observing the
+            // interrupt at all, the way a JDBC call waiting on a lock or a socket does not
+            CountDownLatch insidePoll = new CountDownLatch(1);
+            AtomicBoolean pollReleased = new AtomicBoolean();
+            JpaPollingEventCoordinator blockingCoordinator = new JpaPollingEventCoordinator(
+                    () -> {
+                        insidePoll.countDown();
+                        while (!pollReleased.get()) {
+                            try {
+                                Thread.sleep(Duration.ofMillis(10));
+                            } catch (InterruptedException e) {
+                                // Swallowed on purpose: a query in flight does not end because the
+                                // thread waiting on it was interrupted.
+                            }
+                        }
+                        throw new IllegalStateException("no EntityManager in this test");
+                    },
+                    POLLING_INTERVAL
+            );
+            EventCoordinator.Handle handle = blockingCoordinator.startCoordination(() -> {
+            });
+            assertThat(insidePoll.await(5, TimeUnit.SECONDS)).isTrue();
+
+            try {
+                // when the coordination is terminated while that poll is still blocked
+                CompletableFuture<Void> termination = CompletableFuture.runAsync(handle::terminate);
+
+                // then terminate returns on its own deadline instead of waiting out the query, which
+                // it can afford because the polling thread is a daemon
+                assertThat(termination).succeedsWithin(Duration.ofSeconds(15));
+            } finally {
+                pollReleased.set(true);
+            }
         }
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinatorTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/jpa/JpaPollingEventCoordinatorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore.jpa;
+
+import org.axonframework.eventsourcing.eventstore.EventCoordinator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the polling lifecycle of the {@link JpaPollingEventCoordinator}.
+ *
+ * @author Stefan Dragisic
+ */
+class JpaPollingEventCoordinatorTest {
+
+    private static final Duration POLLING_INTERVAL = Duration.ofMillis(10);
+
+    // Failing to hand out an EntityManager makes every poll throw, which the coordinator logs and
+    // recovers from, so the loop reaches the callback without needing a database.
+    private final JpaPollingEventCoordinator testSubject = new JpaPollingEventCoordinator(
+            () -> {
+                throw new IllegalStateException("no EntityManager in this test");
+            },
+            POLLING_INTERVAL
+    );
+
+    @Nested
+    class Terminate {
+
+        @Test
+        void returnsWhenTheCallbackSwallowedTheTerminatingInterrupt() throws InterruptedException {
+            // given a callback that consumes the interrupt without rethrowing it, the way a JDBC call
+            // or an uninterruptible lock does
+            CountDownLatch insideCallback = new CountDownLatch(1);
+            EventCoordinator.Handle handle = testSubject.startCoordination(() -> {
+                insideCallback.countDown();
+                try {
+                    Thread.sleep(Duration.ofDays(1));
+                } catch (InterruptedException e) {
+                    // Swallowed on purpose: the interrupt that asked the poller to stop is now lost.
+                }
+            });
+            assertThat(insideCallback.await(5, TimeUnit.SECONDS)).isTrue();
+
+            // when the coordination is terminated while that callback is running
+            CompletableFuture<Void> termination = CompletableFuture.runAsync(handle::terminate);
+
+            // then it still stops, because the polling loop does not rely on the interrupt surviving
+            assertThat(termination).succeedsWithin(Duration.ofSeconds(10));
+        }
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngineIT.java
@@ -71,14 +71,13 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.LongStream;
 import javax.sql.DataSource;
 
@@ -245,56 +244,71 @@ class AggregateBasedJpaEventStorageEngineIT
     }
 
     @Test
-    void gapsForVeryOldEventsAreNotIncluded() {
-        EntityManager entityManager = entityManagerProvider.getEntityManager();
-        Transaction transaction = transactionManager.startTransaction();
-        entityManager.createQuery("DELETE FROM AggregateEventEntry dee").executeUpdate();
-        entityManager.clear();
-        transaction.commit();
+    void streamDeliversAnEventCommittedIntoAHoleUnderAnEventOlderThanTheGapTimeout() {
+        // given an event stored under a clock an hour behind, so the reader will see it as far older
+        // than the gap timeout - which is what a long append transaction produces without any clock
+        // trickery, because a timestamp is set when the message is created, not when it commits
+        clearEventTable();
+        ClockUtils.set(fixed(ClockUtils.instant().minus(1, ChronoUnit.HOURS)));
+        appendCommitAndWait(testSubject, AppendCondition.none(), taggedEventMessage("below-the-hole", Set.of()));
+        long belowTheHole = highestGlobalIndex();
 
-        Instant now = ClockUtils.instant();
+        // and a hole directly above it, left by an append that took its index from the sequence and
+        // has not committed yet, with a visible event above that hole
+        restartGlobalIndexSequence(belowTheHole + 2);
+        appendCommitAndWait(testSubject, AppendCondition.none(), taggedEventMessage("above-the-hole", Set.of()));
 
-        ClockUtils.set(fixed(now.minus(1, ChronoUnit.HOURS)));
-        appendCommitAndWait(testSubject, AppendCondition.none(),
-                            taggedEventMessage("-1", Set.of()), taggedEventMessage("0", Set.of()));
-
-        ClockUtils.set(fixed(now.minus(2, ChronoUnit.MINUTES)));
-        appendCommitAndWait(testSubject, AppendCondition.none(),
-                            taggedEventMessage("-2", Set.of()), taggedEventMessage("1", Set.of()));
-
-        ClockUtils.set(fixed(now.minus(50, ChronoUnit.SECONDS)));
-        appendCommitAndWait(testSubject, AppendCondition.none(),
-                            taggedEventMessage("-3", Set.of()), taggedEventMessage("2", Set.of()));
-
-        ClockUtils.set(fixed(now));
-        appendCommitAndWait(testSubject, AppendCondition.none(),
-                            taggedEventMessage("-4", Set.of()), taggedEventMessage("3", Set.of()));
-
-        entityManager.clear();
-        transaction.commit();
-        transaction = transactionManager.startTransaction();
-        entityManager.createQuery("DELETE FROM AggregateEventEntry dee WHERE dee.aggregateSequenceNumber < 0")
-                     .executeUpdate();
-        transaction.commit();
-
+        // when a reader crosses the hole, seeing only the event above it and its hour-old timestamp
+        ClockUtils.reset();
         MessageStream<EventMessage> stream = testSubject.stream(
-                StreamingCondition.startingFrom(new GapAwareTrackingToken(0, Collections.emptySet()))
+                StreamingCondition.startingFrom(GapAwareTrackingToken.newInstance(belowTheHole, emptySet()))
         );
+        assertThat(nextPayload(stream)).isEqualTo("above-the-hole");
 
-        List<GapAwareTrackingToken> tokens = new ArrayList<>();
+        // and the append that was holding the skipped index finally commits
+        restartGlobalIndexSequence(belowTheHole + 1);
+        appendCommitAndWait(testSubject, AppendCondition.none(), taggedEventMessage("committed-late", Set.of()));
 
-        // Grab the messages without using reduce on an infinite stream:
-        await().until(() -> {
-            stream.next().flatMap(e -> TrackingToken.fromContext(e))
-                  .map(GapAwareTrackingToken.class::cast)
-                  .ifPresent(tokens::add);
+        // then the reader comes back for that index, because crossing the hole recorded it as a gap
+        // regardless of how old the event above it looked
+        assertThat(nextPayload(stream)).isEqualTo("committed-late");
+    }
 
-            return tokens.size() == 8;
-        });
+    private void clearEventTable() {
+        inTransaction(entityManager -> entityManager.createQuery("DELETE FROM AggregateEventEntry").executeUpdate());
+    }
 
-        assertThat(tokens).allSatisfy(token -> {
-            assertThat(!token.hasGaps() || token.getGaps().first() >= 5L).isTrue();
-        });
+    private long highestGlobalIndex() {
+        return inTransaction(entityManager -> entityManager
+                .createQuery("SELECT MAX(e.globalIndex) FROM AggregateEventEntry e", Long.class)
+                .getSingleResult());
+    }
+
+    /**
+     * Skips or rewinds the global index sequence, standing in for an append that has taken an index but not committed.
+     */
+    private void restartGlobalIndexSequence(long nextGlobalIndex) {
+        inTransaction(entityManager -> entityManager
+                .createNativeQuery("ALTER SEQUENCE \"aggregate-event-global-index-sequence\" RESTART WITH "
+                                           + nextGlobalIndex)
+                .executeUpdate());
+    }
+
+    private <R> R inTransaction(Function<EntityManager, R> action) {
+        Transaction transaction = transactionManager.startTransaction();
+        try {
+            EntityManager entityManager = entityManagerProvider.getEntityManager();
+            R result = action.apply(entityManager);
+            entityManager.clear();
+            return result;
+        } finally {
+            transaction.commit();
+        }
+    }
+
+    private static String nextPayload(MessageStream<EventMessage> stream) {
+        await().until(() -> stream.peek().isPresent());
+        return stream.next().orElseThrow().message().payloadAs(String.class);
     }
 
     @Test


### PR DESCRIPTION
Fixes #4829
Fixes #4834

## What changed

**Gap recording no longer consults an event's message timestamp.** A global index is taken from a database sequence before the transaction commits, so a reader routinely sees index `n+1` while `n` is a hole that fills later. The reader decided whether to remember that hole by comparing the visible event's own message timestamp against its wall clock, and recorded no gap when that event looked older than `gapTimeout`. A message timestamp is set in the handler, always before the commit, and the interval between the two is unbounded, so the shortcut could only ever fire too eagerly. Worse, the stale path called `advanceTo(index, 0)`, which *discards already-recorded* gaps rather than merely declining new ones: `token(102,{101})` plus row 105 yields `{101,103,104}` now and `{}` before.

Holes are always recorded now, bounded by `maxGapOffset`, which becomes the single give-up point. `gapTimeout` goes back to meaning the gap-cleaning knob its Javadoc always described.

**`terminate()` no longer hangs (#4834).** It blocked on an unbounded `pollingThread.join()`, so it wedged whenever the polling thread could not reach the top of the loop -- including simply being parked inside `countEvents()`'s JDBC call. The join now has a 5-second deadline and warns if the thread has not stopped; the loop also stops on its `terminated` flag rather than only on the interrupt.

**`maxGapOffset = 0` is rejected.** It was accepted and silently restored the old behaviour.

## Tests

`AggregateBasedJpaEventStorageEngineIT#streamDeliversAnEventCommittedIntoAHoleUnderAnEventOlderThanTheGapTimeout` is **red on unmodified `main`** (`ConditionTimeoutException`, the reader never returns the filled index) and green here. It runs on HSQLDB, no container. The hole is made by skipping the global-index sequence, which is what an uncommitted append leaves behind.

It replaces `gapsForVeryOldEventsAreNotIncluded`, which asserted the removed behaviour and tested nothing: its `DELETE ... WHERE aggregateSequenceNumber < 0` matched `NULL` for tagless events, so it deleted no rows and streamed a contiguous store. Its own `tokens.size() == 8` expectation after supposedly deleting 4 of 8 rows is the tell.

`JpaPollingEventCoordinatorTest` covers both `terminate()` paths; the blocked-poll case is 3 of 3 red with the join unbounded.

## For the reviewer

**No reader-only fix can be fully sound.** From committed rows alone a hole is indistinguishable between abandoned and held by a slow transaction. `maxGapOffset` is a bounded mitigation, not a proof. A real proof needs the store's transaction state, on PostgreSQL the `xmin` low watermark, which is not expressible in portable JPQL.

**This makes the surviving unsound comparison in `withGapsCleaned` more reachable, not less.** At a 10% hole rate over 400 batches, `main` crosses `gapCleaningThreshold` (250) on 0 of 400 batches; this branch on 375 of 400, peaking at 940 gaps.

**The real bound on Spring Boot is 60000, not 10000**, because of the swapped defaults in #4799. That is an 88 KB token at 10000 gaps and 527 KB at 60000, written every batch, and a 60000-element `IN` list exceeds Oracle's ORA-01795 limit of 1000. Replay is affected too: every historical hole now becomes a gap.

Related: #2958 is a closed 4.9.1 production report of a processor wedged with `gaps [[]]` whose workaround admits "possibly losing processing of the gap events". Same code path.
