### PR TITLE
Adapt the multi-tenancy examples to multi-tenancy being enabled by default

### DIFF
--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/ProviderAmbiguityGuardrail.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/ProviderAmbiguityGuardrail.java
@@ -21,7 +21,6 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
@@ -62,12 +61,11 @@ public final class ProviderAmbiguityGuardrail {
     public static boolean rejectsTwoProvidersForOneType() {
         MessagingConfigurer configurer = MessagingConfigurer.create();
         configurer.componentRegistry(registry -> {
-            // The parameter resolver that rejects the ambiguity is installed by the multi-tenancy
-            // enhancer, so it is enabled here too. This guardrail is about provider ambiguity, so it
+            // The parameter resolver that rejects the ambiguity comes with multi-tenancy, which is active
+            // as soon as the module is on the classpath. This guardrail is about provider ambiguity, so it
             // runs in memory regardless of whether the demo itself runs against Axon Server. Both
             // Axon Server enhancers are disabled: the multi-tenancy defaults would otherwise register a
             // multi-tenant command bus connector that needs an AxonServerConnectionManager we do not have.
-            MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
             registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
                     .disableEnhancer(AxonServerMultiTenancyConfigurationDefaults.class)
                     .registerComponent(TenantProvider.class,

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
@@ -22,7 +22,6 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
@@ -85,7 +84,6 @@ class CourseEnrollmentCompositionTest {
         EventSourcingConfigurer configurer = EventSourcingConfigurer.create();
         UniversityModuleConfiguration.configure(configurer);
         configurer.componentRegistry(registry -> {
-            MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
             registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
                     .disableEnhancer(AxonServerMultiTenancyConfigurationDefaults.class)
                     .registerComponent(TenantProvider.class, config -> tenantProvider)

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -20,7 +20,6 @@ import io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigur
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
@@ -35,10 +34,10 @@ import org.axonframework.examples.demo.multitenancy.university.read.statistics.C
  * <p>
  * The domain itself, the write slices and the statistics read slice, is registered by
  * {@link UniversityModuleConfiguration}, shared with the Spring Boot demo. This class only adds the
- * multi-tenancy wiring around it: it turns on the multi-tenancy enhancer and registers one
- * {@link TenantComponentProvider} per tenant-scoped component type, so the framework hands each handler
- * the components of the message's tenant, matched by type, and routes the course's events to that
- * tenant's own event store.
+ * multi-tenancy wiring around it. Multi-tenancy itself is active because the {@code axoniq-multi-tenancy}
+ * module is on the classpath, so all this class registers is one {@link TenantComponentProvider} per
+ * tenant-scoped component type. The framework then hands each handler the components of the message's
+ * tenant, matched by type, and routes the course's events to that tenant's own event store.
  */
 public final class UniversityConfiguration {
 
@@ -69,7 +68,6 @@ public final class UniversityConfiguration {
                                  TenantComponentProvider<AuditLog> auditProvider) {
         UniversityModuleConfiguration.configure(configurer)
                                      .componentRegistry(registry -> {
-                                         MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
                                          // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
                                          registry.disableEnhancer(AxonServerConfigurationEnhancer.class)
                                                  .disableEnhancer(AxonServerMultiTenancyConfigurationDefaults.class)
@@ -84,8 +82,8 @@ public final class UniversityConfiguration {
      * Registers the Axon Server backed tenant-aware wiring on the given {@code configurer}: the same
      * university domain, and one {@link TenantComponentProvider} per tenant-scoped component type.
      * <p>
-     * The Axon Server configuration enhancer is left enabled, so the multi-tenancy enhancer registers its
-     * default auto-discovering tenant provider watching Axon Server's contexts, and the course write side
+     * The Axon Server configuration enhancer is left enabled, so multi-tenancy uses its default
+     * auto-discovering tenant provider watching Axon Server's contexts, and the course write side
      * is registered against the per-tenant, tenant-aware event store Axon Server provides. This path needs
      * a running multi-context (Enterprise Edition) Axon Server.
      *
@@ -97,10 +95,9 @@ public final class UniversityConfiguration {
                                               TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                                               TenantComponentProvider<AuditLog> auditProvider) {
         UniversityModuleConfiguration.configure(configurer)
-                                     .componentRegistry(registry -> {
-                                         MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
-                                         registerTenantComponents(registry, statisticsProvider, auditProvider);
-                                     });
+                                     .componentRegistry(registry -> registerTenantComponents(registry,
+                                                                                             statisticsProvider,
+                                                                                             auditProvider));
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -36,11 +36,13 @@ import org.springframework.context.annotation.Configuration;
  * {@link TenantComponentProvider} bean per tenant-scoped component type, the statistics query handler,
  * and each write slice's modules, as ordinary beans.
  * <p>
- * The multi-tenancy auto-configuration from the Axoniq Framework Spring Boot starter activates the
- * feature (tenants are Axon Server contexts, so it activates only while Axon Server is enabled), picks
- * these provider beans up, subscribes them to the tenant lifecycle, and installs the tenant parameter
- * resolver and interceptor. It also registers the default auto-discovering {@link AxonServerTenantProvider},
- * which watches Axon Server's contexts and registers each as a tenant (filtering out {@code _admin}). So
+ * Multi-tenancy is active because the {@code axoniq-multi-tenancy} module is on the classpath. The
+ * auto-configuration from the Axoniq Framework Spring Boot starter only switches it off again when
+ * {@code axon.multitenancy.enabled=false} or {@code axon.axonserver.enabled=false}, since tenants are Axon
+ * Server contexts. The framework picks these provider beans up, subscribes them to the tenant lifecycle,
+ * and installs the tenant parameter resolver and interceptor. It also registers the default
+ * auto-discovering {@link AxonServerTenantProvider}, which watches Axon Server's contexts and registers
+ * each as a tenant (filtering out {@code _admin}). So
  * the framework hands each command and query handler the components of the message's tenant for their
  * {@code @TenantScoped} parameters, matched by type, with no explicit multi-tenancy wiring here at all.
  */

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
@@ -18,12 +18,15 @@ package org.axonframework.integrationtests.testsuite.infrastructure;
 
 import org.axonframework.common.configuration.ComponentRegistry;
 
+import java.util.List;
+
 /**
  * {@link TestInfrastructure} implementation that uses the framework's default in-memory components.
  * <p>
- * No containers are started. The only configuration step is disabling the AxonServer enhancer so that classpath
- * scanning does not replace the in-memory defaults ({@code SimpleCommandBus}, {@code SimpleQueryBus},
- * {@code InMemoryEventStorageEngine}) with distributed AxonServer equivalents.
+ * No containers are started. The only configuration step is disabling the AxonServer-backed enhancers so that
+ * classpath scanning does not replace the in-memory defaults ({@code SimpleCommandBus}, {@code SimpleQueryBus},
+ * {@code InMemoryEventStorageEngine}) with distributed AxonServer equivalents, and does not activate multi-tenancy,
+ * which is AxonServer-backed as well.
  * <p>
  * Data "purging" is a no-op: each test shuts down and recreates the
  * {@link org.axonframework.common.configuration.AxonConfiguration} via
@@ -54,6 +57,17 @@ public final class InMemoryTestInfrastructure implements TestInfrastructure {
     private static final String AXON_SERVER_ENHANCER_FQCN =
             "io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer";
 
+    /**
+     * FQCN strings of the multi-tenancy configuration enhancers, disabled for the same reason and in the same way as
+     * {@link #AXON_SERVER_ENHANCER_FQCN}. Tenants are AxonServer contexts, so multi-tenancy cannot function on an
+     * in-memory infrastructure: its tenant provider would try to resolve an AxonServer connection manager at startup.
+     */
+    private static final List<String> MULTI_TENANCY_ENHANCER_FQCNS = List.of(
+            "io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationDefaults",
+            "io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults",
+            "io.axoniq.framework.messaging.multitenancy.annotation.TenantComponentParameterResolverFactoryConfigurationEnhancer"
+    );
+
     @Override
     public void start() {
         // No containers to start.
@@ -65,6 +79,8 @@ public final class InMemoryTestInfrastructure implements TestInfrastructure {
         // EventSourcingConfigurationDefaults already provides InMemoryEventStorageEngine;
         // MessagingConfigurationDefaults provides SimpleCommandBus / SimpleQueryBus.
         registry.disableEnhancer(AXON_SERVER_ENHANCER_FQCN);
+        // Multi-tenancy is AxonServer-backed, so it has no place on an in-memory infrastructure either.
+        MULTI_TENANCY_ENHANCER_FQCNS.forEach(registry::disableEnhancer);
     }
 
     @Override

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/infrastructure/InMemoryTestInfrastructure.java
@@ -18,15 +18,12 @@ package org.axonframework.integrationtests.testsuite.infrastructure;
 
 import org.axonframework.common.configuration.ComponentRegistry;
 
-import java.util.List;
-
 /**
  * {@link TestInfrastructure} implementation that uses the framework's default in-memory components.
  * <p>
- * No containers are started. The only configuration step is disabling the AxonServer-backed enhancers so that
- * classpath scanning does not replace the in-memory defaults ({@code SimpleCommandBus}, {@code SimpleQueryBus},
- * {@code InMemoryEventStorageEngine}) with distributed AxonServer equivalents, and does not activate multi-tenancy,
- * which is AxonServer-backed as well.
+ * No containers are started. The only configuration step is disabling the AxonServer enhancer so that classpath
+ * scanning does not replace the in-memory defaults ({@code SimpleCommandBus}, {@code SimpleQueryBus},
+ * {@code InMemoryEventStorageEngine}) with distributed AxonServer equivalents.
  * <p>
  * Data "purging" is a no-op: each test shuts down and recreates the
  * {@link org.axonframework.common.configuration.AxonConfiguration} via
@@ -57,17 +54,6 @@ public final class InMemoryTestInfrastructure implements TestInfrastructure {
     private static final String AXON_SERVER_ENHANCER_FQCN =
             "io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer";
 
-    /**
-     * FQCN strings of the multi-tenancy configuration enhancers, disabled for the same reason and in the same way as
-     * {@link #AXON_SERVER_ENHANCER_FQCN}. Tenants are AxonServer contexts, so multi-tenancy cannot function on an
-     * in-memory infrastructure: its tenant provider would try to resolve an AxonServer connection manager at startup.
-     */
-    private static final List<String> MULTI_TENANCY_ENHANCER_FQCNS = List.of(
-            "io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationDefaults",
-            "io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults",
-            "io.axoniq.framework.messaging.multitenancy.annotation.TenantComponentParameterResolverFactoryConfigurationEnhancer"
-    );
-
     @Override
     public void start() {
         // No containers to start.
@@ -79,8 +65,6 @@ public final class InMemoryTestInfrastructure implements TestInfrastructure {
         // EventSourcingConfigurationDefaults already provides InMemoryEventStorageEngine;
         // MessagingConfigurationDefaults provides SimpleCommandBus / SimpleQueryBus.
         registry.disableEnhancer(AXON_SERVER_ENHANCER_FQCN);
-        // Multi-tenancy is AxonServer-backed, so it has no place on an in-memory infrastructure either.
-        MULTI_TENANCY_ENHANCER_FQCNS.forEach(registry::disableEnhancer);
     }
 
     @Override


### PR DESCRIPTION
Tenants are Axon Server contexts, so the multi-tenancy enhancers contributed by the Axoniq `axoniq-multi-tenancy` module have no place on an in-memory infrastructure: their tenant provider resolves an Axon Server connection manager at startup and fails when no server is reachable.

Until now these enhancers self-gated on an opt-in marker component, so merely having the module on the classpath was harmless. That marker is being dropped in favour of enabling multi-tenancy by default, which makes opting out the responsibility of the infrastructure that does not want it.

**That opting out now happens on the Axoniq side, not here.** `SingleTenantInMemoryTestInfrastructure` in `axoniq-integrationtests` composes `InMemoryTestInfrastructure` and calls `MultiTenancy#disable` after it, so the four in-memory suites there get the in-memory defaults plus the opt-out. Three reasons that is the better place for it:

- The enhancers are named as **class literals** in the module that owns them, so a rename is a compile error. Naming them here would mean `String` literals, because Axon Framework cannot depend on Axoniq Framework, and a rename would only produce a log line.
- `ComponentRegistry#disableEnhancer(String)` does **not** treat "not on the classpath" and "found and disabled" identically — it logs a warning when the class cannot be found. This module has no Axoniq dependency at all, so every such name always misses here: a warning per name per configuration, in a build that can never use the feature.
- Axon Framework keeps no knowledge of tenants. `InMemoryTestInfrastructure` is unchanged from `main`.

What is left for this pull request is the multi-tenancy examples, which still registered the dropped `MultiTenancyEnabled` marker and so no longer compile once the Axoniq change lands. Their prose is corrected with them: the declarative example no longer claims to turn the enhancer on, and the Spring Boot example no longer describes the auto-configuration as activating the feature — it only ever switches it off.

The earlier `InMemoryTestInfrastructure` commit is kept in the history and reverted in a commit of its own, so the reasoning above is reviewable rather than silently dropped.

relates to https://github.com/AxonIQ/axoniq-framework/issues/258
relates to https://github.com/AxonIQ/axoniq-framework/pull/303


---

### The build is red until AxonIQ/axoniq-framework#303 lands

`CourseEnrollmentCompositionTest` fails with `TenantNotResolvedException: No tenant descriptor found in processing context`, and that is expected until the Axoniq change is merged and its snapshot published.

The examples here build against the published `axoniq-framework:5.3.0-SNAPSHOT`, which still requires the `MultiTenancyEnabled` marker component. This pull request removes the calls that registered it, because #303 deletes the marker and makes multi-tenancy active on classpath presence. Against the *old* snapshot, removing those calls simply leaves multi-tenancy switched off, so no tenant reaches the `ProcessingContext` and every enrollment fails.

No version of this change is correct against both snapshots at once: the marker either exists or it does not. Re-run this build once #303 is merged and published, and it goes green. Verified locally against #303's branch, where the three example modules build and their tests pass, including `MultiTenancyDisabledTest`.
