### PR TITLE
Fix backport workflow missing checkout step - Phase 4

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,6 +17,8 @@ jobs:
       startsWith(github.event.comment.body, '/backport') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     steps:
+      - uses: actions/checkout@v7
+
       - name: Parse target branch from comment
         id: parse
         env:


### PR DESCRIPTION
Ensure we do a checkout so the action can see the state of the repository.