### PR TITLE
[#4882] Pace stream reopens after empty clean completions

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -756,6 +756,7 @@ class Coordinator {
         private final AtomicBoolean interruptibleScheduledGate = new AtomicBoolean();
         private @Nullable MessageStream<? extends EventMessage> eventStream;
         private AtomicBoolean eventStreamDeliveredEvents = new AtomicBoolean();
+        private AtomicBoolean eventStreamClosedByCoordinator = new AtomicBoolean();
         private TrackingToken lastScheduledToken = NoToken.INSTANCE;
         private boolean availabilityCallbackSupported;
         private long unclaimedSegmentValidationThreshold;
@@ -1027,6 +1028,10 @@ class Coordinator {
          */
         private void closeStreamQuietly() {
             if (eventStream != null) {
+                // Closing a stream that has not completed yet completes it, which invokes its availability callback.
+                // Marking the close as this coordinator's own keeps that callback from reading it as a source ending
+                // the stream.
+                eventStreamClosedByCoordinator.set(true);
                 try {
                     eventStream.close();
                 } catch (Exception e) {
@@ -1224,25 +1229,30 @@ class Coordinator {
                             StreamingCondition.conditionFor(startStreamingFrom, eventCriteria), null
                     );
                     AtomicBoolean deliveredEvents = new AtomicBoolean();
+                    AtomicBoolean closedByCoordinator = new AtomicBoolean();
                     eventStream = stream;
                     eventStreamDeliveredEvents = deliveredEvents;
+                    eventStreamClosedByCoordinator = closedByCoordinator;
                     logger.debug(
                             "Processor [{}] (Coordination Task [{}]) opened stream with tracking token [{}] and criteria [{}].",
                             name, generation, startStreamingFrom, eventCriteria
                     );
                     availabilityCallbackSupported = true;
                     stream.setCallback(() -> {
-                        if (stream.isCompleted() && !deliveredEvents.get()) {
+                        if (stream.isCompleted() && !deliveredEvents.get() && !closedByCoordinator.get()) {
                             // The callback fires on completion, and at registration time on an already completed
-                            // stream. A stream that ended without ever delivering an event holds nothing to act on, so
-                            // replacing it at once would open the next one as fast as the coordinator runs at all.
-                            // Pacing it the way a failed stream is paced keeps that down to a retry.
+                            // stream. A stream a source ended without ever delivering an event holds nothing to act
+                            // on, so replacing it at once would open the next one as fast as the coordinator runs at
+                            // all. Pacing it the way a failed stream is paced keeps that down to a retry. The work
+                            // packages extend their claim on the coordination run this schedules, so it may never be
+                            // delayed past the point where those claims need extending.
+                            long delay = Math.min(errorWaitBackOff, claimExtensionThreshold);
                             logger.trace(
                                     "Processor [{}] (Coordination Task [{}]). Stream completed without delivering "
                                             + "events. Scheduling coordination task (itself) with delay of {}ms.",
-                                    name, generation, errorWaitBackOff
+                                    name, generation, delay
                             );
-                            scheduleCoordinationTask(errorWaitBackOff);
+                            scheduleCoordinationTask(delay);
                             return;
                         }
                         logger.trace(

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -755,6 +755,7 @@ class Coordinator {
         private final AtomicBoolean scheduledGate = new AtomicBoolean();
         private final AtomicBoolean interruptibleScheduledGate = new AtomicBoolean();
         private @Nullable MessageStream<? extends EventMessage> eventStream;
+        private AtomicBoolean eventStreamDeliveredEvents = new AtomicBoolean();
         private TrackingToken lastScheduledToken = NoToken.INSTANCE;
         private boolean availabilityCallbackSupported;
         private long unclaimedSegmentValidationThreshold;
@@ -1219,15 +1220,31 @@ class Coordinator {
                         ? CompletableFuture.completedFuture(trackingToken)
                         : eventSource.firstToken(null);
                 return startPositionFuture.thenAccept(startStreamingFrom -> {
-                    eventStream = eventSource.open(
+                    MessageStream<? extends EventMessage> stream = eventSource.open(
                             StreamingCondition.conditionFor(startStreamingFrom, eventCriteria), null
                     );
+                    AtomicBoolean deliveredEvents = new AtomicBoolean();
+                    eventStream = stream;
+                    eventStreamDeliveredEvents = deliveredEvents;
                     logger.debug(
                             "Processor [{}] (Coordination Task [{}]) opened stream with tracking token [{}] and criteria [{}].",
                             name, generation, startStreamingFrom, eventCriteria
                     );
                     availabilityCallbackSupported = true;
-                    eventStream.setCallback(() -> {
+                    stream.setCallback(() -> {
+                        if (stream.isCompleted() && !deliveredEvents.get()) {
+                            // The callback fires on completion, and at registration time on an already completed
+                            // stream. A stream that ended without ever delivering an event holds nothing to act on, so
+                            // replacing it at once would open the next one as fast as the coordinator runs at all.
+                            // Pacing it the way a failed stream is paced keeps that down to a retry.
+                            logger.trace(
+                                    "Processor [{}] (Coordination Task [{}]). Stream completed without delivering "
+                                            + "events. Scheduling coordination task (itself) with delay of {}ms.",
+                                    name, generation, errorWaitBackOff
+                            );
+                            scheduleCoordinationTask(errorWaitBackOff);
+                            return;
+                        }
                         logger.trace(
                                 "Processor [{}] (Coordination Task [{}]). Events became available (callback triggered). "
                                         + "Scheduling immediate coordination task (itself).",
@@ -1277,7 +1294,11 @@ class Coordinator {
             if (eventStream == null) {
                 return null;
             }
-            return eventStream.next().orElse(null);
+            MessageStream.Entry<? extends EventMessage> entry = eventStream.next().orElse(null);
+            if (entry != null) {
+                eventStreamDeliveredEvents.set(true);
+            }
+            return entry;
         }
 
         private boolean hasNextEvent() {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -1134,10 +1134,17 @@ class PooledStreamingEventProcessorTest {
 
         @Test
         void doesNotSpinWhenTheSourceKeepsHandingOutCompletedStreams() throws InterruptedException {
-            // given - a source that only ever returns completed streams, so every reopen attempt is futile
+            // given - a source that only ever returns completed streams, so every reopen attempt is futile. The
+            //         coordinator gets the single thread it runs on in production, as a second one lets a reopen
+            //         scheduled from the availability callback land while the run that opened the stream still holds
+            //         the processing gate, which drops it and hides the pace the reopens are scheduled at.
+            coordinatorExecutor = new DelegateScheduledExecutorService(Executors.newSingleThreadScheduledExecutor());
+            withTestSubject(List.of(recordingComponent), c -> c.initialSegmentCount(1));
             AtomicInteger openCount = new AtomicInteger();
             doAnswer(invocation -> {
                 openCount.incrementAndGet();
+                // A completed stream invokes the availability callback the moment the coordinator registers one,
+                // which is the notification a source ending every stream it hands out keeps repeating.
                 return MessageStream.empty();
             }).when(stubMessageSource).open(any(), isNull());
 


### PR DESCRIPTION
Fixes #4882

An already completed stream fires the coordinator's availability callback the moment it is registered, and the coordinator reopened at once. A source handing back only completed streams looped at full speed and hammered the token store. Such a stream now waits a short, bounded delay. Reopens after a delivery, or after the coordinator closes a stream itself, stay immediate.