### PR TITLE
Make SpanFactory and SpanAttributesProviderRegistry DescribableComponents

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/tracing/LoggingSpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/tracing/LoggingSpanFactory.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.tracing;
 
 import org.axonframework.common.IdentifierFactory;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
@@ -95,6 +96,11 @@ public final class LoggingSpanFactory implements SpanFactory {
                                               @Nullable ProcessingContext context) {
         return new LoggingSpan(operationName, () -> "Disconnected handler span started (new trace, linked to "
                 + message.getClass().getSimpleName() + ")");
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        // No-op - nothing to describe
     }
 
     private static String handlerSpanStartLog(Message message) {

--- a/messaging/src/main/java/org/axonframework/messaging/tracing/SpanFactory.java
+++ b/messaging/src/main/java/org/axonframework/messaging/tracing/SpanFactory.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.tracing;
 
+import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
@@ -54,7 +55,7 @@ import org.jspecify.annotations.Nullable;
  * @author Mitchell Herrijgers
  * @since 4.6.0
  */
-public interface SpanFactory {
+public interface SpanFactory extends DescribableComponent {
 
     /**
      * Creates a {@link Span} for an outbound (dispatch / producer) operation on the given {@link Message}. The parent

--- a/messaging/src/main/java/org/axonframework/messaging/tracing/attributes/DefaultSpanAttributesProviderRegistry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/tracing/attributes/DefaultSpanAttributesProviderRegistry.java
@@ -21,6 +21,7 @@ import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.common.configuration.ComponentDefinition;
 import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.infra.ComponentDescriptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,5 +59,10 @@ public final class DefaultSpanAttributesProviderRegistry implements SpanAttribut
             providers.add(creator.createComponent().resolve(config));
         }
         return providers;
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeProperty("providerDefinitions", providerDefinitions);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/tracing/attributes/SpanAttributesProviderRegistry.java
+++ b/messaging/src/main/java/org/axonframework/messaging/tracing/attributes/SpanAttributesProviderRegistry.java
@@ -21,6 +21,7 @@ import org.axonframework.common.configuration.ComponentBuilder;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.Configuration;
 import org.axonframework.common.configuration.DecoratorDefinition;
+import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.tracing.SpanAttributesProvider;
 import org.axonframework.messaging.tracing.SpanFactory;
 
@@ -43,7 +44,7 @@ import java.util.List;
  * @since 5.3.0
  */
 @Internal
-public interface SpanAttributesProviderRegistry {
+public interface SpanAttributesProviderRegistry extends DescribableComponent {
 
     /**
      * Registers the given {@code providerBuilder} constructing a {@link SpanAttributesProvider} to include in the

--- a/messaging/src/test/java/org/axonframework/messaging/tracing/NoOpSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/messaging/tracing/NoOpSpanFactory.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.tracing;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
@@ -71,6 +72,11 @@ final class NoOpSpanFactory implements SpanFactory {
     public Span createDisconnectedHandlerSpan(String operationName, Message message,
                                               @Nullable ProcessingContext context) {
         return NO_OP_SPAN;
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        // No-op - not required for testing
     }
 
     private static final class NoOpSpan implements Span {

--- a/messaging/src/test/java/org/axonframework/messaging/tracing/attributes/DefaultSpanAttributesProviderRegistryTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/tracing/attributes/DefaultSpanAttributesProviderRegistryTest.java
@@ -19,10 +19,12 @@ package org.axonframework.messaging.tracing.attributes;
 import org.axonframework.messaging.tracing.SpanAttributesProvider;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.Configuration;
+import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.messaging.core.configuration.MessagingConfigurer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -138,6 +140,38 @@ class DefaultSpanAttributesProviderRegistryTest {
 
             // then
             assertThat(providers).contains(PROVIDER_A);
+        }
+    }
+
+    @Nested
+    class DescribeTo {
+
+        @Test
+        void describesRegisteredProviderDefinitions() {
+            // given two registered providers
+            testSubject.registerProvider(c -> PROVIDER_A)
+                       .registerProvider(c -> PROVIDER_B);
+            MockComponentDescriptor descriptor = new MockComponentDescriptor();
+
+            // when
+            testSubject.describeTo(descriptor);
+
+            // then the registry exposes its provider definitions
+            Collection<?> providerDefinitions = descriptor.getProperty("providerDefinitions");
+            assertThat(providerDefinitions).hasSize(2);
+        }
+
+        @Test
+        void describesAnEmptyRegistry() {
+            // given no registered providers
+            MockComponentDescriptor descriptor = new MockComponentDescriptor();
+
+            // when
+            testSubject.describeTo(descriptor);
+
+            // then the provider definitions are described as an empty collection
+            Collection<?> providerDefinitions = descriptor.getProperty("providerDefinitions");
+            assertThat(providerDefinitions).isEmpty();
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/tracing/support/TestSpanFactory.java
+++ b/messaging/src/test/java/org/axonframework/messaging/tracing/support/TestSpanFactory.java
@@ -20,6 +20,7 @@ import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanAttributesProvider;
 import org.axonframework.messaging.tracing.SpanFactory;
 import org.axonframework.messaging.tracing.SpanScope;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.jspecify.annotations.Nullable;
@@ -126,6 +127,11 @@ public class TestSpanFactory implements SpanFactory {
     public Span createDisconnectedHandlerSpan(String operationName, Message message,
                                               @Nullable ProcessingContext context) {
         return recordMessageSpan(TestSpanType.DISCONNECTED_HANDLER, operationName, message, context);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        // No-op - not required for testing
     }
 
     /**


### PR DESCRIPTION
## Summary

Makes the two tracing components that are registered against the `ComponentRegistry` implement `DescribableComponent`, so the full configuration can be introspected -- consistent with the recent work making `StateManager` and `SnapshotStore` describable, and with the existing `HandlerInterceptorRegistry`.

## Changes

- `SpanAttributesProviderRegistry` now `extends DescribableComponent`; `DefaultSpanAttributesProviderRegistry.describeTo` describes its registered `providerDefinitions` (same style as `DefaultHandlerInterceptorRegistry`).
- `SpanFactory` now `extends DescribableComponent`; `LoggingSpanFactory` gets a no-op `describeTo` (stateless singleton). Test doubles `NoOpSpanFactory` and `TestSpanFactory` get a no-op `describeTo`.
- Added a `DescribeTo` test group to `DefaultSpanAttributesProviderRegistryTest` using the existing `MockComponentDescriptor`.

## Not affected

The tracing bus decorators (`TracingCommandBus`, `TracingQueryBus`, `TracingEventBus`, `TracingEventSink`, `TracingEventHandlingComponent`) are already describable through the bus interfaces they implement, so they needed no change.

## Downstream note

`SpanFactory` is a public SPI, so tracing backends implementing it must add a `describeTo`. The Axoniq Framework's Micrometer `SpanFactory` is updated in a matching PR; that PR only compiles once this change is released and its `axon-framework` version is bumped accordingly.

## Verification

- `./mvnw clean install -DskipTests` (full reactor) passes.
- Tracing/registry tests green (`DefaultSpanAttributesProviderRegistryTest`, `LoggingSpanFactoryTest`, `TracingQueryBusTest`, `TracingCommandBusTest`).