### PR TITLE
Fix bug where publish future could complete before events are visible

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStore.java
@@ -99,7 +99,7 @@ public class StorageEngineBackedEventStore implements EventStore {
             }
             return eventStorageEngine.appendEvents(none, context, taggedEvents)
                                      .thenApply(StorageEngineBackedEventStore::castTransaction)
-                                     .thenCompose(tx -> tx.commit().thenApply(v -> tx.afterCommit(v)))
+                                     .thenCompose(tx -> tx.commit().thenCompose(v -> tx.afterCommit(v)))
                                      .thenApply(marker -> null)
                                      .thenCompose(r -> eventBus.publish(context, events));
         } else {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineBackedEventStoreTest.java
@@ -83,4 +83,36 @@ class StorageEngineBackedEventStoreTest {
         // Check that publish future has completed:
         assertThat(future.isDone()).isTrue();
     }
+
+    @Test
+    void futureFromPublishShouldNotCompleteBeforeAfterCommitFutureCompletes() {
+        CompletableFuture<String> commitFuture = CompletableFuture.completedFuture("ok");
+        CompletableFuture<ConsistencyMarker> afterCommitFuture = new CompletableFuture<>();
+        CompletableFuture<Void> eventBusPublishFuture = CompletableFuture.completedFuture(null);
+
+        when(eventStorageEngine.appendEvents(any(), eq(null), anyList()))
+            .thenReturn(CompletableFuture.completedFuture(appendTransaction));
+
+        when(eventBus.publish(eq(null), anyList()))
+            .thenReturn(eventBusPublishFuture);
+
+        when(appendTransaction.commit()).thenReturn(commitFuture);
+        when(appendTransaction.afterCommit(any())).thenReturn(afterCommitFuture);
+
+        CompletableFuture<Void> future = store.publish(
+            null,
+            Stream.of("A", "B", "C", "D").map(e -> new GenericEventMessage(new MessageType(e.getClass()), e)).toList()
+        );
+
+        // Check that publish future hasn't completed yet as AppendTransaction#afterCommit hasn't yet completed:
+        assertThat(future.isDone()).isFalse();
+
+        // Now complete afterCommit:
+        afterCommitFuture.complete(ConsistencyMarker.ORIGIN);
+
+        future.join();
+
+        // Check that publish future has completed:
+        assertThat(future.isDone()).isTrue();
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSink.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSink.java
@@ -53,7 +53,7 @@ public interface EventSink extends DescribableComponent {
      * @param events  The {@link EventMessage events} to publish in this sink.
      * @return A {@link CompletableFuture} of {@link Void}. When this completes and a non-null {@code context} was
      * given, this means the {@code events} have been successfully staged. When a null {@code context} was provided,
-     * successful completion of this future means the {@code events} where published.
+     * successful completion of this future means the {@code events} were published.
      */
     default CompletableFuture<Void> publish(@Nullable ProcessingContext context,
                                             EventMessage @Nullable ... events) {
@@ -74,7 +74,7 @@ public interface EventSink extends DescribableComponent {
      * @param events  The {@link EventMessage events} to publish in this sink.
      * @return A {@link CompletableFuture} of {@link Void}. When this completes and a non-null {@code context} was
      * given, this means the {@code events} have been successfully staged. When a null {@code context} was provided,
-     * successful completion of this future means the {@code events} where published.
+     * successful completion of this future means the {@code events} were published.
      */
     CompletableFuture<Void> publish(@Nullable ProcessingContext context,
                                     List<? extends EventMessage> events);


### PR DESCRIPTION
This is a real bug that caused tests on Axoniq side to fail due to timing issues (but can also cause other real problems).