### PR TITLE
[#4880] Branch StubProcessingContext resources instead of mutating the shared context

### DIFF
--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStoreTest.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.snapshot.store.tracing;
 
 import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.Context;
 import org.axonframework.messaging.tracing.support.TestSpanFactory;
 import org.axonframework.messaging.tracing.support.TestSpanFactory.TestSpanType;
 import org.axonframework.eventsourcing.eventstore.Position;
@@ -73,13 +74,16 @@ class TracingSnapshotStoreTest {
         void threadsProcessingContextToTheDelegate() {
             // given - the pc is what lets the span nest under the surrounding entity-source trace
             QualifiedName name = new QualifiedName("Booking");
-            ProcessingContext context = new StubProcessingContext();
+            Context.ResourceKey<String> marker = Context.ResourceKey.withLabel("marker");
+            StubProcessingContext context = new StubProcessingContext();
+            context.putResource(marker, "store-marker");
 
             // when
             joinAndUnwrap(testSubject.store(name, "room-42", aSnapshot(), context));
 
-            // then
-            assertThat(delegate.storeContext).isSameAs(context);
+            // then - the delegate may receive a branch of the given context, never an unrelated one
+            assertThat(delegate.storeContext).isNotNull();
+            assertThat(delegate.storeContext.getResource(marker)).isEqualTo("store-marker");
         }
     }
 
@@ -104,13 +108,16 @@ class TracingSnapshotStoreTest {
         void threadsProcessingContextToTheDelegate() {
             // given
             QualifiedName name = new QualifiedName("Booking");
-            ProcessingContext context = new StubProcessingContext();
+            Context.ResourceKey<String> marker = Context.ResourceKey.withLabel("marker");
+            StubProcessingContext context = new StubProcessingContext();
+            context.putResource(marker, "load-marker");
 
             // when
             joinAndUnwrap(testSubject.load(name, "room-42", context));
 
-            // then
-            assertThat(delegate.loadContext).isSameAs(context);
+            // then - the delegate may receive a branch of the given context, never an unrelated one
+            assertThat(delegate.loadContext).isNotNull();
+            assertThat(delegate.loadContext.getResource(marker)).isEqualTo("load-marker");
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/core/interception/CorrelationDataInterceptorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/interception/CorrelationDataInterceptorTest.java
@@ -101,7 +101,8 @@ class CorrelationDataInterceptorTest {
 
         verify(providerOne).correlationDataFor(TEST_MESSAGE);
         verify(providerTwo).correlationDataFor(TEST_MESSAGE);
-        verify(handlerInterceptorChain)
-                .proceed(TEST_MESSAGE, testContext.withResource(CORRELATION_DATA, expectedCorrelationData));
+        ArgumentCaptor<ProcessingContext> contextCaptor = ArgumentCaptor.forClass(ProcessingContext.class);
+        verify(handlerInterceptorChain).proceed(eq(TEST_MESSAGE), contextCaptor.capture());
+        assertThat(contextCaptor.getValue().getResource(CORRELATION_DATA)).isEqualTo(expectedCorrelationData);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
@@ -46,6 +46,9 @@ import java.util.function.UnaryOperator;
 
 /**
  * Stubbed implementation of the {@link ProcessingContext} used for testing purposes.
+ * <p>
+ * The {@code putResource}/{@code updateResource}/{@code removeResource} operations mutate this instance, while
+ * {@link #withResource(ResourceKey, Object)} branches: it returns a new context and leaves this one untouched.
  *
  * @author Allard Buijze
  */
@@ -151,13 +154,6 @@ public class StubProcessingContext implements ProcessingContext {
     public <T> T getResource(@NonNull ResourceKey<T> key) {
         //noinspection unchecked
         return (T) resources.get(key);
-    }
-
-    @Override
-    public <T> @NonNull ProcessingContext withResource(@NonNull ResourceKey<T> key,
-                                              @NonNull T resource) {
-        resources.put(key, resource);
-        return this;
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/tracing/TracingEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/tracing/TracingEventHandlingComponentTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,8 +125,8 @@ class TracingEventHandlingComponentTest {
             EventMessage firstEvent = new GenericEventMessage(new MessageType("FirstEvent"), "first");
             EventMessage secondEvent = new GenericEventMessage(new MessageType("SecondEvent"), "second");
 
-            // when both handlers enter concurrently; the context coordinates the former check-then-put path so both
-            // observe the absent batch-span resource before either proceeds
+            // when both handlers enter concurrently; the context holds both back until each has observed the absent
+            // batch-span initializer, so they race for it
             try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
                 CompletableFuture<Void> firstHandling =
                         CompletableFuture.runAsync(() -> streamingSubject.handle(firstEvent, context), executor);
@@ -207,18 +208,17 @@ class TracingEventHandlingComponentTest {
 
         private static final class CoordinatedBatchProcessingContext extends StubProcessingContext {
 
-            private static final String BATCH_SPAN_RESOURCE_LABEL =
-                    "org.axonframework.messaging.tracing.batchSpan";
+            private static final String BATCH_SPAN_INITIALIZER_LABEL =
+                    "org.axonframework.messaging.tracing.batchSpanInitializer";
 
             private final CyclicBarrier absentBatchSpanReads = new CyclicBarrier(2);
 
             @Override
-            public <T> T getResource(Context.ResourceKey<T> key) {
-                T resource = super.getResource(key);
-                if (resource == null && BATCH_SPAN_RESOURCE_LABEL.equals(key.label())) {
+            public <T> T computeResourceIfAbsent(Context.ResourceKey<T> key, Supplier<T> resourceSupplier) {
+                if (BATCH_SPAN_INITIALIZER_LABEL.equals(key.label()) && !containsResource(key)) {
                     awaitConcurrentBatchSpanRead();
                 }
-                return resource;
+                return super.computeResourceIfAbsent(key, resourceSupplier);
             }
 
             private void awaitConcurrentBatchSpanRead() {


### PR DESCRIPTION
Fixes #4880

StubProcessingContext#withResource put the resource in its own map and returned itself, so a resource meant for one branch became visible to every holder of the context. It now inherits the branching default, matching production. This removes a flake in TracingEventHandlingComponentTest where a span scope leaked between threads.
