### PR TITLE
Add a persistent-streams option to the multi-tenancy demo

### DIFF
--- a/examples/university-multi-tenancy-examples/README.md
+++ b/examples/university-multi-tenancy-examples/README.md
@@ -29,6 +29,11 @@ that code. The demo shows, at the moment:
 * **The one knob there is** (Axon Server): a tenant change restarts the running processors, and each restart is
   bounded by a timeout. The framework defaults it, and both demos show where an application would raise it for a
   deployment whose processors are slow to stop and start.
+* **Persistent streams instead of pooled streaming** (Axon Server, opt-in): a toggle in each demo swaps that one
+  processor for a subscribing processor fed by a persistent stream, opened in every tenant's own context and
+  fanned into that single processor by the multi-tenant persistent stream support. Still one processor, still no
+  configuration change when a tenant is added, but no token store and no processor restart on a tenant change,
+  since each tenant's stream opens and closes on its own.
 * **An idempotent projection**, which a streamed read model has to be. Events arrive at least once, and
   re-opening the stream on a tenant change makes a repeat more likely than usual, so the statistics are
   derived from the student identifiers in the events rather than counted. Handling the same enrollment twice

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/EventProcessingStyle.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/EventProcessingStyle.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared;
+
+/**
+ * The style for event processing in the demo, whether it being pooled streaming processors or persistent streams.
+ * Orthogonal to {@link DemoBacking}: both values only apply against Axon Server, and either way the projection
+ * stays a single processor serving every tenant.
+ *
+ * @author Jakob Hatzl
+ * @since 5.3.0
+ */
+public enum EventProcessingStyle {
+
+    /** A pooled streaming processor reading the tenant-aware event store directly. The framework's default. */
+    POOLED_STREAMING,
+
+    /**
+     * A subscribing processor fed by one persistent stream per tenant, fanned into a single consumer by the
+     * multi-tenant persistent stream support. Demonstrates persistent streams in a multi-tenant setting.
+     */
+    PERSISTENT_STREAMS
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoApplication.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoApplication.java
@@ -30,7 +30,6 @@ import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.eventhandling.processing.EventProcessor;
-import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 
 import java.util.List;
@@ -46,7 +45,7 @@ import java.util.Objects;
  * @param auditProvider      the provider of the per-tenant audit logs
  * @param provisioning       how this run adds and removes tenants, and what backs it
  * @param snapshots          reads a single tenant's own snapshot store
- * @param processorNames     the names of every streaming event processor the application registered
+ * @param processorNames     the names of every event processor the application registered
  * @param shutdown           shuts the started application down
  * @author Laura Devriendt
  * @since 5.3.0
@@ -124,12 +123,13 @@ public record DemoApplication(CommandGateway commandGateway,
     }
 
     /**
-     * The names of every streaming event processor the given {@code configuration} registered, sorted so a run
-     * reports them predictably. A per-tenant implementation would have registered its processors here too, so
-     * reading them shows whether one processor really served every tenant.
+     * The names of every event processor the given {@code configuration} registered, sorted so a run reports
+     * them predictably. A per-tenant implementation would have registered its processors here too, so reading
+     * them shows whether one processor really served every tenant. Looked up by {@link EventProcessor} rather
+     * than a streaming-specific subtype, since persistent streams are subscribing processors.
      */
     private static List<String> registeredProcessorNames(AxonConfiguration configuration) {
-        return configuration.getComponents(StreamingEventProcessor.class)
+        return configuration.getComponents(EventProcessor.class)
                             .values()
                             .stream()
                             .map(EventProcessor::name)

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/run/DemoLifecycle.java
@@ -64,8 +64,9 @@ import java.util.stream.IntStream;
  * handler, the query handler, and the {@link CourseStatisticsProjection} alike.
  * <p>
  * Where each tenant has its own event store, the projection is where the tenants come back together: one
- * ordinary pooled streaming event processor consumes every tenant's events and writes each into the read model
- * of the tenant it came from. A read model is then eventually consistent rather than written by the command, so
+ * ordinary event processor consumes every tenant's events and writes each into the read model of the tenant it
+ * came from, whether it streams from the tenant-aware event store directly or from a persistent stream per
+ * tenant. A read model is then eventually consistent rather than written by the command, so
  * every observation of one below waits for it to catch up. On a shared event store the command handler fills it
  * instead, and those waits return at once.
  * <p>
@@ -470,7 +471,7 @@ public final class DemoLifecycle {
      * one per tenant. Springfield and Shelbyville hold the same course identifier, so a leak between them would
      * show up as a wrong count. Counts are read fresh here rather than reused from the waits above.
      *
-     * @param processorNames the names of every streaming event processor the application registered
+     * @param processorNames the names of every event processor the application registered
      * @param queryGateway the gateway the tenants' statistics are read on
      * @return the observed event-processing outcome
      */
@@ -484,7 +485,7 @@ public final class DemoLifecycle {
         int shelbyvilleProjected = StatisticsQueries.read(queryGateway, SHELBYVILLE).totalEnrollments();
         int ogdenvilleProjected = StatisticsQueries.read(queryGateway, OGDENVILLE).totalEnrollments();
         logger.info("""
-                    Three tenants were served by {} streaming event processor(s) {}. \
+                    Three tenants were served by {} event processor(s) {}. \
                     Projected enrollments per tenant: springfield={}, shelbyville={}, ogdenville={}""",
                     processorNames.size(), processorNames,
                     springfieldProjected, shelbyvilleProjected, ogdenvilleProjected);

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/MultiTenantPersistentStreams.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/shared/tenant/MultiTenantPersistentStreams.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy.shared.tenant;
+
+import io.axoniq.axonserver.connector.event.PersistentStreamProperties;
+import io.axoniq.framework.axonserver.connector.event.PersistentStreamScheduledExecutorBuilder;
+import io.axoniq.framework.axonserver.connector.event.PersistentStreamSequencingPolicy;
+import io.axoniq.framework.messaging.multitenancy.axonserver.eventstreaming.MultiTenantPersistentStreamEventSourceFactory;
+import org.axonframework.common.configuration.Configuration;
+import org.axonframework.messaging.core.SubscribableEventSource;
+
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * Builds the {@link SubscribableEventSource} the declarative demo hands to a subscribing processor to run it on
+ * a persistent stream, consumed from every tenant's own Axon Server context and fanned into that one processor.
+ * <p>
+ * The Spring Boot demo needs none of this: its starter fabricates the same kind of source from properties alone
+ * ({@code axon.axonserver.auto-persistent-streams-enabled} together with multi-tenancy on the classpath). The
+ * declarative demo has no such auto-configuration layer, so it builds the source itself, through the same
+ * {@link MultiTenantPersistentStreamEventSourceFactory} the Spring Boot starter uses underneath.
+ *
+ * @author Jakob Hatzl
+ * @since 5.3.0
+ */
+public final class MultiTenantPersistentStreams {
+
+    private static final int SEGMENT_COUNT = 1;
+    private static final int BATCH_SIZE = 10;
+
+    private MultiTenantPersistentStreams() {
+        // Utility class, not meant to be instantiated.
+    }
+
+    /**
+     * Builds the multi-tenant persistent stream source named {@code streamName}, one ordinary persistent stream
+     * per tenant under that same name in every tenant's context, fanned into a single consumer.
+     * <p>
+     * Each tenant's stream runs on a scheduler of its own, named after the stream and the tenant it serves, so a
+     * thread dump shows whose stream a thread is working on and a retrying tenant cannot starve the others.
+     *
+     * @param streamName    the name the stream carries in every tenant's Axon Server context
+     * @param configuration the started configuration to resolve the tenant provider and connector components from
+     * @return the multi-tenant {@link SubscribableEventSource} for the named stream
+     */
+    public static SubscribableEventSource eventSource(String streamName, Configuration configuration) {
+        Objects.requireNonNull(streamName, "The stream name must not be null");
+        Objects.requireNonNull(configuration, "The configuration must not be null");
+        PersistentStreamProperties properties = new PersistentStreamProperties(
+                streamName,
+                SEGMENT_COUNT,
+                PersistentStreamSequencingPolicy.SEQUENTIAL_POLICY,
+                Collections.emptyList(),
+                PersistentStreamProperties.TAIL_POSITION,
+                null);
+        return new MultiTenantPersistentStreamEventSourceFactory().build(
+                streamName,
+                properties,
+                poolName -> PersistentStreamScheduledExecutorBuilder.defaultFactory().build(SEGMENT_COUNT, poolName),
+                BATCH_SIZE,
+                configuration);
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/UniversityModuleConfiguration.java
@@ -17,6 +17,7 @@
 package org.axonframework.examples.demo.multitenancy.university;
 
 import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.examples.demo.multitenancy.shared.EventProcessingStyle;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourseConfiguration;
@@ -35,10 +36,8 @@ public final class UniversityModuleConfiguration {
     }
 
     /**
-     * Registers the write slices and the statistics read slice on the given {@code configurer}.
-     * <p>
-     * The given {@code backing} settles the one thing the two slices have to agree on: whichever of
-     * them fills the read model, the other leaves it alone, so an enrollment is never counted twice.
+     * Registers the write slices and the statistics read slice on the given {@code configurer}, with the
+     * projection processor run in {@link EventProcessingStyle#POOLED_STREAMING}.
      *
      * @param configurer the event sourcing configurer to register the domain on
      * @param backing    what backs this run
@@ -46,13 +45,31 @@ public final class UniversityModuleConfiguration {
      */
     public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
                                                     DemoBacking backing) {
+        return configure(configurer, backing, EventProcessingStyle.POOLED_STREAMING);
+    }
+
+    /**
+     * Registers the write slices and the statistics read slice on the given {@code configurer}.
+     * <p>
+     * The given {@code backing} settles the one thing the two slices have to agree on: whichever of
+     * them fills the read model, the other leaves it alone, so an enrollment is never counted twice. The given
+     * {@code streamingMode} settles how that projection processor is fed, and only matters where one runs at all.
+     *
+     * @param configurer    the event sourcing configurer to register the domain on
+     * @param backing       what backs this run
+     * @param streamingMode how the projection processor is fed, where the {@code backing} runs one
+     * @return the given {@code configurer}, for further configuring
+     */
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
+                                                    DemoBacking backing,
+                                                    EventProcessingStyle streamingMode) {
         // Recorded on the configuration, so what assembles the run afterwards reads the same backing this was
         // configured with rather than being told again and risking a different answer.
         configurer = configurer.componentRegistry(registry -> registry.registerComponent(DemoBacking.class,
                                                                                          config -> backing));
         configurer = OpenCourseConfiguration.configure(configurer);
         configurer = EnrollStudentConfiguration.configure(configurer, backing);
-        configurer = StatisticsConfiguration.configure(configurer, backing);
+        configurer = StatisticsConfiguration.configure(configurer, backing, streamingMode);
         return configurer;
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/StatisticsConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-core/src/main/java/org/axonframework/examples/demo/multitenancy/university/read/statistics/StatisticsConfiguration.java
@@ -18,16 +18,19 @@ package org.axonframework.examples.demo.multitenancy.university.read.statistics;
 
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.examples.demo.multitenancy.shared.EventProcessingStyle;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.MultiTenantPersistentStreams;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
 import org.axonframework.messaging.eventhandling.processing.streaming.pooled.PooledStreamingEventProcessorModule;
+import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorModule;
 import org.axonframework.messaging.queryhandling.configuration.QueryHandlingModule;
 
 /**
  * Registers the tenant-statistics read slice: the {@link TenantStatisticsQueryHandler}, whose
  * {@code @TenantScoped} parameters the framework injects with the query tenant's components, and, on a backing
  * whose tenants each have their own event store, the {@link CourseStatisticsProjection} and the processor
- * running it. The declarative demo calls {@link #configure(EventSourcingConfigurer, DemoBacking)}; the Spring
- * Boot demo declares the query handler as a bean and the processor through an
+ * running it. The declarative demo calls {@link #configure(EventSourcingConfigurer, DemoBacking, EventProcessingStyle)};
+ * the Spring Boot demo declares the query handler as a bean and the processor through an
  * {@code EventProcessorDefinition}, since a module bean holding an event processor is ignored on that path.
  */
 public final class StatisticsConfiguration {
@@ -38,13 +41,20 @@ public final class StatisticsConfiguration {
      */
     public static final String PROCESSOR_NAME = "Projection_CourseStatistics_Processor";
 
+    /**
+     * The name the persistent stream carries in every tenant's Axon Server context, when the projection
+     * processor runs in {@link EventProcessingStyle#PERSISTENT_STREAMS}.
+     */
+    public static final String PERSISTENT_STREAM_NAME = PROCESSOR_NAME + "-stream";
+
     private StatisticsConfiguration() {
         // Utility class, not meant to be instantiated.
     }
 
     /**
-     * Registers the statistics query handling module on the given {@code configurer}, and the projection
-     * processor when the given {@code backing} projects the read model.
+     * Registers the statistics query handling module on the given {@code configurer}, and, when the given
+     * {@code backing} projects the read model, the projection processor running it in
+     * {@link EventProcessingStyle#POOLED_STREAMING}.
      *
      * @param configurer the event sourcing configurer to register the read slice on
      * @param backing    what backs this run
@@ -52,24 +62,63 @@ public final class StatisticsConfiguration {
      */
     public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
                                                     DemoBacking backing) {
+        return configure(configurer, backing, EventProcessingStyle.POOLED_STREAMING);
+    }
+
+    /**
+     * Registers the statistics query handling module on the given {@code configurer}, and the projection
+     * processor when the given {@code backing} projects the read model, run in the given {@code streamingMode}.
+     *
+     * @param configurer   the event sourcing configurer to register the read slice on
+     * @param backing      what backs this run
+     * @param streamingMode how the projection processor is fed, ignored unless {@code backing} projects the
+     *                      read model
+     * @return the given {@code configurer}, for further configuring
+     */
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer,
+                                                    DemoBacking backing,
+                                                    EventProcessingStyle streamingMode) {
         configurer = configurer.registerQueryHandlingModule(queryModule());
         if (backing.projectsReadModel()) {
-            configurer = configurer.modelling(
-                    modelling -> modelling.messaging(
-                            messaging -> messaging.eventProcessing(
-                                    eventProcessing -> eventProcessing.pooledStreaming(
-                                            pooled -> pooled.processor(projectionProcessorModule())))));
+            configurer = switch (streamingMode) {
+                case POOLED_STREAMING -> configurer.modelling(
+                        modelling -> modelling.messaging(
+                                messaging -> messaging.eventProcessing(
+                                        eventProcessing -> eventProcessing.pooledStreaming(
+                                                pooled -> pooled.processor(pooledStreamingProcessorModule())))));
+                case PERSISTENT_STREAMS -> configurer.modelling(
+                        modelling -> modelling.messaging(
+                                messaging -> messaging.eventProcessing(
+                                        eventProcessing -> eventProcessing.subscribing(
+                                                subscribing -> subscribing.processor(
+                                                        persistentStreamProcessorModule())))));
+            };
         }
         return configurer;
     }
 
-    private static PooledStreamingEventProcessorModule projectionProcessorModule() {
+    private static PooledStreamingEventProcessorModule pooledStreamingProcessorModule() {
         return EventProcessorModule.pooledStreaming(PROCESSOR_NAME)
                                    .eventHandlingComponents(
                                            components -> components.autodetected(
                                                    "courseStatisticsProjection",
                                                    config -> new CourseStatisticsProjection()))
                                    .notCustomized();
+    }
+
+    /**
+     * Builds the same projection processor over a persistent stream, one per tenant fanned into this single
+     * subscribing processor by {@link MultiTenantPersistentStreams#eventSource}.
+     */
+    private static SubscribingEventProcessorModule persistentStreamProcessorModule() {
+        return EventProcessorModule.subscribing(PROCESSOR_NAME)
+                                   .eventHandlingComponents(
+                                           components -> components.autodetected(
+                                                   "courseStatisticsProjection",
+                                                   config -> new CourseStatisticsProjection()))
+                                   .customized((configuration, subscribing) -> subscribing.eventSource(
+                                           MultiTenantPersistentStreams.eventSource(PERSISTENT_STREAM_NAME,
+                                                                                    configuration)));
     }
 
     private static QueryHandlingModule queryModule() {

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/README.md
@@ -122,6 +122,17 @@ from the projection, and this run has none, so the log says the step is not show
 is where update isolation and completion are proven. A query is rejected the same way a command is when its
 tenant is unknown, removed, or not named at all.
 
+### Persistent streams instead of pooled streaming
+
+By default the projection processor is a pooled streaming processor reading the tenant-aware event store
+directly. Flip `demo.axon-server.persistent-streams.enabled` to `true` (alongside `demo.axon-server.enabled`)
+to run it as a subscribing processor instead, fed by an ordinary persistent stream opened in every tenant's
+own context and fanned into that single processor by the multi-tenant persistent stream support
+(`MultiTenantPersistentStreamEventSourceFactory`). The run is otherwise identical: it is still one processor
+serving every tenant, the tenant added at runtime still gets its own stream opened automatically, and step 6 of
+the log still reports one processor name. Unlike the pooled path, there is no token store and no processor
+restart when the tenant set changes: each tenant's stream opens and closes on its own as tenants come and go.
+
 ## The same demo, wired by Spring Boot
 
 The [Spring Boot demo](../university-multi-tenancy-springboot/README.md) proves the same behavior with

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/DemoProperties.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/DemoProperties.java
@@ -23,10 +23,13 @@ import java.util.Properties;
 /**
  * Runtime configuration toggles for the demo, loaded from {@code application.properties}.
  *
- * @param axonServerEnabled whether the demo should drive tenants from Axon Server contexts rather
- *                          than the bundled in-memory tenant provider
+ * @param axonServerEnabled        whether the demo should drive tenants from Axon Server contexts rather than the
+ *                                 bundled in-memory tenant provider
+ * @param persistentStreamsEnabled whether the course-statistics projection runs on a persistent stream instead of a
+ *                                 pooled streaming processor, only read while {@code axonServerEnabled} is
+ *                                 {@code true}
  */
-public record DemoProperties(boolean axonServerEnabled) {
+public record DemoProperties(boolean axonServerEnabled, boolean persistentStreamsEnabled) {
 
     /**
      * Loads the properties from the {@code application.properties} classpath resource, defaulting to
@@ -44,7 +47,8 @@ public record DemoProperties(boolean axonServerEnabled) {
             throw new IllegalStateException("Could not load application.properties", e);
         }
         return new DemoProperties(
-                Boolean.parseBoolean(properties.getProperty("demo.axon-server.enabled", "false"))
+                Boolean.parseBoolean(properties.getProperty("demo.axon-server.enabled", "false")),
+                Boolean.parseBoolean(properties.getProperty("demo.axon-server.persistent-streams.enabled", "false"))
         );
     }
 }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/MultiTenancyApplication.java
@@ -19,13 +19,13 @@ package org.axonframework.examples.demo.multitenancy;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.examples.demo.multitenancy.shared.EventProcessingStyle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoApplication;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.DemoTenantProvider;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantComponents;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.TenantProvisioning;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.slf4j.Logger;
@@ -58,7 +58,10 @@ public class MultiTenancyApplication {
         logger.info("Two providers for one component type are rejected at configuration time: {}",
                     ProviderAmbiguityGuardrail.rejectsTwoProvidersForOneType());
         MultiTenancyApplication demo = new MultiTenancyApplication();
-        DemoOutcome outcome = properties.axonServerEnabled() ? demo.runWithAxonServer() : demo.run();
+        EventProcessingStyle streamingMode = properties.persistentStreamsEnabled()
+                ? EventProcessingStyle.PERSISTENT_STREAMS
+                : EventProcessingStyle.POOLED_STREAMING;
+        DemoOutcome outcome = properties.axonServerEnabled() ? demo.runWithAxonServer(streamingMode) : demo.run();
         logger.info("Demo finished. Outcome: {}", outcome);
     }
 
@@ -87,19 +90,33 @@ public class MultiTenancyApplication {
     }
 
     /**
+     * Runs the demo end to end against Axon Server with the projection processor run in
+     * {@link EventProcessingStyle#POOLED_STREAMING}, sourcing the tenants from Axon Server contexts rather than
+     * from an in-memory provider. The lifecycle is identical to {@link #run()}, and the backing is the only
+     * difference. This path needs a running multi-context (Enterprise Edition) Axon Server, reachable on its
+     * default {@code localhost} address.
+     *
+     * @return the observed outcome of the demo run
+     */
+    public DemoOutcome runWithAxonServer() {
+        return runWithAxonServer(EventProcessingStyle.POOLED_STREAMING);
+    }
+
+    /**
      * Runs the demo end to end against Axon Server, sourcing the tenants from Axon Server contexts
      * rather than from an in-memory provider. The lifecycle is identical to {@link #run()}, and the
      * backing is the only difference. This path needs a running multi-context (Enterprise Edition)
      * Axon Server, reachable on its default {@code localhost} address.
      *
+     * @param streamingMode how the course-statistics projection processor is fed
      * @return the observed outcome of the demo run
      */
-    public DemoOutcome runWithAxonServer() {
+    public DemoOutcome runWithAxonServer(EventProcessingStyle streamingMode) {
         TenantComponentProvider<CourseStatisticsStore> statisticsProvider = TenantComponents.courseStatisticsProvider();
         TenantComponentProvider<AuditLog> auditProvider = TenantComponents.auditLogProvider();
 
         EventSourcingConfigurer configurer = EventSourcingConfigurer.create();
-        UniversityConfiguration.configureForAxonServer(configurer, statisticsProvider, auditProvider);
+        UniversityConfiguration.configureForAxonServer(configurer, statisticsProvider, auditProvider, streamingMode);
         AxonConfiguration configuration = configurer.build();
         configuration.start();
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -27,10 +27,11 @@ import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
+import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
+import org.axonframework.examples.demo.multitenancy.shared.EventProcessingStyle;
 import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.UniversityModuleConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
-import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
 
 import java.time.Duration;
 
@@ -102,9 +103,9 @@ public final class UniversityConfiguration {
      * a running multi-context (Enterprise Edition) Axon Server.
      * <p>
      * Because every tenant has its own event store here, the framework knows which tenant a streamed event
-     * came from, so this path fills the read model from a projection.
-     * One ordinary pooled streaming processor consumes every tenant's events, and no multi-tenancy wiring is
-     * needed to make it tenant-aware.
+     * came from, so this path fills the read model from a projection. One ordinary event processor consumes
+     * every tenant's events, run in the given {@code streamingMode}, and no multi-tenancy wiring is needed to
+     * make it tenant-aware.
      * <p>
      * This path also routes direct queries through the per-tenant connector rather than serving them from a
      * locally subscribed handler, so that {@code query()} dispatch is really exercised, not only made
@@ -113,14 +114,18 @@ public final class UniversityConfiguration {
      * @param configurer         the configurer to extend
      * @param statisticsProvider the provider of the per-tenant course-statistics stores
      * @param auditProvider      the provider of the per-tenant audit logs
+     * @param streamingMode      how the projection processor is fed
      */
     public static void configureForAxonServer(EventSourcingConfigurer configurer,
                                               TenantComponentProvider<CourseStatisticsStore> statisticsProvider,
-                                              TenantComponentProvider<AuditLog> auditProvider) {
-        UniversityModuleConfiguration.configure(configurer, DemoBacking.AXON_SERVER)
+                                              TenantComponentProvider<AuditLog> auditProvider,
+                                              EventProcessingStyle streamingMode) {
+        UniversityModuleConfiguration.configure(configurer, DemoBacking.AXON_SERVER, streamingMode)
                                      .componentRegistry(registry -> {
                                          registerTenantComponents(registry, statisticsProvider, auditProvider);
-                                         registerProcessorRestartTimeout(registry);
+                                         if (streamingMode == EventProcessingStyle.POOLED_STREAMING) {
+                                             registerProcessorRestartTimeout(registry);
+                                         }
                                          registerDirectQueryRouting(registry);
                                      });
     }

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/resources/application.properties
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/main/resources/application.properties
@@ -7,3 +7,8 @@
 #
 # This is a demo-only key, not a framework property. Axon Server's real toggle is axon.axonserver.enabled.
 demo.axon-server.enabled=false
+
+# Only read while the toggle above is true. Set to true to run the course-statistics projection on a
+# persistent stream, consumed from every tenant's own context and fanned into that one processor, instead
+# of the default pooled streaming processor reading the tenant-aware event store directly.
+demo.axon-server.persistent-streams.enabled=false

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-declarative/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoTest.java
@@ -27,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * per-tenant isolation, subscription-query isolation, the unknown-tenant guardrail on both commands
  * and queries, destroy on tenant removal, and cleanup on shutdown. The configuration-time ambiguity
  * guardrail is asserted separately.
+ * <p>
+ * This test only runs the in-memory path, so it exercises neither of the two {@code EventProcessingStyle}
+ * kinds the course-statistics projection can run in: both need each tenant to have its own event store, which
+ * only a real Axon Server provides. {@code MultiTenancyDemoIT} in the Spring Boot module covers both styles
+ * against a containerized Axon Server.
  */
 class MultiTenancyDemoTest {
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/README.md
@@ -16,40 +16,46 @@ application and its beans:
 
 ```
 org.axonframework.examples.demo.multitenancy
-+- MultiTenancyApplication   the @SpringBootApplication, no multi-tenancy wiring of its own
-+- UniversityConfiguration   the beans: providers, handlers, modules, projection, processor, stores, knobs
-+- DemoRunner                a CommandLineRunner that runs the lifecycle, then stops
++- MultiTenancyApplication              the @SpringBootApplication, no multi-tenancy wiring of its own
++- UniversityConfiguration              providers, handlers, modules, projection, and knobs shared by both processor variants
++- PooledStreamingProjectionConfiguration   the default: token store, and the pooled streaming processor
++- PersistentStreamProjectionConfiguration  the persistent-stream backed subscribing processor, run instead when a property says so
++- DemoRunner                           a CommandLineRunner that runs the lifecycle, then stops
 ```
 
-`UniversityConfiguration` declares one `TenantComponentProvider` bean per tenant-scoped component type,
-the statistics query handler, the event-sourced course as two module beans, and the projection processor,
-and nothing else. The enrollment command handler is registered with the course, so there is no separate
-handler bean for it. The starter's multi-tenancy auto-configuration picks the provider beans up, subscribes
-them to the tenant lifecycle, installs the tenant parameter resolver and interceptor, and registers the
-default auto-discovering `AxonServerTenantProvider`. The starter also registers the course module beans, so
-the course is sourced from and appended to its tenant's own event store, and snapshotted into that tenant's
-own snapshot store. There is no manual multi-tenancy wiring at all: the tenants are discovered from Axon
-Server's contexts (with `_admin` filtered out), exactly as in the declarative demo's Axon Server path.
+`UniversityConfiguration` declares one `TenantComponentProvider` bean per tenant-scoped component type, the statistics
+query handler, the event-sourced course as two module beans, and the projection itself (`CourseStatisticsProjection`).
+The enrollment command handler is registered with the course, so there is no separate handler bean for it. The starter's
+multi-tenancy auto-configuration picks the provider beans up, subscribes them to the tenant lifecycle, installs the
+tenant parameter resolver and interceptor, and registers the default auto-discovering
+`AxonServerTenantProvider`. The starter also registers the course module beans, so the course is sourced from and
+appended to its tenant's own event store, and snapshotted into that tenant's own snapshot store. There is no manual
+multi-tenancy wiring at all: the tenants are discovered from Axon Server's contexts (with `_admin` filtered out),
+exactly as in the declarative demo's Axon Server path.
 
-The projection processor bean is worth looking at for what it does not say. It names no tenant and declares no
-processor per tenant. A single one serves every tenant, because the auto-configuration makes the event store it
-streams from tenant-aware and re-opens that stream when the set of tenants changes.
-
-One bean is there purely to show a knob: `MultiTenantStreamingProcessorRestartConfiguration` bounds how long each
+Which processor runs that projection is a separate `@Configuration` class per variant.
+`PooledStreamingProjectionConfiguration`
+is the default, active whenever `PersistentStreamProjectionConfiguration` is not (see
+[Persistent streams instead of pooled streaming](#persistent-streams-instead-of-pooled-streaming) below). Its processor
+bean is worth looking at for what it does not say: it names no tenant and declares no processor per tenant. A single one
+serves every tenant, because the auto-configuration makes the event store it streams from tenant-aware and re-opens that
+stream when the set of tenants changes. Its
+`MultiTenantStreamingProcessorRestartConfiguration` bean is there purely to show a knob: it bounds how long that
 processor gets to stop and start when the set of tenants changes. The starter defaults it, so an application only
 declares it to raise it, which a deployment with slow-starting processors would.
 
-Another bean turns off preferring a locally subscribed query handler
+Another bean, back in `UniversityConfiguration`, turns off preferring a locally subscribed query handler
 (`DistributedQueryBusConfiguration.preferLocalQueryHandler(false)`). This whole demo runs in one process,
 where a query handler is always subscribed locally, so without this a direct query never reaches the per-tenant
 query connector, leaving that routing unshown. Correctness does not depend on it: the tenant is checked before
 dispatch either way. A subscription query always routes through the connector regardless.
 
-Two Spring specifics are worth knowing, since neither applies to the declarative demo. The processor is
-declared through an `EventProcessorDefinition`, because a `Module` bean holding an event processor is silently
-ignored on this path. And the token store bean has to be named exactly `tokenStore`, because Spring resolves a
-processor's token store by bean name and fails hard when that name is missing, where the declarative path
-resolves by type and falls back to an in-memory store.
+Two Spring specifics are worth knowing, since neither applies to the declarative demo. Each processor is declared
+through an `EventProcessorDefinition`, because a `Module` bean holding an event processor is silently ignored on this
+path. And the pooled streaming variant's token store bean has to be named exactly
+`tokenStore`, because Spring resolves a processor's token store by bean name and fails hard when that name is missing,
+where the declarative path resolves by type and falls back to an in-memory store. The subscribing variant needs no such
+bean: it tracks no position at all.
 
 ## Requires Axon Server
 
@@ -73,6 +79,15 @@ demo's job.
    walks the same steps as the declarative demo, so its
    [What to look for](../university-multi-tenancy-declarative/README.md#what-to-look-for) applies here
    too.
+
+## Persistent streams instead of pooled streaming
+
+Set `axon.axonserver.auto-persistent-streams-enabled=true` (see `application.yml`) to run the projection processor as a
+subscribing processor fed by a persistent stream instead of the default pooled streaming processor. This real framework
+property is reused in this demo to turn `PooledStreamingProjectionConfiguration` off and
+`PersistentStreamProjectionConfiguration` on. Because multi-tenancy is active, the starter's
+`MultiTenancyPersistentStreamAutoConfiguration` builds that stream through the multi-tenant persistent stream support,
+so it is really one ordinary stream per tenant, fanned into the single subscribing processor.
 
 ## The tests
 

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/PersistentStreamProjectionConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/PersistentStreamProjectionConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
+import org.axonframework.extension.spring.config.EventProcessorDefinition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Runs the course-statistics projection processor as a subscribing processor fed by a persistent stream,
+ * instead of {@link PooledStreamingProjectionConfiguration}'s default pooled streaming processor. Active while
+ * multi-tenancy and Axon Server are both on and {@code axon.axonserver.auto-persistent-streams-enabled=true}.
+ * <p>
+ * Guarded once at class level: the one bean here is the only thing this variant needs, and none of
+ * {@link PooledStreamingProjectionConfiguration}'s beans apply to it.
+ */
+@Configuration
+@ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+@ConditionalOnProperty(name = "axon.axonserver.auto-persistent-streams-enabled", havingValue = "true")
+public class PersistentStreamProjectionConfiguration {
+
+    /**
+     * The subscribing processor that projects every tenant's events over a persistent stream, running the same
+     * {@code UniversityConfiguration.courseStatisticsProjection()} bean.
+     * <p>
+     * No event source is set here: {@code axon.axonserver.auto-persistent-streams-enabled} (see
+     * {@code application.yml}) is what makes the starter fabricate one named after this processor, and because
+     * multi-tenancy is active, it builds that stream through the multi-tenant persistent stream support, one
+     * ordinary stream per tenant fanned into this single processor. That one property therefore both activates
+     * this configuration and supplies the processor's event source. Unlike the pooled streaming variant, this
+     * processor needs no token store, since a subscribing processor tracks no position at all.
+     *
+     * @return the course-statistics projection processor definition, run on a persistent stream
+     */
+    @Bean
+    public EventProcessorDefinition courseStatisticsPersistentStreamProcessor() {
+        return EventProcessorDefinition
+                .subscribing(StatisticsConfiguration.PROCESSOR_NAME)
+                .assigningHandlers(descriptor -> CourseStatisticsProjection.class.equals(descriptor.beanType()))
+                .notCustomized();
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/PooledStreamingProjectionConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/PooledStreamingProjectionConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.examples.demo.multitenancy;
+
+import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantStreamingProcessorRestartConfiguration;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
+import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
+import org.axonframework.extension.spring.config.EventProcessorDefinition;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Runs the course-statistics projection processor as the default pooled streaming processor, reading the
+ * tenant-aware event store directly. Active while multi-tenancy and Axon Server are both on, and
+ * {@code axon.axonserver.auto-persistent-streams-enabled} is not set to {@code true}; see
+ * {@link PersistentStreamProjectionConfiguration} for the alternative that property switches to.
+ * <p>
+ * Guarded once at class level, rather than on each bean, since every bean here exists for this one variant
+ * and none of them makes sense without the others.
+ */
+@Configuration
+@ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
+@ConditionalOnProperty(name = "axon.axonserver.auto-persistent-streams-enabled",
+                       havingValue = "false",
+                       matchIfMissing = true)
+public class PooledStreamingProjectionConfiguration {
+
+    // The framework's own default.
+    private static final Duration PROCESSOR_RESTART_TIMEOUT = Duration.ofSeconds(30);
+
+    /**
+     * The single token store tracking every tenant's position, which the pooled streaming processor needs.
+     * <p>
+     * One store serves every tenant, holding one position per tenant in a single token. A real deployment would
+     * use a persistent store so positions survive a restart.
+     * <p>
+     * The bean has to be named exactly {@code tokenStore}: Spring resolves a processor's token store by bean
+     * name, defaulting to that, and fails when no such bean exists. The declarative demo needs no equivalent.
+     *
+     * @return the token store shared by every tenant
+     */
+    @Bean
+    public TokenStore tokenStore() {
+        return new InMemoryTokenStore();
+    }
+
+    /**
+     * The pooled streaming processor that projects every tenant's events, running the
+     * {@code UniversityConfiguration.courseStatisticsProjection()} bean, reading the tenant-aware event store
+     * directly.
+     * <p>
+     * An ordinary processor definition: nothing here mentions a tenant, and none is defined per tenant. The
+     * multi-tenancy autoconfiguration makes the event store it streams from tenant-aware, and re-opens that
+     * stream when the set of tenants changes.
+     * <p>
+     * Declared through an {@link EventProcessorDefinition} because a {@code Module} bean holding an event
+     * processor is silently ignored on this path.
+     *
+     * @return the course-statistics projection processor definition
+     */
+    @Bean
+    public EventProcessorDefinition courseStatisticsProcessor() {
+        return EventProcessorDefinition
+                .pooledStreaming(StatisticsConfiguration.PROCESSOR_NAME)
+                .assigningHandlers(descriptor -> CourseStatisticsProjection.class.equals(descriptor.beanType()))
+                .notCustomized();
+    }
+
+    /**
+     * How long the processor above gets to stop and start again when the set of tenants changes.
+     * <p>
+     * A tenant change restarts a running pooled streaming processor, and this bounds how long it gets. The
+     * starter already registers a default, so declare this only to raise it for a deployment whose processor
+     * is slow to stop and start. Shown here at the default value. Not needed by
+     * {@link PersistentStreamProjectionConfiguration}: a persistent stream opens and closes each tenant's
+     * share of it independently, so nothing there ever restarts on a tenant change.
+     *
+     * @return the restart configuration bounding the processor's restart
+     */
+    @Bean
+    public MultiTenantStreamingProcessorRestartConfiguration processorRestartConfiguration() {
+        return MultiTenantStreamingProcessorRestartConfiguration.DEFAULT.restartTimeout(PROCESSOR_RESTART_TIMEOUT);
+    }
+}

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/java/org/axonframework/examples/demo/multitenancy/UniversityConfiguration.java
@@ -19,7 +19,6 @@ package org.axonframework.examples.demo.multitenancy;
 import io.axoniq.framework.messaging.multitenancy.api.TenantComponentProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.api.AxonServerTenantProvider;
 import io.axoniq.framework.messaging.multitenancy.axonserver.queryhandling.MultiTenantAxonServerQueryBusConnector;
-import io.axoniq.framework.messaging.multitenancy.configuration.MultiTenantStreamingProcessorRestartConfiguration;
 import io.axoniq.framework.messaging.queryhandling.distributed.DistributedQueryBusConfiguration;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.eventsourcing.snapshot.inmemory.InMemorySnapshotStore;
@@ -29,18 +28,12 @@ import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsProjection;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.axonframework.examples.demo.multitenancy.shared.DemoBacking;
-import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.TenantStatisticsQueryHandler;
 import org.axonframework.examples.demo.multitenancy.university.write.enrollstudent.EnrollStudentConfiguration;
 import org.axonframework.examples.demo.multitenancy.university.write.opencourse.OpenCourseConfiguration;
-import org.axonframework.extension.spring.config.EventProcessorDefinition;
-import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
-import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 
 /**
  * The whole multi-tenancy configuration a Spring Boot developer writes for the feature: declare one
@@ -56,12 +49,14 @@ import java.time.Duration;
  * each as a tenant (filtering out {@code _admin}). So
  * the framework hands each command and query handler the components of the message's tenant for their
  * {@code @TenantScoped} parameters, matched by type, with no explicit multi-tenancy wiring here at all.
+ * <p>
+ * The projection processor itself is declared here, but which kind runs it is not: that choice, and every
+ * bean specific to it, lives in {@link PooledStreamingProjectionConfiguration} or
+ * {@link PersistentStreamProjectionConfiguration}, whichever {@code axon.axonserver.auto-persistent-streams-enabled}
+ * selects.
  */
 @Configuration
 public class UniversityConfiguration {
-
-    // The framework's own default.
-    private static final Duration PROCESSOR_RESTART_TIMEOUT = Duration.ofSeconds(30);
 
     /**
      * The provider of per-tenant {@link CourseStatisticsStore} instances.
@@ -174,60 +169,6 @@ public class UniversityConfiguration {
     @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
     public CourseStatisticsProjection courseStatisticsProjection() {
         return new CourseStatisticsProjection();
-    }
-
-    /**
-     * The single token store tracking every tenant's position, which the projection processor needs.
-     * <p>
-     * One store serves every tenant, holding one position per tenant in a single token. A real deployment would
-     * use a persistent store so positions survive a restart.
-     * <p>
-     * The bean has to be named exactly {@code tokenStore}: Spring resolves a processor's token store by bean
-     * name, defaulting to that, and fails when no such bean exists. The declarative demo needs no equivalent.
-     *
-     * @return the token store shared by every tenant
-     */
-    @Bean
-    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
-    public TokenStore tokenStore() {
-        return new InMemoryTokenStore();
-    }
-
-    /**
-     * The one pooled streaming processor that projects every tenant's events, running the
-     * {@link #courseStatisticsProjection()} bean.
-     * <p>
-     * An ordinary processor definition: nothing here mentions a tenant, and none is defined per tenant. The
-     * multi-tenancy autoconfiguration makes the event store it streams from tenant-aware, and re-opens that
-     * stream when the set of tenants changes.
-     * <p>
-     * Declared through an {@link EventProcessorDefinition} because a {@code Module} bean holding an event
-     * processor is silently ignored on this path.
-     *
-     * @return the course-statistics projection processor definition
-     */
-    @Bean
-    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
-    public EventProcessorDefinition courseStatisticsProcessor() {
-        return EventProcessorDefinition
-                .pooledStreaming(StatisticsConfiguration.PROCESSOR_NAME)
-                .assigningHandlers(descriptor -> CourseStatisticsProjection.class.equals(descriptor.beanType()))
-                .notCustomized();
-    }
-
-    /**
-     * How long each processor gets to stop and start again when the set of tenants changes.
-     * <p>
-     * A tenant change restarts the running streaming event processors, and this bounds how long each one gets.
-     * The starter already registers a default, so declare this only to raise it for a deployment whose
-     * processors are slow to stop and start. Shown here at the default value.
-     *
-     * @return the restart configuration bounding each processor's restart
-     */
-    @Bean
-    @ConditionalOnExpression("${axon.multitenancy.enabled:true} and ${axon.axonserver.enabled:true}")
-    public MultiTenantStreamingProcessorRestartConfiguration processorRestartConfiguration() {
-        return MultiTenantStreamingProcessorRestartConfiguration.DEFAULT.restartTimeout(PROCESSOR_RESTART_TIMEOUT);
     }
 
     /**

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/resources/application.yml
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/main/resources/application.yml
@@ -6,6 +6,12 @@ axon:
   # one in a container.
   axonserver:
     enabled: true
+    # Set to true to run the course-statistics projection on a persistent stream, consumed from every
+    # tenant's own context and fanned into that one processor, instead of the default pooled streaming
+    # processor reading the tenant-aware event store directly. This same property is what switches
+    # PooledStreamingProjectionConfiguration off and PersistentStreamProjectionConfiguration on, so this one
+    # toggle both selects the configuration class and supplies its persistent stream.
+    auto-persistent-streams-enabled: false
 
 logging:
   level:

--- a/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
+++ b/examples/university-multi-tenancy-examples/university-multi-tenancy-springboot/src/test/java/org/axonframework/examples/demo/multitenancy/MultiTenancyDemoIT.java
@@ -23,19 +23,20 @@ import io.axoniq.framework.messaging.multitenancy.api.TenantProvider;
 import io.axoniq.framework.testcontainer.AxonServerContainer;
 import org.awaitility.Awaitility;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoApplication;
-import org.axonframework.examples.demo.multitenancy.shared.tenant.AxonServerTenantContextManager;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoLifecycle;
 import org.axonframework.examples.demo.multitenancy.shared.run.DemoOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.EventStorageOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.ProviderAmbiguityGuardrail;
 import org.axonframework.examples.demo.multitenancy.shared.run.SnapshottingOutcome;
 import org.axonframework.examples.demo.multitenancy.shared.run.StreamingOutcome;
-import org.axonframework.examples.demo.multitenancy.shared.audit.AuditLog;
+import org.axonframework.examples.demo.multitenancy.shared.tenant.AxonServerTenantContextManager;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.CourseStatisticsStore;
 import org.axonframework.examples.demo.multitenancy.university.read.statistics.StatisticsConfiguration;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -59,9 +60,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * shutdown. It also asserts that the {@code _admin} context is filtered out of the discovered tenants.
  * <p>
  * Being the Axon Server path, this is also where the per-tenant features the in-memory demo cannot show are
- * asserted: event-store and snapshot isolation, tenant-aware event processing, where one ordinary pooled
- * streaming processor projects every tenant's events into that tenant's own read model, and direct queries
- * actually routed through the per-tenant query connector rather than served from the local segment.
+ * asserted: event-store and snapshot isolation, tenant-aware event processing, where one ordinary event
+ * processor projects every tenant's events into that tenant's own read model, and direct queries actually
+ * routed through the per-tenant query connector rather than served from the local segment. The test runs
+ * twice, once per {@code EventProcessingStyle} the projection processor can run in: a pooled streaming
+ * processor reading the tenant-aware event store directly, and a subscribing processor fed by one persistent
+ * stream per tenant, fanned into that one processor. Both runs assert the exact same outcome; only the
+ * presence of the persistent stream itself tells them apart.
  * <p>
  * The application is booted directly rather than through {@code @SpringBootTest}, because the demo stops
  * the context as its final step and a managed test context must not be closed from within a test. The
@@ -70,7 +75,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * The test runs a licensed Enterprise Edition Axon Server in a container, so it needs Docker. The README
  * explains how the container is licensed, with a license file or an Axoniq Platform token. The test skips
- * itself when no license source is available.
+ * itself when no license source is available. The container is a fresh instance per run rather than one
+ * shared across the class, because both runs enroll the same fixed course identifiers into the same fixed
+ * tenant contexts; sharing a container would have the second run collide with events the first run left
+ * behind.
  */
 @Testcontainers
 @EnabledIf("axonServerLicensable")
@@ -140,8 +148,11 @@ class MultiTenancyDemoIT {
         return value;
     }
 
+    // a fresh container per parameterized run, so the persistent-streams run does not inherit
+    // event state the pooled-streaming run already wrote under the same fixed tenant contexts and course
+    // identifiers.
     @Container
-    private static final AxonServerContainer AXON_SERVER = licensedContainer();
+    private final AxonServerContainer axonServer = licensedContainer();
 
     // The license file wins over the token, so a repository CI run (which writes the license from a
     // secret) always boots from the license file. The token path is the local fallback for developers
@@ -163,14 +174,30 @@ class MultiTenancyDemoIT {
         return container;
     }
 
-    @Test
-    void runsTheTenantLifecycleEndToEnd() {
-        // given the autoconfigured Spring Boot application, booted against the containerized Axon Server
+    @ParameterizedTest(name = "runs the tenant lifecycle end to end (persistent streams enabled: {0})")
+    @ValueSource(booleans = {false, true})
+    void runsTheTenantLifecycleEndToEnd(boolean persistentStreamsEnabled) {
+        // given the autoconfigured Spring Boot application, booted against the containerized Axon Server,
+        // with the course-statistics projection running in the EventProcessingStyle this run tests. Passed as
+        // command-line arguments rather than SpringApplicationBuilder#properties: that method sets Spring
+        // Boot's lowest-precedence "defaultProperties", which can never override the explicit
+        // auto-persistent-streams-enabled: false already declared in application.yml
         try (ConfigurableApplicationContext context = new SpringApplicationBuilder(MultiTenancyApplication.class)
                 .web(WebApplicationType.NONE)
                 .profiles("test")
-                .properties("axon.axonserver.servers=" + AXON_SERVER.getAxonServerAddress())
-                .run()) {
+                .run("--axon.axonserver.servers=" + axonServer.getAxonServerAddress(),
+                     "--axon.axonserver.auto-persistent-streams-enabled=" + persistentStreamsEnabled)) {
+
+            // and the toggle activated the EventProcessingStyle this run tests: PersistentStreamProjectionConfiguration
+            // and PooledStreamingProjectionConfiguration are mutually exclusive @ConditionalOnProperty variants, each
+            // contributing one differently-named EventProcessorDefinition bean
+            if (persistentStreamsEnabled) {
+                assertThat(context.containsBean("courseStatisticsPersistentStreamProcessor")).isTrue();
+                assertThat(context.containsBean("courseStatisticsProcessor")).isFalse();
+            } else {
+                assertThat(context.containsBean("courseStatisticsProcessor")).isTrue();
+                assertThat(context.containsBean("courseStatisticsPersistentStreamProcessor")).isFalse();
+            }
 
             AxonConfiguration configuration = context.getBean(AxonConfiguration.class);
             TenantProvider tenantProvider = configuration.getComponent(TenantProvider.class);
@@ -237,8 +264,9 @@ class MultiTenancyDemoIT {
             assertThat(snapshotting.bothTenantsHoldOwnSnapshot()).isTrue();
             assertThat(snapshotting.snapshotsHoldTheirOwnStudents()).isTrue();
 
-            // and one ordinary pooled streaming processor projected every tenant's events, rather than one
-            // processor per tenant. Asserted by name, so a per-tenant processor would show up as an extra entry
+            // and one ordinary event processor projected every tenant's events, rather than one processor per
+            // tenant, regardless of whether it is fed by pooled streaming or a persistent stream. Asserted by
+            // name, so a per-tenant processor would show up as an extra entry
             StreamingOutcome streaming = outcome.streaming();
             assertThat(streaming.demonstrated()).isTrue();
             assertThat(streaming.processorNames()).containsExactly(StatisticsConfiguration.PROCESSOR_NAME);


### PR DESCRIPTION
## Summary

Adds an opt-in toggle to run the university multi-tenancy demo's course-statistics projection on a
persistent stream instead of the default pooled streaming processor, in both the declarative and Spring
Boot entry-point modules.

- Persistent streams are single-context (`PersistentStreamEventSource` implements `SubscribableEventSource`,
  not `StreamableEventSource`), but the multi-tenant persistent stream support
  (`MultiTenantPersistentStreamEventSourceFactory`/`MultiTenantPersistentStreamEventSource`) fans one ordinary
  stream per tenant into a single subscribing processor, so the demo's "one processor serves every tenant"
  story is unchanged either way.
- **Declarative module**: new `EventStreamingMode` enum threaded through `UniversityModuleConfiguration` /
  `StatisticsConfiguration`, picked via the `demo.axon-server.persistent-streams.enabled` property. A new
  `MultiTenantPersistentStreams` helper (core module) builds the multi-tenant source by hand, since this
  path has no auto-configuration layer to do it for it.
- **Spring Boot module**: the projection processor bean and its supporting beans are split out of
  `UniversityConfiguration` into `PooledStreamingProjectionConfiguration` and
  `PersistentStreamProjectionConfiguration`, each guarded once at class level rather than per bean. Toggling
  is done entirely through the real framework property `axon.axonserver.auto-persistent-streams-enabled` (no
  demo-only property here) — the starter's `MultiTenancyPersistentStreamAutoConfiguration` already fabricates
  the multi-tenant stream from that property alone.
- Fixed `DemoApplication.registeredProcessorNames()`, which looked up `StreamingEventProcessor` and so missed
  a subscribing processor entirely (it doesn't extend that interface); now looks up `EventProcessor`.
- Updated the parent and both entry-point READMEs to document the new toggle.