### PR TITLE
[#4883] Turn synchronous subscriber failures into failed publication results

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSubscribers.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/EventSubscribers.java
@@ -85,6 +85,9 @@ class EventSubscribers implements DescribableComponent {
      * Notifies all subscribers with the given events and processing context.
      * <p>
      * All subscriber futures are executed in parallel and the returned future completes when all of them complete.
+     * <p>
+     * A failing subscriber never stops the remaining subscribers from being notified. Whether it returns a failed
+     * future or throws, its failure is reported through the returned future.
      *
      * @param events  The list of events to notify subscribers about.
      * @param context The {@link ProcessingContext} associated with the events, may be {@code null}.
@@ -95,10 +98,22 @@ class EventSubscribers implements DescribableComponent {
             @Nullable ProcessingContext context
     ) {
         var consumeFutures = subscribers.stream()
-                                        .map(subscriber -> subscriber.apply(events, context))
+                                        .map(subscriber -> notify(subscriber, events, context))
                                         .toArray(CompletableFuture[]::new);
 
         return CompletableFuture.allOf(consumeFutures);
+    }
+
+    private static CompletableFuture<?> notify(
+            BiFunction<List<? extends EventMessage>, ProcessingContext, CompletableFuture<?>> subscriber,
+            List<? extends EventMessage> events,
+            @Nullable ProcessingContext context
+    ) {
+        try {
+            return subscriber.apply(events, context);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
@@ -230,6 +230,54 @@ class SimpleEventBusTest {
             assertThat(laterListener.getReceivedEvents()).hasSize(1);
             assertThat(publishResult).isCompletedExceptionally();
         }
+
+        @Test
+        void publishReportsSynchronousSubscriberFailureThroughReturnedFuture() {
+            // given
+            RuntimeException failure = new RuntimeException("subscriber threw");
+            testSubject.subscribe((events, context) -> {
+                throw failure;
+            });
+            RecordingEventListener laterListener = new RecordingEventListener();
+            testSubject.subscribe(laterListener);
+
+            // when - a subscriber throwing must not surface at the publishing call site
+            CompletableFuture<Void> publishResult = testSubject.publish(null, List.of(newEvent("event1")));
+
+            // then - the throw is carried by the publication future and the later subscriber still received the event
+            assertThat(publishResult)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .havingCause()
+                    .isEqualTo(failure);
+            assertThat(laterListener.getReceivedEvents()).hasSize(1);
+        }
+
+        @Test
+        void firstFailureIsReportedWhenMultipleSubscribersThrowSynchronously() {
+            // given
+            RuntimeException firstFailure = new RuntimeException("first subscriber threw");
+            RuntimeException secondFailure = new RuntimeException("second subscriber threw");
+            testSubject.subscribe((events, context) -> {
+                throw firstFailure;
+            });
+            testSubject.subscribe((events, context) -> {
+                throw secondFailure;
+            });
+            RecordingEventListener laterListener = new RecordingEventListener();
+            testSubject.subscribe(laterListener);
+
+            // when
+            CompletableFuture<Void> publishResult = testSubject.publish(null, List.of(newEvent("event1")));
+
+            // then - the failure of the first throwing subscriber is reported, the remaining ones still ran
+            assertThat(publishResult)
+                    .failsWithin(Duration.ZERO)
+                    .withThrowableThat()
+                    .havingCause()
+                    .isEqualTo(firstFailure);
+            assertThat(laterListener.getReceivedEvents()).hasSize(1);
+        }
     }
 
     @Nested
@@ -368,11 +416,9 @@ class SimpleEventBusTest {
             uow.runOnInvocation(ctx -> testSubject.publish(ctx, List.of(newEvent("event1"))));
             CompletableFuture<Void> result = uow.execute();
 
-            // then
+            // then - the throwing subscriber fails the UnitOfWork without hiding the event from the next subscriber
             assertThat(result).isCompletedExceptionally();
-            // When exception is thrown, the entire UnitOfWork fails and no events are committed
-            // The exception prevents event processing from completing, so listeners may or may not receive events
-            // The key assertion is that the UnitOfWork completed exceptionally
+            assertThat(recordingListener.getReceivedEvents()).hasSize(1);
         }
 
         @Test


### PR DESCRIPTION
Fixes #4883

A subscriber that threw instead of returning a failed future let that exception escape the publish call, and it also stopped the loop, so subscribers registered after it never got the event. Each subscriber call is now guarded: a throw becomes a failed future for that subscriber and is reported through the publication future.
