### PR TITLE
[#4879] Create intercepting event store transaction per context

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStore.java
@@ -76,7 +76,6 @@ public class InterceptingEventStore implements EventStore {
     private final InterceptingEventBus delegateBus;
 
     private final Context.ResourceKey<EventStoreTransaction> delegateTransactionKey;
-    private final Context.ResourceKey<EventStoreTransaction> interceptingTransactionKey;
 
     /**
      * Constructs a {@code InterceptingEventStore}, delegating all operation to the given {@code delegate}.
@@ -91,7 +90,6 @@ public class InterceptingEventStore implements EventStore {
     public InterceptingEventStore(EventStore delegate,
                                   List<MessageDispatchInterceptor<? super EventMessage>> interceptors) {
         this.delegateTransactionKey = Context.ResourceKey.withLabel("delegateTransaction");
-        this.interceptingTransactionKey = Context.ResourceKey.withLabel("interceptingTransaction");
 
         this.delegate = Objects.requireNonNull(delegate, "The EventStore may not be null.");
         this.interceptors = Objects.requireNonNull(interceptors, "The dispatch interceptors must not be null.");
@@ -100,15 +98,17 @@ public class InterceptingEventStore implements EventStore {
         this.delegateBus = new InterceptingEventBus(delegate, interceptors);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The returned transaction is bound to the given {@code processingContext} and is therefore constructed anew on
+     * every invocation. Only the delegate transaction is shared for the processing session.
+     */
     @Override
     public EventStoreTransaction transaction(ProcessingContext processingContext) {
         // Set the delegate transaction to ensure the InterceptingAppender can reach the correct EventStoreTransaction.
         EventStoreTransaction delegateTransaction = getAndSetDelegateTransaction(processingContext);
-        // Set the intercepting transaction to ensure subsequent transaction operation receive the same intercepting transaction.
-        return processingContext.computeResourceIfAbsent(
-                interceptingTransactionKey,
-                () -> new InterceptingEventStoreTransaction(processingContext, delegateTransaction)
-        );
+        return new InterceptingEventStoreTransaction(processingContext, delegateTransaction);
     }
 
     /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/InterceptingEventStoreTest.java
@@ -18,10 +18,12 @@ package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.common.util.MockException;
+import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageDispatchInterceptor;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.ResourceOverridingProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
@@ -35,6 +37,7 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -229,6 +232,39 @@ class InterceptingEventStoreTest {
         assertThat(result).isDone();
         assertThat(result).isCompletedExceptionally();
         assertThat(result.exceptionNow()).isInstanceOf(MockException.class);
+    }
+
+    @Nested
+    class SiblingContextBranches {
+
+        @Test
+        void appendIsInterceptedWithTheContextItsTransactionWasRequestedFor() {
+            // given a batch context with two sibling branches, as an event processor creates them per message
+            when(eventStore.transaction(any())).thenReturn(eventStoreTransaction);
+            Context.ResourceKey<String> handledMessageKey = Context.ResourceKey.withLabel("handledMessage");
+            List<String> interceptedMessages = new ArrayList<>();
+            InterceptingEventStore testSubject = new InterceptingEventStore(
+                    eventStore,
+                    List.of((message, context, chain) -> {
+                        interceptedMessages.add(context.getResource(handledMessageKey));
+                        return chain.proceed(message, context);
+                    })
+            );
+            ProcessingContext batchContext = new StubProcessingContext();
+            ProcessingContext firstBranch =
+                    new ResourceOverridingProcessingContext<>(batchContext, handledMessageKey, "first");
+            ProcessingContext secondBranch =
+                    new ResourceOverridingProcessingContext<>(batchContext, handledMessageKey, "second");
+
+            // when appending an event through the transaction of each branch
+            testSubject.transaction(firstBranch)
+                       .appendEvent(new GenericEventMessage(TEST_EVENT_TYPE, "first"));
+            testSubject.transaction(secondBranch)
+                       .appendEvent(new GenericEventMessage(TEST_EVENT_TYPE, "second"));
+
+            // then each append is intercepted with the branch its transaction was requested for
+            assertThat(interceptedMessages).containsExactly("first", "second");
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #4879

The event store cached one intercepting transaction per processing session, and it kept a reference to the context that first created it. In a processor batch, events appended for messages after the first were then intercepted with the first message's context, giving them the wrong correlation and causation ids. The transaction is now created fresh per context.
