### PR TITLE
Add tenant-aware query processing to the multi-tenancy demo

### DIFF
--- a/examples/university-multi-tenancy-examples/README.md
+++ b/examples/university-multi-tenancy-examples/README.md
@@ -7,19 +7,32 @@ the declarative Configuration API and through Spring Boot autoconfiguration.
 
 A platform hosts several universities. Each is its own tenant, and their data must never mix.
 Multi-tenancy lets you register a tenant-scoped component once and have the framework inject the right
-tenant's instance into each message handler, so a handler never resolves a tenant itself. The
-[core module](university-multi-tenancy-core/README.md) holds that code. The demo shows, at the moment:
+tenant's instance into each message handler, so a handler never resolves a tenant itself, whether it
+handles a command, a query, or an event. The [core module](university-multi-tenancy-core/README.md) holds
+that code. The demo shows, at the moment:
 
-* **One enrollment, both features at once.** Enrolling a student is a single event-sourced command whose
-  handler sources the `Course` from, and appends to, the tenant's own event store, and updates that
-  tenant's `@TenantScoped` read-model components, each resolved from the message's tenant. The realistic
-  part is the write side: event sourcing plus tenant-scoped injection in one handler. Updating the
-  read-model components from that same handler is a deliberate interim shortcut (see the next bullet).
+* **One enrollment, event-sourced per tenant.** Enrolling a student is a single command whose handler
+  sources the `Course` from, and appends to, the tenant's own event store, without naming a tenant itself.
 * **Per-tenant event storage** (Axon Server): because each tenant has its own event store, the same course
   identifier in two tenants is two isolated event streams, so a course full in one tenant still has free
-  seats in another. Reading a tenant's events back as a stream, to rebuild the statistics as a projection
-  instead of updating them in the handler, is added in a later step. In memory there is one shared event
-  store, so this isolation is shown only against Axon Server.
+  seats in another. In memory there is one shared event store, so this isolation is shown only against
+  Axon Server.
+* **Tenant-aware event processing** (Axon Server): one ordinary pooled streaming event processor consumes
+  every tenant's events and writes each into that tenant's own read model. There is no processor and no
+  token store per tenant, and nothing in the processor declaration mentions a tenant. Nothing identifies
+  the tenant inside the stored event either: the tenant follows from which store the event was streamed
+  from, and the framework puts it on the processing context so the handler's `@TenantScoped` parameters
+  resolve to that tenant. Adding a tenant at runtime needs no configuration change, since the framework
+  re-opens the stream to include it. In memory a shared event store leaves a streamed event with no tenant
+  to attribute it to, so that run fills the read model from the command handler instead. That is a shortcut, not
+  the shape to copy: given per-tenant event stores, prefer the projection.
+* **The one knob there is** (Axon Server): a tenant change restarts the running processors, and each restart is
+  bounded by a timeout. The framework defaults it, and both demos show where an application would raise it for a
+  deployment whose processors are slow to stop and start.
+* **An idempotent projection**, which a streamed read model has to be. Events arrive at least once, and
+  re-opening the stream on a tenant change makes a repeat more likely than usual, so the statistics are
+  derived from the student identifiers in the events rather than counted. Handling the same enrollment twice
+  leaves the read model unchanged.
 * **Per-tenant snapshotting** (Axon Server): the course carries a snapshot policy, and each tenant's
   snapshots live in that tenant's own context, so the same course identifier in two tenants is two
   unrelated snapshots. A snapshot is a performance optimization, so no behavior reveals which tenant's

--- a/examples/university-multi-tenancy-examples/README.md
+++ b/examples/university-multi-tenancy-examples/README.md
@@ -42,8 +42,16 @@ that code. The demo shows, at the moment:
   shares one snapshot store, so this isolation is not shown.
 * **Tenant-scoped injection on the read side too**: the statistics query handler is handed the querying
   tenant's own components, matched by type, with the tenant resolved from the message metadata.
+* **Tenant-aware subscription queries**: both tenants known at startup subscribe to their own statistics
+  before enrolling a single student. Recording an enrollment emits an update through a deliberately
+  tenant-blind predicate, and each subscription still only ever receives its own tenant's updates: the
+  framework isolates emission by the tenant it resolves for the update, not by anything the predicate says.
+* **Direct queries routed through the per-tenant connector** (Axon Server): this whole demo runs in one
+  process, where a query handler is always subscribed locally, so the demos explicitly turn off preferring
+  that local handler. Without it, a direct query would never reach the per-tenant connector at all.
 * **The tenant lifecycle**: tenants known at startup, a tenant added at runtime, an unknown tenant
-  rejected, a tenant removed (closing its instances), and cleanup on shutdown.
+  rejected on both the command and the query side, a tenant removed (closing its instances), and cleanup
+  on shutdown.
 * **A configuration-time guardrail**: registering two providers for one component type is refused 
   because the framework cannot know which instance a parameter of that type should receive.
 * **Context filtering** (Axon Server): tenants are discovered from Axon Server's contexts, with the

--- a/examples/university-multi-tenancy-examples/pom.xml
+++ b/examples/university-multi-tenancy-examples/pom.xml
@@ -47,6 +47,11 @@
         <awaitility.version>4.3.0</awaitility.version>
         <!-- Log4j2 as the single logging solution, matching the other plain-Java examples. -->
         <log4j.version>2.26.1</log4j.version>
+        <!-- Reactor Core, which the subscription-query gateway method needs at runtime (axon-messaging
+             depends on it only optionally). Kept in step with the version the framework builds against
+             (build/parent), which is not inherited here because the flattened parent pom drops its
+             properties. -->
+        <reactor.version>3.8.6</reactor.version>
 
         <!-- Spring Boot, for the Spring Boot demo. Kept in step with the version the framework builds
              against (build/parent), which is not inherited here because the flattened parent pom drops

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
@@ -17,12 +17,17 @@ org.axonframework.examples.demo.multitenancy
 |  +- write/opencourse                the open-course slice: command, handler (+ its State entity), wiring
 |  +- write/enrollstudent             the enroll-student slice: command, handler (+ its State entity), exceptions, wiring
 |  +- read/statistics                 the statistics read slice: query, response, handler, the CourseStatisticsStore read model, wiring
+|     +- CourseStatisticsProjection   projects every tenant's events into that tenant's own read model
+|     +- ReadModelWrites              the one write both of them use, so either fills it identically
 +- shared                             the demo harness both runnable demos use, grouped by what each part does
+   +- DemoBacking                     in memory or Axon Server, the one fact the two runs' differences derive from
    +- run                             runs the scenario and reports what it observed
+   |  +- DemoApplication              the started application to drive, assembled per backing in one place
    |  +- DemoLifecycle                the tenant lifecycle the demos walk, top to bottom
    |  +- DemoOutcome                  what a run observed, asserted by the demos' tests
    |  +- EventStorageOutcome          what the per-tenant event-storage isolation observed, asserted by the tests
    |  +- SnapshottingOutcome          what the per-tenant snapshot isolation observed, asserted by the tests
+   |  +- StreamingOutcome             what the tenant-aware event processing observed, asserted by the tests
    |  +- TenantView                   renders one tenant's isolated view
    |  +- ProviderAmbiguityGuardrail   the configuration-time guardrail
    +- messaging                       drives the command and query gateways
@@ -44,12 +49,11 @@ org.axonframework.examples.demo.multitenancy
 application:
 
 1. Enroll students in the tenants known at startup, and read each tenant's statistics back to show it
-   sees only its own. Each enrollment is one command that both appends to the tenant's own event store
-   and updates that tenant's components. Against Axon Server the two known tenants open a course under the
-   same identifier: one fills it to capacity and a further enrollment is rejected as full, while the same
-   identifier still accepts an enrollment in the other tenant, which proves each tenant's events live in
-   its own store. In memory there is one shared event store, so the tenants use distinct identifiers and
-   this isolation is not shown.
+   sees only its own. Each enrollment is one command that appends to the tenant's own event store. Against
+   Axon Server the two known tenants open a course under the same identifier: one fills it to capacity and
+   a further enrollment is rejected as full, while the same identifier still accepts an enrollment in the
+   other tenant, which proves each tenant's events live in its own store. In memory there is one shared
+   event store, so the tenants use distinct identifiers and this isolation is not shown.
 2. Show where those snapshots ended up. The course carries a snapshot policy, so enrolling the second
    student snapshots it, and the rejected third enrollment sources the course from that snapshot. Against
    Axon Server both tenants end up with their own snapshot of the same course identifier, and each snapshot
@@ -59,17 +63,52 @@ application:
    read the other's snapshot. A snapshot captures the state its triggering load sourced rather than the
    state that command leaves behind, so each holds one student. In memory every tenant shares one snapshot
    store, so this isolation is not shown.
-3. Add a tenant at runtime, enroll into it, and show its components appear on first use.
-4. Send a command for an unknown tenant and confirm it is rejected.
-5. Remove a tenant and confirm its per-tenant instances are closed.
-6. Shut down and confirm every remaining tenant's instances are closed.
+3. Add a tenant at runtime, enroll into it, and show its components appear on first use. Against Axon
+   Server this also shows the running processor picking the tenant up: it re-opens its stream to include a
+   tenant that did not exist when it started, and projects that tenant's enrollment.
+4. Count what served all three tenants' projections. Against Axon Server there is one streaming event
+   processor rather than one per tenant, and each tenant's read model holds only its own enrollments even
+   though two of them use the same course identifier. In memory no projection runs, so this is not shown.
+5. Send a command for an unknown tenant and confirm it is rejected.
+6. Remove a tenant and confirm its per-tenant instances are closed.
+7. Shut down and confirm every remaining tenant's instances are closed.
 
 The configuration-time guardrail (`ProviderAmbiguityGuardrail`) is a separate, standalone check, since
 it is about configuration rather than the running lifecycle.
 
-The statistics the enrollment handler updates are an interim read model. Once per-tenant event streaming
-lands, they become a projection built from the stored events instead of being written in the command
-handler.
+## Where the read model comes from
+
+Against Axon Server the statistics are a projection. One ordinary pooled streaming event processor runs
+`CourseStatisticsProjection` for every tenant at once, and each event is written into the read model of the
+tenant whose event store it came from. The projection is an ordinary event handler: it names no tenant, and
+the only thing multi-tenancy adds is that its `@TenantScoped` parameters are resolved for the event's
+tenant. Nothing identifies the tenant inside the stored event. The tenant follows from which store the
+event was streamed from, and the framework puts it on the processing context of the event being handled.
+
+That makes the read model eventually consistent, so every observation of one in the lifecycle waits for the
+projection to catch up.
+
+### The projection is idempotent, on purpose
+
+`ReadModelWrites` is written so that recording the same enrollment twice leaves the read model exactly
+as it was. `CourseStatisticsStore` keeps the enrolled student identifiers per course and reports their count,
+rather than incrementing a counter, and `AuditLog` records each entry once.
+
+That is not defensive padding. Events are delivered at least once, and on a multi-tenant stream a duplicate
+is more likely than usual: adding or removing a tenant re-opens the stream, and the processor cannot always
+tell that an event belonging to another tenant was already handled. A counter would then drift upwards on
+every tenant change, and the demo's own assertions would start failing for reasons that have nothing to do
+with tenants. Deriving the read model from the identifiers in the event is what makes it correct, and it is
+the shape any projection on a streamed event should have.
+
+In memory all tenants share one event store, so an event streamed from it cannot be attributed to a tenant
+and no projection could tell them apart. That run therefore has the command handler fill the read model
+while it still knows the command's tenant. `DemoBacking` is the single fact that decides this, the same fact
+`TenantProvisioning` reports, so the two cannot disagree. `ReadModelWrites` is the one write both paths use,
+so what the lifecycle observes does not depend on which one filled it.
+
+That inline write is a shortcut, not the shape to copy. It survives only because one shared event store leaves
+a streamed event with no tenant to attribute it to. Given per-tenant event stores, prefer the projection.
 
 The enroll-student slice's course entity is an immutable record whose event sourcing handlers return the
 evolved course, rather than a mutable class that changes itself. A snapshot is the entity handed to the

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/README.md
@@ -28,10 +28,11 @@ org.axonframework.examples.demo.multitenancy
    |  +- EventStorageOutcome          what the per-tenant event-storage isolation observed, asserted by the tests
    |  +- SnapshottingOutcome          what the per-tenant snapshot isolation observed, asserted by the tests
    |  +- StreamingOutcome             what the tenant-aware event processing observed, asserted by the tests
+   |  +- SubscriptionQueryOutcome     what the tenant-aware subscription-query isolation observed, asserted by the tests
    |  +- TenantView                   renders one tenant's isolated view
    |  +- ProviderAmbiguityGuardrail   the configuration-time guardrail
    +- messaging                       drives the command and query gateways
-   |  +- Enrollments                  opens courses, enrolls, and reads statistics through the gateways
+   |  +- Enrollments                  opens courses, enrolls, and reads or subscribes to statistics through the gateways
    |  +- TenantMetadataFactory        builds the metadata that carries a tenant on a message
    |  +- RemoteExceptions             recognizes a handler failure whether raised as itself or reconstructed over Axon Server
    +- tenant                          supplies the tenants and their per-tenant components
@@ -48,13 +49,18 @@ org.axonframework.examples.demo.multitenancy
 `DemoLifecycle.run` reads top to bottom as the story both demos tell, against an already-started
 application:
 
-1. Enroll students in the tenants known at startup, and read each tenant's statistics back to show it
-   sees only its own. Each enrollment is one command that appends to the tenant's own event store. Against
-   Axon Server the two known tenants open a course under the same identifier: one fills it to capacity and
-   a further enrollment is rejected as full, while the same identifier still accepts an enrollment in the
-   other tenant, which proves each tenant's events live in its own store. In memory there is one shared
-   event store, so the tenants use distinct identifiers and this isolation is not shown.
-2. Show where those snapshots ended up. The course carries a snapshot policy, so enrolling the second
+1. Subscribe to both tenants known at startup's statistics, before either enrolls a single student.
+2. Enroll students in those tenants, and read each tenant's statistics back to show it sees only its own.
+   Each enrollment is one command that appends to the tenant's own event store. Against Axon Server the two
+   known tenants open a course under the same identifier: one fills it to capacity and a further enrollment
+   is rejected as full, while the same identifier still accepts an enrollment in the other tenant, which
+   proves each tenant's events live in its own store. In memory there is one shared event store, so the
+   tenants use distinct identifiers and this isolation is not shown.
+3. Confirm neither tenant's subscription received the other's updates. Recording an enrollment emits an
+   update through a deliberately tenant-blind predicate, so this is what proves isolation is enforced by the
+   framework rather than by the predicate: each subscription received exactly as many updates as its own
+   tenant's accepted enrollments account for, and no more.
+4. Show where those snapshots ended up. The course carries a snapshot policy, so enrolling the second
    student snapshots it, and the rejected third enrollment sources the course from that snapshot. Against
    Axon Server both tenants end up with their own snapshot of the same course identifier, and each snapshot
    holds only its own tenant's student, which is what proves neither tenant read the other's. It compares
@@ -63,15 +69,15 @@ application:
    read the other's snapshot. A snapshot captures the state its triggering load sourced rather than the
    state that command leaves behind, so each holds one student. In memory every tenant shares one snapshot
    store, so this isolation is not shown.
-3. Add a tenant at runtime, enroll into it, and show its components appear on first use. Against Axon
+5. Add a tenant at runtime, enroll into it, and show its components appear on first use. Against Axon
    Server this also shows the running processor picking the tenant up: it re-opens its stream to include a
    tenant that did not exist when it started, and projects that tenant's enrollment.
-4. Count what served all three tenants' projections. Against Axon Server there is one streaming event
+6. Count what served all three tenants' projections. Against Axon Server there is one streaming event
    processor rather than one per tenant, and each tenant's read model holds only its own enrollments even
    though two of them use the same course identifier. In memory no projection runs, so this is not shown.
-5. Send a command for an unknown tenant and confirm it is rejected.
-6. Remove a tenant and confirm its per-tenant instances are closed.
-7. Shut down and confirm every remaining tenant's instances are closed.
+7. Send a command, and then a query, for an unknown tenant and confirm both are rejected.
+8. Remove a tenant and confirm its per-tenant instances are closed.
+9. Shut down and confirm every remaining tenant's instances are closed.
 
 The configuration-time guardrail (`ProviderAmbiguityGuardrail`) is a separate, standalone check, since
 it is about configuration rather than the running lifecycle.

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/pom.xml
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>axoniq-multi-tenancy</artifactId>
         </dependency>
 
