### PR TITLE
[#4886] Let loadOrCreate create through a cached not-found entry

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElseGet;
 
 /**
  * {@link Repository} implementation which manages event-sourced entities and delegates
@@ -196,11 +195,35 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
         ).thenApply(
                 entity -> {
                     if (create && entity.entity() == null) {
-                        throw requireNonNullElseGet(failureRef.get(), () -> new EntityNotFoundException(identifier));
+                        EntityNotFoundException failure = failureRef.get();
+                        if (failure != null) {
+                            throw failure;
+                        }
+                        initializeIfAbsent(identifier, context, entity);
                     }
                     return entity;
                 }
         );
+    }
+
+    /**
+     * Initializes the state of the given {@code entity} through the
+     * {@link EntityLifecycleHandler#initialize(Object, ProcessingContext) lifecycle handler}, unless it already holds
+     * state.
+     * <p>
+     * The given {@link EventSourcedEntity} instance is kept, so callers already holding a reference to it observe the
+     * initialized state as well.
+     *
+     * @param identifier the identifier of the entity to initialize
+     * @param context    the {@link ProcessingContext} to initialize the entity in
+     * @param entity     the managed entity to initialize the state of
+     * @throws EntityNotFoundException when the entity cannot be constructed from its identifier alone
+     */
+    private void initializeIfAbsent(ID identifier,
+                                    ProcessingContext context,
+                                    EventSourcedEntity<ID, E> entity) {
+        E initialized = lifecycleHandler.initialize(identifier, context);
+        entity.applyStateChange(current -> current != null ? current : initialized);
     }
 
     /**

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -42,6 +42,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.UnaryOperator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -260,24 +262,90 @@ class EventSourcingRepositoryTest {
         assertEquals("test(created)", secondResult.entity());
     }
 
-    @Test
-    void loadThenLoadOrCreateReusesCachedEntityWithoutInvokingInitialize() {
-        ProcessingContext processingContext = new StubProcessingContext();
-        eventsToLoad = List.of();
+    @Nested
+    class LoadAndLoadOrCreateWithinOneProcessingContext {
 
-        // load() caches a ManagedEntity with a null entity() for "test", without ever invoking initialize(...)
-        ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
-        assertNull(loaded.entity());
+        private final ProcessingContext processingContext = new StubProcessingContext();
 
-        // loadOrCreate() for the same identifier, within the same context, reuses that cached future instead of
-        // recomputing it, so initialize(...) is never invoked for this identifier.
-        CompletableFuture<ManagedEntity<String, String>> result =
-                testSubject.loadOrCreate("test", processingContext);
+        @BeforeEach
+        void noEventsForTheIdentifier() {
+            eventsToLoad = List.of();
+        }
 
-        ExecutionException exception = assertThrows(ExecutionException.class, result::get);
-        assertInstanceOf(EntityNotFoundException.class, exception.getCause());
+        @Test
+        void loadOrCreateAfterNotFoundLoadCreatesThroughTheLifecycleHandler() {
+            // given a load reporting the entity as missing, without invoking initialize(...)
+            when(handler.initialize("test", processingContext)).thenReturn("test()");
 
-        verify(handler, never()).initialize(eq("test"), eq(processingContext));
+            ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
+            assertThat(loaded.entity()).isNull();
+
+            // when loadOrCreate follows for the same identifier in the same context
+            ManagedEntity<String, String> created = testSubject.loadOrCreate("test", processingContext).join();
+
+            // then the entity was created, on the very same managed instance the earlier load handed out
+            assertThat(created.entity()).isEqualTo("test()");
+            assertThat(created).isSameAs(loaded);
+            assertThat(loaded.entity()).isEqualTo("test()");
+        }
+
+        @Test
+        void loadOrCreateAfterNotFoundLoadFailsWhenTheEntityRequiresAFirstEvent() {
+            // given an entity that cannot be constructed from its identifier alone
+            when(handler.initialize("test", processingContext)).thenThrow(new EntityNotFoundException("test"));
+
+            ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
+            assertThat(loaded.entity()).isNull();
+
+            // when loadOrCreate follows for the same identifier in the same context
+            CompletableFuture<ManagedEntity<String, String>> result =
+                    testSubject.loadOrCreate("test", processingContext);
+
+            // then it fails, leaving the managed instance available for the first appended event to evolve
+            assertThatThrownBy(result::join).hasCauseInstanceOf(EntityNotFoundException.class);
+            assertThat(loaded.entity()).isNull();
+        }
+
+        @Test
+        void loadAfterLoadOrCreateObservesTheCreatedEntity() {
+            // given loadOrCreate created the entity
+            when(handler.initialize("test", processingContext)).thenReturn("test()");
+
+            ManagedEntity<String, String> created = testSubject.loadOrCreate("test", processingContext).join();
+
+            // when load follows for the same identifier in the same context
+            ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
+
+            // then both calls describe the same managed entity
+            assertThat(loaded).isSameAs(created);
+            assertThat(loaded.entity()).isEqualTo("test()");
+        }
+
+        @Test
+        void repeatedLoadOrCreateCreatesTheEntityOnlyOnce() {
+            // given a first loadOrCreate creating the entity
+            when(handler.initialize("test", processingContext)).thenReturn("test()");
+
+            ManagedEntity<String, String> first = testSubject.loadOrCreate("test", processingContext).join();
+
+            // when loadOrCreate is invoked again for the same identifier in the same context
+            ManagedEntity<String, String> second = testSubject.loadOrCreate("test", processingContext).join();
+
+            // then the cached entity is returned without creating a second instance
+            assertThat(second).isSameAs(first);
+            assertThat(second.entity()).isEqualTo("test()");
+            verify(handler, times(1)).initialize("test", processingContext);
+        }
+
+        @Test
+        void loadOfMissingEntityDoesNotInvokeTheLifecycleHandlerInitialization() {
+            // when loading an identifier without events
+            ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
+
+            // then the managed entity holds no state and no creation was attempted
+            assertThat(loaded.entity()).isNull();
+            verify(handler, never()).initialize(any(), any());
+        }
     }
 
     private static boolean conditionPredicate(SourcingCondition condition) {


### PR DESCRIPTION
Fixes #4886

Loading an entity that does not exist caches a placeholder for the rest of the unit of work. A loadOrCreate for that same id then found the placeholder, skipped the entity factory and failed, even though a plain loadOrCreate would have created the entity. It now creates through that cached placeholder, so the result no longer depends on call order.
