### PR TITLE
Invoke `MessageStream` callbacks outside the stream lock

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -265,8 +265,15 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      * Lock direction: consumer-side calls (next, peek, hasNextAvailable, setCallback, close)
      * acquire locks from outer to inner (downstream). Producer-side signals (signalProgress and
      * the callbacks they trigger) flow in the opposite direction: inner to outer (upstream).
-     * To prevent deadlock, signalProgress releases its lock before invoking the callback rather
-     * than holding it across the call.
+     * To prevent deadlock, a callback is never invoked while this stream's lock is held: two
+     * streams that notify each other would otherwise take their locks in opposite orders.
+     *
+     * Consequently, completion may not invoke the callback either, because completion is reached
+     * from consumer-side calls that hold the lock (next -> fetchNext -> complete). Instead it
+     * records that a notification is owed in callbackPending, and the consumer-side entry point
+     * flushes it after releasing the lock. Internal variants of those entry points (nextInternal,
+     * peekInternal) exist so nesting them cannot flush while an outer frame still holds the lock -
+     * the monitor is reentrant, so a nested flush would run the callback locked after all.
      *
      * Ordering requirement: signalProgress() must only be called after the state change it
      * announces is fully visible via fetchNext(). This ensures that if a signal arrives while
@@ -340,6 +347,15 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
     private boolean initialized;
 
     /**
+     * Indicates that the consumer is owed a callback invocation, recorded while this stream's lock is held so that the
+     * invocation itself can happen after the lock is released. Setting it is idempotent: the consumer is notified once,
+     * no matter how many state changes asked for a notification.
+     * <p>
+     * Only access while synchronized on this class.
+     */
+    private boolean callbackPending;
+
+    /**
      * This method can be used after the super constructor call completes in a subtype to set the initial state of the
      * stream. It may only be called during construction, and will throw an exception if the stream already has a valid
      * state.
@@ -373,24 +389,19 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         synchronized (this) {
             this.callback = callback;
 
-            boolean wasCompleted = isCompleted();
-
-            if (!hasNextAvailable() && !isCompleted()) {
-                return;
-            }
-
-            if (!wasCompleted && isCompleted()) {
+            if (peekInternal().isPresent() || completed) {
 
                 /*
-                 * complete() or completeExceptionally() was triggered by the hasNextAvailable()
-                 * probe above, which already fired the callback - don't fire again
+                 * There is something to report right away. Should the probe above have completed the
+                 * stream, complete() already recorded the notification; recording it is idempotent,
+                 * so the flush below invokes the callback exactly once either way.
                  */
 
-                return;
+                this.callbackPending = true;
             }
         }
 
-        invokeCallbackSafely();
+        flushPendingCallback();
     }
 
     /**
@@ -401,7 +412,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      * a consumer of another (sub)stream they own.
      */
     @Override
