### PR TITLE
[#4881] Judge stored progress on both bounds of a range token

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -501,11 +501,9 @@ class WorkPackage implements SegmentProgressContext {
     /**
      * Stores {@code safe}, keeping the stored {@link TrackingToken} monotonic. A {@code null} or already-stored token
      * is ignored. A token that does not
-     * {@link TrackingTokenUtils#coversWhenUnwrapped(TrackingToken, TrackingToken) cover} the last
-     * stored token (whether a strict regression or an <em>incomparable</em> position, such as a
-     * partially-regressed multi-source token where one source advanced while another fell behind) is ignored with a
-     * warning rather than persisted, so a misbehaving component can never rewind progress on any source. A concluding
-     * replay is still recognized as an advance, as the coverage is judged on the unwrapped positions.
+     * {@link TrackingTokenUtils#coversWhenUnwrapped(TrackingToken, TrackingToken) cover} the last stored token on both
+     * ends of its range is ignored with a warning rather than persisted, so a misbehaving component can never rewind
+     * progress on any source, nor rewind the position streaming resumes from.
      */
     private CompletableFuture<Void> storeIfAdvanced(@Nullable TrackingToken safe, ProcessingContext ctx) {
         if (safe == null || safe.equals(lastStoredToken)) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtils.java
@@ -66,22 +66,27 @@ public abstract class TrackingTokenUtils {
 
     /**
      * Indicates whether {@code candidate} represents a position at or beyond {@code reference}, comparing the raw
-     * {@link WrappedToken#unwrapUpperBound(TrackingToken) unwrapped} upper-bound positions rather than the tokens
-     * directly.
+     * {@link WrappedToken#unwrapLowerBound(TrackingToken) unwrapped} lower-bound and
+     * {@link WrappedToken#unwrapUpperBound(TrackingToken) upper-bound} positions rather than the tokens directly.
      * <p>
-     * Unwrapping keeps the comparison robust when a replay concludes: {@code reference} may still be a
-     * {@link ReplayToken} while {@code candidate} is the plain stream token it advances to, and a direct
-     * {@code candidate.covers(reference)} would then either throw (the raw token type rejecting the wrapped one) or
-     * report a false regression. Comparing the unwrapped positions reports that transition as an advance, while still
-     * returning {@code false} for a genuine regression or an incomparable token (such as a partially-regressed
-     * multi-source token).
+     * A wrapped token may describe a range, of which both ends must cover {@code reference} to count as an advance. An
+     * unwrapped end that is absent on {@code candidate} is never an advance; absent on {@code reference} it leaves
+     * nothing to regress from.
      *
      * @param candidate the token whose position is tested
      * @param reference the token to compare against
-     * @return {@code true} if {@code candidate} covers {@code reference} once both are unwrapped to their raw
-     * upper-bound positions
+     * @return {@code true} if both ends of {@code candidate} cover the matching ends of {@code reference} once
+     * unwrapped to their raw positions
      */
     public static boolean coversWhenUnwrapped(TrackingToken candidate, TrackingToken reference) {
-        return WrappedToken.unwrapUpperBound(candidate).covers(WrappedToken.unwrapUpperBound(reference));
+        return covers(WrappedToken.unwrapUpperBound(candidate), WrappedToken.unwrapUpperBound(reference))
+                && covers(WrappedToken.unwrapLowerBound(candidate), WrappedToken.unwrapLowerBound(reference));
+    }
+
+    private static boolean covers(@Nullable TrackingToken candidate, @Nullable TrackingToken reference) {
+        if (reference == null) {
+            return true;
+        }
+        return candidate != null && candidate.covers(reference);
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.progress.T
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.Segment;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.TrackerStatus;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.GlobalSequenceTrackingToken;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.MergedTrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
@@ -427,6 +428,43 @@ class WorkPackageTest {
                 any(ProcessingContext.class)
         );
         assertEquals(new GlobalSequenceTrackingToken(5L), fetchStoredToken());
+    }
+
+    @Test
+    void persistProgressIgnoresAMergedTokenThatRewindsTheResumePosition() {
+        // given: the stored token has advanced to position 600
+        persistProgressInUnitOfWork(new GlobalSequenceTrackingToken(600L));
+        assertEquals(new GlobalSequenceTrackingToken(600L), fetchStoredToken());
+        clearInvocations(tokenStore);
+
+        // when: a merged range is persisted whose furthest half is ahead but which resumes from the start of the stream
+        TrackingToken rewinding =
+                MergedTrackingToken.merged(TrackingToken.FIRST, new GlobalSequenceTrackingToken(700L));
+        persistProgressInUnitOfWork(rewinding);
+
+        // then: the rewinding range is ignored, not stored, and the advanced token is retained
+        verify(tokenStore, never()).storeToken(
+                eq(rewinding), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any(ProcessingContext.class)
+        );
+        assertEquals(new GlobalSequenceTrackingToken(600L), fetchStoredToken());
+    }
+
+    @Test
+    void persistProgressIgnoresATokenWithoutAPositionInsteadOfFailing() {
+        // given: the stored token has advanced to position 600
+        persistProgressInUnitOfWork(new GlobalSequenceTrackingToken(600L));
+        assertEquals(new GlobalSequenceTrackingToken(600L), fetchStoredToken());
+        clearInvocations(tokenStore);
+
+        // when: a freshly created reset token, which has no current position at all, is persisted
+        TrackingToken freshReset = ReplayToken.createReplayToken(new GlobalSequenceTrackingToken(600L));
+        persistProgressInUnitOfWork(freshReset);
+
+        // then: the token without a position is ignored, not stored, and the advanced token is retained
+        verify(tokenStore, never()).storeToken(
+                eq(freshReset), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any(ProcessingContext.class)
+        );
+        assertEquals(new GlobalSequenceTrackingToken(600L), fetchStoredToken());
     }
 
     private void persistProgressInUnitOfWork(TrackingToken candidate) {

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/token/TrackingTokenUtilsTest.java
@@ -157,5 +157,59 @@ class TrackingTokenUtilsTest {
             // when / then -- comparing unwrapped upper-bound positions reports the transition as an advance
             assertThat(TrackingTokenUtils.coversWhenUnwrapped(token(5), replaying)).isTrue();
         }
+
+        @Test
+        void reportsAdvanceWhenAConcludingReplayIsTheCandidate() {
+            // given -- the candidate concludes a replay at a position beyond the plain reference
+            TrackingToken concluding = ReplayToken.createReplayToken(token(5), token(4));
+
+            // when / then
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(concluding, token(3))).isTrue();
+        }
+
+        @Test
+        void reportsFalseWhenTheLowerHalfOfAMergedCandidateRegresses() {
+            // given -- a merged range whose furthest half is ahead, but which resumes from the start of the stream
+            TrackingToken rewinding = MergedTrackingToken.merged(TrackingToken.FIRST, token(7));
+
+            // when / then -- the resume position falls behind the reference, so this is not an advance
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(rewinding, token(6))).isFalse();
+        }
+
+        @Test
+        void reportsTrueWhenBothHalvesOfAMergedCandidateAreAhead() {
+            // given -- a merged range entirely beyond the reference
+            TrackingToken advancing = MergedTrackingToken.merged(token(7), token(9));
+
+            // when / then
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(advancing, token(6))).isTrue();
+        }
+
+        @Test
+        void reportsFalseWhenTheUpperHalfOfAMergedCandidateIsBehind() {
+            // given -- the furthest half of the merged range has not reached the reference
+            TrackingToken behind = MergedTrackingToken.merged(token(2), token(4));
+
+            // when / then
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(behind, token(6))).isFalse();
+        }
+
+        @Test
+        void reportsFalseWhenTheCandidateHasNoPositionYet() {
+            // given -- a freshly created reset token, which has no current position at all
+            TrackingToken freshReset = ReplayToken.createReplayToken(token(5));
+
+            // when / then -- an unset position is not an advance, and must not throw
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(freshReset, token(3))).isFalse();
+        }
+
+        @Test
+        void reportsAdvanceWhenTheReferenceHasNoPositionYet() {
+            // given -- the reference is a freshly created reset token, which has no current position at all
+            TrackingToken freshReset = ReplayToken.createReplayToken(token(5));
+
+            // when / then -- there is no progress to regress from, so the candidate advances beyond it
+            assertThat(TrackingTokenUtils.coversWhenUnwrapped(token(3), freshReset)).isTrue();
+        }
     }
 }


### PR DESCRIPTION
Fixes #4881

The guard keeping stored progress moving forward only looked at a token's upper bound. A merged token holds two halves and its upper bound is the furthest one, so a merged token whose other half had rewound was still stored, moving the segment's resume position back. It now checks both bounds, and a token with no position is skipped with a warning instead of throwing.
