### PR TITLE
[#212]: add navigation for multi tenancy migration path

### DIFF
--- a/docs/reference-guide/modules/migration/pages/paths/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/index.adoc
@@ -27,6 +27,7 @@ Whether you are performing a straightforward version bump or a deep architectura
 * xref:migration:paths/distributed-tracing.adoc[Distributed Tracing migration]
 ifdef::advanced-framework[]
 * xref:migration:paths/upcasters.adoc[Upcaster Migration]
+* xref:migration:paths/multi-tenancy.adoc[Multi-Tenancy Migration]
 * xref:advanced-migration:paths/5.0-to-5.1.adoc[Axon Framework 5.0 to Axoniq Framework migration]
 endif::[]
 ifdef::data-protection[]
@@ -292,6 +293,7 @@ For ease of dependency management, it is highly recommended to use the Axon Fram
 </dependencyManagement>
 ----
 
+[#what-is-not-yet-there]
 == What is not yet there
 
 As Axon Framework 5.0 is the first step in this new major version, not all features from the 4.x lineage have been fully migrated or redesigned yet.

--- a/docs/reference-guide/modules/migration/partials/nav.adoc
+++ b/docs/reference-guide/modules/migration/partials/nav.adoc
@@ -25,6 +25,7 @@
 *** xref:migration:paths/distributed-tracing.adoc[[.advanced-framework]#Distributed Tracing#]
 ifdef::advanced-framework[]
 include::message-transformation:partial$migration-nav.adoc[]
+include::multi-tenancy:partial$migration-nav.adoc[]
 include::advanced-migration:partial$nav.adoc[]
 endif::[]
 ifdef::data-protection[]


### PR DESCRIPTION
Companion to AxonIQ/axoniq-framework#212, which adds
`migration/paths/multi-tenancy.adoc` to the shared `migration` module.
