### PR TITLE
Add project linking to backport workflow - Phase 6

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Axon Framework (Dependency Upgrade to project)
+name: Axon Framework (Add to project)
 
 on:
   pull_request:
@@ -7,14 +7,14 @@ on:
 
 jobs:
   add-to-project:
-    name: Add Dependency Upgrade PR to project
+    name: Add PR to project
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' }}
     steps:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/Axoniq/projects/25
           github-token: ${{ secrets.ADD_PROJECT_TOKEN }}
-          labeled: 'Type: Dependency Upgrade'
+          labeled: 'Type: Dependency Upgrade,Type: Port'
         # prevent failure if the PR is already added to the project
         continue-on-error: true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -34,14 +34,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_branches: ${{ steps.parse.outputs.branch }}
           add_author_as_assignee: true
+          add_labels: 'Type: Port'
           copy_labels_pattern: '.*'
-
-      - name: Add backport PRs to project
-        if: steps.backport.outputs.created_pull_requests != '[]'
-        env:
-          GH_TOKEN: ${{ secrets.ADD_PROJECT_TOKEN }}
-        run: |
-          echo '${{ steps.backport.outputs.created_pull_requests }}' | jq -r '.[]' | while read pr; do
-            gh project item-add 25 --owner AxonIQ --url "https://github.com/${{ github.repository }}/pull/$pr"
-          done
-        continue-on-error: true


### PR DESCRIPTION
The previous attempt at adding project didn't work, but this one utilizes an existing method shared with dependabot PR's.