### PR TITLE
Make `StateManager` and `SnapshotStore` `DescribableComponents`

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/inmemory/InMemorySnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/inmemory/InMemorySnapshotStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.inmemory;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
 import org.axonframework.messaging.core.QualifiedName;
@@ -42,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 5.1.0
  */
 public class InMemorySnapshotStore implements SnapshotStore {
+
     private final Map<QualifiedName, Map<Object, Snapshot>> entitiesByIdentifierByName = new ConcurrentHashMap<>();
 
     @Override
@@ -67,5 +69,10 @@ public class InMemorySnapshotStore implements SnapshotStore {
         Map<Object, Snapshot> entitiesByIdentifier = entitiesByIdentifierByName.get(qualifiedName);
 
         return CompletableFuture.completedFuture(entitiesByIdentifier == null ? null : entitiesByIdentifier.get(identifier));
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        // No-op - nothing to describe
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/SnapshotStore.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.snapshot.store;
 
 import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -37,7 +38,7 @@ import java.util.concurrent.CompletableFuture;
  * @since 5.1.0
  */
 @Internal
-public interface SnapshotStore {
+public interface SnapshotStore extends DescribableComponent {
 
     /**
      * Persists a snapshot under the given name and identifier. This replaces any previous

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.store.tracing;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanFactory;
 import org.axonframework.messaging.tracing.attributes.EntityIdSpanAttributesProvider;
@@ -91,5 +92,11 @@ public final class TracingSnapshotStore implements SnapshotStore {
             span.addAttribute(EntityIdSpanAttributesProvider.DEFAULT_ATTRIBUTE_KEY, identifier.toString());
         }
         return span;
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(descriptor);
+        descriptor.describeProperty("spanFactory", spanFactory);
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTransaction;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
@@ -27,8 +28,7 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -230,6 +230,7 @@ class SnapshotCapableEventStorageEngineTest {
 
     private static SnapshotStore failingSnapshotStore() {
         return new SnapshotStore() {
+
             @Override
             public CompletableFuture<Void> store(QualifiedName qn, Object id, Snapshot s,
                                                  ProcessingContext context) {
@@ -239,6 +240,11 @@ class SnapshotCapableEventStorageEngineTest {
             @Override
             public CompletableFuture<Snapshot> load(QualifiedName qn, Object id, ProcessingContext context) {
                 return CompletableFuture.failedFuture(new RuntimeException("snapshot store failure"));
+            }
+
+            @Override
+            public void describeTo(ComponentDescriptor descriptor) {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStoreTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.store.tracing;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.tracing.support.TestSpanFactory;
 import org.axonframework.messaging.tracing.support.TestSpanFactory.TestSpanType;
 import org.axonframework.eventsourcing.eventstore.Position;
@@ -132,6 +133,11 @@ class TracingSnapshotStoreTest {
                                                           @Nullable ProcessingContext context) {
             this.loadContext = context;
             return loadResult;
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            // No-op - not required for testing
         }
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
@@ -17,6 +17,7 @@
 package org.axonframework.modelling;
 
 import org.axonframework.common.configuration.Module;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
@@ -120,5 +121,11 @@ public class HierarchicalStateManager implements StateManager {
      */
     public StateManager getChild() {
         return child;
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("parent", parent);
+        descriptor.describeProperty("child", child);
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
@@ -18,7 +18,6 @@ package org.axonframework.modelling;
 
 import org.axonframework.common.BuilderUtils;
 import org.axonframework.common.infra.ComponentDescriptor;
-import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
  * @see StateManager
  * @since 5.0.0
  */
-public class SimpleStateManager implements StateManager, DescribableComponent {
+public class SimpleStateManager implements StateManager {
 
     private final String name;
     private final List<Repository<?, ?>> repositories = new CopyOnWriteArrayList<>();

--- a/modelling/src/main/java/org/axonframework/modelling/StateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/StateManager.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling;
 
+import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
@@ -40,7 +41,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
-public interface StateManager {
+public interface StateManager extends DescribableComponent {
 
     /**
      * Registers an {@link Repository} for use with this {@code StateManager}. The combination of

--- a/modelling/src/main/java/org/axonframework/modelling/tracing/TracingStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/tracing/TracingStateManager.java
@@ -16,11 +16,12 @@
 
 package org.axonframework.modelling.tracing;
 
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanFactory;
 import org.axonframework.messaging.tracing.attributes.EntityIdSpanAttributesProvider;
-import org.axonframework.common.annotation.Internal;
-import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
@@ -133,5 +134,11 @@ public final class TracingStateManager implements StateManager {
     @Override
     public <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
         return delegate.repository(entityType, idType);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(descriptor);
+        descriptor.describeProperty("spanFactory", spanFactory);
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/tracing/TracingStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/tracing/TracingStateManagerTest.java
@@ -138,6 +138,11 @@ class TracingStateManagerTest {
         public <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
             return null;
         }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            // No-op - not required for testing
+        }
     }
 
     /**


### PR DESCRIPTION
Axon Framework's infrastructure components are intended to be describable.
This can be used by user to debug their Axon configuration, but can also be used by monitoring tools (e.g., Axoniq Platform) to explain in one go what's in place.
While working on other tasks, I noted the `StateManager` and `SnapshotStore` did not extend the `DescribableComponent` interface.
This PR rectifies this.