+        <!-- Subscription queries: axon-messaging depends on reactor-core only optionally, so the
+             subscription-query gateway method needs it added here explicitly. -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${reactor.version}</version>
+        </dependency>
+
         <!-- Used by the Axon Server context helper to await context creation and deletion. -->
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/DemoBacking.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/DemoBacking.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared;
+
+/**
+ * What backs a demo run. The demo runs the same lifecycle two ways, and every difference between them follows
+ * from this one choice.
+ *
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+public enum DemoBacking {
+
+    /** One shared in-memory event store for every tenant. Needs no infrastructure. */
+    IN_MEMORY,
+
+    /**
+     * Axon Server, where each tenant is a context and therefore has its own event store and snapshot store.
+     * Needs a running multi-context (Enterprise Edition) server.
+     */
+    AXON_SERVER;
+
+    /**
+     * Whether each tenant has its own event store, which only Axon Server gives.
+     *
+     * @return {@code true} against Axon Server, {@code false} in memory
+     */
+    public boolean hasPerTenantEventStore() {
+        return this == AXON_SERVER;
+    }
+
+    /**
+     * Whether a projection builds the read model, rather than the command handler filling it. A projection can
+     * only tell which tenant a streamed event belongs to when each tenant has its own event store.
+     *
+     * @return {@code true} when a projection fills the read model
+     */
+    public boolean projectsReadModel() {
+        return hasPerTenantEventStore();
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/audit/AuditLog.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/audit/AuditLog.java
@@ -40,8 +40,11 @@ public interface AuditLog extends AutoCloseable {
 
     /**
      * Records the given audit {@code entry} for this tenant.
+     * <p>
+     * Recording the same {@code entry} again has no effect, so an entry written from a streamed event survives
+     * that event reaching the handler more than once.
      *
-     * @param entry the audit entry to record
+     * @param entry the audit entry to record, ignored when an identical entry was already recorded
      */
     void record(String entry);
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/audit/InMemoryAuditLog.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/audit/InMemoryAuditLog.java
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * In-memory {@link AuditLog}, backing the demo without external infrastructure.
@@ -31,7 +32,9 @@ class InMemoryAuditLog implements AuditLog {
     private static final Logger logger = LoggerFactory.getLogger(InMemoryAuditLog.class);
 
     private final String tenantId;
-    private final List<String> entries = new CopyOnWriteArrayList<>();
+    // A set, so recording the same entry twice is a no-op. Insertion-ordered and lock-free for reads, so the
+    // log still reads in the order things happened.
+    private final Set<String> entries = new CopyOnWriteArraySet<>();
     private volatile boolean closed = false;
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/messaging/Enrollments.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/messaging/Enrollments.java
@@ -20,6 +20,7 @@ import io.axoniq.framework.messaging.multitenancy.api.MetadataBasedTenantResolve
 import io.axoniq.framework.messaging.multitenancy.api.TenantDescriptor;
 import io.axoniq.framework.messaging.multitenancy.api.TenantNotResolvedException;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.GetTenantStatistics;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.ReadModelWrites;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatistics;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseFullException;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudent;
@@ -29,6 +30,7 @@ import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.queryhandling.GenericQueryMessage;
 import org.axonframework.messaging.queryhandling.QueryMessage;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+import org.reactivestreams.Publisher;
 
 import java.util.concurrent.TimeUnit;
 
@@ -131,6 +133,29 @@ public final class Enrollments {
         return queryGateway.query(query, TenantStatistics.class)
                            .orTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                            .join();
+    }
+
+    /**
+     * Subscribes to the given {@code tenant}'s statistics by sending a {@link GetTenantStatistics}
+     * subscription query carrying that tenant in metadata. The returned publisher emits the tenant's
+     * current statistics first, and every fresh update {@link ReadModelWrites} emits after, for as long as
+     * it is subscribed to.
+     * <p>
+     * The tenant travels only in the query's metadata, resolved once from this initial query. Emitting a
+     * later update never names a tenant either, and still only this subscription's own tenant receives it:
+     * the framework isolates emission by the tenant it resolves for the update, not by anything this
+     * subscription's own query says.
+     *
+     * @param queryGateway the gateway to send the subscription query on
+     * @param tenant       the tenant whose statistics to subscribe to
+     * @return a publisher of the tenant's statistics, starting with its current value
+     */
+    public static Publisher<TenantStatistics> subscribeToStatistics(QueryGateway queryGateway,
+                                                                    TenantDescriptor tenant) {
+        QueryMessage query = new GenericQueryMessage(new MessageType(GetTenantStatistics.class),
+                                                     new GetTenantStatistics())
+                .andMetadata(TenantMetadataFactory.forTenant(tenant));
+        return queryGateway.subscriptionQuery(query, TenantStatistics.class);
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/messaging/Enrollments.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/messaging/Enrollments.java
@@ -69,9 +69,9 @@ public final class Enrollments {
 
     /**
      * Enrolls a student by sending an {@link EnrollStudent} command for the given {@code tenant}, and
-     * blocks until it has been handled. The handler both appends to that tenant's own event store and
-     * updates that tenant's injected components, so the enrollment lands in the right tenant's event stream
-     * and read model.
+     * blocks until it has been handled. The handler appends to that tenant's own event store, so the
+     * enrollment lands in the right tenant's event stream, and the tenant's read model follows from that
+     * event.
      *
      * @param commandGateway the gateway to send the command on
      * @param tenant         the tenant the enrollment belongs to

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoApplication.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoApplication.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.run;
+
+import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
+import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.eventhandling.processing.EventProcessor;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
+import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The started application {@link DemoLifecycle} drives, and everything it needs to drive it. Pick the factory
+ * matching the backing the application was configured for.
+ *
+ * @param commandGateway     the gateway enrollments are sent on
+ * @param queryGateway       the gateway statistics are read on
+ * @param statisticsProvider the provider of the per-tenant course-statistics stores
+ * @param auditProvider      the provider of the per-tenant audit logs
+ * @param provisioning       how this run adds and removes tenants, and what backs it
+ * @param snapshots          reads a single tenant's own snapshot store
+ * @param processorNames     the names of every streaming event processor the application registered
+ * @param shutdown           shuts the started application down
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+public record DemoApplication(CommandGateway commandGateway,
+                              QueryGateway queryGateway,
+                              TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
+                              TenantComponentProvider<AuditLog> auditProvider,
+                              TenantProvisioning provisioning,
+                              TenantSnapshots<CourseSnapshot> snapshots,
+                              List<String> processorNames,
+                              Runnable shutdown) {
+
+    /** Rejects a missing part, and copies the processor names so the record stays immutable. */
+    public DemoApplication {
+        Objects.requireNonNull(commandGateway, "The command gateway must not be null");
+        Objects.requireNonNull(queryGateway, "The query gateway must not be null");
+        Objects.requireNonNull(statisticsProvider, "The course-statistics provider must not be null");
+        Objects.requireNonNull(auditProvider, "The audit-log provider must not be null");
+        Objects.requireNonNull(provisioning, "The tenant provisioning must not be null");
+        Objects.requireNonNull(snapshots, "The tenant snapshots must not be null");
+        Objects.requireNonNull(shutdown, "The shutdown action must not be null");
+        processorNames = List.copyOf(processorNames);
+    }
+
+    /**
+     * The in-memory application, whose tenants are entries in the given {@code tenantProvider}.
+     *
+     * @param configuration      the started configuration to resolve the framework components from
+     * @param tenantProvider     the in-memory provider supplying the tenants
+     * @param statisticsProvider the provider of the per-tenant course-statistics stores
+     * @param auditProvider      the provider of the per-tenant audit logs
+     * @return the in-memory application to drive
+     */
+    public static DemoApplication inMemory(AxonConfiguration configuration,
+                                           DemoTenantProvider tenantProvider,
+                                           TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
+                                           TenantComponentProvider<AuditLog> auditProvider) {
+        requireConfiguredFor(configuration, DemoBacking.IN_MEMORY);
+        return new DemoApplication(configuration.getComponent(CommandGateway.class),
+                                   configuration.getComponent(QueryGateway.class),
+                                   statisticsProvider,
+                                   auditProvider,
+                                   TenantProvisioning.inMemory(tenantProvider),
+                                   TenantSnapshots.inMemory(),
+                                   registeredProcessorNames(configuration),
+                                   configuration::shutdown);
+    }
+
+    /**
+     * The Axon Server backed application, whose tenants are real contexts and which therefore gives each tenant
+     * its own event store and snapshot store.
+     *
+     * @param configuration      the started configuration to resolve the framework components from
+     * @param statisticsProvider the provider of the per-tenant course-statistics stores
+     * @param auditProvider      the provider of the per-tenant audit logs
+     * @param shutdown           shuts the started application down, which differs per entry point
+     * @return the Axon Server backed application to drive
+     */
+    public static DemoApplication axonServer(AxonConfiguration configuration,
+                                             TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
+                                             TenantComponentProvider<AuditLog> auditProvider,
+                                             Runnable shutdown) {
+        requireConfiguredFor(configuration, DemoBacking.AXON_SERVER);
+        QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
+                configuration.getComponent(MessageTypeResolver.class));
+        return new DemoApplication(configuration.getComponent(CommandGateway.class),
+                                   configuration.getComponent(QueryGateway.class),
+                                   statisticsProvider,
+                                   auditProvider,
+                                   TenantProvisioning.axonServer(configuration, DemoLifecycle.KNOWN_TENANTS),
+                                   TenantSnapshots.axonServer(configuration, courseSnapshots, CourseSnapshot.class),
+                                   registeredProcessorNames(configuration),
+                                   shutdown);
+    }
+
+    /**
+     * The names of every streaming event processor the given {@code configuration} registered, sorted so a run
+     * reports them predictably. A per-tenant implementation would have registered its processors here too, so
+     * reading them shows whether one processor really served every tenant.
+     */
+    private static List<String> registeredProcessorNames(AxonConfiguration configuration) {
+        return configuration.getComponents(StreamingEventProcessor.class)
+                            .values()
+                            .stream()
+                            .map(EventProcessor::name)
+                            .sorted()
+                            .toList();
+    }
+
+    /**
+     * Rejects assembling a run for one backing on a configuration built for the other, which would otherwise
+     * surface as a puzzling outcome much later. A configuration built without a backing, as the Spring Boot
+     * demo's beans are, is left alone.
+     */
+    private static void requireConfiguredFor(AxonConfiguration configuration, DemoBacking expected) {
+        DemoBacking configured = configuration.getOptionalComponent(DemoBacking.class).orElse(expected);
+        if (configured != expected) {
+            throw new IllegalStateException(
+                    "This configuration was built for the " + configured + " backing, so it cannot be driven as "
+                            + expected + ". Configure and assemble the run for the same backing.");
+        }
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
@@ -26,6 +26,8 @@ import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisio
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.GetTenantStatistics;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.ReadModelWrites;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatistics;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
@@ -33,6 +35,8 @@ import org.axonframework.examples.demo.multitenancy.university.write.enrollstude
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudent;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +44,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 
@@ -62,9 +67,13 @@ import java.util.function.BooleanSupplier;
  * every observation of one below waits for it to catch up. On a shared event store the command handler fills it
  * instead, and those waits return at once.
  * <p>
- * {@link #run} reads top to bottom as the story: tenants known at startup, the course snapshotted per
- * tenant, a tenant added at runtime, one processor serving all of them, an unknown tenant rejected, a tenant
- * removed, and shutdown.
+ * Either way, recording an enrollment is also the one place that emits an update for any of that tenant's open
+ * {@link GetTenantStatistics} subscription queries, through {@link ReadModelWrites}. Subscribing and emitting
+ * both name no tenant, and each subscription still only ever receives its own tenant's updates.
+ * <p>
+ * {@link #run} reads top to bottom as the story: tenants known at startup, their subscriptions proven isolated,
+ * the course snapshotted per tenant, a tenant added at runtime, one processor serving all of them, an unknown
+ * tenant rejected on both the command and the query side, a tenant removed, and shutdown.
  */
 public final class DemoLifecycle {
 
@@ -140,7 +149,12 @@ public final class DemoLifecycle {
         provisioning.prepareKnownTenants();
         logger.info("Providers subscribed at startup. Known tenants: {}", tenantIds(statisticsProvider));
 
-        // 1. Enroll students in the tenants known at startup. Each enrollment appends to the tenant's own
+        // 1. Subscribe to both known tenants' statistics before either enrolls a student, so their own
+        // subscription receives the updates the enrollments below trigger, not just their final value.
+        LiveStatistics springfieldLive = subscribeToStatistics(queryGateway, SPRINGFIELD);
+        LiveStatistics shelbyvilleLive = subscribeToStatistics(queryGateway, SHELBYVILLE);
+
+        // 2. Enroll students in the tenants known at startup. Each enrollment appends to the tenant's own
         // event store, and against Axon Server the same course identifier in two tenants shows the event
         // stores are isolated.
         EventStorageOutcome eventStorage = enrollStudents(commandGateway, provisioning.hasPerTenantEventStore());
@@ -149,34 +163,42 @@ public final class DemoLifecycle {
         logTenantView("Springfield University", queryGateway, SPRINGFIELD);
         logTenantView("Shelbyville University", queryGateway, SHELBYVILLE);
 
-        // 2. Filling those courses snapshotted them. Each snapshot went to its own tenant's snapshot store,
+        // 3. Neither subscription received the other's updates, even though recording an enrollment never
+        // names a tenant when it emits one. Both subscriptions are done once this is observed.
+        SubscriptionQueryOutcome subscriptionOutcome =
+                proveSubscriptionUpdateIsolation(springfieldLive, shelbyvilleLive);
+        springfieldLive.cancel();
+        shelbyvilleLive.cancel();
+
+        // 4. Filling those courses snapshotted them. Each snapshot went to its own tenant's snapshot store,
         // so the same course identifier yields two snapshots holding two different sets of students.
         SnapshottingOutcome snapshottingOutcome = snapshots.hasPerTenantSnapshotStore()
                 ? proveSnapshotIsolation(snapshots)
                 : SnapshottingOutcome.notDemonstrated();
 
-        // 3. Add a tenant at runtime. Its instances materialize on its first command, no config change, and
+        // 5. Add a tenant at runtime. Its instances materialize on its first command, no config change, and
         // the running processor re-opens its stream so this tenant's events are projected too.
         provisioning.addTenant(OGDENVILLE);
         enrollWhenTenantReady(commandGateway);
         awaitProjected(queryGateway, OGDENVILLE, OGDENVILLE_ENROLLMENTS, RUNTIME_TENANT_PROJECTION_TIMEOUT);
         logTenantView("Ogdenville University (added at runtime)", queryGateway, OGDENVILLE);
 
-        // 4. All three tenants were served by one processor, not one processor each. Read before Shelbyville
+        // 6. All three tenants were served by one processor, not one processor each. Read before Shelbyville
         // is removed below, while its read model is still there to compare.
         StreamingOutcome streaming = observeStreaming(processorNames, queryGateway);
 
-        // 5. A command for a tenant the application does not know is rejected.
+        // 7. A command or query for a tenant the application does not know is rejected.
         boolean unknownTenantRejected = unknownTenantIsRejected(commandGateway);
+        boolean unknownTenantQueryRejected = unknownTenantQueryIsRejected(queryGateway);
 
-        // 6. Removing a tenant closes its per-tenant instances.
+        // 8. Removing a tenant closes its per-tenant instances.
         boolean shelbyvilleClosedOnRemoval =
                 removingTenantClosesItsInstances(provisioning, statisticsProvider, auditProvider);
 
-        // 7. Shutting down closes every remaining tenant's instances.
+        // 9. Shutting down closes every remaining tenant's instances.
         return shutDownAndBuildOutcome(shutdown, queryGateway, statisticsProvider, auditProvider,
-                                       unknownTenantRejected, shelbyvilleClosedOnRemoval, eventStorage,
-                                       snapshottingOutcome, streaming);
+                                       unknownTenantRejected, unknownTenantQueryRejected, shelbyvilleClosedOnRemoval,
+                                       eventStorage, snapshottingOutcome, streaming, subscriptionOutcome);
     }
 
     /**
@@ -313,6 +335,99 @@ public final class DemoLifecycle {
     }
 
     /**
+     * Subscribes to the given {@code tenant}'s statistics and collects every update the subscription
+     * receives, including its initial result, so {@link #proveSubscriptionUpdateIsolation} can inspect what
+     * arrived without anything leaking from the other tenant's own subscription.
+     * <p>
+     * Returns only once that initial result has arrived. In memory, registering a subscription query is
+     * synchronous, so this returns at once. Against Axon Server it is a round trip over the tenant's own
+     * connection, and the registration for future updates completes before the initial result does, the same
+     * ordering the local query bus uses; an enrollment sent before this returns could otherwise race that
+     * registration and never reach this subscription, which would misreport as a leak rather than as what it
+     * is: an update missed because nothing was listening for it yet.
+     *
+     * @param queryGateway the gateway the subscription query is sent on
+     * @param tenant       the tenant to subscribe to
+     * @return the tenant's open subscription and what it has received so far
+     */
+    private static LiveStatistics subscribeToStatistics(QueryGateway queryGateway, TenantDescriptor tenant) {
+        List<TenantStatistics> received = new CopyOnWriteArrayList<>();
+        AtomicReference<Subscription> subscription = new AtomicReference<>();
+        Enrollments.subscribeToStatistics(queryGateway, tenant).subscribe(new Subscriber<>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscription.set(s);
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(TenantStatistics statistics) {
+                received.add(statistics);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                logger.warn("Tenant [{}]'s statistics subscription failed.", tenant.tenantId(), throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                // Nothing to do: the demo cancels the subscription itself once it is done observing it.
+            }
+        });
+        holdsWithin("tenant [" + tenant.tenantId() + "] subscription active", TENANT_READY_TIMEOUT,
+                   () -> !received.isEmpty());
+        return new LiveStatistics(received, subscription);
+    }
+
+    /**
+     * Proves that recording an enrollment never reaches the other tenant's subscription, even though neither
+     * {@link ReadModelWrites} nor {@link Enrollments#subscribeToStatistics} names a tenant when emitting or
+     * subscribing. Springfield and Shelbyville each opened their own subscription before either enrolled a
+     * student, so each should have received exactly its own initial result plus one update per accepted
+     * enrollment, and no more: a leak would add the other tenant's updates on top of that.
+     *
+     * @param springfield Springfield's own open subscription
+     * @param shelbyville Shelbyville's own open subscription
+     * @return the observed subscription-query isolation outcome
+     */
+    private static SubscriptionQueryOutcome proveSubscriptionUpdateIsolation(LiveStatistics springfield,
+                                                                             LiveStatistics shelbyville) {
+        int expectedSpringfieldUpdates = SPRINGFIELD_ENROLLMENTS + 1;
+        int expectedShelbyvilleUpdates = SHELBYVILLE_ENROLLMENTS + 1;
+        holdsWithin("Springfield's subscription received " + expectedSpringfieldUpdates + " update(s)",
+                    PROJECTION_TIMEOUT, () -> springfield.received().size() >= expectedSpringfieldUpdates);
+        holdsWithin("Shelbyville's subscription received " + expectedShelbyvilleUpdates + " update(s)",
+                    PROJECTION_TIMEOUT, () -> shelbyville.received().size() >= expectedShelbyvilleUpdates);
+
+        int springfieldUpdatesReceived = springfield.received().size();
+        int shelbyvilleUpdatesReceived = shelbyville.received().size();
+        boolean isolatedByTenant = springfieldUpdatesReceived == expectedSpringfieldUpdates
+                && shelbyvilleUpdatesReceived == expectedShelbyvilleUpdates;
+        logger.info("""
+                    Springfield's subscription received {} update(s), Shelbyville's received {}. \
+                    Neither received the other's: {}""",
+                    springfieldUpdatesReceived, shelbyvilleUpdatesReceived, isolatedByTenant);
+        return new SubscriptionQueryOutcome(springfieldUpdatesReceived, shelbyvilleUpdatesReceived, isolatedByTenant);
+    }
+
+    /**
+     * One tenant's open subscription query: every {@link TenantStatistics} update it has received so far, and
+     * the means to cancel it. The subscription itself is captured through an {@link AtomicReference} since it
+     * only arrives once the publisher calls back {@code onSubscribe}, which for these in-process publishers
+     * has already happened by the time {@link #subscribeToStatistics} returns.
+     *
+     * @param received     every update received so far, including the initial result
+     * @param subscription the subscription {@link #cancel()} cancels
+     */
+    private record LiveStatistics(List<TenantStatistics> received, AtomicReference<Subscription> subscription) {
+
+        void cancel() {
+            subscription.get().cancel();
+        }
+    }
+
+    /**
      * Reports what served the three tenants' projections, so the demo can show it was one processor rather than
      * one per tenant. Springfield and Shelbyville hold the same course identifier, so a leak between them would
      * show up as a wrong count. Counts are read fresh here rather than reused from the waits above.
@@ -401,6 +516,23 @@ public final class DemoLifecycle {
     }
 
     /**
+     * Sends a statistics query for a tenant the application does not know and confirms it is rejected. The
+     * query gateway resolves tenants against the same known tenants the command gateway does, so an
+     * unrecognized tenant is rejected on the read side exactly as it is on the write side.
+     */
+    private static boolean unknownTenantQueryIsRejected(QueryGateway queryGateway) {
+        boolean rejected;
+        try {
+            Enrollments.statistics(queryGateway, UNKNOWN);
+            rejected = false;
+        } catch (RuntimeException e) {
+            rejected = Enrollments.causedByTenantNotResolved(e);
+        }
+        logger.info("Query for an unknown tenant rejected: {}", rejected);
+        return rejected;
+    }
+
+    /**
      * Removes Shelbyville through the {@code provisioning} and confirms both of its instances were
      * closed. The per-tenant components are {@link AutoCloseable} and closed by the framework on
      * removal, so this reads their state before and after removing the tenant.
@@ -426,10 +558,12 @@ public final class DemoLifecycle {
                                                        TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                                                        TenantComponentProvider<AuditLog> auditProvider,
                                                        boolean unknownTenantRejected,
+                                                       boolean unknownTenantQueryRejected,
                                                        boolean shelbyvilleClosedOnRemoval,
                                                        EventStorageOutcome eventStorage,
                                                        SnapshottingOutcome snapshotting,
-                                                       StreamingOutcome streaming) {
+                                                       StreamingOutcome streaming,
+                                                       SubscriptionQueryOutcome subscriptionQuery) {
         // Read the totals through queries while the application is still running.
         TenantStatistics springfield = Enrollments.statistics(queryGateway, SPRINGFIELD);
         int ogdenvilleEnrollments = Enrollments.statistics(queryGateway, OGDENVILLE).totalEnrollments();
@@ -452,11 +586,13 @@ public final class DemoLifecycle {
                                springfield.auditEntries(),
                                ogdenvilleEnrollments,
                                unknownTenantRejected,
+                               unknownTenantQueryRejected,
                                shelbyvilleClosedOnRemoval,
                                allClosedOnShutdown,
                                eventStorage,
                                snapshotting,
-                               streaming);
+                               streaming,
+                               subscriptionQuery);
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
@@ -24,7 +24,9 @@ import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.shared.messaging.Enrollments;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatistics;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
@@ -49,12 +51,20 @@ import java.util.function.BooleanSupplier;
  * <p>
  * A platform hosts several universities, each an isolated tenant. Enrolling a student is an
  * {@link EnrollStudent} command and reading a tenant's statistics is a
- * {@link TenantStatisticsQueryHandler} query. Enrolling both appends to the tenant's own event store and
- * updates that tenant's {@link CourseStatisticsStore} and {@link AuditLog}, injected by type, so one
- * command shows per-tenant event storage and per-tenant component injection together. Enrolling enough
- * students also snapshots the course, into that same tenant's own snapshot store. {@link #run} reads top
- * to bottom as the story: tenants known at startup, the course snapshotted per tenant, a tenant added at
- * runtime, an unknown tenant rejected, a tenant removed, and shutdown.
+ * {@link TenantStatisticsQueryHandler} query. An enrollment appends to the tenant's own event store, and
+ * enrolling enough students also snapshots the course, into that same tenant's own snapshot store. Each
+ * tenant's {@link CourseStatisticsStore} and {@link AuditLog} are injected by type, into the command
+ * handler, the query handler, and the {@link CourseStatisticsProjection} alike.
+ * <p>
+ * Where each tenant has its own event store, the projection is where the tenants come back together: one
+ * ordinary pooled streaming event processor consumes every tenant's events and writes each into the read model
+ * of the tenant it came from. A read model is then eventually consistent rather than written by the command, so
+ * every observation of one below waits for it to catch up. On a shared event store the command handler fills it
+ * instead, and those waits return at once.
+ * <p>
+ * {@link #run} reads top to bottom as the story: tenants known at startup, the course snapshotted per
+ * tenant, a tenant added at runtime, one processor serving all of them, an unknown tenant rejected, a tenant
+ * removed, and shutdown.
  */
 public final class DemoLifecycle {
 
@@ -83,10 +93,23 @@ public final class DemoLifecycle {
     // The runtime-added tenant uses its own identifier as well.
     private static final String OGDENVILLE_COURSE_ID = "econ-300";
 
+    // How many enrollments each tenant ends up with, and so how many its read model should show. Both tenants
+    // known at startup fill their course to capacity, so both cross the snapshot threshold, while the
+    // runtime-added tenant enrolls one student. A rejected enrollment appends nothing, so it never reaches a
+    // read model.
+    private static final int SPRINGFIELD_ENROLLMENTS = COURSE_CAPACITY;
+    private static final int SHELBYVILLE_ENROLLMENTS = COURSE_CAPACITY;
+    private static final int OGDENVILLE_ENROLLMENTS = 1;
+
     // A tenant's context and command bus connector are created asynchronously, so its first command waits.
     private static final Duration TENANT_READY_TIMEOUT = Duration.ofSeconds(15);
     // Storing a snapshot does not hold up the command that triggered it, so the lookup waits for it.
     private static final Duration SNAPSHOT_LOOKUP_TIMEOUT = Duration.ofSeconds(15);
+    // A projection trails the command that appended the event, so every read model observation waits for it.
+    private static final Duration PROJECTION_TIMEOUT = Duration.ofSeconds(20);
+    // A tenant added at runtime waits longer: the processor has to restart before its events are streamed at
+    // all, and that restart is deliberately coalesced rather than immediate.
+    private static final Duration RUNTIME_TENANT_PROJECTION_TIMEOUT = Duration.ofSeconds(60);
     // Closing every tenant's instances happens as shutdown unwinds, so the check waits for it.
     private static final Duration SHUTDOWN_CLEANUP_TIMEOUT = Duration.ofSeconds(5);
 
@@ -100,40 +123,29 @@ public final class DemoLifecycle {
      * per-tenant components it reads for the cleanup checks are {@link AutoCloseable}, but the framework
      * closes them on tenant removal and shutdown, so this only reads their state.
      *
-     * @param commandGateway     the gateway enrollments are sent on
-     * @param queryGateway       the gateway statistics are read on
-     * @param statisticsProvider the provider of the per-tenant course-statistics stores
-     * @param auditProvider      the provider of the per-tenant audit logs
-     * @param provisioning       how this run adds and removes tenants, and whether it has a per-tenant
-     *                           event store (in memory or against Axon Server)
-     * @param snapshots          reads a single tenant's own snapshot store, to observe where the course's
-     *                           snapshot ended up
-     * @param shutdown           shuts the started application down, which is where the framework closes
-     *                           every remaining tenant's instances (the configuration or Spring context)
+     * @param application the started application to drive, and everything needed to drive it
      * @return the observed outcome of the demo run
      */
-    public static DemoOutcome run(CommandGateway commandGateway,
-                                  QueryGateway queryGateway,
-                                  TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
-                                  TenantComponentProvider<AuditLog> auditProvider,
-                                  TenantProvisioning provisioning,
-                                  TenantSnapshots<CourseSnapshot> snapshots,
-                                  Runnable shutdown) {
-        Objects.requireNonNull(commandGateway, "The command gateway must not be null");
-        Objects.requireNonNull(queryGateway, "The query gateway must not be null");
-        Objects.requireNonNull(statisticsProvider, "The course-statistics provider must not be null");
-        Objects.requireNonNull(auditProvider, "The audit-log provider must not be null");
-        Objects.requireNonNull(provisioning, "The tenant provisioning must not be null");
-        Objects.requireNonNull(snapshots, "The tenant snapshots must not be null");
-        Objects.requireNonNull(shutdown, "The shutdown action must not be null");
+    public static DemoOutcome run(DemoApplication application) {
+        Objects.requireNonNull(application, "The demo application must not be null");
+        CommandGateway commandGateway = application.commandGateway();
+        QueryGateway queryGateway = application.queryGateway();
+        TenantComponentProvider<CourseStatisticsStore> statisticsProvider = application.statisticsProvider();
+        TenantComponentProvider<AuditLog> auditProvider = application.auditProvider();
+        TenantProvisioning provisioning = application.provisioning();
+        TenantSnapshots<CourseSnapshot> snapshots = application.snapshots();
+        List<String> processorNames = application.processorNames();
+        Runnable shutdown = application.shutdown();
 
         provisioning.prepareKnownTenants();
         logger.info("Providers subscribed at startup. Known tenants: {}", tenantIds(statisticsProvider));
 
-        // 1. Enroll students in the tenants known at startup. Each enrollment both appends to the tenant's
-        // own event store and updates that tenant's components, and against Axon Server the same course
-        // identifier in two tenants shows the event stores are isolated.
+        // 1. Enroll students in the tenants known at startup. Each enrollment appends to the tenant's own
+        // event store, and against Axon Server the same course identifier in two tenants shows the event
+        // stores are isolated.
         EventStorageOutcome eventStorage = enrollStudents(commandGateway, provisioning.hasPerTenantEventStore());
+        awaitProjected(queryGateway, SPRINGFIELD, SPRINGFIELD_ENROLLMENTS, PROJECTION_TIMEOUT);
+        awaitProjected(queryGateway, SHELBYVILLE, SHELBYVILLE_ENROLLMENTS, PROJECTION_TIMEOUT);
         logTenantView("Springfield University", queryGateway, SPRINGFIELD);
         logTenantView("Shelbyville University", queryGateway, SHELBYVILLE);
 
@@ -143,29 +155,36 @@ public final class DemoLifecycle {
                 ? proveSnapshotIsolation(snapshots)
                 : SnapshottingOutcome.notDemonstrated();
 
-        // 3. Add a tenant at runtime. Its instances materialize on its first command, no config change.
+        // 3. Add a tenant at runtime. Its instances materialize on its first command, no config change, and
+        // the running processor re-opens its stream so this tenant's events are projected too.
         provisioning.addTenant(OGDENVILLE);
         enrollWhenTenantReady(commandGateway);
+        awaitProjected(queryGateway, OGDENVILLE, OGDENVILLE_ENROLLMENTS, RUNTIME_TENANT_PROJECTION_TIMEOUT);
         logTenantView("Ogdenville University (added at runtime)", queryGateway, OGDENVILLE);
 
-        // 4. A command for a tenant the application does not know is rejected.
+        // 4. All three tenants were served by one processor, not one processor each. Read before Shelbyville
+        // is removed below, while its read model is still there to compare.
+        StreamingOutcome streaming = observeStreaming(processorNames, queryGateway);
+
+        // 5. A command for a tenant the application does not know is rejected.
         boolean unknownTenantRejected = unknownTenantIsRejected(commandGateway);
 
-        // 5. Removing a tenant closes its per-tenant instances.
+        // 6. Removing a tenant closes its per-tenant instances.
         boolean shelbyvilleClosedOnRemoval =
                 removingTenantClosesItsInstances(provisioning, statisticsProvider, auditProvider);
 
-        // 6. Shutting down closes every remaining tenant's instances.
+        // 7. Shutting down closes every remaining tenant's instances.
         return shutDownAndBuildOutcome(shutdown, queryGateway, statisticsProvider, auditProvider,
                                        unknownTenantRejected, shelbyvilleClosedOnRemoval, eventStorage,
-                                       snapshottingOutcome);
+                                       snapshottingOutcome, streaming);
     }
 
     /**
      * Enrolls students in the tenants known at startup and returns what the per-tenant event storage
-     * showed. Each enrollment is one command that both appends to the tenant's own event store, through the
-     * event-sourced course it sources, and updates that tenant's {@link CourseStatisticsStore} and
-     * {@link AuditLog}, injected by type.
+     * showed. Each enrollment is one command that appends to the tenant's own event store, through the
+     * event-sourced course it sources. Where each tenant has its own event store, the tenant's
+     * {@link CourseStatisticsStore} and {@link AuditLog} follow from those appended events by way of the
+     * {@link CourseStatisticsProjection}, and otherwise the command handler fills them.
      * <p>
      * Both tenants fill their course to capacity, so a further enrollment is rejected as full, decided from
      * that tenant's own events. Against Axon Server both courses carry the same identifier, so the two
@@ -266,6 +285,61 @@ public final class DemoLifecycle {
     }
 
     /**
+     * Waits until the given {@code tenant}'s read model holds at least {@code expected} enrollments.
+     * <p>
+     * Against Axon Server the read model is written by the {@link CourseStatisticsProjection}, which trails
+     * the command that appended the event, so this is where the demo lets it catch up. In memory the command
+     * handler has already written it, so the wait returns immediately.
+     *
+     * @param queryGateway the gateway the tenant's statistics are read on
+     * @param tenant       the tenant whose read model to wait for
+     * @param expected     the number of enrollments to wait for
+     * @param atMost       how long to wait before giving up
+     */
+    private static void awaitProjected(QueryGateway queryGateway,
+                                       TenantDescriptor tenant,
+                                       int expected,
+                                       Duration atMost) {
+        boolean caughtUp = holdsWithin(
+                "tenant [" + tenant.tenantId() + "] projected " + expected + " enrollments",
+                atMost,
+                () -> Enrollments.statistics(queryGateway, tenant).totalEnrollments() >= expected);
+        if (!caughtUp) {
+            // Said loudly, so a run that ends with an unexplained count says why rather than leaving the
+            // reader to infer it from a missing number.
+            logger.warn("Tenant [{}] did not project {} enrollments within {}. Its read model is behind.",
+                        tenant.tenantId(), expected, atMost);
+        }
+    }
+
+    /**
+     * Reports what served the three tenants' projections, so the demo can show it was one processor rather than
+     * one per tenant. Springfield and Shelbyville hold the same course identifier, so a leak between them would
+     * show up as a wrong count. Counts are read fresh here rather than reused from the waits above.
+     *
+     * @param processorNames the names of every streaming event processor the application registered
+     * @param queryGateway the gateway the tenants' statistics are read on
+     * @return the observed event-processing outcome
+     */
+    private static StreamingOutcome observeStreaming(List<String> processorNames, QueryGateway queryGateway) {
+        if (!processorNames.contains(StatisticsConfiguration.PROCESSOR_NAME)) {
+            return StreamingOutcome.notDemonstrated();
+        }
+        int springfieldProjected = Enrollments.statistics(queryGateway, SPRINGFIELD).totalEnrollments();
+        int shelbyvilleProjected = Enrollments.statistics(queryGateway, SHELBYVILLE).totalEnrollments();
+        int ogdenvilleProjected = Enrollments.statistics(queryGateway, OGDENVILLE).totalEnrollments();
+        logger.info("""
+                    Three tenants were served by {} streaming event processor(s) {}. \
+                    Projected enrollments per tenant: springfield={}, shelbyville={}, ogdenville={}""",
+                    processorNames.size(), processorNames,
+                    springfieldProjected, shelbyvilleProjected, ogdenvilleProjected);
+        return StreamingOutcome.demonstratedWith(processorNames,
+                                                 springfieldProjected,
+                                                 shelbyvilleProjected,
+                                                 ogdenvilleProjected);
+    }
+
+    /**
      * Enrolls in a tenant added at runtime, once that tenant accepts commands.
      */
     private static void enrollWhenTenantReady(CommandGateway commandGateway) {
@@ -354,7 +428,8 @@ public final class DemoLifecycle {
                                                        boolean unknownTenantRejected,
                                                        boolean shelbyvilleClosedOnRemoval,
                                                        EventStorageOutcome eventStorage,
-                                                       SnapshottingOutcome snapshotting) {
+                                                       SnapshottingOutcome snapshotting,
+                                                       StreamingOutcome streaming) {
         // Read the totals through queries while the application is still running.
         TenantStatistics springfield = Enrollments.statistics(queryGateway, SPRINGFIELD);
         int ogdenvilleEnrollments = Enrollments.statistics(queryGateway, OGDENVILLE).totalEnrollments();
@@ -380,7 +455,8 @@ public final class DemoLifecycle {
                                shelbyvilleClosedOnRemoval,
                                allClosedOnShutdown,
                                eventStorage,
-                               snapshotting);
+                               snapshotting,
+                               streaming);
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
@@ -24,6 +24,7 @@ package org.axonframework.examples.demo.multitenancy.shared.run;
  * @param springfieldAuditEntries    the entries recorded in Springfield's audit log
  * @param ogdenvilleEnrollments      the enrollments recorded in the runtime-added Ogdenville's store
  * @param unknownTenantRejected      whether a command for an unknown tenant was rejected
+ * @param unknownTenantQueryRejected whether a query for an unknown tenant was rejected
  * @param shelbyvilleClosedOnRemoval whether Shelbyville's instances were closed when its tenant was removed
  * @param allClosedOnShutdown        whether every remaining tenant's instances were closed on shutdown
  * @param eventStorage               what the per-tenant event-storage demonstration observed (only demonstrated
@@ -32,15 +33,18 @@ package org.axonframework.examples.demo.multitenancy.shared.run;
  *                                   against Axon Server)
  * @param streaming                  what the tenant-aware event-processing demonstration observed (only
  *                                   demonstrated against Axon Server)
+ * @param subscriptionQuery          what the tenant-aware subscription-query demonstration observed
  */
 public record DemoOutcome(int springfieldEnrollments,
                           int springfieldAuditEntries,
                           int ogdenvilleEnrollments,
                           boolean unknownTenantRejected,
+                          boolean unknownTenantQueryRejected,
                           boolean shelbyvilleClosedOnRemoval,
                           boolean allClosedOnShutdown,
                           EventStorageOutcome eventStorage,
                           SnapshottingOutcome snapshotting,
-                          StreamingOutcome streaming) {
+                          StreamingOutcome streaming,
+                          SubscriptionQueryOutcome subscriptionQuery) {
 
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoOutcome.java
@@ -30,6 +30,8 @@ package org.axonframework.examples.demo.multitenancy.shared.run;
  *                                   against Axon Server)
  * @param snapshotting               what the per-tenant snapshotting demonstration observed (only demonstrated
  *                                   against Axon Server)
+ * @param streaming                  what the tenant-aware event-processing demonstration observed (only
+ *                                   demonstrated against Axon Server)
  */
 public record DemoOutcome(int springfieldEnrollments,
                           int springfieldAuditEntries,
@@ -38,6 +40,7 @@ public record DemoOutcome(int springfieldEnrollments,
                           boolean shelbyvilleClosedOnRemoval,
                           boolean allClosedOnShutdown,
                           EventStorageOutcome eventStorage,
-                          SnapshottingOutcome snapshotting) {
+                          SnapshottingOutcome snapshotting,
+                          StreamingOutcome streaming) {
 
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/StreamingOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/StreamingOutcome.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.run;
+
+import java.util.List;
+
+/**
+ * What the tenant-aware event processing demonstration observed. It needs each tenant to have its own event
+ * store, so it only runs on the Axon Server paths. In memory it is {@link #notDemonstrated() not demonstrated}.
+ *
+ * @param demonstrated           whether the event-processing demonstration ran (only against Axon Server)
+ * @param processorNames         the names of every streaming event processor the application registered, which
+ *                               should be the projection's alone
+ * @param springfieldProjected   the enrollments the projection wrote into Springfield's own read model
+ * @param shelbyvilleProjected   the enrollments the projection wrote into Shelbyville's own read model, proving one
+ *                               processor kept the two tenants' read models apart
+ * @param ogdenvilleProjected   the enrollments the projection wrote into the runtime-added Ogdenville's read
+ *                               model, proving the stream re-opened with a tenant that did not exist when the
+ *                               processor started
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+public record StreamingOutcome(boolean demonstrated,
+                               List<String> processorNames,
+                               int springfieldProjected,
+                               int shelbyvilleProjected,
+                               int ogdenvilleProjected) {
+
+    /**
+     * The outcome of a run that exercised tenant-aware event processing, carrying what it observed.
+     *
+     * @param processorNames         the names of every registered streaming event processor
+     * @param springfieldProjected   the enrollments projected into Springfield's own read model
+     * @param shelbyvilleProjected   the enrollments projected into Shelbyville's own read model
+     * @param ogdenvilleProjected the enrollments projected into the runtime-added tenant's read model
+     * @return an outcome marked as demonstrated
+     */
+    public static StreamingOutcome demonstratedWith(List<String> processorNames,
+                                                    int springfieldProjected,
+                                                    int shelbyvilleProjected,
+                                                    int ogdenvilleProjected) {
+        return new StreamingOutcome(true,
+                                    List.copyOf(processorNames),
+                                    springfieldProjected,
+                                    shelbyvilleProjected,
+                                    ogdenvilleProjected);
+    }
+
+    /**
+     * The outcome of a run that did not exercise tenant-aware event processing, such as the in-memory demo.
+     *
+     * @return an outcome marked as not demonstrated
+     */
+    public static StreamingOutcome notDemonstrated() {
+        return new StreamingOutcome(false, List.of(), 0, 0, 0);
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/SubscriptionQueryOutcome.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/SubscriptionQueryOutcome.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.run;
+
+/**
+ * What the tenant-aware subscription-query demonstration observed. Unlike per-tenant event storage,
+ * snapshotting, and event processing, this holds identically in memory and against Axon Server, so there is
+ * no not-demonstrated case: both tenants known at startup subscribe to their own statistics before either
+ * enrolls a student.
+ *
+ * @param springfieldUpdatesReceived the number of updates Springfield's own subscription received, including
+ *                                   its initial result
+ * @param shelbyvilleUpdatesReceived the number of updates Shelbyville's own subscription received, including
+ *                                   its initial result
+ * @param isolatedByTenant           whether each subscription received exactly as many updates as its own
+ *                                   tenant's accepted enrollments account for, and so none of the other
+ *                                   tenant's updates
+ */
+public record SubscriptionQueryOutcome(int springfieldUpdatesReceived,
+                                       int shelbyvilleUpdatesReceived,
+                                       boolean isolatedByTenant) {
+
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantProvisioning.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/TenantProvisioning.java
@@ -22,14 +22,15 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
 import org.awaitility.Awaitility;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
 
 import java.time.Duration;
 import java.util.List;
 
 /**
- * How a run provisions and removes its tenants, and the only thing that differs between the demo's
- * in-memory and Axon Server runs. The rest of the lifecycle is identical, so isolating these three
- * operations captures the whole difference between the two backings.
+ * How a run provisions and removes its tenants. The rest of the lifecycle is identical between the demo's
+ * in-memory and Axon Server runs, so isolating these three operations captures the whole difference in how
+ * tenants come and go.
  * <p>
  * Get one through {@link #inMemory(DemoTenantProvider)} or {@link #axonServer(AxonConfiguration, List)}.
  */
@@ -58,9 +59,7 @@ public interface TenantProvisioning {
     void removeTenant(TenantDescriptor tenant);
 
     /**
-     * Whether this backing gives each tenant its own event store, which only Axon Server does. The
-     * per-tenant event-storage demonstration of the demo needs this, so the lifecycle reads it to decide
-     * whether to run that demonstration rather than taking a separate flag that could disagree with the backing.
+     * Whether this backing gives each tenant its own event store, which only Axon Server does.
      *
      * @return {@code true} against Axon Server, {@code false} in memory
      */
@@ -92,7 +91,7 @@ public interface TenantProvisioning {
 
             @Override
             public boolean hasPerTenantEventStore() {
-                return false;
+                return DemoBacking.IN_MEMORY.hasPerTenantEventStore();
             }
         };
     }
@@ -142,7 +141,7 @@ public interface TenantProvisioning {
 
             @Override
             public boolean hasPerTenantEventStore() {
-                return true;
+                return DemoBacking.AXON_SERVER.hasPerTenantEventStore();
             }
         };
     }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.examples.demo.multitenancy.university;
 
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourseConfiguration;
@@ -35,14 +36,23 @@ public final class UniversityModuleConfiguration {
 
     /**
      * Registers the write slices and the statistics read slice on the given {@code configurer}.
+     * <p>
+     * The given {@code backing} settles the one thing the two slices have to agree on: whichever of
+     * them fills the read model, the other leaves it alone, so an enrollment is never counted twice.
      *
      * @param configurer the event sourcing configurer to register the domain on
+     * @param backing    what backs this run
      * @return the given {@code configurer}, for further configuring
      */
-    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer) {
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
+                                                    DemoBacking backing) {
+        // Recorded on the configuration, so what assembles the run afterwards reads the same backing this was
+        // configured with rather than being told again and risking a different answer.
+        configurer = configurer.componentRegistry(registry -> registry.registerComponent(DemoBacking.class,
+                                                                                         config -> backing));
         configurer = OpenCourseConfiguration.configure(configurer);
-        configurer = EnrollStudentConfiguration.configure(configurer);
-        configurer = StatisticsConfiguration.configure(configurer);
+        configurer = EnrollStudentConfiguration.configure(configurer, backing);
+        configurer = StatisticsConfiguration.configure(configurer, backing);
         return configurer;
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjection.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjection.java
@@ -20,6 +20,7 @@ import io.axoniq.framework.messaging.multitenancy.annotation.TenantScoped;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 
 /**
  * Builds every tenant's course statistics from the enrollment events of every tenant, writing each into the
@@ -30,7 +31,9 @@ import org.axonframework.messaging.eventhandling.annotation.EventHandler;
  * <p>
  * Which tenant an event belongs to follows from the event store it was streamed from, not from anything stored
  * in the event. The framework puts that tenant on the processing context and resolves the {@link TenantScoped}
- * parameters below from it, the same injection the command and query handlers use.
+ * parameters below from it, the same injection the command and query handlers use. The
+ * {@link QueryUpdateEmitter} parameter resolves from that same processing context, so the statistics update it
+ * emits is isolated to that tenant's own subscription queries too.
  *
  * @author Laura Devriendt
  * @since 5.3.0
@@ -39,16 +42,19 @@ public class CourseStatisticsProjection {
 
     /**
      * Records the enrollment in the course statistics and audit log of the tenant whose event store this
-     * event was streamed from.
+     * event was streamed from, and emits the tenant's fresh statistics to any open subscription query.
      *
      * @param event                 the enrollment event being projected
      * @param courseStatisticsStore the injected course-statistics store of the event's tenant
      * @param auditLog              the injected audit log of the event's tenant
+     * @param updateEmitter         the update emitter to notify open subscription queries through
      */
     @EventHandler
     public void on(StudentEnrolledInCourse event,
                    @TenantScoped CourseStatisticsStore courseStatisticsStore,
-                   @TenantScoped AuditLog auditLog) {
-        ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, event.courseId(), event.studentId());
+                   @TenantScoped AuditLog auditLog,
+                   QueryUpdateEmitter updateEmitter) {
+        ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, updateEmitter,
+                                         event.courseId(), event.studentId());
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjection.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.statistics;
+
+import io.axoniq.framework.messaging.multitenancy.annotation.TenantScoped;
+import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+
+/**
+ * Builds every tenant's course statistics from the enrollment events of every tenant, writing each into the
+ * read model of the tenant its event came from.
+ * <p>
+ * This is an ordinary event handler. One pooled streaming event processor runs it for every tenant at once, so
+ * there is no processor and no token store per tenant, and adding a tenant needs no configuration change.
+ * <p>
+ * Which tenant an event belongs to follows from the event store it was streamed from, not from anything stored
+ * in the event. The framework puts that tenant on the processing context and resolves the {@link TenantScoped}
+ * parameters below from it, the same injection the command and query handlers use.
+ *
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+public class CourseStatisticsProjection {
+
+    /**
+     * Records the enrollment in the course statistics and audit log of the tenant whose event store this
+     * event was streamed from.
+     *
+     * @param event                 the enrollment event being projected
+     * @param courseStatisticsStore the injected course-statistics store of the event's tenant
+     * @param auditLog              the injected audit log of the event's tenant
+     */
+    @EventHandler
+    public void on(StudentEnrolledInCourse event,
+                   @TenantScoped CourseStatisticsStore courseStatisticsStore,
+                   @TenantScoped AuditLog auditLog) {
+        ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, event.courseId(), event.studentId());
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsStore.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsStore.java
@@ -40,11 +40,18 @@ public interface CourseStatisticsStore extends AutoCloseable {
     }
 
     /**
-     * Records one enrollment for the given {@code courseId}.
+     * Records that the given {@code studentId} is enrolled in the given {@code courseId}.
+     * <p>
+     * Recording the same student in the same course again has no effect. That matters because this store is
+     * filled from a streamed event, and an event can reach a handler more than once: the stream is re-opened
+     * whenever a tenant is added or removed, and the processor cannot always tell that an event was already
+     * handled. Counting enrollments instead of remembering who is enrolled would drift upwards every time
+     * that happens.
      *
-     * @param courseId the identifier of the course to record an enrollment for
+     * @param courseId  the identifier of the course enrolled in
+     * @param studentId the identifier of the enrolled student
      */
-    void recordEnrollment(String courseId);
+    void recordEnrollment(String courseId, String studentId);
 
     /**
      * Returns the enrollment statistics per course held for this tenant.

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/InMemoryCourseStatisticsStore.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/InMemoryCourseStatisticsStore.java
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * In-memory {@link CourseStatisticsStore}, backing the demo without external infrastructure.
@@ -36,7 +36,8 @@ class InMemoryCourseStatisticsStore implements CourseStatisticsStore {
     private static final Logger logger = LoggerFactory.getLogger(InMemoryCourseStatisticsStore.class);
 
     private final String tenantId;
-    private final ConcurrentMap<String, AtomicInteger> enrollmentsByCourse = new ConcurrentHashMap<>();
+    // The enrolled students per course rather than a count, so recording the same enrollment twice is a no-op.
+    private final ConcurrentMap<String, Set<String>> enrolledStudentsByCourse = new ConcurrentHashMap<>();
     private volatile boolean closed = false;
 
     /**
@@ -49,16 +50,17 @@ class InMemoryCourseStatisticsStore implements CourseStatisticsStore {
     }
 
     @Override
-    public void recordEnrollment(String courseId) {
-        enrollmentsByCourse.computeIfAbsent(courseId, ignored -> new AtomicInteger()).incrementAndGet();
+    public void recordEnrollment(String courseId, String studentId) {
+        enrolledStudentsByCourse.computeIfAbsent(courseId, ignored -> ConcurrentHashMap.newKeySet())
+                                .add(studentId);
     }
 
     @Override
     public List<CourseStatistics> statistics() {
-        return enrollmentsByCourse.entrySet()
-                                  .stream()
-                                  .map(entry -> new CourseStatistics(entry.getKey(), entry.getValue().get()))
-                                  .toList();
+        return enrolledStudentsByCourse.entrySet()
+                                       .stream()
+                                       .map(entry -> new CourseStatistics(entry.getKey(), entry.getValue().size()))
+                                       .toList();
     }
 
     @Override

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/ReadModelWrites.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/ReadModelWrites.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.statistics;
+
+import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+
+import java.util.Objects;
+
+/**
+ * The one write that records an enrollment in a tenant's read model, so the {@link CourseStatisticsProjection}
+ * and the enroll-student command handler fill it identically.
+ * <p>
+ * Recording the same enrollment twice leaves the read model as it was. See
+ * {@link CourseStatisticsStore#recordEnrollment} for why that matters.
+ *
+ * @author Laura Devriendt
+ * @since 5.3.0
+ */
+public final class ReadModelWrites {
+
+    private ReadModelWrites() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Records one enrollment in the given tenant's {@code courseStatisticsStore} and {@code auditLog}. Both
+     * belong to a single tenant, so this never names one: the caller was handed the instances of the tenant
+     * whose message it is handling.
+     *
+     * @param courseStatisticsStore the course-statistics store of the tenant the enrollment belongs to
+     * @param auditLog              the audit log of the tenant the enrollment belongs to
+     * @param courseId              the identifier of the course enrolled in
+     * @param studentId             the identifier of the enrolled student
+     */
+    public static void recordEnrollment(CourseStatisticsStore courseStatisticsStore,
+                                        AuditLog auditLog,
+                                        String courseId,
+                                        String studentId) {
+        Objects.requireNonNull(courseStatisticsStore, "The course-statistics store must not be null");
+        Objects.requireNonNull(auditLog, "The audit log must not be null");
+        Objects.requireNonNull(courseId, "The course id must not be null");
+        Objects.requireNonNull(studentId, "The student id must not be null");
+        courseStatisticsStore.recordEnrollment(courseId, studentId);
+        auditLog.record("Enrolled student [" + studentId + "] in course [" + courseId + "]");
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/ReadModelWrites.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/ReadModelWrites.java
@@ -17,6 +17,7 @@
 package org.axonframework.examples.demo.multitenancy.university.read.statistics;
 
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 
 import java.util.Objects;
 
@@ -26,6 +27,11 @@ import java.util.Objects;
  * <p>
  * Recording the same enrollment twice leaves the read model as it was. See
  * {@link CourseStatisticsStore#recordEnrollment} for why that matters.
+ * <p>
+ * Being the one write also makes this the one place that emits the fresh statistics to any open
+ * {@link GetTenantStatistics} subscription query. The predicate handed to the emitter never names a tenant, and
+ * still only that tenant's own subscriptions receive it: the framework resolves the update's tenant from the
+ * store and audit log it was built from, and isolates emission by it.
  *
  * @author Laura Devriendt
  * @since 5.3.0
@@ -37,24 +43,30 @@ public final class ReadModelWrites {
     }
 
     /**
-     * Records one enrollment in the given tenant's {@code courseStatisticsStore} and {@code auditLog}. Both
-     * belong to a single tenant, so this never names one: the caller was handed the instances of the tenant
-     * whose message it is handling.
+     * Records one enrollment in the given tenant's {@code courseStatisticsStore} and {@code auditLog}, and
+     * emits the tenant's fresh statistics to any open {@link GetTenantStatistics} subscription query through
+     * the given {@code updateEmitter}. All three belong to a single tenant, so this never names one: the
+     * caller was handed the instances of the tenant whose message it is handling.
      *
      * @param courseStatisticsStore the course-statistics store of the tenant the enrollment belongs to
      * @param auditLog              the audit log of the tenant the enrollment belongs to
+     * @param updateEmitter         the update emitter to notify open subscription queries through
      * @param courseId              the identifier of the course enrolled in
      * @param studentId             the identifier of the enrolled student
      */
     public static void recordEnrollment(CourseStatisticsStore courseStatisticsStore,
                                         AuditLog auditLog,
+                                        QueryUpdateEmitter updateEmitter,
                                         String courseId,
                                         String studentId) {
         Objects.requireNonNull(courseStatisticsStore, "The course-statistics store must not be null");
         Objects.requireNonNull(auditLog, "The audit log must not be null");
+        Objects.requireNonNull(updateEmitter, "The update emitter must not be null");
         Objects.requireNonNull(courseId, "The course id must not be null");
         Objects.requireNonNull(studentId, "The student id must not be null");
         courseStatisticsStore.recordEnrollment(courseId, studentId);
         auditLog.record("Enrolled student [" + studentId + "] in course [" + courseId + "]");
+        updateEmitter.emit(GetTenantStatistics.class, query -> true,
+                          new TenantStatistics(courseStatisticsStore.statistics(), auditLog.entries().size()));
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/StatisticsConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/StatisticsConfiguration.java
@@ -17,32 +17,65 @@
 package org.axonframework.examples.demo.multitenancy.university.read.statistics;
 
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorModule;
 import org.axonframework.messaging.queryhandling.configuration.QueryHandlingModule;
 
 /**
  * Registers the tenant-statistics read slice: the {@link TenantStatisticsQueryHandler}, whose
- * {@code @TenantScoped} parameters the framework injects with the query tenant's components. The
- * declarative demo calls {@link #configure(EventSourcingConfigurer)}; the Spring Boot demo instead
- * declares the query handler as a bean the starter picks up.
+ * {@code @TenantScoped} parameters the framework injects with the query tenant's components, and, on a backing
+ * whose tenants each have their own event store, the {@link CourseStatisticsProjection} and the processor
+ * running it. The declarative demo calls {@link #configure(EventSourcingConfigurer, DemoBacking)}; the Spring
+ * Boot demo declares the query handler as a bean and the processor through an
+ * {@code EventProcessorDefinition}, since a module bean holding an event processor is ignored on that path.
  */
 public final class StatisticsConfiguration {
+
+    /**
+     * The name of the one processor that projects every tenant's events. There is deliberately only one, and
+     * it is named for what it projects rather than for any tenant, since the same processor serves them all.
+     */
+    public static final String PROCESSOR_NAME = "Projection_CourseStatistics_Processor";
 
     private StatisticsConfiguration() {
         // Utility class, not meant to be instantiated.
     }
 
     /**
-     * Registers the statistics query handling module on the given {@code configurer}.
+     * Registers the statistics query handling module on the given {@code configurer}, and the projection
+     * processor when the given {@code backing} projects the read model.
      *
      * @param configurer the event sourcing configurer to register the read slice on
+     * @param backing    what backs this run
      * @return the given {@code configurer}, for further configuring
      */
-    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer) {
-        QueryHandlingModule queryModule =
-                QueryHandlingModule.named("tenant-statistics")
-                                   .queryHandlers()
-                                   .autodetectedQueryHandlingComponent(config -> new TenantStatisticsQueryHandler())
-                                   .build();
-        return configurer.registerQueryHandlingModule(queryModule);
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
+                                                    DemoBacking backing) {
+        configurer = configurer.registerQueryHandlingModule(queryModule());
+        if (backing.projectsReadModel()) {
+            configurer = configurer.modelling(
+                    modelling -> modelling.messaging(
+                            messaging -> messaging.eventProcessing(
+                                    eventProcessing -> eventProcessing.pooledStreaming(
+                                            pooled -> pooled.processor(projectionProcessorModule())))));
+        }
+        return configurer;
+    }
+
+    private static PooledStreamingEventProcessorModule projectionProcessorModule() {
+        return EventProcessorModule.pooledStreaming(PROCESSOR_NAME)
+                                   .eventHandlingComponents(
+                                           components -> components.autodetected(
+                                                   "courseStatisticsProjection",
+                                                   config -> new CourseStatisticsProjection()))
+                                   .notCustomized();
+    }
+
+    private static QueryHandlingModule queryModule() {
+        return QueryHandlingModule.named("tenant-statistics")
+                                  .queryHandlers()
+                                  .autodetectedQueryHandlingComponent(config -> new TenantStatisticsQueryHandler())
+                                  .build();
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
@@ -31,6 +31,7 @@ import org.axonframework.eventsourcing.annotation.Snapshotting;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
 import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 import org.axonframework.modelling.annotation.InjectEntity;
 
 import java.util.Collections;
@@ -88,17 +89,21 @@ class EnrollStudentCommandHandler {
      * @param eventAppender         the appender the enrollment event is appended through
      * @param courseStatisticsStore the injected course-statistics store of the command's tenant
      * @param auditLog              the injected audit log of the command's tenant
+     * @param updateEmitter         the update emitter to notify open subscription queries through, on the
+     *                              backing that fills the read model here
      */
     @CommandHandler
     void handle(EnrollStudent command,
                 @InjectEntity(idProperty = UniversityTags.COURSE_ID) State state,
                 EventAppender eventAppender,
                 @TenantScoped CourseStatisticsStore courseStatisticsStore,
-                @TenantScoped AuditLog auditLog) {
+                @TenantScoped AuditLog auditLog,
+                QueryUpdateEmitter updateEmitter) {
         List<StudentEnrolledInCourse> events = decide(command, state);
         eventAppender.append(events);
         if (!backing.projectsReadModel() && !events.isEmpty()) {
-            ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, command.courseId(), command.studentId());
+            ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, updateEmitter,
+                                             command.courseId(), command.studentId());
         }
     }
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentCommandHandler.java
@@ -21,7 +21,10 @@ import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.UniversityTags;
 import org.axonframework.examples.demo.multitenancy.university.events.CourseOpened;
 import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.ReadModelWrites;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
 import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
 import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
 import org.axonframework.eventsourcing.annotation.Snapshotting;
@@ -33,6 +36,7 @@ import org.axonframework.modelling.annotation.InjectEntity;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -42,12 +46,29 @@ import java.util.Set;
  * <p>
  * The handler names no tenant. Sourcing the injected {@link State} and appending the resulting event are
  * both routed to the tenant's own event store by the framework, so the same course identifier in two
- * tenants is two isolated event streams. It also shows the two features working together in one handler:
- * alongside the event-sourced {@link State}, it takes the tenant's {@link TenantScoped}
- * {@link CourseStatisticsStore} and {@link AuditLog}, each injected for the command's tenant, matched by
- * type.
+ * tenants is two isolated event streams.
+ * <p>
+ * Where each tenant has its own event store, appending is all this handler does, and the
+ * {@link CourseStatisticsProjection} builds the read model from the appended events. On a backing without
+ * per-tenant event stores it also fills the read model itself, from the {@link TenantScoped}
+ * {@link CourseStatisticsStore} and {@link AuditLog} injected for the command's tenant.
+ * <p>
+ * That second path is a shortcut, not the shape to copy. A read model belongs on the event side, and it only
+ * survives here because one shared event store leaves a streamed event with no tenant to attribute it to.
  */
 class EnrollStudentCommandHandler {
+
+    private final DemoBacking backing;
+
+    /**
+     * Constructs a handler that fills the read model itself only when the given {@code backing}
+     * says no projection does.
+     *
+     * @param backing    what backs this run
+     */
+    EnrollStudentCommandHandler(DemoBacking backing) {
+        this.backing = Objects.requireNonNull(backing, "The backing must not be null");
+    }
 
     /**
      * Enrolls a student, rejecting the command with a {@link CourseNotOpenException} when the course was
@@ -55,11 +76,12 @@ class EnrollStudentCommandHandler {
      * in the course is idempotent. Both decisions read the course sourced from the command's tenant's own
      * event store, so they reflect only that tenant's events.
      * <p>
-     * The statistics store and audit log are updated here to keep this demo self-contained while the
-     * tenant-aware read stream is still to come. That is a shortcut, not the recommended shape: a read
-     * model should be a projection that consumes the appended {@link StudentEnrolledInCourse} events, not
-     * something a command handler writes to. Once per-tenant event streaming is available, this write side
-     * appends only, and the statistics become such a projection.
+     * Appending the event is all this handler does against Axon Server, where the
+     * {@link CourseStatisticsProjection} builds the read model from the appended
+     * {@link StudentEnrolledInCourse} events instead. Only the in-memory run, whose single shared event
+     * store leaves a streamed event with no tenant to attribute it to, has this handler fill the read model
+     * as well. The {@link TenantScoped} parameters are injected either way, since a command always resolves
+     * to a tenant.
      *
      * @param command               the command enrolling the student
      * @param state                 the injected course state, sourced from the command's tenant's event store
@@ -75,9 +97,8 @@ class EnrollStudentCommandHandler {
                 @TenantScoped AuditLog auditLog) {
         List<StudentEnrolledInCourse> events = decide(command, state);
         eventAppender.append(events);
-        if (!events.isEmpty()) {
-            courseStatisticsStore.recordEnrollment(command.courseId());
-            auditLog.record("Enrolled student [" + command.studentId() + "] in course [" + command.courseId() + "]");
+        if (!backing.projectsReadModel() && !events.isEmpty()) {
+            ReadModelWrites.recordEnrollment(courseStatisticsStore, auditLog, command.courseId(), command.studentId());
         }
     }
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/write/enrollstudent/EnrollStudentConfiguration.java
@@ -20,6 +20,7 @@ import org.axonframework.common.configuration.Module;
 import org.axonframework.common.configuration.ModuleBuilder;
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
 import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
@@ -41,11 +42,13 @@ public final class EnrollStudentConfiguration {
      * Registers the slice's entity and command handler on the given {@code configurer}.
      *
      * @param configurer the event sourcing configurer to register the slice on
+     * @param backing    what backs this run
      * @return the given {@code configurer}, for further configuring
      */
-    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer) {
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
+                                                    DemoBacking backing) {
         return configurer.registerEntity(entityModuleBuilder())
-                         .registerCommandHandlingModule(commandModuleBuilder());
+                         .registerCommandHandlingModule(commandModuleBuilder(backing));
     }
 
     /**
@@ -62,10 +65,11 @@ public final class EnrollStudentConfiguration {
      * The slice's command handling module, for wiring styles that register modules as beans, such as
      * Spring Boot.
      *
+     * @param backing    what backs this run
      * @return the command handling module
      */
-    public static Module commandModule() {
-        return commandModuleBuilder().build();
+    public static Module commandModule(DemoBacking backing) {
+        return commandModuleBuilder(backing).build();
     }
 
     /**
@@ -88,9 +92,10 @@ public final class EnrollStudentConfiguration {
         return EventSourcedEntityModule.autodetected(String.class, EnrollStudentCommandHandler.State.class);
     }
 
-    private static ModuleBuilder<CommandHandlingModule> commandModuleBuilder() {
+    private static ModuleBuilder<CommandHandlingModule> commandModuleBuilder(DemoBacking backing) {
         return CommandHandlingModule.named("EnrollStudent")
                                     .commandHandlers()
-                                    .autodetectedCommandHandlingComponent(config -> new EnrollStudentCommandHandler());
+                                    .autodetectedCommandHandlingComponent(
+                                            config -> new EnrollStudentCommandHandler(backing));
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
@@ -83,7 +83,11 @@ class CourseEnrollmentCompositionTest {
         TenantProvider tenantProvider = new DemoTenantProvider(TENANT);
 
         EventSourcingConfigurer configurer = EventSourcingConfigurer.create();
-        UniversityModuleConfiguration.configure(configurer);
+        // A backing without per-tenant event stores keeps the read model written by the command handler, so
+        // this test observes an enrollment's
+        // full effect without a projection to wait for. It is also the only shape a single shared event store
+        // supports, since an event streamed from it cannot be attributed to a tenant.
+        UniversityModuleConfiguration.configure(configurer, DemoBacking.IN_MEMORY);
         configurer.componentRegistry(registry -> {
             MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
             registry.disableEnhancer(AxonServerConfigurationEnhancer.class)

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/shared/CourseEnrollmentCompositionTest.java
@@ -28,11 +28,14 @@ import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+import org.awaitility.Awaitility;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.shared.messaging.Enrollments;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatistics;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatistics;
 import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseFullException;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseNotOpenException;
@@ -43,12 +46,18 @@ import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,6 +82,7 @@ class CourseEnrollmentCompositionTest {
 
     private AxonConfiguration configuration;
     private CommandGateway commandGateway;
+    private QueryGateway queryGateway;
     private TenantComponentProvider<CourseStatisticsStore> statisticsProvider;
     private TenantComponentProvider<AuditLog> auditProvider;
 
@@ -102,6 +112,7 @@ class CourseEnrollmentCompositionTest {
         configuration = configurer.build();
         configuration.start();
         commandGateway = configuration.getComponent(CommandGateway.class);
+        queryGateway = configuration.getComponent(QueryGateway.class);
     }
 
     @AfterEach
@@ -191,6 +202,22 @@ class CourseEnrollmentCompositionTest {
                 .containsExactly(new CourseStatistics(COURSE_ID, 1));
     }
 
+    @Test
+    void enrollingAStudentEmitsAnUpdateToTheTenantsOwnSubscription() {
+        openCourse(COURSE_ID, CAPACITY);
+        List<TenantStatistics> received = subscribeToStatistics();
+
+        enroll(COURSE_ID, "alice");
+
+        // The subscription's initial result is the tenant's statistics at subscribe time, empty here since
+        // the course was only just opened, followed by the update the enrollment's handler emits.
+        Awaitility.await("the enrollment's update is received")
+                  .atMost(Duration.ofSeconds(TIMEOUT_SECONDS))
+                  .untilAsserted(() -> assertThat(received).containsExactly(
+                          new TenantStatistics(List.of(), 0),
+                          new TenantStatistics(List.of(new CourseStatistics(COURSE_ID, 1)), 1)));
+    }
+
     // Reads the snapshot straight from the store the configuration was given, under the same name the
     // entity's repository stores it with.
     @Nullable
@@ -217,5 +244,34 @@ class CourseEnrollmentCompositionTest {
                       .getResultMessage()
                       .orTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                       .join();
+    }
+
+    // Subscribes to the tenant's statistics and collects every update received, including the initial
+    // result, requesting an unbounded number of updates up front so the demo's own Subscriber shape stays
+    // out of the assertion.
+    private List<TenantStatistics> subscribeToStatistics() {
+        List<TenantStatistics> received = new CopyOnWriteArrayList<>();
+        Enrollments.subscribeToStatistics(queryGateway, TENANT).subscribe(new Subscriber<>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(TenantStatistics statistics) {
+                received.add(statistics);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                // Not expected in this test; a missing update speaks for itself in the assertion.
+            }
+
+            @Override
+            public void onComplete() {
+                // Not expected in this test: the subscription stays open until the test ends.
+            }
+        });
+        return received;
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjectionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjectionTest.java
@@ -16,10 +16,18 @@
 
 package org.axonframework.examples.demo.multitenancy.university.read.statistics;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,10 +49,11 @@ class CourseStatisticsProjectionTest {
     private final CourseStatisticsProjection testSubject = new CourseStatisticsProjection();
     private final CourseStatisticsStore statisticsStore = CourseStatisticsStore.inMemory("springfield");
     private final AuditLog auditLog = AuditLog.inMemory("springfield");
+    private final RecordingQueryUpdateEmitter updateEmitter = new RecordingQueryUpdateEmitter();
 
     @Test
     void projectsAnEnrollmentIntoTheStatisticsAndTheAuditLog() {
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog, updateEmitter);
 
         assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 1));
         assertThat(auditLog.entries()).containsExactly("Enrolled student [alice] in course [" + COURSE_ID + "]");
@@ -52,11 +61,21 @@ class CourseStatisticsProjectionTest {
 
     @Test
     void countsEachStudentOfACourseSeparately() {
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog, updateEmitter);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog, updateEmitter);
 
         assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 2));
         assertThat(auditLog.entries()).hasSize(2);
+    }
+
+    @Test
+    void emitsTheFreshStatisticsForEveryEnrollment() {
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog, updateEmitter);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog, updateEmitter);
+
+        assertThat(updateEmitter.emitted()).containsExactly(
+                new TenantStatistics(List.of(new CourseStatistics(COURSE_ID, 1)), 1),
+                new TenantStatistics(List.of(new CourseStatistics(COURSE_ID, 2)), 2));
     }
 
     @Nested
@@ -66,8 +85,8 @@ class CourseStatisticsProjectionTest {
         void handlingTheSameEnrollmentTwiceLeavesTheStatisticsUnchanged() {
             StudentEnrolledInCourse event = new StudentEnrolledInCourse(COURSE_ID, "alice");
 
-            testSubject.on(event, statisticsStore, auditLog);
-            testSubject.on(event, statisticsStore, auditLog);
+            testSubject.on(event, statisticsStore, auditLog, updateEmitter);
+            testSubject.on(event, statisticsStore, auditLog, updateEmitter);
 
             assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 1));
         }
@@ -76,8 +95,8 @@ class CourseStatisticsProjectionTest {
         void handlingTheSameEnrollmentTwiceLeavesTheAuditLogUnchanged() {
             StudentEnrolledInCourse event = new StudentEnrolledInCourse(COURSE_ID, "alice");
 
-            testSubject.on(event, statisticsStore, auditLog);
-            testSubject.on(event, statisticsStore, auditLog);
+            testSubject.on(event, statisticsStore, auditLog, updateEmitter);
+            testSubject.on(event, statisticsStore, auditLog, updateEmitter);
 
             assertThat(auditLog.entries()).hasSize(1);
         }
@@ -86,9 +105,9 @@ class CourseStatisticsProjectionTest {
         void aRepeatOfOneEnrollmentDoesNotAffectAnother() {
             StudentEnrolledInCourse alice = new StudentEnrolledInCourse(COURSE_ID, "alice");
 
-            testSubject.on(alice, statisticsStore, auditLog);
-            testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
-            testSubject.on(alice, statisticsStore, auditLog);
+            testSubject.on(alice, statisticsStore, auditLog, updateEmitter);
+            testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog, updateEmitter);
+            testSubject.on(alice, statisticsStore, auditLog, updateEmitter);
 
             assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 2));
             assertThat(auditLog.entries()).hasSize(2);
@@ -97,8 +116,8 @@ class CourseStatisticsProjectionTest {
 
     @Test
     void keepsTheEnrollmentsOfTwoCoursesApart() {
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
-        testSubject.on(new StudentEnrolledInCourse("law-200", "bob"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog, updateEmitter);
+        testSubject.on(new StudentEnrolledInCourse("law-200", "bob"), statisticsStore, auditLog, updateEmitter);
 
         assertThat(statisticsStore.statistics()).containsExactlyInAnyOrder(
                 new CourseStatistics(COURSE_ID, 1),
@@ -113,11 +132,57 @@ class CourseStatisticsProjectionTest {
 
     @Test
     void theAuditLogKeepsTheOrderThingsHappenedIn() {
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
-        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog, updateEmitter);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog, updateEmitter);
 
         assertThat(auditLog.entries()).containsExactly(
                 "Enrolled student [alice] in course [" + COURSE_ID + "]",
                 "Enrolled student [bob] in course [" + COURSE_ID + "]");
+    }
+
+    // A recording QueryUpdateEmitter rather than a mock: the interaction under test is "what was emitted",
+    // a plain state-based capture, not a call that must or must not have happened.
+    private static final class RecordingQueryUpdateEmitter implements QueryUpdateEmitter {
+
+        private final List<Object> emitted = new ArrayList<>();
+
+        List<Object> emitted() {
+            return emitted;
+        }
+
+        @Override
+        public <Q> void emit(Class<Q> queryType, Predicate<? super Q> filter, Supplier<Object> updateSupplier) {
+            emitted.add(updateSupplier.get());
+        }
+
+        @Override
+        public void emit(QualifiedName queryName, Predicate<Object> filter, Supplier<Object> updateSupplier) {
+            emitted.add(updateSupplier.get());
+        }
+
+        @Override
+        public <Q> void complete(Class<Q> queryType, Predicate<? super Q> filter) {
+            // Not exercised by these tests.
+        }
+
+        @Override
+        public void complete(QualifiedName queryName, Predicate<Object> filter) {
+            // Not exercised by these tests.
+        }
+
+        @Override
+        public <Q> void completeExceptionally(Class<Q> queryType, Predicate<? super Q> filter, Throwable cause) {
+            // Not exercised by these tests.
+        }
+
+        @Override
+        public void completeExceptionally(QualifiedName queryName, Predicate<Object> filter, Throwable cause) {
+            // Not exercised by these tests.
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            descriptor.describeProperty("emitted", emitted);
+        }
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjectionTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/test/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/CourseStatisticsProjectionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.university.read.statistics;
+
+import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.events.StudentEnrolledInCourse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the projection that builds a tenant's course statistics from its enrollment events.
+ * <p>
+ * The projection is handed the components of the tenant whose event store the event was streamed from, so
+ * these tests hand it a single tenant's stores directly. Which tenant's stores it receives is the framework's
+ * job, and the Spring Boot integration test covers that against a real Axon Server.
+ * <p>
+ * Handling the same event twice is exercised on purpose. Events are delivered at least once, and re-opening
+ * the stream on a tenant change makes a repeat more likely than usual, so the demo's exact-count assertions
+ * only hold because the read model is keyed on identity rather than counted.
+ */
+class CourseStatisticsProjectionTest {
+
+    private static final String COURSE_ID = "cs-101";
+
+    private final CourseStatisticsProjection testSubject = new CourseStatisticsProjection();
+    private final CourseStatisticsStore statisticsStore = CourseStatisticsStore.inMemory("springfield");
+    private final AuditLog auditLog = AuditLog.inMemory("springfield");
+
+    @Test
+    void projectsAnEnrollmentIntoTheStatisticsAndTheAuditLog() {
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
+
+        assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 1));
+        assertThat(auditLog.entries()).containsExactly("Enrolled student [alice] in course [" + COURSE_ID + "]");
+    }
+
+    @Test
+    void countsEachStudentOfACourseSeparately() {
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
+
+        assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 2));
+        assertThat(auditLog.entries()).hasSize(2);
+    }
+
+    @Nested
+    class RepeatedDelivery {
+
+        @Test
+        void handlingTheSameEnrollmentTwiceLeavesTheStatisticsUnchanged() {
+            StudentEnrolledInCourse event = new StudentEnrolledInCourse(COURSE_ID, "alice");
+
+            testSubject.on(event, statisticsStore, auditLog);
+            testSubject.on(event, statisticsStore, auditLog);
+
+            assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 1));
+        }
+
+        @Test
+        void handlingTheSameEnrollmentTwiceLeavesTheAuditLogUnchanged() {
+            StudentEnrolledInCourse event = new StudentEnrolledInCourse(COURSE_ID, "alice");
+
+            testSubject.on(event, statisticsStore, auditLog);
+            testSubject.on(event, statisticsStore, auditLog);
+
+            assertThat(auditLog.entries()).hasSize(1);
+        }
+
+        @Test
+        void aRepeatOfOneEnrollmentDoesNotAffectAnother() {
+            StudentEnrolledInCourse alice = new StudentEnrolledInCourse(COURSE_ID, "alice");
+
+            testSubject.on(alice, statisticsStore, auditLog);
+            testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
+            testSubject.on(alice, statisticsStore, auditLog);
+
+            assertThat(statisticsStore.statistics()).containsExactly(new CourseStatistics(COURSE_ID, 2));
+            assertThat(auditLog.entries()).hasSize(2);
+        }
+    }
+
+    @Test
+    void keepsTheEnrollmentsOfTwoCoursesApart() {
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse("law-200", "bob"), statisticsStore, auditLog);
+
+        assertThat(statisticsStore.statistics()).containsExactlyInAnyOrder(
+                new CourseStatistics(COURSE_ID, 1),
+                new CourseStatistics("law-200", 1));
+    }
+
+    @Test
+    void aCourseWithoutEnrollmentsIsNotReported() {
+        assertThat(statisticsStore.statistics()).isEmpty();
+        assertThat(auditLog.entries()).isEmpty();
+    }
+
+    @Test
+    void theAuditLogKeepsTheOrderThingsHappenedIn() {
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "alice"), statisticsStore, auditLog);
+        testSubject.on(new StudentEnrolledInCourse(COURSE_ID, "bob"), statisticsStore, auditLog);
+
+        assertThat(auditLog.entries()).containsExactly(
+                "Enrolled student [alice] in course [" + COURSE_ID + "]",
+                "Enrolled student [bob] in course [" + COURSE_ID + "]");
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
@@ -26,6 +26,14 @@ or against Axon Server with the toggle, starts it, and hands the gateways and pr
 `DemoLifecycle`. In memory the event store is a single shared store; against Axon Server each tenant has
 its own.
 
+That difference decides where the statistics come from. Against Axon Server the configuration also
+registers one ordinary pooled streaming processor running `CourseStatisticsProjection`, which builds every
+tenant's statistics from the stored events. Making that processor tenant-aware takes no wiring at all: the
+declaration names no tenant, and the multi-tenancy defaults make the event store it streams from
+tenant-aware. In memory a shared event store leaves a streamed event with no tenant to attribute it to, so
+that run registers no projection and has the command handler fill the read model instead. That inline write is a
+shortcut, not the shape to copy: given per-tenant event stores, prefer the projection.
+
 The course carries a snapshot policy, so a `SnapshotStore` is needed too. In memory `UniversityConfiguration`
 registers one shared `InMemorySnapshotStore`. Against Axon Server it registers none: the multi-tenancy
 defaults own that registration so each tenant's snapshots land in its own context, and a store the
@@ -84,6 +92,19 @@ It also shows per-tenant snapshotting. Enrolling the second student crosses the 
 threshold, and each tenant's snapshot goes to its own snapshot store. Both tenants therefore hold a
 snapshot of the same course identifier, and each holds only its own tenant's student. The in-memory run
 snapshots into one store shared by every tenant, so it cannot show the isolation.
+
+It also registers a `MultiTenantProcessorRestartConfiguration`, which is the only thing about tenant-aware
+event processing an application configures. A tenant change restarts the running processors, and this bounds how
+long each one gets to stop and start. It is registered at the value the framework already defaults to, so the
+run behaves identically and the point is only to show where the knob is.
+
+Finally, it shows tenant-aware event processing. The log reports how many streaming event processors served
+all three tenants, and the answer is one rather than one per tenant. The two known tenants hold the same
+course identifier, so their separate enrollment counts show that single processor keeping their read models
+apart. Ogdenville, added while the application is running, is picked up
+without any configuration change: the framework re-opens the stream to include it, and its enrollment is
+projected into its own read model. Because the read model now trails the command that appended the event,
+the run waits for the projection to catch up before reading it.
 
 ## The same demo, wired by Spring Boot
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
@@ -59,10 +59,12 @@ The run walks the whole tenant lifecycle (the behaviors listed in the
 * **Multiple component types.** Every tenant view prints both an enrollment count and an audit-entry
   count, so both providers are injected, each matched by type.
 * **Isolation.** Springfield, Shelbyville, and Ogdenville each see only their own enrollments.
+* **Subscription-query isolation.** Springfield's and Shelbyville's own subscriptions, opened before
+  either enrolls a student, each receive only their own tenant's updates.
 * **Replay on startup.** The provider already knows the tenants before the first command.
 * **Runtime tenants.** Ogdenville is added while running and its instances appear on its first command.
-* **Unknown tenant rejected.** A command for a tenant the application does not know fails with a
-  `TenantNotResolvedException`, so no instance is ever built for it.
+* **Unknown tenant rejected.** A command, and then a query, for a tenant the application does not know
+  each fail with a `TenantNotResolvedException`, so no instance is ever built for it.
 * **Ambiguity rejected.** Registering two providers for one component type is refused.
 * **Cleanup.** Removing a tenant closes its instances, and shutting down closes the rest.
 
@@ -93,18 +95,31 @@ threshold, and each tenant's snapshot goes to its own snapshot store. Both tenan
 snapshot of the same course identifier, and each holds only its own tenant's student. The in-memory run
 snapshots into one store shared by every tenant, so it cannot show the isolation.
 
-It also registers a `MultiTenantProcessorRestartConfiguration`, which is the only thing about tenant-aware
+It also registers a `MultiTenantStreamingProcessorRestartConfiguration`, which is the only thing about tenant-aware
 event processing an application configures. A tenant change restarts the running processors, and this bounds how
 long each one gets to stop and start. It is registered at the value the framework already defaults to, so the
 run behaves identically and the point is only to show where the knob is.
 
-Finally, it shows tenant-aware event processing. The log reports how many streaming event processors served
+Against Axon Server, the demo also turns off preferring a locally subscribed query handler
+(`DistributedQueryBusConfiguration.preferLocalQueryHandler(false)`). This whole demo runs in one process,
+where a query handler is always subscribed locally, so without this a direct query would never reach the
+per-tenant query connector at all: tenant resolution would only ever happen once handling starts, never at
+dispatch. A subscription query always routes through the connector regardless of this setting.
+
+It shows tenant-aware event processing too. The log reports how many streaming event processors served
 all three tenants, and the answer is one rather than one per tenant. The two known tenants hold the same
 course identifier, so their separate enrollment counts show that single processor keeping their read models
 apart. Ogdenville, added while the application is running, is picked up
 without any configuration change: the framework re-opens the stream to include it, and its enrollment is
 projected into its own read model. Because the read model now trails the command that appended the event,
 the run waits for the projection to catch up before reading it.
+
+Finally, it shows tenant-aware subscription queries. Both known tenants subscribe to their own statistics
+before either enrolls a student, and recording an enrollment emits an update through a deliberately
+tenant-blind predicate. The log reports how many updates each subscription received: each is exactly its
+own tenant's accepted enrollments plus its initial result, never inflated by the other tenant's activity,
+which is what proves the framework isolates emission by the tenant it resolves for the update rather than
+by the predicate. A query for an unknown tenant is rejected the same way an unknown-tenant command is.
 
 ## The same demo, wired by Spring Boot
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
@@ -19,21 +19,15 @@ package org.axonframework.examples.demo.multitenancy;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.examples.demo.multitenancy.shared.run.DemoApplication;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.messaging.core.MessageTypeResolver;
-import org.axonframework.messaging.core.QualifiedName;
-import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The same lifecycle runs two ways, selected by the {@code demo.axon-server.enabled} toggle: in memory by
  * default (tenants from a {@link DemoTenantProvider}), or against Axon Server (tenants are real
- * contexts). Only the {@link TenantProvisioning} changes.
+ * contexts). Which backing a run uses is the only choice each entry point makes.
  */
 public class MultiTenancyApplication {
 
@@ -86,19 +80,16 @@ public class MultiTenancyApplication {
         AxonConfiguration configuration = configurer.build();
         configuration.start();
 
-        return DemoLifecycle.run(configuration.getComponent(CommandGateway.class),
-                                 configuration.getComponent(QueryGateway.class),
-                                 statisticsProvider,
-                                 auditProvider,
-                                 TenantProvisioning.inMemory(tenantProvider),
-                                 TenantSnapshots.<CourseSnapshot>inMemory(),
-                                 configuration::shutdown);
+        return DemoLifecycle.run(DemoApplication.inMemory(configuration,
+                                                          tenantProvider,
+                                                          statisticsProvider,
+                                                          auditProvider));
     }
 
     /**
      * Runs the demo end to end against Axon Server, sourcing the tenants from Axon Server contexts
-     * rather than from an in-memory provider. The lifecycle is identical to {@link #run()}. Only the
-     * {@link TenantProvisioning} differs. This path needs a running multi-context (Enterprise Edition)
+     * rather than from an in-memory provider. The lifecycle is identical to {@link #run()}, and the
+     * backing is the only difference. This path needs a running multi-context (Enterprise Edition)
      * Axon Server, reachable on its default {@code localhost} address.
      *
      * @return the observed outcome of the demo run
@@ -112,15 +103,9 @@ public class MultiTenancyApplication {
         AxonConfiguration configuration = configurer.build();
         configuration.start();
 
-        QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
-                configuration.getComponent(MessageTypeResolver.class));
-
-        return DemoLifecycle.run(configuration.getComponent(CommandGateway.class),
-                                 configuration.getComponent(QueryGateway.class),
-                                 statisticsProvider,
-                                 auditProvider,
-                                 TenantProvisioning.axonServer(configuration, DemoLifecycle.KNOWN_TENANTS),
-                                 TenantSnapshots.axonServer(configuration, courseSnapshots, CourseSnapshot.class),
-                                 configuration::shutdown);
+        return DemoLifecycle.run(DemoApplication.axonServer(configuration,
+                                                           statisticsProvider,
+                                                           auditProvider,
+                                                           configuration::shutdown));
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -21,7 +21,8 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantProcessorRestartConfiguration;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantStreamingProcessorRestartConfiguration;
+import io.axoniq.framework.messaging.queryhandling.distributed.DistributedQueryBusConfiguration;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
@@ -105,6 +106,10 @@ public final class UniversityConfiguration {
      * came from, so this path fills the read model from a projection.
      * One ordinary pooled streaming processor consumes every tenant's events, and no multi-tenancy wiring is
      * needed to make it tenant-aware.
+     * <p>
+     * This path also routes direct queries through the per-tenant connector rather than serving them from a
+     * locally subscribed handler, so that {@code query()} dispatch is really exercised, not only made
+     * tenant-aware once handling starts.
      *
      * @param configurer         the configurer to extend
      * @param statisticsProvider the provider of the per-tenant course-statistics stores
@@ -118,6 +123,7 @@ public final class UniversityConfiguration {
                                          MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
                                          registerTenantComponents(registry, statisticsProvider, auditProvider);
                                          registerProcessorRestartTimeout(registry);
+                                         registerDirectQueryRouting(registry);
                                      });
     }
 
@@ -131,9 +137,26 @@ public final class UniversityConfiguration {
      * @param registry the registry to register the restart configuration on
      */
     private static void registerProcessorRestartTimeout(ComponentRegistry registry) {
-        registry.registerComponent(MultiTenantProcessorRestartConfiguration.class,
-                                   config -> MultiTenantProcessorRestartConfiguration.DEFAULT
+        registry.registerComponent(MultiTenantStreamingProcessorRestartConfiguration.class,
+                                   config -> MultiTenantStreamingProcessorRestartConfiguration.DEFAULT
                                            .restartTimeout(PROCESSOR_RESTART_TIMEOUT));
+    }
+
+    /**
+     * Turns off preferring a locally subscribed query handler, so a direct query is routed through the
+     * per-tenant {@code MultiTenantAxonServerQueryBusConnector} rather than served from the local segment.
+     * <p>
+     * This whole demo runs in one process, where every query handler is always subscribed locally, so
+     * without this a direct {@code query()} would never reach the connector at all: tenant resolution would
+     * only ever happen once handling starts, never at dispatch. A subscription query always routes through
+     * the connector regardless of this setting.
+     *
+     * @param registry the registry to register the distributed query bus configuration on
+     */
+    private static void registerDirectQueryRouting(ComponentRegistry registry) {
+        registry.registerComponent(DistributedQueryBusConfiguration.class,
+                                   config -> DistributedQueryBusConfiguration.DEFAULT
+                                           .preferLocalQueryHandler(false));
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -21,6 +21,7 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.configuration.AxonServerMultiTenancyConfigurationDefaults;
 import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenancyConfigurationUtils.MultiTenancyEnabled;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantProcessorRestartConfiguration;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
@@ -28,6 +29,9 @@ import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+
+import java.time.Duration;
 
 /**
  * Wires the university's tenant-aware pieces onto an {@link EventSourcingConfigurer}, the declarative
@@ -41,6 +45,9 @@ import org.axonframework.examples.demo.multitenancy.university.read.statistics.C
  * tenant's own event store.
  */
 public final class UniversityConfiguration {
+
+    // The framework's own default.
+    private static final Duration PROCESSOR_RESTART_TIMEOUT = Duration.ofSeconds(30);
 
     private UniversityConfiguration() {
         // Utility class, not meant to be instantiated.
@@ -57,6 +64,11 @@ public final class UniversityConfiguration {
      * memory that is one shared store rather than one per tenant. Against Axon Server the application
      * registers none: the multi-tenancy defaults own that registration so every tenant's snapshots land
      * in its own context, and an application-registered store is refused.
+     * <p>
+     * That single shared event store is also why this path fills the read model
+     * inline rather than from a projection. An event streamed from a store
+     * every tenant shares cannot be attributed to one tenant, so tenant-aware event processing needs the
+     * per-tenant event stores only {@link #configureForAxonServer} has.
      *
      * @param configurer         the configurer to extend
      * @param tenantProvider     the provider of the application's tenants
@@ -67,7 +79,7 @@ public final class UniversityConfiguration {
                                  TenantProvider tenantProvider,
                                  TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                                  TenantComponentProvider<AuditLog> auditProvider) {
-        UniversityModuleConfiguration.configure(configurer)
+        UniversityModuleConfiguration.configure(configurer, DemoBacking.IN_MEMORY)
                                      .componentRegistry(registry -> {
                                          MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
                                          // Run in memory: no Axon Server connection, tenants come from the DemoTenantProvider.
@@ -88,6 +100,11 @@ public final class UniversityConfiguration {
      * default auto-discovering tenant provider watching Axon Server's contexts, and the course write side
      * is registered against the per-tenant, tenant-aware event store Axon Server provides. This path needs
      * a running multi-context (Enterprise Edition) Axon Server.
+     * <p>
+     * Because every tenant has its own event store here, the framework knows which tenant a streamed event
+     * came from, so this path fills the read model from a projection.
+     * One ordinary pooled streaming processor consumes every tenant's events, and no multi-tenancy wiring is
+     * needed to make it tenant-aware.
      *
      * @param configurer         the configurer to extend
      * @param statisticsProvider the provider of the per-tenant course-statistics stores
@@ -96,11 +113,27 @@ public final class UniversityConfiguration {
     public static void configureForAxonServer(EventSourcingConfigurer configurer,
                                               TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                                               TenantComponentProvider<AuditLog> auditProvider) {
-        UniversityModuleConfiguration.configure(configurer)
+        UniversityModuleConfiguration.configure(configurer, DemoBacking.AXON_SERVER)
                                      .componentRegistry(registry -> {
                                          MultiTenancyEnabled.enableMultiTenancyEnhancer(registry);
                                          registerTenantComponents(registry, statisticsProvider, auditProvider);
+                                         registerProcessorRestartTimeout(registry);
                                      });
+    }
+
+    /**
+     * Registers how long each processor gets to stop and start again when the set of tenants changes.
+     * <p>
+     * A tenant change restarts the running streaming event processors, and this bounds how long each one gets.
+     * The framework already registers a default, so raise this only for a deployment whose processors are slow
+     * to stop and start. Shown here at the default value, so the knob is visible without changing the demo.
+     *
+     * @param registry the registry to register the restart configuration on
+     */
+    private static void registerProcessorRestartTimeout(ComponentRegistry registry) {
+        registry.registerComponent(MultiTenantProcessorRestartConfiguration.class,
+                                   config -> MultiTenantProcessorRestartConfiguration.DEFAULT
+                                           .restartTimeout(PROCESSOR_RESTART_TIMEOUT));
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/resources/application.properties
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # Server on its default localhost address. See the README for how to run it.
 #
 # This is a demo-only key, not a framework property. Axon Server's real toggle is axon.axonserver.enabled.
-demo.axon-server.enabled=false
+demo.axon-server.enabled=true

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -24,8 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Smoke test running the demo through its own entry point and asserting the observed outcome:
- * per-tenant isolation, the unknown-tenant guardrail, destroy on tenant removal, and cleanup on
- * shutdown. The configuration-time ambiguity guardrail is asserted separately.
+ * per-tenant isolation, subscription-query isolation, the unknown-tenant guardrail on both commands
+ * and queries, destroy on tenant removal, and cleanup on shutdown. The configuration-time ambiguity
+ * guardrail is asserted separately.
  */
 class MultiTenancyDemoTest {
 
@@ -45,6 +46,10 @@ class MultiTenancyDemoTest {
         assertThat(outcome.ogdenvilleEnrollments()).isEqualTo(1);
         // and a command for an unknown tenant was rejected
         assertThat(outcome.unknownTenantRejected()).isTrue();
+        // and a query for an unknown tenant was rejected too
+        assertThat(outcome.unknownTenantQueryRejected()).isTrue();
+        // and Springfield's and Shelbyville's own subscription queries each received only their own updates
+        assertThat(outcome.subscriptionQuery().isolatedByTenant()).isTrue();
         // and removing Shelbyville closed its instances
         assertThat(outcome.shelbyvilleClosedOnRemoval()).isTrue();
         // and shutting down closed every remaining tenant's instances

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -56,6 +56,10 @@ class MultiTenancyDemoTest {
         // shares one snapshot store. CourseEnrollmentCompositionTest covers the snapshot round trip
         // against that shared store
         assertThat(outcome.snapshotting().demonstrated()).isFalse();
+        // and neither did tenant-aware event processing, which needs each tenant to have its own event store
+        // so that a streamed event can be attributed to a tenant. This run therefore registers no projection
+        // and has its command handler fill the read model instead, which is what the counts above reflect
+        assertThat(outcome.streaming().demonstrated()).isFalse();
     }
 
     @Test

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
@@ -17,19 +17,33 @@ application and its beans:
 ```
 org.axonframework.examples.demo.multitenancy
 +- MultiTenancyApplication   the @SpringBootApplication, no multi-tenancy wiring of its own
-+- UniversityConfiguration   the beans: the two per-tenant providers, the query handler, the course modules, and a snapshot store for when multi-tenancy is off
++- UniversityConfiguration   the beans: providers, handlers, course modules, projection, processor, stores, timeout
 +- DemoRunner                a CommandLineRunner that runs the lifecycle, then stops
 ```
 
 `UniversityConfiguration` declares one `TenantComponentProvider` bean per tenant-scoped component type,
-the statistics query handler, and the event-sourced course as two module beans, and nothing else. The
-enrollment command handler is registered with the course, so there is no separate handler bean for it.
-The starter's multi-tenancy auto-configuration picks the provider beans up, subscribes them to the tenant
-lifecycle, installs the tenant parameter resolver and interceptor, and registers the default
-auto-discovering `AxonServerTenantProvider`. The starter also registers the course module beans, so the
-course is sourced from and appended to its tenant's own event store, and snapshotted into that tenant's own
-snapshot store. There is no manual multi-tenancy wiring at all: the tenants are discovered from Axon
+the statistics query handler, the event-sourced course as two module beans, and the projection processor,
+and nothing else. The enrollment command handler is registered with the course, so there is no separate
+handler bean for it. The starter's multi-tenancy auto-configuration picks the provider beans up, subscribes
+them to the tenant lifecycle, installs the tenant parameter resolver and interceptor, and registers the
+default auto-discovering `AxonServerTenantProvider`. The starter also registers the course module beans, so
+the course is sourced from and appended to its tenant's own event store, and snapshotted into that tenant's
+own snapshot store. There is no manual multi-tenancy wiring at all: the tenants are discovered from Axon
 Server's contexts (with `_admin` filtered out), exactly as in the declarative demo's Axon Server path.
+
+The projection processor bean is worth looking at for what it does not say. It names no tenant and declares no
+processor per tenant. A single one serves every tenant, because the auto-configuration makes the event store it
+streams from tenant-aware and re-opens that stream when the set of tenants changes.
+
+One bean is there purely to show a knob: `MultiTenantProcessorRestartConfiguration` bounds how long each
+processor gets to stop and start when the set of tenants changes. The starter defaults it, so an application only
+declares it to raise it, which a deployment with slow-starting processors would.
+
+Two Spring specifics are worth knowing, since neither applies to the declarative demo. The processor is
+declared through an `EventProcessorDefinition`, because a `Module` bean holding an event processor is silently
+ignored on this path. And the token store bean has to be named exactly `tokenStore`, because Spring resolves a
+processor's token store by bean name and fails hard when that name is missing, where the declarative path
+resolves by type and falls back to an in-memory store.
 
 ## Requires Axon Server
 
@@ -65,6 +79,12 @@ to capacity and rejects a further enrollment in one tenant, while still acceptin
 sourced from that tenant's own event store. It asserts the per-tenant snapshot demonstration for the same
 reason: both tenants hold their own snapshot of that same course identifier, and each holds only its own
 tenant's student.
+
+It also asserts tenant-aware event processing, which likewise needs per-tenant event stores. Exactly one
+streaming event processor served all three tenants, and each tenant's read model holds only its own
+enrollments even though two of them use the same course identifier. The tenant added while the
+application was running is projected too, which only happens if the processor re-opened its stream to
+include a tenant that did not exist when it started.
 
 Because hosting several tenant contexts needs a licensed Enterprise Edition server, the test licenses
 the container in one of two ways, checked in that order:

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
@@ -17,7 +17,7 @@ application and its beans:
 ```
 org.axonframework.examples.demo.multitenancy
 +- MultiTenancyApplication   the @SpringBootApplication, no multi-tenancy wiring of its own
-+- UniversityConfiguration   the beans: providers, handlers, course modules, projection, processor, stores, timeout
++- UniversityConfiguration   the beans: providers, handlers, course modules, projection, processor, stores, timeout, query routing
 +- DemoRunner                a CommandLineRunner that runs the lifecycle, then stops
 ```
 
@@ -35,9 +35,15 @@ The projection processor bean is worth looking at for what it does not say. It n
 processor per tenant. A single one serves every tenant, because the auto-configuration makes the event store it
 streams from tenant-aware and re-opens that stream when the set of tenants changes.
 
-One bean is there purely to show a knob: `MultiTenantProcessorRestartConfiguration` bounds how long each
+One bean is there purely to show a knob: `MultiTenantStreamingProcessorRestartConfiguration` bounds how long each
 processor gets to stop and start when the set of tenants changes. The starter defaults it, so an application only
 declares it to raise it, which a deployment with slow-starting processors would.
+
+Another bean turns off preferring a locally subscribed query handler
+(`DistributedQueryBusConfiguration.preferLocalQueryHandler(false)`). This whole demo runs in one process,
+where a query handler is always subscribed locally, so without this a direct query would never reach the
+per-tenant query connector at all. A subscription query always routes through the connector regardless of
+this setting.
 
 Two Spring specifics are worth knowing, since neither applies to the declarative demo. The processor is
 declared through an `EventProcessorDefinition`, because a `Module` bean holding an event processor is silently
@@ -85,6 +91,12 @@ streaming event processor served all three tenants, and each tenant's read model
 enrollments even though two of them use the same course identifier. The tenant added while the
 application was running is projected too, which only happens if the processor re-opened its stream to
 include a tenant that did not exist when it started.
+
+It also asserts tenant-aware subscription queries and the query-side unknown-tenant guardrail: both known
+tenants' own subscriptions received only their own updates, and a query for an unknown tenant is rejected
+the same way an unknown-tenant command is. Being the Axon Server path, with `preferLocalQueryHandler(false)`
+set, this is also where a direct query is proven to actually route through the per-tenant connector rather
+than being served from a locally subscribed handler.
 
 Because hosting several tenant contexts needs a licensed Enterprise Edition server, the test licenses
 the container in one of two ways, checked in that order:

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/DemoRunner.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/DemoRunner.java
@@ -18,19 +18,12 @@ package org.axonframework.examples.demo.multitenancy;
 
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.shared.run.DemoApplication;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.messaging.core.MessageTypeResolver;
-import org.axonframework.messaging.core.QualifiedName;
-import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
@@ -39,10 +32,10 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
- * Drives the demo end to end once the Spring Boot application has started, then stops it. It resolves
- * the framework gateways, the Axon configuration, and the tenant-aware providers as ordinary beans and
- * hands them to the shared {@link DemoLifecycle}, so it runs the identical story the declarative demo
- * runs, only against Axon Server.
+ * Drives the demo end to end once the Spring Boot application has started, then stops it. It takes the
+ * tenant-aware providers and the Axon configuration as ordinary beans, and hands the application the
+ * configuration describes to the shared {@link DemoLifecycle}, so it runs the identical story the declarative
+ * demo runs, only against Axon Server.
  * <p>
  * It is excluded from the {@code test} profile, so the smoke test can boot the same autoconfigured
  * context and drive the lifecycle itself rather than have this runner stop the context out from under
@@ -54,8 +47,6 @@ public class DemoRunner implements CommandLineRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(DemoRunner.class);
 
-    private final CommandGateway commandGateway;
-    private final QueryGateway queryGateway;
     private final TenantComponentProvider<CourseStatisticsStore> statisticsProvider;
     private final TenantComponentProvider<AuditLog> auditProvider;
     private final AxonConfiguration axonConfiguration;
@@ -64,22 +55,16 @@ public class DemoRunner implements CommandLineRunner {
     /**
      * Constructs the runner from the autoconfigured framework and demo beans.
      *
-     * @param commandGateway     the gateway enrollments are sent on
-     * @param queryGateway       the gateway statistics are read on
      * @param statisticsProvider the provider of the per-tenant course-statistics stores
      * @param auditProvider      the provider of the per-tenant audit logs
-     * @param axonConfiguration  the Axon configuration, to resolve the Axon Server tenant provider and the
-     *                           per-tenant snapshot stores from
+     * @param axonConfiguration  the Axon configuration, which the gateways, tenant provider, per-tenant
+     *                           snapshot stores and registered processors are all resolved from
      * @param applicationContext the context to close when the demo has finished, triggering cleanup
      */
-    public DemoRunner(CommandGateway commandGateway,
-                      QueryGateway queryGateway,
-                      TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
+    public DemoRunner(TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
                       TenantComponentProvider<AuditLog> auditProvider,
                       AxonConfiguration axonConfiguration,
                       ConfigurableApplicationContext applicationContext) {
-        this.commandGateway = commandGateway;
-        this.queryGateway = queryGateway;
         this.statisticsProvider = statisticsProvider;
         this.auditProvider = auditProvider;
         this.axonConfiguration = axonConfiguration;
@@ -88,20 +73,12 @@ public class DemoRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
-                axonConfiguration.getComponent(MessageTypeResolver.class));
         logger.info("Two providers for one component type are rejected at configuration time: {}",
                     ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType());
-        DemoOutcome outcome = DemoLifecycle.run(commandGateway,
-                                                queryGateway,
-                                                statisticsProvider,
-                                                auditProvider,
-                                                TenantProvisioning.axonServer(axonConfiguration,
-                                                                              DemoLifecycle.KNOWN_TENANTS),
-                                                TenantSnapshots.axonServer(axonConfiguration,
-                                                                           courseSnapshots,
-                                                                           CourseSnapshot.class),
-                                                applicationContext::close);
+        DemoOutcome outcome = DemoLifecycle.run(DemoApplication.axonServer(axonConfiguration,
+                                                                           statisticsProvider,
+                                                                           auditProvider,
+                                                                           applicationContext::close));
         logger.info("Demo finished. Outcome: {}", outcome);
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -18,7 +18,8 @@ package org.axonframework.examples.demo.multitenancy;
 
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantProcessorRestartConfiguration;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantStreamingProcessorRestartConfiguration;
+import io.axoniq.framework.messaging.queryhandling.distributed.DistributedQueryBusConfiguration;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
@@ -222,7 +223,24 @@ public class UniversityConfiguration {
      */
     @Bean
     @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
-    public MultiTenantProcessorRestartConfiguration processorRestartConfiguration() {
-        return MultiTenantProcessorRestartConfiguration.DEFAULT.restartTimeout(PROCESSOR_RESTART_TIMEOUT);
+    public MultiTenantStreamingProcessorRestartConfiguration processorRestartConfiguration() {
+        return MultiTenantStreamingProcessorRestartConfiguration.DEFAULT.restartTimeout(PROCESSOR_RESTART_TIMEOUT);
+    }
+
+    /**
+     * Turns off preferring a locally subscribed query handler, so a direct query is routed through the
+     * per-tenant {@code MultiTenantAxonServerQueryBusConnector} rather than served from the local segment.
+     * <p>
+     * This whole demo runs in one process, where every query handler is always subscribed locally, so
+     * without this a direct {@code query()} would never reach the connector at all: tenant resolution would
+     * only ever happen once handling starts, never at dispatch. A subscription query always routes through
+     * the connector regardless of this setting.
+     *
+     * @return the distributed query bus configuration with direct queries routed through the connector
+     */
+    @Bean
+    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+    public DistributedQueryBusConfiguration distributedQueryBusConfiguration() {
+        return DistributedQueryBusConfiguration.DEFAULT.preferLocalQueryHandler(false);
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -18,18 +18,27 @@ package org.axonframework.examples.demo.multitenancy;
 
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantProcessorRestartConfiguration;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourseConfiguration;
+import org.axonframework.extension.spring.config.EventProcessorDefinition;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
 
 /**
  * The whole multi-tenancy configuration a Spring Boot developer writes for the feature: declare one
@@ -46,6 +55,9 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class UniversityConfiguration {
+
+    // The framework's own default.
+    private static final Duration PROCESSOR_RESTART_TIMEOUT = Duration.ofSeconds(30);
 
     /**
      * The provider of per-tenant {@link CourseStatisticsStore} instances.
@@ -132,13 +144,85 @@ public class UniversityConfiguration {
     }
 
     /**
-     * The enroll-student slice's command handling module, whose handler both appends to the tenant's event
-     * store and updates that tenant's {@code @TenantScoped} components.
+     * The enroll-student slice's command handling module. The demonstration runs against Axon Server, so the
+     * read model is built by the {@link CourseStatisticsProjection} and this handler only appends to the
+     * tenant's event store.
+     * <p>
+     * The backing is fixed rather than read from the properties. That only matters to the configuration which
+     * switches multi-tenancy off, where a command is rejected before anything is appended anyway.
      *
      * @return the enroll-student command handling module
      */
     @Bean
     public Module enrollStudentCommandHandling() {
-        return EnrollStudentConfiguration.commandModule();
+        return EnrollStudentConfiguration.commandModule(DemoBacking.AXON_SERVER);
+    }
+
+    /**
+     * The projection building every tenant's course statistics from the enrollment events of every tenant.
+     * <p>
+     * An ordinary event handler bean. Its {@code @TenantScoped} parameters are injected with the components of
+     * the tenant whose event store the event was streamed from.
+     *
+     * @return the course-statistics projection
+     */
+    @Bean
+    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+    public CourseStatisticsProjection courseStatisticsProjection() {
+        return new CourseStatisticsProjection();
+    }
+
+    /**
+     * The single token store tracking every tenant's position, which the projection processor needs.
+     * <p>
+     * One store serves every tenant, holding one position per tenant in a single token. A real deployment would
+     * use a persistent store so positions survive a restart.
+     * <p>
+     * The bean has to be named exactly {@code tokenStore}: Spring resolves a processor's token store by bean
+     * name, defaulting to that, and fails when no such bean exists. The declarative demo needs no equivalent.
+     *
+     * @return the token store shared by every tenant
+     */
+    @Bean
+    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+    public TokenStore tokenStore() {
+        return new InMemoryTokenStore();
+    }
+
+    /**
+     * The one pooled streaming processor that projects every tenant's events, running the
+     * {@link #courseStatisticsProjection()} bean.
+     * <p>
+     * An ordinary processor definition: nothing here mentions a tenant, and none is defined per tenant. The
+     * multi-tenancy autoconfiguration makes the event store it streams from tenant-aware, and re-opens that
+     * stream when the set of tenants changes.
+     * <p>
+     * Declared through an {@link EventProcessorDefinition} because a {@code Module} bean holding an event
+     * processor is silently ignored on this path.
+     *
+     * @return the course-statistics projection processor definition
+     */
+    @Bean
+    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+    public EventProcessorDefinition courseStatisticsProcessor() {
+        return EventProcessorDefinition
+                .pooledStreaming(StatisticsConfiguration.PROCESSOR_NAME)
+                .assigningHandlers(descriptor -> CourseStatisticsProjection.class.equals(descriptor.beanType()))
+                .notCustomized();
+    }
+
+    /**
+     * How long each processor gets to stop and start again when the set of tenants changes.
+     * <p>
+     * A tenant change restarts the running streaming event processors, and this bounds how long each one gets.
+     * The starter already registers a default, so declare this only to raise it for a deployment whose
+     * processors are slow to stop and start. Shown here at the default value.
+     *
+     * @return the restart configuration bounding each processor's restart
+     */
+    @Bean
+    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+    public MultiTenantProcessorRestartConfiguration processorRestartConfiguration() {
+        return MultiTenantProcessorRestartConfiguration.DEFAULT.restartTimeout(PROCESSOR_RESTART_TIMEOUT);
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
@@ -54,13 +54,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * driving the shared demo lifecycle through the framework beans the multi-tenancy autoconfiguration
  * wired. Because the Spring Boot multi-tenancy path activates only against Axon Server, the test runs
  * one in a container. It asserts the same observed outcome as the declarative demo: per-tenant
- * isolation across both component types, the unknown-tenant and ambiguity guardrails, destroy on tenant
- * removal, and cleanup on shutdown. It also asserts that the {@code _admin} context is filtered out of
- * the discovered tenants.
+ * isolation across both component types, subscription-query isolation, the unknown-tenant guardrail on
+ * both commands and queries, the ambiguity guardrail, destroy on tenant removal, and cleanup on
+ * shutdown. It also asserts that the {@code _admin} context is filtered out of the discovered tenants.
  * <p>
  * Being the Axon Server path, this is also where the per-tenant features the in-memory demo cannot show are
- * asserted: event-store and snapshot isolation, and tenant-aware event processing, where one ordinary pooled
- * streaming processor projects every tenant's events into that tenant's own read model.
+ * asserted: event-store and snapshot isolation, tenant-aware event processing, where one ordinary pooled
+ * streaming processor projects every tenant's events into that tenant's own read model, and direct queries
+ * actually routed through the per-tenant query connector rather than served from the local segment.
  * <p>
  * The application is booted directly rather than through {@code @SpringBootTest}, because the demo stops
  * the context as its final step and a managed test context must not be closed from within a test. The
@@ -197,6 +198,11 @@ class MultiTenancyDemoIT {
             assertThat(outcome.ogdenvilleEnrollments()).isEqualTo(1);
             // and a command for an unknown tenant was rejected
             assertThat(outcome.unknownTenantRejected()).isTrue();
+            // and a query for an unknown tenant was rejected too
+            assertThat(outcome.unknownTenantQueryRejected()).isTrue();
+            // and Springfield's and Shelbyville's own subscription queries each received only their own
+            // updates, routed through their own tenant's Axon Server connection
+            assertThat(outcome.subscriptionQuery().isolatedByTenant()).isTrue();
             // and removing Shelbyville closed its instances
             assertThat(outcome.shelbyvilleClosedOnRemoval()).isTrue();
             // and shutting down closed every remaining tenant's instances

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
@@ -23,22 +23,17 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.testcontainer.AxonServerContainer;
 import org.awaitility.Awaitility;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.shared.run.DemoApplication;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.AxonServerTenantContextManager;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.EventStorageOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.run.SnapshottingOutcome;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantSnapshots;
+import org.axonframework.examples.demo.multitenancy.shared.run.StreamingOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.CourseSnapshot;
-import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.messaging.core.MessageTypeResolver;
-import org.axonframework.messaging.core.QualifiedName;
-import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.springframework.boot.WebApplicationType;
@@ -62,6 +57,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * isolation across both component types, the unknown-tenant and ambiguity guardrails, destroy on tenant
  * removal, and cleanup on shutdown. It also asserts that the {@code _admin} context is filtered out of
  * the discovered tenants.
+ * <p>
+ * Being the Axon Server path, this is also where the per-tenant features the in-memory demo cannot show are
+ * asserted: event-store and snapshot isolation, and tenant-aware event processing, where one ordinary pooled
+ * streaming processor projects every tenant's events into that tenant's own read model.
  * <p>
  * The application is booted directly rather than through {@code @SpringBootTest}, because the demo stops
  * the context as its final step and a managed test context must not be closed from within a test. The
@@ -173,8 +172,6 @@ class MultiTenancyDemoIT {
                 .run()) {
 
             AxonConfiguration configuration = context.getBean(AxonConfiguration.class);
-            QualifiedName courseSnapshots = EnrollStudentConfiguration.courseSnapshotName(
-                    configuration.getComponent(MessageTypeResolver.class));
             TenantProvider tenantProvider = configuration.getComponent(TenantProvider.class);
             AxonServerTenantContextManager serverContexts =
                     new AxonServerTenantContextManager(configuration.getComponent(AxonServerConnectionManager.class));
@@ -187,16 +184,10 @@ class MultiTenancyDemoIT {
             assertThat(tenantProvider.tenants()).extracting(TenantDescriptor::tenantId).doesNotContain(ADMIN_CONTEXT);
 
             // when the demo runs end to end through the beans, the multi-tenancy autoconfiguration wired
-            DemoOutcome outcome = DemoLifecycle.run(context.getBean(CommandGateway.class),
-                                                    context.getBean(QueryGateway.class),
-                                                    courseStatisticsProvider(context),
-                                                    auditProvider(context),
-                                                    TenantProvisioning.axonServer(configuration,
-                                                                                  DemoLifecycle.KNOWN_TENANTS),
-                                                    TenantSnapshots.axonServer(configuration,
-                                                                               courseSnapshots,
-                                                                               CourseSnapshot.class),
-                                                    context::close);
+            DemoOutcome outcome = DemoLifecycle.run(DemoApplication.axonServer(configuration,
+                                                                               courseStatisticsProvider(context),
+                                                                               auditProvider(context),
+                                                                               context::close));
 
             // then both of Springfield's components saw only its own two enrollments, matched by type
             // and isolated from the other tenants
@@ -226,6 +217,19 @@ class MultiTenancyDemoIT {
             assertThat(snapshotting.demonstrated()).isTrue();
             assertThat(snapshotting.bothTenantsHoldOwnSnapshot()).isTrue();
             assertThat(snapshotting.snapshotsHoldTheirOwnStudents()).isTrue();
+
+            // and one ordinary pooled streaming processor projected every tenant's events, rather than one
+            // processor per tenant. Asserted by name, so a per-tenant processor would show up as an extra entry
+            StreamingOutcome streaming = outcome.streaming();
+            assertThat(streaming.demonstrated()).isTrue();
+            assertThat(streaming.processorNames()).containsExactly(StatisticsConfiguration.PROCESSOR_NAME);
+            // and that one processor kept the three tenants' read models apart. Springfield and Shelbyville
+            // hold the same course identifier, so a leak between them would show up as a wrong count here
+            assertThat(streaming.springfieldProjected()).isEqualTo(2);
+            assertThat(streaming.shelbyvilleProjected()).isEqualTo(2);
+            // and the tenant added at runtime was picked up: the processor re-opened its stream to include a
+            // tenant that did not exist when it started, and projected that tenant's enrollment
+            assertThat(streaming.ogdenvilleProjected()).isEqualTo(1);
 
             // and registering two providers for one component type is rejected at configuration time
             assertThat(ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType()).isTrue();

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -86,6 +87,9 @@ import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
 class Coordinator {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final int INITIAL_STREAM_REOPEN_DELAY = 500;
+    private static final int MAX_STREAM_REOPEN_DELAY = 60000;
 
     private final String name;
     private final StreamableEventSource eventSource;
@@ -758,6 +762,10 @@ class Coordinator {
         private TrackingToken lastScheduledToken = NoToken.INSTANCE;
         private boolean availabilityCallbackSupported;
         private long unclaimedSegmentValidationThreshold;
+        // Grows while the source keeps completing the stream with an error, and returns to its initial value as soon as
+        // a replacement stream delivers an event.
+        private int streamReopenDelay = INITIAL_STREAM_REOPEN_DELAY;
+        private Instant reopenStreamNotBefore = Instant.EPOCH;
         private final long generation = coordinationTaskGeneration.incrementAndGet();
 
         @Override
@@ -1195,11 +1203,23 @@ class Coordinator {
             // the last scheduled token, thus we started new WorkPackages and need to start at the new position.
             if (eventStream != null
                     && (eventStream.isCompleted() || !Objects.equals(trackingToken, lastScheduledToken))) {
-                if (eventStream.isCompleted()) {
-                    // The trailing argument is only logged when the source completed the stream with an error.
+                Optional<Throwable> completionError = eventStream.isCompleted()
+                        ? eventStream.error()
+                        : Optional.empty();
+                if (completionError.isPresent()) {
+                    // A source that fails on open, or right after it, keeps failing for as long as whatever it depends
+                    // on is unavailable. Replacing the stream at once would reopen it as fast as the coordination task
+                    // runs, so the replacement waits, and waits longer the longer the source keeps failing.
+                    streamReopenDelay = Math.min(streamReopenDelay * 2, MAX_STREAM_REOPEN_DELAY);
+                    reopenStreamNotBefore = clock.instant().plusMillis(streamReopenDelay);
+                    logger.warn("""
+                                Processor [{}] (Coordination Task [{}]) will replace the stream its source completed \
+                                with an error by one starting at token [{}], in {}ms.""",
+                                name, generation, trackingToken, streamReopenDelay, completionError.get());
+                } else if (eventStream.isCompleted()) {
                     logger.info("Processor [{}] (Coordination Task [{}]) will replace the stream its source completed "
                                         + "by one starting at token [{}].",
-                                name, generation, trackingToken, eventStream.error().orElse(null));
+                                name, generation, trackingToken);
                 } else {
                     logger.debug("Processor [{}] (Coordination Task [{}]) will close the current stream.",
                                  name, generation);
@@ -1207,6 +1227,12 @@ class Coordinator {
                 closeStreamQuietly();
                 eventStream = null;
                 lastScheduledToken = NoToken.INSTANCE;
+            }
+
+            if (eventStream == null && clock.instant().isBefore(reopenStreamNotBefore)) {
+                // Still waiting out the delay after a failing source. This path leaves the claims alone, so a source
+                // that is briefly away does not move segments between nodes by itself.
+                return emptyCompletedFuture();
             }
 
             if (eventStream == null && !workPackages.isEmpty() && !(trackingToken instanceof NoToken)) {
@@ -1250,7 +1276,12 @@ class Coordinator {
             if (eventStream == null) {
                 return null;
             }
-            return eventStream.next().orElse(null);
+            MessageStream.Entry<? extends EventMessage> entry = eventStream.next().orElse(null);
+            if (entry != null) {
+                // The source delivered, so a later failure starts waiting from the initial delay again.
+                streamReopenDelay = INITIAL_STREAM_REOPEN_DELAY;
+            }
+            return entry;
         }
 
         private boolean hasNextEvent() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/AsyncInMemoryStreamableEventSource.java
@@ -204,6 +204,21 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
     }
 
     /**
+     * Completes every currently open stream with the given {@code cause}, as if this source failed them, without
+     * clearing the published events.
+     * <p>
+     * Such a stream reports {@link MessageStream#isCompleted()} as {@code true} and the given {@code cause} as its
+     * {@link MessageStream#error()}. This mirrors a source that cannot serve a stream at all, such as a backend that is
+     * unreachable or does not know the requested context yet. Combined with {@link #setOnOpen(Runnable)} it also models
+     * a source that keeps failing every stream opened against it.
+     *
+     * @param cause the error to complete every currently open stream with
+     */
+    public void failOpenStreams(Throwable cause) {
+        openStreams.forEach(stream -> stream.completeExceptionally(cause));
+    }
+
+    /**
      * Set a handler to be called whenever a stream is opened.
      *
      * @param onOpen the handler to call
@@ -244,6 +259,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
         private final AtomicReference<Runnable> callback = new AtomicReference<>(NO_OP_CALLBACK);
         private final StreamingCondition condition;
         private volatile boolean closed = false;
+        private volatile @Nullable Throwable completionError;
 
         public AsyncMessageStream(StreamingCondition condition) {
             this.condition = condition;
@@ -357,7 +373,7 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
 
         @Override
         public @NonNull Optional<Throwable> error() {
-            return Optional.empty();
+            return Optional.ofNullable(completionError);
         }
 
         @Override
@@ -406,6 +422,14 @@ public class AsyncInMemoryStreamableEventSource implements StreamableEventSource
                     currentCallback.run();
                 }
             }
+        }
+
+        private void completeExceptionally(Throwable cause) {
+            if (closed) {
+                return;
+            }
+            completionError = cause;
+            complete();
         }
 
         private void complete() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -1193,6 +1193,53 @@ class PooledStreamingEventProcessorTest {
                    .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(nextEvent));
             verify(stubMessageSource, atLeast(2)).open(any(), isNull());
         }
+
+        @Test
+        void pacesReopeningWhileTheSourceKeepsFailingEveryStreamItHandsOut() throws InterruptedException {
+            // given - a source that keeps failing every stream it hands out, as a backend that cannot serve one yet
+            //         does. Each attempt costs a call on that backend, so retrying on every coordination run is what
+            //         has to be avoided.
+            AtomicInteger openCount = new AtomicInteger();
+            stubMessageSource.setOnOpen(openCount::incrementAndGet);
+            startEventProcessor();
+
+            // when - the failure arrives the way a remote source reports one, after the coordination run that opened
+            //        the stream rather than during it
+            failStreamsFor(1500);
+
+            // then - the wait before replacing a failed stream grows, rather than the replacement following every
+            // coordination run
+            assertThat(openCount.get()).describedAs("streams opened in 1500ms").isLessThanOrEqualTo(5);
+        }
+
+        @Test
+        void resumesOnceTheSourceStopsFailingEveryStream() throws InterruptedException {
+            // given - a source failing every stream it hands out for a while
+            AtomicInteger openCount = new AtomicInteger();
+            stubMessageSource.setOnOpen(openCount::incrementAndGet);
+            startEventProcessor();
+            failStreamsFor(700);
+            assertThat(openCount).describedAs("streams opened while failing").hasValueGreaterThan(0);
+
+            // when - the source recovers
+            EventMessage event = EventTestUtils.asEventMessage("event-1");
+            stubMessageSource.publishMessage(event);
+
+            // then - waiting between attempts does not wedge the processor, it picks the segment back up and handles
+            // what it missed
+            await().atMost(10, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordingComponent.recorded()).contains(event));
+            assertThat(testSubject.processingStatus()).containsKey(0);
+        }
+
+        // Fails whatever stream is open, repeatedly, for the given duration. Runs on the calling thread so every
+        // failure lands between two coordination runs, which is when a remote source reports one.
+        private void failStreamsFor(long millis) throws InterruptedException {
+            for (long elapsed = 0; elapsed < millis; elapsed += 25) {
+                stubMessageSource.failOpenStreams(new IllegalStateException("Source unreachable"));
+                Thread.sleep(25);
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
Demo for query processing (showing subscription query and update emission)