### PR TITLE
[#4839] Back off before reopening a stream whose source failed

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1188,20 +1188,25 @@ class Coordinator {
         private CompletableFuture<Void> ensureOpenStream(@Nullable TrackingToken trackingToken) {
             // Close the old stream when it can no longer be read from. Either it is completed, or the token differs from
             // the last scheduled token, thus we started new WorkPackages and need to start at the new position.
+            Throwable sourceFailure = null;
             if (eventStream != null
                     && (eventStream.isCompleted() || !Objects.equals(trackingToken, lastScheduledToken))) {
-                if (eventStream.isCompleted()) {
-                    // The trailing argument is only logged when the source completed the stream with an error.
-                    logger.info("Processor [{}] (Coordination Task [{}]) will replace the stream its source completed "
-                                        + "by one starting at token [{}].",
-                                name, generation, trackingToken, eventStream.error().orElse(null));
-                } else {
-                    logger.debug("Processor [{}] (Coordination Task [{}]) will close the current stream.",
-                                 name, generation);
-                }
+                boolean completed = eventStream.isCompleted();
+                // Read once, so the reason logged is the reason acted on.
+                sourceFailure = completed ? eventStream.error().orElse(null) : null;
+                logClosingStream(completed, sourceFailure, trackingToken);
                 closeStreamQuietly();
                 eventStream = null;
                 lastScheduledToken = NoToken.INSTANCE;
+            }
+
+            if (sourceFailure != null) {
+                // A source that failed a stream keeps failing it for as long as whatever it depends on is unavailable.
+                // Opening a replacement right here would do so on every coordination run, which is as fast as the
+                // coordinator runs at all. Reporting the failure instead hands the retry to the coordinator's own error
+                // handling, which logs the cause, releases the claims and paces the next attempt about a second later.
+                // That is what a failing source did before a completed stream became a reason to reopen.
+                return CompletableFuture.failedFuture(sourceFailure);
             }
 
             if (eventStream == null && !workPackages.isEmpty() && !(trackingToken instanceof NoToken)) {
@@ -1229,6 +1234,28 @@ class Coordinator {
                 });
             }
             return emptyCompletedFuture();
+        }
+
+        /**
+         * Logs why the stream about to be closed can no longer be read from: its source completed it, or a new position
+         * is needed. A source that failed the stream is not logged here, since reporting that failure logs its cause.
+         *
+         * @param completed     whether the source completed the stream about to be closed
+         * @param sourceFailure the error the source completed the stream with, or {@code null} if it did not fail it
+         * @param trackingToken the position a replacement stream would start at, if any
+         */
+        private void logClosingStream(boolean completed,
+                                      @Nullable Throwable sourceFailure,
+                                      @Nullable TrackingToken trackingToken) {
+            if (!completed) {
+                logger.debug("Processor [{}] (Coordination Task [{}]) will close the current stream.",
+                             name, generation);
+            } else if (sourceFailure == null) {
+                logger.info("""
+                            Processor [{}] (Coordination Task [{}]) will replace the stream its source completed by one \
+                            starting at token [{}].""",
+                            name, generation, trackingToken);
+            }
         }
 
         private boolean isSpaceAvailable() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
@@ -204,6 +204,21 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
     }
 
     /**
+     * Completes every currently open stream with the given {@code cause}, as if this source failed them, without
+     * clearing the published events.
+     * <p>
+     * Such a stream reports {@link MessageStream#isCompleted()} as {@code true} and the given {@code cause} as its
+     * {@link MessageStream#error()}. This mirrors a source that cannot serve a stream at all, such as a backend that is
+     * unreachable or does not know the requested context yet. Call this repeatedly to model a source that keeps failing
+     * every stream opened against it.
+     *
+     * @param cause the error to complete every currently open stream with
+     */
+    public void failOpenStreams(Throwable cause) {
+        openStreams.forEach(stream -> stream.completeExceptionally(cause));
+    }
+
+    /**
      * Set a handler to be called whenever a stream is opened.
      *
      * @param onOpen the handler to call
@@ -244,6 +259,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
         private final AtomicReference<Runnable> callback = new AtomicReference<>(NO_OP_CALLBACK);
         private final StreamingCondition condition;
         private volatile boolean closed = false;
+        private volatile @Nullable Throwable completionError;
 
         public AsyncMessageStream(StreamingCondition condition) {
             this.condition = condition;
@@ -357,7 +373,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
 
         @Override
         public @NonNull Optional<Throwable> error() {
-            return Optional.empty();
+            return Optional.ofNullable(completionError);
         }
 
         @Override
@@ -406,6 +422,14 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                     currentCallback.run();
                 }
             }
+        }
+
+        private void completeExceptionally(Throwable cause) {
+            if (closed) {
+                return;
+            }
+            completionError = cause;
+            complete();
         }
 
         private void complete() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -1030,6 +1030,63 @@ class PooledStreamingEventProcessorTest {
                    .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(nextEvent));
             verify(stubMessageSource, atLeast(2)).open(any(), isNull());
         }
+
+        @Test
+        void pacesReopeningWhileTheSourceKeepsFailingEveryStreamItHandsOut() throws InterruptedException {
+            // given - a source that keeps failing every stream it hands out, as a backend that cannot serve one yet
+            //         does. Each attempt costs a call on that backend, so retrying on every coordination run is what
+            //         has to be avoided.
+            AtomicInteger openCount = new AtomicInteger();
+            stubMessageSource.setOnOpen(openCount::incrementAndGet);
+            startEventProcessor();
+
+            // when - the failure arrives the way a remote source reports one, after the coordination run that opened
+            //        the stream rather than during it
+            boolean reportedError = failStreamsFor(1500);
+
+            // then - the retry is paced by the coordinator's error handling rather than following every coordination
+            // run. 1500ms at a one-second pace allows two opens, so five leaves room for a slow machine.
+            assertThat(openCount.get()).describedAs("streams opened in 1500ms").isLessThanOrEqualTo(5);
+            // and the failure is reported rather than swallowed by an immediate replacement. Observed while the source
+            // was failing, since the flag clears again on every run that manages to open a stream.
+            assertThat(reportedError).describedAs("processor reported the failing source").isTrue();
+            // and the retry is scheduled with a delay rather than immediately
+            verify(coordinatorExecutor, atLeastOnce())
+                    .schedule(any(Runnable.class), longThat(delay -> delay >= 500), eq(TimeUnit.MILLISECONDS));
+        }
+
+        @Test
+        void resumesOnceTheSourceStopsFailingEveryStream() throws InterruptedException {
+            // given - a source failing every stream it hands out for a while
+            AtomicInteger openCount = new AtomicInteger();
+            stubMessageSource.setOnOpen(openCount::incrementAndGet);
+            startEventProcessor();
+            failStreamsFor(700);
+            assertThat(openCount).describedAs("streams opened while failing").hasValueGreaterThan(0);
+
+            // when - the source recovers
+            EventMessage event = EventTestUtils.asEventMessage("event-1");
+            stubMessageSource.publishMessage(event);
+
+            // then - waiting between attempts does not wedge the processor, it picks the segment back up and handles
+            // what it missed
+            await().atMost(10, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(event));
+            assertThat(testSubject.processingStatus()).containsKey(0);
+        }
+
+        // Fails whatever stream is open, repeatedly, for the given duration. Runs on the calling thread so every
+        // failure lands between two coordination runs, which is when a remote source reports one. Returns whether the
+        // processor reported an error at any point, which a single read after the fact could miss.
+        private boolean failStreamsFor(long millis) throws InterruptedException {
+            boolean reportedError = false;
+            for (long elapsed = 0; elapsed < millis; elapsed += 25) {
+                stubMessageSource.failOpenStreams(new IllegalStateException("Source unreachable"));
+                Thread.sleep(25);
+                reportedError |= testSubject.isError();
+            }
+            return reportedError;
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #4839

## Problem

`Coordinator.ensureOpenStream` replaces a stream its source completed with an error immediately, on every coordination run. While the source stays unavailable the processor reopens the stream as fast as the coordinator runs.

The error never reached the coordinator's own error handling, because `ensureOpenStream` runs earlier in the same coordination run and replaced the failed stream, leaving the check that follows to inspect a fresh stream that had not failed yet.

Measured against a real Axon Server with one context unavailable, over a single 72 second run: **2474 stream reopens, 0 back offs, 4662 `firstToken()` calls** on the source. Each reopen costs one token lookup and one stream call per source, so a multi-tenant event store multiplies this by the tenant count.

## Change

A completion carrying an error is reported as a failed future instead of being replaced. The coordination run's existing handler then logs the cause once, aborts the work packages with that cause, and schedules the retry. A clean completion keeps being replaced immediately, which is the behaviour #4785 added and which this keeps intact.

## Consequences worth naming

- The retry travels the abort path, so **token claims are released and `isError()` becomes true** while the source is away. That is what a failing source did in 5.0 through 5.2.1. Retaining claims while not reopening needs coordinator-scoped state and a separate exit from the coordination run, which is a larger change than this fix.
- The retry is paced at **about a second**, not an escalating back off. `errorWaitBackOff` returns to its initial value on every run that opens a stream, and each retry cycle contains exactly such a run, so it settles at one doubling. Making the escalation real means changing when that field resets, which affects every error path in the coordinator and does not belong in this fix. Worth a follow-up.

## Verification

- `pacesReopeningWhileTheSourceKeepsFailingEveryStreamItHandsOut` fails without the change and passes with it. It bounds the reopen count, asserts the processor reports the failure while the source is failing, and asserts the retry is scheduled with a delay rather than immediately.
- `resumesOnceTheSourceStopsFailingEveryStream` covers recovery.
- Confirmed from the test log that the failing-source path now logs the real cause and no longer trips the "no event stream" guard, which previously discarded that cause and logged a second, misleading warning.
- Full `messaging` module suite green.
- Reproduced and re-verified end to end through a multi-tenant Spring Boot demo against a containerized Axon Server.

## Affects

Released in 5.2.2 (`11faffc8a8`), hence the base on `axon-5.2.x` to flow upward. Ported to `main` in #4841.