-    public final synchronized void close() {
+    public final void close() {
 
         /*
          * Close is generally called by the consumer, indicating a loss of interest
@@ -410,7 +421,11 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
          * availability of further elements.
          */
 
-        complete();
+        synchronized (this) {
+            complete();
+        }
+
+        flushPendingCallback();
     }
 
     /**
@@ -485,25 +500,65 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
     }
 
     @Override
-    public final synchronized boolean hasNextAvailable() {
-        return peek().isPresent();
+    public final boolean hasNextAvailable() {
+        boolean available;
+
+        synchronized (this) {
+            available = peekInternal().isPresent();
+        }
+
+        flushPendingCallback();
+
+        return available;
     }
 
     @Override
-    public final synchronized Optional<Entry<M>> peek() {
+    public final Optional<Entry<M>> peek() {
+        Optional<Entry<M>> peeked;
+
+        synchronized (this) {
+            peeked = peekInternal();
+        }
+
+        flushPendingCallback();
+
+        return peeked;
+    }
+
+    @Override
+    public final Optional<Entry<M>> next() {
+        Optional<Entry<M>> nextEntry;
+
+        synchronized (this) {
+            nextEntry = nextInternal();
+        }
+
+        flushPendingCallback();
+
+        return nextEntry;
+    }
+
+    /**
+     * Same as {@link #peek()}, but without flushing a pending callback. Callers must hold this stream's lock, and are
+     * responsible for flushing once they release it.
+     */
+    private Optional<Entry<M>> peekInternal() {
         if (completed) {
             return Optional.empty();
         }
 
         if (peekedEntry == null) {
-            peekedEntry = next().orElse(null);
+            peekedEntry = nextInternal().orElse(null);
         }
 
         return Optional.ofNullable(peekedEntry);
     }
 
-    @Override
-    public final synchronized Optional<Entry<M>> next() {
+    /**
+     * Same as {@link #next()}, but without flushing a pending callback. Callers must hold this stream's lock, and are
+     * responsible for flushing once they release it.
+     */
+    private Optional<Entry<M>> nextInternal() {
         if (!this.initialized) {
             initialize(FetchResult.notReady());
         }
@@ -636,6 +691,29 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
             this.awaitingData = false;
             this.peekedEntry = null;
 
+            /*
+             * Completion is reached from consumer-side calls that hold this lock, so the callback
+             * cannot be invoked here: doing so takes the next lock upstream while holding this one.
+             * The consumer-side entry point invokes it once it has released the lock.
+             */
+
+            this.callbackPending = true;
+        }
+    }
+
+    /**
+     * Invokes the callback if one is owed to the consumer. Must be called without holding this stream's lock, so the
+     * callback can take locks upstream freely.
+     */
+    private void flushPendingCallback() {
+        boolean owed;
+
+        synchronized (this) {
+            owed = callbackPending;
+            this.callbackPending = false;
+        }
+
+        if (owed) {
             invokeCallbackSafely();
         }
     }
@@ -652,6 +730,13 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
         } catch (Throwable t) {
             synchronized (this) {
                 completeExceptionally(t);
+
+                /*
+                 * Completing here recorded another notification, but the callback that would receive it
+                 * is the one that just threw. Drop it; the failure is observable through error().
+                 */
+
+                this.callbackPending = false;
             }
         }
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -456,7 +456,7 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
      * <p>
      * Failing to observe this ordering may result in a lost wake-up scenario where:
      * <ul>
-     *     <li>progress is signalled, but</li>
+     *     <li>progress is signaled, but</li>
      *     <li>the consumer observes no available element and returns {@link FetchResult.NotReady}</li>
      * </ul>
      * even though data is available.

