### PR TITLE
Ensure `Message#payloadAs(TypeReference)` honors parameterized type contained in `TypeReference`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
@@ -177,6 +177,11 @@ public class GenericMessage extends AbstractMessage {
     }
 
     @Override
+    public @Nullable <T> T payloadAs(TypeReference<T> type) {
+        return payloadAs(type.getType(), this.converter);
+    }
+
+    @Override
     @Nullable
     public <T> T payloadAs(Type type, @Nullable Converter converter) {
         //noinspection rawtypes,unchecked

--- a/messaging/src/main/java/org/axonframework/messaging/core/Message.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/Message.java
@@ -180,7 +180,10 @@ public interface Message {
      */
     @Nullable
     default <T> T payloadAs(TypeReference<T> type) {
-        return payloadAs(type.getTypeAsClass());
+        Type targetType = type.getType();
+        return targetType instanceof Class<?>
+                ? payloadAs(type.getTypeAsClass())
+                : payloadAs(targetType, null);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageDecorator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageDecorator.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.core;
 
 import org.jspecify.annotations.Nullable;
+import org.axonframework.common.TypeReference;
 import org.axonframework.conversion.Converter;
 
 import java.lang.reflect.Type;
@@ -65,6 +66,12 @@ public abstract class MessageDecorator implements Message {
     @Override
     @Nullable
     public <T> T payloadAs(Class<T> type) {
+        return delegate.payloadAs(type);
+    }
+
+    @Override
+    @Nullable
+    public <T> T payloadAs(TypeReference<T> type) {
         return delegate.payloadAs(type);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTestSuite.java
@@ -25,6 +25,7 @@ import org.axonframework.conversion.Converter;
 import org.junit.jupiter.api.*;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +51,8 @@ public abstract class MessageTestSuite<M extends Message> {
     private static final TypeReference<byte[]> BYTE_ARRAY_TYPE_REF = new TypeReference<>() {
     };
     private static final TypeReference<String> STRING_TYPE_REFERENCE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<Integer>> PARAMETERIZED_LIST_TYPE_REF = new TypeReference<>() {
     };
 
     /**
@@ -239,6 +242,14 @@ public abstract class MessageTestSuite<M extends Message> {
         M testSubject = buildMessage(STRING_PAYLOAD);
 
         assertThatThrownBy(() -> testSubject.payloadAs(BYTE_ARRAY_TYPE_REF, null))
+                .isExactlyInstanceOf(ConversionException.class);
+    }
+
+    @Test
+    void payloadAsWithParameterizedTypeReferencePreservesGenericTypeInsteadOfRawClass() {
+        M testSubject = buildMessage(List.of("a", "b"));
+
+        assertThatThrownBy(() -> testSubject.payloadAs(PARAMETERIZED_LIST_TYPE_REF))
                 .isExactlyInstanceOf(ConversionException.class);
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.messaging.queryhandling;
 
 import org.axonframework.common.TypeReference;
+import org.axonframework.conversion.TestConverter;
 import org.axonframework.messaging.core.FluxUtils;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
@@ -114,7 +115,9 @@ class FutureAsResponseTypeToQueryHandlersTest {
 
         Flux<List<String>> response = FluxUtils.of(queryBus.subscriptionQuery(testQuery, null, 50))
                                                .map(MessageStream.Entry::message)
-                                               .mapNotNull(m -> m.payloadAs(LIST_OF_STRINGS));
+                                               .mapNotNull(m -> m.payloadAs(
+                                                       LIST_OF_STRINGS, TestConverter.JACKSON.getConverter()
+                                               ));
         queryBus.completeSubscriptions(s -> true, null);
         StepVerifier.create(response)
                     .expectNext(asList("Response1", "Response2"))


### PR DESCRIPTION
This pull request adjusts the `Message`, `GenericMessage`, and `MessageDecorator`, alongside introducing a test case. 
What is does, is ensuring that a parameterized type inside `TypeReference` is honored when invoking `Message#payloadAs(TypeReference)`. 

To that end, the `Message#payloadAs(TypeReference)` checks if the contained `Type` is a `Class`. 
If it's a `Class`, we can pass through to `Message#payloadAs(Class)`. 
If not, we should pass through to `Message#payloadAs(Type, Converter)`. 
In `Message`, that means the `Converter` will become `null` for this latter flow. 

On top of that, the `GenericMessage#payloadAs(TypeReference)` needs to be overridden, as otherwise this flow will not use the `Converter` when present. 
This similarly requires the `MessageDecorator` to be adjusted.

In doing so, this PR resolves #4874