### PR TITLE
Support detail conversion for `HandlerExecutionException`

### DIFF
--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/exceptionhandling/details/OrderClient.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/exceptionhandling/details/OrderClient.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.exceptionhandling.details;
+
+import messagingconcepts.exceptionhandling.PlaceOrderCommand;
+
+// tag::exception-details-retrieval[]
+import org.axonframework.common.TypeReference;
+import org.axonframework.messaging.commandhandling.CommandExecutionException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+
+import java.util.Map;
+import java.util.Optional;
+
+class OrderClient {
+
+    void placeOrder(CommandGateway commandGateway, PlaceOrderCommand command) {
+        try {
+            commandGateway.send(command).wait(Void.class);
+        } catch (CommandExecutionException e) {
+            Optional<Map<String, String>> details = e.getDetails(new TypeReference<Map<String, String>>() {
+            });
+            details.ifPresent(errorDetails -> {
+                String errorCode = errorDetails.get("errorCode");
+                boolean retryable = Boolean.parseBoolean(errorDetails.get("retryable"));
+                // Decide on retry behavior or user feedback based on errorCode and retryable.
+            });
+        }
+    }
+}
+// end::exception-details-retrieval[]

--- a/docs/reference-guide/modules/messaging-concepts/pages/exception-handling.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/exception-handling.adoc
@@ -77,6 +77,15 @@ include::example$messagingconcepts/exceptionhandling/details/InventoryAutomation
 
 The details map allows you to pass structured information about the exception that the receiver can use to make decisions about retry logic, error presentation, or recovery strategies. Note that any `Object` is supported as the details. Other reasonable options are failure objects and status enumerations, specific to the domain.
 