--- a/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.*;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -633,6 +635,126 @@ class AbstractMessageStreamTest {
             // then
             assertThat(result).isInstanceOf(FetchResult.Error.class);
             assertThat(((FetchResult.Error<?>) result).error()).isSameAs(failure);
+        }
+    }
+
+    @Nested
+    class WhenCompletionTriggersCallback {
+
+        /*
+         * The concurrency model of this class states that producer-side signals, and the callbacks they
+         * trigger, flow upstream (inner to outer), and that a callback must therefore never be invoked
+         * while this stream's lock is held. signalProgress() honors that; completion must do the same.
+         *
+         * A composed stream registers a callback that reads the stream it wraps, so a callback running
+         * while the completing stream is locked takes a second lock in the opposite direction. Two
+         * streams completing at once then deadlock, leaving an event processor with no events, no error,
+         * and no thread of its own to blame.
+         */
+
+        @Test
+        void thenCallbackDoesNotRunWhileStreamIsLocked() {
+            // given: a callback that lets another thread interact with the very stream that is completing
+            ControllableStream stream = new ControllableStream();
+            AtomicBoolean otherThreadCouldReadStream = new AtomicBoolean();
+
+            CountDownLatch probeReadStream = new CountDownLatch(1);
+
+            stream.setCallback(() -> {
+                Thread probe = new Thread(() -> {
+                    stream.isCompleted();
+
+                    probeReadStream.countDown();
+                });
+
+                probe.setDaemon(true);
+                probe.start();
+
+                try {
+                    // recorded inside the callback: whether the other thread got through while it runs
+                    otherThreadCouldReadStream.set(probeReadStream.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            stream.enqueue(FetchResult.completed());
+
+            // when: the stream completes, firing the callback
+            stream.next();
+
+            // then
+            assertThat(otherThreadCouldReadStream).isTrue();
+        }
+
+        @Test
+        void thenTwoStreamsCompletingConcurrentlyDoNotDeadlock() throws Exception {
+            // given: two streams whose callbacks read each other, as composed streams do
+            ControllableStream first = new ControllableStream();
+            ControllableStream second = new ControllableStream();
+            CyclicBarrier bothInsideCallback = new CyclicBarrier(2);
+
+            first.setCallback(() -> {
+                awaitQuietly(bothInsideCallback);
+
+                second.isCompleted();
+            });
+            second.setCallback(() -> {
+                awaitQuietly(bothInsideCallback);
+
+                first.isCompleted();
+            });
+
+            first.enqueue(FetchResult.completed());
+            second.enqueue(FetchResult.completed());
+
+            CountDownLatch bothReturned = new CountDownLatch(2);
+
+            // when: both complete at the same moment, each callback reaching into the other stream
+            startDaemon(() -> {
+                first.next();
+
+                bothReturned.countDown();
+            });
+            startDaemon(() -> {
+                second.next();
+
+                bothReturned.countDown();
+            });
+
+            // then: neither thread holds a lock the other one needs
+            assertThat(bothReturned.await(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        @Test
+        void thenCompletionIsVisibleToTheCallback() {
+            // given: the completion the callback announces must be observable by that callback
+            ControllableStream stream = new ControllableStream();
+            AtomicBoolean completedDuringCallback = new AtomicBoolean();
+
+            stream.setCallback(() -> completedDuringCallback.set(stream.isCompleted()));
+            stream.enqueue(FetchResult.completed());
+
+            // when
+            stream.next();
+
+            // then
+            assertThat(completedDuringCallback).isTrue();
+        }
+
+        private void awaitQuietly(CyclicBarrier barrier) {
+            try {
+                barrier.await(5, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to synchronize both callbacks.", e);
+            }
+        }
+
+        private void startDaemon(Runnable task) {
+            Thread thread = new Thread(task);
+
+            thread.setDaemon(true);
+            thread.start();
         }
     }
 }


### PR DESCRIPTION
### Problem

`AbstractMessageStream` documents its own concurrency contract: consumer-side calls (`next`, `peek`, `hasNextAvailable`, `setCallback`, `close`) lock **outer → inner**, while producer-side signals and the callbacks they trigger travel **inner → outer**. To keep those two directions from meeting, a callback must never be invoked while the stream's own monitor is held.

`signalProgress()` honours that — it releases the lock before calling the callback. **`complete()` did not.** Completion is only ever reached *from* consumer-side frames that already hold the lock (`next` → `fetchNext` → `complete`), so the outward notification ran with the inner lock still held.

A single thread doing this only recurses, since monitors are reentrant. It deadlocks when a second thread walks the composition the other way at that moment:

- thread A (consumer pull) holds **outer**, wants **inner**
- thread B (producer callback, fired while locked) holds **inner**, wants **outer**

### How it presents

Silently, which is what makes it expensive. The deadlocked threads are the ones delivering entries, so a pooled streaming event processor stops receiving events while its coordinator keeps extending token claims: tokens frozen, no handler invoked, nothing dead-lettered, nothing logged, all segments still shown as claimed. Only a restart clears it, because it builds fresh stream instances.

It surfaces when a stream completes from the producer side while another thread is attaching a continuation through `DelayedMessageStream.setCallback` — two threads entering the same composition from opposite ends. The interleaving has to be exact, hence the intermittency. Compositions that filter entries widen the window considerably, because each notification then traverses many nested `IgnoredEntriesMessageStream` frames while locks are held.

### Fix

Completion records that a notification is owed (`callbackPending`); the consumer-side entry point invokes it after releasing the lock, mirroring `signalProgress()`. Those entry points delegate to private `nextInternal()` / `peekInternal()` variants so nesting them cannot flush while an outer frame still holds the reentrant monitor. Recording is idempotent, which also removes the "did the probe already fire the callback" bookkeeping from `setCallback()`.

### Tests

Three tests in `AbstractMessageStreamTest.WhenCompletionTriggersCallback`:

- `thenTwoStreamsCompletingConcurrentlyDoNotDeadlock` — two streams whose callbacks read each other, completing on two threads with a barrier to force the interleaving. Deadlocks without the fix.
- `thenCallbackDoesNotRunWhileStreamIsLocked` — records, inside the callback, whether another thread can reach the stream.
- `thenCompletionIsVisibleToTheCallback` — guards the ordering the fix must preserve.

Both of the first two fail on this base without the source change and pass with it. `messaging` (4142) and `eventsourcing` (519) suites pass. Existing callback-throws semantics are unchanged, except that a callback which throws is no longer re-invoked with the notification its own failure scheduled.

