### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,24 @@
+name: Axon Framework (Backport)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    if: >
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/backport') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    steps:
+      - name: Backport
+        uses: korthout/backport-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          conflict_behaviour: draft_commit_conflicts


### PR DESCRIPTION
Adds a `/backport <branch>` command that can be used on any merged PR to cherry-pick its changes onto the specified branch and open a new backport PR automatically.

**Usage:** Comment `/backport <branch>` on a merged PR (e.g. `/backport axoniq-5.2.x`). Only maintainers (repo owners, org members, and collaborators) can  trigger this. If there are conflicts, a draft PR is opened with conflict markers for manual resolution.