+On the receiving end, retrieve the details through `getDetails(Class)` or, for a generic type such as `Map<String, String>`, `getDetails(TypeReference)`:
+
+[source,java]
+----
+include::example$messagingconcepts/exceptionhandling/details/OrderClient.java[tag=exception-details-retrieval,indent=0]
+----
+
+Both operations return an `Optional`, converting the details into the requested type on demand when the sender and receiver do not share the same details class or version (for example, across an Axon Server boundary). Pass an explicit `Converter` to either operation to override the one attached to the exception, if any. This replaces the older, untyped `getDetails()`, which is deprecated in its favor.
+
 [TIP]
 ====
 Consider whether you really need an exception or whether a result object would serve your use case better!

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
@@ -50,7 +50,7 @@ public class CommandExecutionException extends HandlerExecutionException {
      *
      * @param message the message describing the exception
      * @param cause   the cause of the exception
-     * @param details an object providing more error details (maybe {@code null})
+     * @param details an object providing more error details (might be {@code null})
      */
     public CommandExecutionException(String message,
                                      Throwable cause,
@@ -64,7 +64,7 @@ public class CommandExecutionException extends HandlerExecutionException {
      *
      * @param message            the message describing the exception
      * @param cause              the cause of the exception
-     * @param details            an object providing more error details (maybe {@code null})
+     * @param details            an object providing more error details (might be {@code null})
      * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
      */
     public CommandExecutionException(String message,

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
@@ -17,7 +17,10 @@
 package org.axonframework.messaging.commandhandling;
 
 
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.HandlerExecutionException;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Indicates that an exception has occurred while handling a command. Typically, this class is used to wrap checked
@@ -27,7 +30,7 @@ import org.axonframework.messaging.core.HandlerExecutionException;
  * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Allard Buijze
- * @since 1.3
+ * @since 1.3.0
  */
 public class CommandExecutionException extends HandlerExecutionException {
 
@@ -45,11 +48,13 @@ public class CommandExecutionException extends HandlerExecutionException {
      * Initializes the exception with given {@code message}, {@code cause} and an object providing application-specific
      * {@code details}.
      *
-     * @param message The message describing the exception.
-     * @param cause   The cause of the exception.
-     * @param details An object providing more error details (maybe {@code null}).
+     * @param message the message describing the exception
+     * @param cause   the cause of the exception
+     * @param details an object providing more error details (maybe {@code null})
      */
-    public CommandExecutionException(String message, Throwable cause, Object details) {
+    public CommandExecutionException(String message,
+                                     Throwable cause,
+                                     @Nullable Object details) {
         super(message, cause, details);
     }
 
@@ -57,12 +62,42 @@ public class CommandExecutionException extends HandlerExecutionException {
      * Initializes the exception with given {@code message}, {@code cause}, an object providing application-specific
      * {@code details}, and {@code writableStackTrace}
      *
-     * @param message            The message describing the exception.
-     * @param cause              The cause of the exception.
-     * @param details            An object providing more error details (maybe {@code null}).
-     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false}).
+     * @param message            the message describing the exception
+     * @param cause              the cause of the exception
+     * @param details            an object providing more error details (maybe {@code null})
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
      */
-    public CommandExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+    public CommandExecutionException(String message,
+                                     Throwable cause,
+                                     @Nullable Object details,
+                                     boolean writableStackTrace) {
         super(message, cause, details, writableStackTrace);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, an object providing application-specific
+     * {@code details}, a {@code converter}, and {@code writableStackTrace}.
+     * <p/>
+     * This constructor is used by messaging infrastructure to attach a {@link Converter} when reconstructing
+     * {@code details} from raw data received over an infrastructure boundary (for example, a command dispatched through
+     * Axon Server). It is not meant to be used directly by application code, which typically already has the details
+     * object in its final form and can use {@link #CommandExecutionException(String, Throwable, Object)} instead.
+     *
+     * @param message            the message describing the exception
+     * @param cause              the cause of the exception
+     * @param details            an object providing more error details, potentially raw data awaiting conversion (maybe
+     *                           {@code null})
+     * @param converter          the {@link Converter} to lazily apply when {@link #getDetails(Class)} is called with a
+     *                           type {@code details} does not already match, or {@code null} if no such conversion is
+     *                           available
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    @Internal
+    public CommandExecutionException(String message,
+                                     Throwable cause,
+                                     @Nullable Object details,
+                                     @Nullable Converter converter,
+                                     boolean writableStackTrace) {
+        super(message, cause, details, converter, writableStackTrace);
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandExecutionException.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.messaging.commandhandling;
 
-
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.HandlerExecutionException;

--- a/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
@@ -270,7 +270,7 @@ public abstract class HandlerExecutionException extends AxonException {
         if (details == null) {
             return Optional.empty();
         }
-        if (TypeReference.fromType(type).getTypeAsClass().isInstance(details)) {
+        if (type instanceof Class<?> clazz && clazz.isInstance(details)) {
             //noinspection unchecked
             return Optional.of((R) details);
         }

--- a/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
@@ -132,7 +132,7 @@ public abstract class HandlerExecutionException extends AxonException {
 
     /**
      * Resolve details from the given {@code throwable}, taking into account that the details may be available in any of
-     * the {@code HandlerExecutionExceptions} is the "cause" chain.
+     * the {@code HandlerExecutionExceptions} in the "cause" chain.
      *
      * @param throwable the exception to resolve the details from
      * @param <R>       the type of details expected

--- a/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
@@ -17,9 +17,13 @@
 package org.axonframework.messaging.core;
 
 import org.axonframework.common.AxonException;
+import org.axonframework.common.TypeReference;
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.conversion.ConversionException;
+import org.axonframework.conversion.Converter;
 import org.jspecify.annotations.Nullable;
 
-
+import java.lang.reflect.Type;
 import java.util.Optional;
 
 /**
@@ -29,19 +33,26 @@ import java.util.Optional;
  * <p/>
  * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
  * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
+ * <p/>
+ * When these details cross an infrastructure boundary (for example, a remote command or query dispatched through Axon
+ * Server), they may arrive as raw data alongside a {@link Converter} rather than as the original application object. In
+ * that case, {@link #getDetails(Class)}, {@link #getDetails(TypeReference)}, and {@link #getDetails(Type)} apply the
+ * {@link Converter} lazily, on request, mirroring how {@link Message#payloadAs(Class)} defers payload conversion. This
+ * keeps the thrower and the receiver decoupled from having to agree on the exact same details class or version.
  *
  * @author Allard Buize
- * @since 4.2
+ * @since 4.2.0
  */
 public abstract class HandlerExecutionException extends AxonException {
 
     private final @Nullable Object details;
+    private final @Nullable Converter converter;
 
     /**
      * Initializes an execution exception with given {@code message}. The cause and application-specific details are set
      * to {@code null}.
      *
-     * @param message A message describing the exception
+     * @param message a message describing the exception
      */
     public HandlerExecutionException(String message) {
         this(message, null, null);
@@ -51,10 +62,11 @@ public abstract class HandlerExecutionException extends AxonException {
      * Initializes an execution exception with given {@code message} and {@code cause}. The application-specific details
      * are set to {@code null}.
      *
-     * @param message A message describing the exception
+     * @param message a message describing the exception
      * @param cause   the cause of the execution exception
      */
-    public HandlerExecutionException(String message, @Nullable Throwable cause) {
+    public HandlerExecutionException(String message,
+                                     @Nullable Throwable cause) {
         this(message, cause, resolveDetails(cause).orElse(null));
     }
 
@@ -62,11 +74,13 @@ public abstract class HandlerExecutionException extends AxonException {
      * Initializes an execution exception with given {@code message}, {@code cause} and application-specific
      * {@code details}.
      *
-     * @param message A message describing the exception
-     * @param cause   The cause of the execution exception
-     * @param details An object providing application-specific details of the exception
+     * @param message a message describing the exception
+     * @param cause   the cause of the execution exception
+     * @param details an object providing application-specific details of the exception
      */
-    public HandlerExecutionException(String message, @Nullable Throwable cause, @Nullable Object details) {
+    public HandlerExecutionException(String message,
+                                     @Nullable Throwable cause,
+                                     @Nullable Object details) {
         this(message, cause, details, false);
     }
 
@@ -74,23 +88,55 @@ public abstract class HandlerExecutionException extends AxonException {
      * Initializes an execution exception with given {@code message}, {@code cause}, application-specific
      * {@code details}, and {@code writableStackTrace}
      *
-     * @param message            A message describing the exception
-     * @param cause              The cause of the execution exception
-     * @param details            An object providing application-specific details of the exception
-     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     * @param message            a message describing the exception
+     * @param cause              the cause of the execution exception
+     * @param details            an object providing application-specific details of the exception
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
      */
-    public HandlerExecutionException(String message, @Nullable Throwable cause, @Nullable Object details, boolean writableStackTrace) {
+    public HandlerExecutionException(String message,
+                                     @Nullable Throwable cause,
+                                     @Nullable Object details,
+                                     boolean writableStackTrace) {
+        this(message, cause, details, null, writableStackTrace);
+    }
+
+    /**
+     * Initializes an execution exception with given {@code message}, {@code cause}, application-specific
+     * {@code details}, {@code converter}, and {@code writableStackTrace}.
+     * <p/>
+     * This constructor is used by messaging infrastructure to attach a {@link Converter} when reconstructing
+     * {@code details} from raw data received over an infrastructure boundary (for example, a remote command or query
+     * response). It is not meant to be used directly by application code, which typically already has the details
+     * object in its final form and can use {@link #HandlerExecutionException(String, Throwable, Object)} instead.
+     *
+     * @param message            a message describing the exception
+     * @param cause              the cause of the execution exception
+     * @param details            an object providing application-specific details of the exception, potentially raw data
+     *                           awaiting conversion
+     * @param converter          the {@link Converter} to lazily apply when {@link #getDetails(Class)},
+     *                           {@link #getDetails(TypeReference)}, or {@link #getDetails(Type)} is called with a type
+     *                           {@code details} does not already match, or {@code null} if no such conversion is
+     *                           available
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    @Internal
+    public HandlerExecutionException(String message,
+                                     @Nullable Throwable cause,
+                                     @Nullable Object details,
+                                     @Nullable Converter converter,
+                                     boolean writableStackTrace) {
         super(message, cause, writableStackTrace);
         this.details = details;
+        this.converter = converter;
     }
 
     /**
      * Resolve details from the given {@code throwable}, taking into account that the details may be available in any of
-     * the {@code HandlerExecutionException}s is the "cause" chain.
+     * the {@code HandlerExecutionExceptions} is the "cause" chain.
      *
-     * @param throwable The exception to resolve the details from
-     * @param <R>       The type of details expected
-     * @return an Optional containing details, if present in the given {@code throwable}
+     * @param throwable the exception to resolve the details from
+     * @param <R>       the type of details expected
+     * @return an {@code Optional} containing details, if present in the given {@code throwable}
      */
     public static <R> Optional<R> resolveDetails(@Nullable Throwable throwable) {
         if (throwable instanceof HandlerExecutionException) {
@@ -102,15 +148,138 @@ public abstract class HandlerExecutionException extends AxonException {
     }
 
     /**
-     * Returns an Optional containing application-specific details of the exception, if any were provided. These details
-     * are implicitly cast to the expected type. A mismatch in type may lead to a {@link ClassCastException} further
-     * downstream, when accessing the Optional's enclosed value.
+     * Returns an {@code Optional} containing application-specific details of the exception, if any were provided.
+     * <p>
+     * These details are implicitly cast to the expected type. A mismatch in type may lead to a
+     * {@link ClassCastException} further downstream, when accessing the {@code Optional's} enclosed value.
      *
-     * @param <R> The type of details expected
+     * @param <R> the type of details expected
      * @return an Optional containing the details, if provided
+     * @deprecated in favor of {@link #getDetails(Class)}, or any of the {@link Type}, {@link TypeReference}, or
+     * {@link Converter} parameter combinations, as those ensure the details are converted to the desired type
      */
+    @Deprecated(since = "5.3.0", forRemoval = true)
     @SuppressWarnings("unchecked")
     public <R> Optional<R> getDetails() {
         return Optional.ofNullable((R) details);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the {@link Converter} attached to this exception (if any).
+     *
+     * @param type the type to return the details as
+     * @param <R>  the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@link Converter} is available or the conversion fails
+     */
+    public <R> Optional<R> getDetails(Class<R> type) {
+        return getDetails(type, this.converter);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the given {@code converter}.
+     * <p/>
+     * If the current details already are an instance of {@code type}, no conversion takes place and the given
+     * {@code converter} is ignored. Otherwise, the given {@code converter} is used to convert the details into
+     * {@code type}. This allows the thrower and the receiver of these details to use different classes or versions for
+     * the same logical details.
+     *
+     * @param type      the type to return the details as
+     * @param converter the converter to convert the details with, or {@code null} if no conversion is available
+     * @param <R>       the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@code converter} is given or the conversion fails
+     */
+    public <R> Optional<R> getDetails(Class<R> type, @Nullable Converter converter) {
+        return getDetails((Type) type, converter);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the {@link Converter} attached to this exception (if any).
+     * <p/>
+     * Behaves identically to {@link #getDetails(Class)}, but supports generic types (for example {@code List<String>})
+     * through a {@link TypeReference}.
+     *
+     * @param type the type to return the details as
+     * @param <R>  the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@link Converter} is available or the conversion fails
+     */
+    public <R> Optional<R> getDetails(TypeReference<R> type) {
+        return getDetails(type, this.converter);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the given {@code converter}.
+     * <p/>
+     * Behaves identically to {@link #getDetails(Class, Converter)}, but supports generic types (for example
+     * {@code List<String>}) through a {@link TypeReference}.
+     *
+     * @param type      the type to return the details as
+     * @param converter the converter to convert the details with, or {@code null} if no conversion is available
+     * @param <R>       the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@code converter} is given or the conversion fails
+     */
+    public <R> Optional<R> getDetails(TypeReference<R> type, @Nullable Converter converter) {
+        return getDetails(type.getType(), converter);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the {@link Converter} attached to this exception (if any).
+     * <p/>
+     * Behaves identically to {@link #getDetails(Class)}, but accepts a raw {@link Type}, for callers that already have
+     * one at hand (for example, obtained through reflection) instead of a {@link Class} or {@link TypeReference}.
+     *
+     * @param type the type to return the details as
+     * @param <R>  the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@link Converter} is available or the conversion fails
+     */
+    public <R> Optional<R> getDetails(Type type) {
+        return getDetails(type, this.converter);
+    }
+
+    /**
+     * Returns an {@code Optional} containing application-specific details of the exception, converted into the given
+     * {@code type} if necessary, using the given {@code converter}.
+     * <p/>
+     * If the current details already are an instance of {@code type}, no conversion takes place and the given
+     * {@code converter} is ignored. Otherwise, the given {@code converter} is used to convert the details into
+     * {@code type}. This allows the thrower and the receiver of these details to use different classes or versions for
+     * the same logical details. This is the terminal operation every other {@code getDetails} overload delegates to.
+     *
+     * @param type      the type to return the details as
+     * @param converter the converter to convert the details with, or {@code null} if no conversion is available
+     * @param <R>       the type of details expected
+     * @return an {@code Optional} containing the details converted to {@code type}, if provided
+     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     *                             {@code converter} is given or the conversion fails
+     */
+    public <R> Optional<R> getDetails(Type type, @Nullable Converter converter) {
+        if (details == null) {
+            return Optional.empty();
+        }
+        if (TypeReference.fromType(type).getTypeAsClass().isInstance(details)) {
+            //noinspection unchecked
+            return Optional.of((R) details);
+        }
+        if (converter == null) {
+            throw new ConversionException(
+                    "Cannot convert details of type [" + details.getClass().getName() + "] to [" + type
+                            + "] without a Converter."
+            );
+        }
+        return Optional.ofNullable(converter.convert(details, type));
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
@@ -171,7 +171,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param type the type to return the details as
      * @param <R>  the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@link Converter} is available or the conversion fails
      */
     public <R> Optional<R> getDetails(Class<R> type) {
@@ -191,7 +191,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param converter the converter to convert the details with, or {@code null} if no conversion is available
      * @param <R>       the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@code converter} is given or the conversion fails
      */
     public <R> Optional<R> getDetails(Class<R> type, @Nullable Converter converter) {
@@ -208,7 +208,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param type the type to return the details as
      * @param <R>  the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@link Converter} is available or the conversion fails
      */
     public <R> Optional<R> getDetails(TypeReference<R> type) {
@@ -226,7 +226,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param converter the converter to convert the details with, or {@code null} if no conversion is available
      * @param <R>       the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@code converter} is given or the conversion fails
      */
     public <R> Optional<R> getDetails(TypeReference<R> type, @Nullable Converter converter) {
@@ -243,7 +243,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param type the type to return the details as
      * @param <R>  the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@link Converter} is available or the conversion fails
      */
     public <R> Optional<R> getDetails(Type type) {
@@ -263,7 +263,7 @@ public abstract class HandlerExecutionException extends AxonException {
      * @param converter the converter to convert the details with, or {@code null} if no conversion is available
      * @param <R>       the type of details expected
      * @return an {@code Optional} containing the details converted to {@code type}, if provided
-     * @throws ConversionException if the details are present, do not match {@code type}, and either no
+     * @throws ConversionException if the details are present but do not match {@code type}, and either no
      *                             {@code converter} is given or the conversion fails
      */
     public <R> Optional<R> getDetails(Type type, @Nullable Converter converter) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/HandlerExecutionException.java
@@ -59,15 +59,26 @@ public abstract class HandlerExecutionException extends AxonException {
     }
 
     /**
-     * Initializes an execution exception with given {@code message} and {@code cause}. The application-specific details
-     * are set to {@code null}.
+     * Initializes an execution exception with given {@code message} and {@code cause}. Application-specific details
+     * and their {@link Converter}, if any, are inherited from the first {@code HandlerExecutionException} in the
+     * {@code cause} chain that carries details.
      *
      * @param message a message describing the exception
      * @param cause   the cause of the execution exception
      */
     public HandlerExecutionException(String message,
                                      @Nullable Throwable cause) {
-        this(message, cause, resolveDetails(cause).orElse(null));
+        this(message, cause, findExceptionWithDetails(cause));
+    }
+
+    private HandlerExecutionException(String message,
+                                      @Nullable Throwable cause,
+                                      @Nullable HandlerExecutionException detailsSource) {
+        this(message,
+            cause,
+            detailsSource == null ? null : detailsSource.details,
+            detailsSource == null ? null : detailsSource.converter,
+            false);
     }
 
     /**
@@ -139,12 +150,26 @@ public abstract class HandlerExecutionException extends AxonException {
      * @return an {@code Optional} containing details, if present in the given {@code throwable}
      */
     public static <R> Optional<R> resolveDetails(@Nullable Throwable throwable) {
-        if (throwable instanceof HandlerExecutionException) {
-            return ((HandlerExecutionException) throwable).getDetails();
-        } else if (throwable != null && throwable.getCause() != null) {
-            return resolveDetails(throwable.getCause());
+        HandlerExecutionException detailsSource = findExceptionWithDetails(throwable);
+        return detailsSource == null ? Optional.empty() : detailsSource.getDetails();
+    }
+
+    /**
+     * Finds the first {@code HandlerExecutionException} in the {@code throwable}'s "cause" chain (including
+     * {@code throwable} itself) that carries application-specific details.
+     *
+     * @param throwable the exception to walk the "cause" chain of
+     * @return the first {@code HandlerExecutionException} carrying details, or {@code null} if none is found
+     */
+    private static @Nullable HandlerExecutionException findExceptionWithDetails(@Nullable Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof HandlerExecutionException exception && exception.details != null) {
+                return exception;
+            }
+            current = current.getCause();
         }
-        return Optional.empty();
+        return null;
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryExecutionException.java
@@ -47,7 +47,7 @@ public class QueryExecutionException extends HandlerExecutionException {
      *
      * @param message message explaining the context of the error
      * @param cause   the underlying cause of the invocation failure
-     * @param details an object providing more error details (maybe {@code null})
+     * @param details an object providing more error details (might be {@code null})
      */
     public QueryExecutionException(String message,
                                    Throwable cause,
@@ -61,7 +61,7 @@ public class QueryExecutionException extends HandlerExecutionException {
      *
      * @param message            message explaining the context of the error
      * @param cause              the underlying cause of the invocation failure
-     * @param details            an object providing more error details (maybe {@code null})
+     * @param details            an object providing more error details (might be {@code null})
      * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
      */
     public QueryExecutionException(String message,
@@ -82,8 +82,8 @@ public class QueryExecutionException extends HandlerExecutionException {
      *
      * @param message            message explaining the context of the error
      * @param cause              the underlying cause of the invocation failure
-     * @param details            an object providing more error details, potentially raw data awaiting conversion (maybe
-     *                           {@code null})
+     * @param details            an object providing more error details, potentially raw data awaiting conversion (may
+     *                           be {@code null})
      * @param converter          the {@link Converter} to lazily apply when {@link #getDetails(Class)} is called with a
      *                           type {@code details} does not already match, or {@code null} if no such conversion is
      *                           available

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryExecutionException.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryExecutionException.java
@@ -15,38 +15,43 @@
  */
 package org.axonframework.messaging.queryhandling;
 
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.conversion.Converter;
 import org.axonframework.messaging.core.HandlerExecutionException;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Exception indicating that the execution of a Query Handler has resulted in an exception.
  * <p/>
- * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced explicitly
- * via the constructor accepting the {@code writableStackTrace} parameter.
+ * By default, a stack trace is not generated for this exception. However, the stack trace creation can be enforced
+ * explicitly via the constructor accepting the {@code writableStackTrace} parameter.
  *
  * @author Marc Gathier
- * @since 3.1
+ * @since 3.1.0
  */
 public class QueryExecutionException extends HandlerExecutionException {
 
     /**
      * Initializes the exception with given {@code message} and {@code cause}
      *
-     * @param message Message explaining the context of the error
-     * @param cause   The underlying cause of the invocation failure
+     * @param message message explaining the context of the error
+     * @param cause   the underlying cause of the invocation failure
      */
-    public QueryExecutionException(String message, @Nullable Throwable cause) {
+    public QueryExecutionException(String message,
+                                   @Nullable Throwable cause) {
         super(message, cause);
     }
 
     /**
      * Initializes the exception with given {@code message}, {@code cause} and {@code details}.
      *
-     * @param message Message explaining the context of the error
-     * @param cause   The underlying cause of the invocation failure
-     * @param details An object providing more error details (may be {@code null})
+     * @param message message explaining the context of the error
+     * @param cause   the underlying cause of the invocation failure
+     * @param details an object providing more error details (maybe {@code null})
      */
-    public QueryExecutionException(String message, Throwable cause, Object details) {
+    public QueryExecutionException(String message,
+                                   Throwable cause,
+                                   @Nullable Object details) {
         super(message, cause, details);
     }
 
@@ -54,12 +59,42 @@ public class QueryExecutionException extends HandlerExecutionException {
      * Initializes the exception with given {@code message}, {@code cause}, {@code details} and
      * {@code writableStackTrace}
      *
-     * @param message            Message explaining the context of the error
-     * @param cause              The underlying cause of the invocation failure
-     * @param details            An object providing more error details (may be {@code null})
-     * @param writableStackTrace Whether the stack trace should be generated ({@code true}) or not ({@code false})
+     * @param message            message explaining the context of the error
+     * @param cause              the underlying cause of the invocation failure
+     * @param details            an object providing more error details (maybe {@code null})
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
      */
-    public QueryExecutionException(String message, Throwable cause, Object details, boolean writableStackTrace) {
+    public QueryExecutionException(String message,
+                                   Throwable cause,
+                                   @Nullable Object details,
+                                   boolean writableStackTrace) {
         super(message, cause, details, writableStackTrace);
+    }
+
+    /**
+     * Initializes the exception with given {@code message}, {@code cause}, {@code details}, a {@code converter}, and
+     * {@code writableStackTrace}.
+     * <p/>
+     * This constructor is used by messaging infrastructure to attach a {@link Converter} when reconstructing
+     * {@code details} from raw data received over an infrastructure boundary (for example, a query dispatched through
+     * Axon Server). It is not meant to be used directly by application code, which typically already has the details
+     * object in its final form and can use {@link #QueryExecutionException(String, Throwable, Object)} instead.
+     *
+     * @param message            message explaining the context of the error
+     * @param cause              the underlying cause of the invocation failure
+     * @param details            an object providing more error details, potentially raw data awaiting conversion (maybe
+     *                           {@code null})
+     * @param converter          the {@link Converter} to lazily apply when {@link #getDetails(Class)} is called with a
+     *                           type {@code details} does not already match, or {@code null} if no such conversion is
+     *                           available
+     * @param writableStackTrace whether the stack trace should be generated ({@code true}) or not ({@code false})
+     */
+    @Internal
+    public QueryExecutionException(String message,
+                                   Throwable cause,
+                                   @Nullable Object details,
+                                   @Nullable Converter converter,
+                                   boolean writableStackTrace) {
+        super(message, cause, details, converter, writableStackTrace);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/commandhandling/CommandExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/commandhandling/CommandExecutionExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.commandhandling;
+
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class validating the {@link CommandExecutionException}.
+ */
+class CommandExecutionExceptionTest {
+
+    @Test
+    void constructorWithDetailsExposesThemUnconverted() {
+        CommandExecutionException exception = new CommandExecutionException("message", null, "details");
+
+        assertThat(exception.getDetails(String.class)).contains("details");
+    }
+
+    @Test
+    void constructorWithConverterAppliesItLazilyOnTypeMismatch() {
+        // given
+        String stringDetails = "details";
+        byte[] byteDetails = stringDetails.getBytes(StandardCharsets.UTF_8);
+        Converter converter = spy(new ChainingContentTypeConverter());
+
+        // when
+        CommandExecutionException exception =
+                new CommandExecutionException("message", null, byteDetails, converter, false);
+        String result = exception.getDetails(String.class).orElse(null);
+
+        // then
+        assertThat(result).isEqualTo(stringDetails);
+        verify(converter).convert(eq(byteDetails), eq((Type) String.class));
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/core/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/HandlerExecutionExceptionTest.java
@@ -16,9 +16,20 @@
 
 package org.axonframework.messaging.core;
 
+import org.assertj.core.api.Assertions;
+import org.axonframework.common.TypeReference;
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.ConversionException;
+import org.axonframework.conversion.Converter;
 import org.junit.jupiter.api.*;
 
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link HandlerExecutionException}.
@@ -67,6 +78,78 @@ class HandlerExecutionExceptionTest {
         assertTrue(exception.getStackTrace().length > 0);
     }
 
+    @Nested
+    class TypedDetails {
+
+        private Converter converter;
+        private final String exStringDetails = "details";
+        private final byte[] exByteDetails = exStringDetails.getBytes(StandardCharsets.UTF_8);
+
+        @BeforeEach
+        void setUp() {
+            converter = spy(new ChainingContentTypeConverter());
+        }
+
+        @Test
+        void getDetailsClassReturnsDetailsWithoutConversionOnSameType() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exStringDetails, converter, false);
+
+            String result = exception.getDetails(String.class).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+        }
+
+        @Test
+        void getDetailsClassInvokesConverterOnDifferentType() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+
+            String result = exception.getDetails(String.class).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(converter).convert(eq(exByteDetails), eq((Type) String.class));
+        }
+
+        @Test
+        void getDetailsClassFailsWithConversionExceptionWithoutConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails);
+
+            Assertions.assertThatThrownBy(() -> exception.getDetails(Integer.class))
+                      .isInstanceOf(ConversionException.class);
+        }
+
+        @Test
+        void getDetailsClassReturnsEmptyWhenNoDetailsPresent() {
+            StubHandlerExecutionException exception = new StubHandlerExecutionException("test");
+
+            assertThat(exception.getDetails(String.class)).isEmpty();
+        }
+
+        @Test
+        void getDetailsTypeReferenceInvokesConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+
+            String result = exception.getDetails(new TypeReference<String>() {
+            }).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(converter).convert(eq(exByteDetails), eq((Type) String.class));
+        }
+
+        @Test
+        void getDetailsTypeReferenceFailsWithConversionExceptionWithoutConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails);
+
+            Assertions.assertThatThrownBy(() -> exception.getDetails(new TypeReference<Integer>() {
+                      }))
+                      .isInstanceOf(ConversionException.class);
+        }
+    }
+
     private static class StubHandlerExecutionException extends HandlerExecutionException {
 
         public StubHandlerExecutionException(String message) {
@@ -86,6 +169,14 @@ class HandlerExecutionExceptionTest {
                                              Object details,
                                              boolean writableStackTrace) {
             super(message, cause, details, writableStackTrace);
+        }
+
+        public StubHandlerExecutionException(String message,
+                                             Throwable cause,
+                                             Object details,
+                                             Converter converter,
+                                             boolean writableStackTrace) {
+            super(message, cause, details, converter, writableStackTrace);
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/HandlerExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/HandlerExecutionExceptionTest.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.messaging.core;
 
-import org.assertj.core.api.Assertions;
 import org.axonframework.common.TypeReference;
 import org.axonframework.conversion.ChainingContentTypeConverter;
 import org.axonframework.conversion.ConversionException;
@@ -25,8 +24,10 @@ import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -116,8 +117,21 @@ class HandlerExecutionExceptionTest {
             StubHandlerExecutionException exception =
                     new StubHandlerExecutionException("test", null, exByteDetails);
 
-            Assertions.assertThatThrownBy(() -> exception.getDetails(Integer.class))
-                      .isInstanceOf(ConversionException.class);
+            assertThatThrownBy(() -> exception.getDetails(Integer.class))
+                    .isInstanceOf(ConversionException.class);
+        }
+
+        @Test
+        void getDetailsClassWithExplicitConverterOverridesStoredConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+            Converter explicitConverter = spy(new ChainingContentTypeConverter());
+
+            String result = exception.getDetails(String.class, explicitConverter).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(explicitConverter).convert(eq(exByteDetails), eq((Type) String.class));
+            verifyNoInteractions(converter);
         }
 
         @Test
@@ -144,9 +158,95 @@ class HandlerExecutionExceptionTest {
             StubHandlerExecutionException exception =
                     new StubHandlerExecutionException("test", null, exByteDetails);
 
-            Assertions.assertThatThrownBy(() -> exception.getDetails(new TypeReference<Integer>() {
-                      }))
-                      .isInstanceOf(ConversionException.class);
+            assertThatThrownBy(() -> exception.getDetails(new TypeReference<Integer>() {
+                    }))
+                    .isInstanceOf(ConversionException.class);
+        }
+
+        @Test
+        void getDetailsTypeReferenceWithExplicitConverterOverridesStoredConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+            Converter explicitConverter = spy(new ChainingContentTypeConverter());
+
+            String result = exception.getDetails(new TypeReference<String>() {
+            }, explicitConverter).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(explicitConverter).convert(eq(exByteDetails), eq((Type) String.class));
+            verifyNoInteractions(converter);
+        }
+
+        @Test
+        void getDetailsTypeReferenceInvokesConverterForParameterizedTypeEvenWhenRawTypeMatches() {
+            // given: details whose raw type (List) matches the requested TypeReference's raw type, but not its
+            // generic parameter
+            List<String> storedDetails = List.of("a", "b");
+            List<Integer> convertedDetails = List.of(1, 2);
+            Converter explicitConverter = mock(Converter.class);
+            when(explicitConverter.convert(eq(storedDetails), any(Type.class))).thenReturn(convertedDetails);
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, storedDetails);
+
+            // when
+            List<Integer> result = exception.getDetails(new TypeReference<List<Integer>>() {
+            }, explicitConverter).orElse(null);
+
+            // then: the converter is invoked rather than the raw-type match being (unsafely) treated as a hit
+            assertThat(result).isEqualTo(convertedDetails);
+            verify(explicitConverter).convert(eq(storedDetails), any(Type.class));
+        }
+
+        @Test
+        void getDetailsTypeInvokesConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+            Type type = String.class;
+
+            String result = exception.<String>getDetails(type).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(converter).convert(eq(exByteDetails), eq(type));
+        }
+
+        @Test
+        void getDetailsTypeFailsWithConversionExceptionWithoutConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails);
+            Type type = Integer.class;
+
+            assertThatThrownBy(() -> exception.<Integer>getDetails(type))
+                    .isInstanceOf(ConversionException.class);
+        }
+
+        @Test
+        void getDetailsTypeWithExplicitConverterOverridesStoredConverter() {
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("test", null, exByteDetails, converter, false);
+            Converter explicitConverter = spy(new ChainingContentTypeConverter());
+            Type type = String.class;
+
+            String result = exception.<String>getDetails(type, explicitConverter).orElse(null);
+
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(explicitConverter).convert(eq(exByteDetails), eq(type));
+            verifyNoInteractions(converter);
+        }
+
+        @Test
+        void getDetailsUsesConverterInheritedFromCause() {
+            // given: a cause carrying raw details alongside a Converter able to convert them
+            StubHandlerExecutionException cause =
+                    new StubHandlerExecutionException("cause", null, exByteDetails, converter, false);
+            StubHandlerExecutionException exception =
+                    new StubHandlerExecutionException("outer", cause);
+
+            // when
+            String result = exception.getDetails(String.class).orElse(null);
+
+            // then: the outer exception inherited both the details and the converter from the cause
+            assertThat(result).isEqualTo(exStringDetails);
+            verify(converter).convert(eq(exByteDetails), eq((Type) String.class));
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/QueryExecutionExceptionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/QueryExecutionExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.queryhandling;
+
+import org.axonframework.conversion.ChainingContentTypeConverter;
+import org.axonframework.conversion.Converter;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class validating the {@link QueryExecutionException}.
+ */
+class QueryExecutionExceptionTest {
+
+    @Test
+    void constructorWithDetailsExposesThemUnconverted() {
+        QueryExecutionException exception = new QueryExecutionException("message", null, "details");
+
+        assertThat(exception.getDetails(String.class)).contains("details");
+    }
+
+    @Test
+    void constructorWithConverterAppliesItLazilyOnTypeMismatch() {
+        // given
+        String stringDetails = "details";
+        byte[] byteDetails = stringDetails.getBytes(StandardCharsets.UTF_8);
+        Converter converter = spy(new ChainingContentTypeConverter());
+
+        // when
+        QueryExecutionException exception =
+                new QueryExecutionException("message", null, byteDetails, converter, false);
+        String result = exception.getDetails(String.class).orElse(null);
+
+        // then
+        assertThat(result).isEqualTo(stringDetails);
+        verify(converter).convert(eq(byteDetails), eq((Type) String.class));
+    }
+}


### PR DESCRIPTION
This pull request adjusts the `HandlerExecutionException`, by adding several `getDetails(...)` operations to it.
While making the shift for `Message` to be payload-type-agnostic, we simplify forgot taking care of the `HandlerExecutionException#details`. 

This PR rectifies that, by adding `getDetails(Class<R>)`, `getDetails(TypeReference<R>)`, and `getDetails(Type)`. 
Added, there are versions of this method that allow providing the desired `Converter` to convert the details with.
When no `Converter` is given, the `Converter` on the `HandlerExecutionException` itself (included through a new constructor) is used, if present.

This change follows the same pattern as `Message#payloadAs(...)`. Note there is one deliberate difference:
`getDetails(TypeReference<R>)` preserves the full generic `Type` (via `getType()`) for both the raw-type shortcut and
the `Converter` invocation, whereas `Message#payloadAs(TypeReference<T>)` currently narrows to the raw `Class` (via
`getTypeAsClass()`) and therefore does not use `GenericMessage`'s stored `Converter` for that overload. That's a
pre-existing discrepancy on the `Message` side, not something introduced or fixed here; it's tracked separately in
#4874.

In doing so, we are one step closer for users to be able to throw a custom `CommandExecutionException` or `QueryExecutionException` from their command and query handlers, including domain-specific details.