### PR TITLE
[#4884 & #4885] Fine tune emit-and-count flow of `QueryUpdateEmitter` and `QueryBus`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
@@ -147,6 +147,9 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * to.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query to which delivery of the update fails (for example due to a full update buffer) is
+     * excluded from this count, even though that failure still terminates the subscription.
      *
      * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
      *                       will only be sent to subscription queries matching this filter
@@ -186,6 +189,8 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * the given {@code filter}, returning the number of subscription queries that were completed.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which completion fails is excluded from this count.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed
@@ -224,6 +229,8 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * that were completed exceptionally.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which the exceptional completion fails to be delivered is excluded from this count.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed exceptionally

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -119,7 +119,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits the outcome of the {@code updateSupplier} to subscription queries matching the given {@code queryType} and
      * given {@code filter}, returning the number of subscription queries the update was emitted to.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryType      the type of the {@link QueryMessage} to filter on
      * @param filter         a predicate to filter matching subscription queries based on the
@@ -179,7 +179,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Emits the outcome of the {@code updateSupplier} to subscription queries matching the given {@code queryName} and
      * given {@code filter}, returning the number of subscription queries the update was emitted to.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryName      the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter         a predicate to filter matching subscription queries based on the raw
@@ -216,7 +216,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Completes subscription queries matching the given {@code queryType} and {@code filter}, returning the number of
      * subscription queries that were completed.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryType the type of the {@link QueryMessage} to filter on.
      * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
@@ -247,7 +247,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Completes subscription queries matching the given {@code queryName} and {@code filter}, returning the number of
      * subscription queries that were completed.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter    a predicate testing the raw {@link QueryMessage#payload()} as is
@@ -281,7 +281,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Completes subscription queries with the given {@code cause} matching given {@code queryType} and {@code filter},
      * returning the number of subscription queries that were completed exceptionally.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryType the type of the {@link QueryMessage} to filter on
      * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
@@ -319,7 +319,7 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * Completes subscription queries with the given {@code cause} matching given {@code queryName} and {@code filter},
      * returning the number of subscription queries that were completed exceptionally.
      * <p>
-     * Implementations that cannot determine this number return {@link QueryBus#UNKNOWN_MATCH_COUNT} instead.
+     * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      *
      * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter    a predicate to filter matching subscription queries based on the raw

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryUpdateEmitter.java
@@ -120,6 +120,9 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * given {@code filter}, returning the number of subscription queries the update was emitted to.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query to which delivery of the update fails (for example due to a full update buffer) is
+     * excluded from this count, even though that failure still terminates the subscription.
      *
      * @param queryType      the type of the {@link QueryMessage} to filter on
      * @param filter         a predicate to filter matching subscription queries based on the
@@ -180,6 +183,9 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * given {@code filter}, returning the number of subscription queries the update was emitted to.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query to which delivery of the update fails (for example due to a full update buffer) is
+     * excluded from this count, even though that failure still terminates the subscription.
      *
      * @param queryName      the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter         a predicate to filter matching subscription queries based on the raw
@@ -217,6 +223,8 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * subscription queries that were completed.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which completion fails is excluded from this count.
      *
      * @param queryType the type of the {@link QueryMessage} to filter on.
      * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
@@ -248,6 +256,8 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * subscription queries that were completed.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which completion fails is excluded from this count.
      *
      * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter    a predicate testing the raw {@link QueryMessage#payload()} as is
@@ -282,6 +292,8 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * returning the number of subscription queries that were completed exceptionally.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which the exceptional completion fails to be delivered is excluded from this count.
      *
      * @param queryType the type of the {@link QueryMessage} to filter on
      * @param filter    a predicate to filter matching subscription queries based on the {@link QueryMessage#payload()}
@@ -320,6 +332,8 @@ public interface QueryUpdateEmitter extends DescribableComponent {
      * returning the number of subscription queries that were completed exceptionally.
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
+     * <p>
+     * A subscription query for which the exceptional completion fails to be delivered is excluded from this count.
      *
      * @param queryName the qualified name of the {@link QueryMessage#type()} to filter on
      * @param filter    a predicate to filter matching subscription queries based on the raw

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -259,17 +259,19 @@ public class SimpleQueryBus implements QueryBus {
                               .filter(entry -> filter.test(entry.getKey()))
                               .toList();
 
-        matchingHandlers.forEach(entry -> {
+        int completedCount = 0;
+        for (Map.Entry<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> entry : matchingHandlers) {
             QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler = entry.getValue();
             try {
                 updateHandler.seal();
+                completedCount++;
             } catch (Exception e) {
                 updateHandler.sealExceptionally(e);
             }
             updateHandlers.remove(entry.getKey(), updateHandler);
-        });
+        }
 
-        return matchingHandlers.size();
+        return completedCount;
     }
 
     @Override
@@ -297,9 +299,14 @@ public class SimpleQueryBus implements QueryBus {
                               .filter(entry -> filter.test(entry.getKey()))
                               .toList();
 
-        matchingHandlers.forEach(entry -> emitError(entry.getValue(), cause, entry.getKey()));
+        int completedCount = 0;
+        for (Map.Entry<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> entry : matchingHandlers) {
+            if (emitError(entry.getValue(), cause, entry.getKey())) {
+                completedCount++;
+            }
+        }
 
-        return matchingHandlers.size();
+        return completedCount;
     }
 
     /**
@@ -349,14 +356,16 @@ public class SimpleQueryBus implements QueryBus {
                                    .count();
     }
 
-    private void emitError(QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler,
-                           Throwable cause,
-                           QueryMessage query) {
+    private boolean emitError(QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler,
+                              Throwable cause,
+                              QueryMessage query) {
         try {
             updateHandler.sealExceptionally(cause);
+            return true;
         } catch (Exception e) {
             logger.error("An error happened while trying to inform an update handler about the error. Query: {}",
                          query);
+            return false;
         }
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -202,23 +203,30 @@ public class SimpleQueryBus implements QueryBus {
         return runAfterCommitOrImmediately(context, filter, () -> emitUpdate(filter, updateSupplier));
     }
 
-    private void emitUpdate(Predicate<QueryMessage> filter,
-                            Supplier<SubscriptionQueryUpdateMessage> updateSupplier) {
+    private int emitUpdate(Predicate<QueryMessage> filter,
+                           Supplier<SubscriptionQueryUpdateMessage> updateSupplier) {
+        int deliveredCount = 0;
         Map<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> matchingHandlers =
                 updateHandlers.entrySet()
                               .stream()
                               .filter(entry -> filter.test(entry.getKey()))
                               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         if (matchingHandlers.isEmpty()) {
-            return;
+            return deliveredCount;
         }
 
         SubscriptionQueryUpdateMessage update = updateSupplier.get();
-        matchingHandlers.forEach((query, updateHandler) -> {
+        for (Map.Entry<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> entry
+                : matchingHandlers.entrySet()) {
+            QueryMessage query = entry.getKey();
+            QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler = entry.getValue();
             try {
-                if (!updateHandler.offer(update, Context.empty())) {
-                    updateHandler.sealExceptionally(new QueryExecutionException("Subscription update buffer overflow",
-                                                                                null));
+                if (updateHandler.offer(update, Context.empty())) {
+                    deliveredCount++;
+                } else {
+                    updateHandler.sealExceptionally(new QueryExecutionException(
+                            "Subscription update buffer overflow", null
+                    ));
                     updateHandlers.remove(query, updateHandler);
                 }
             } catch (Exception e) {
@@ -228,7 +236,8 @@ public class SimpleQueryBus implements QueryBus {
                 updateHandler.sealExceptionally(e);
                 updateHandlers.remove(query, updateHandler);
             }
-        });
+        }
+        return deliveredCount;
     }
 
     @Override
@@ -243,19 +252,24 @@ public class SimpleQueryBus implements QueryBus {
         return runAfterCommitOrImmediately(context, filter, () -> completeSubscriptions(filter));
     }
 
-    private void completeSubscriptions(Predicate<QueryMessage> filter) {
-        updateHandlers.entrySet()
-                      .stream()
-                      .filter(entry -> filter.test(entry.getKey()))
-                      .forEach(entry -> {
-                          QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler = entry.getValue();
-                          try {
-                              updateHandler.seal();
-                          } catch (Exception e) {
-                              updateHandler.sealExceptionally(e);
-                          }
-                          updateHandlers.remove(entry.getKey(), updateHandler);
-                      });
+    private int completeSubscriptions(Predicate<QueryMessage> filter) {
+        List<Map.Entry<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>>> matchingHandlers =
+                updateHandlers.entrySet()
+                              .stream()
+                              .filter(entry -> filter.test(entry.getKey()))
+                              .toList();
+
+        matchingHandlers.forEach(entry -> {
+            QueueMessageStream<SubscriptionQueryUpdateMessage> updateHandler = entry.getValue();
+            try {
+                updateHandler.seal();
+            } catch (Exception e) {
+                updateHandler.sealExceptionally(e);
+            }
+            updateHandlers.remove(entry.getKey(), updateHandler);
+        });
+
+        return matchingHandlers.size();
     }
 
     @Override
@@ -276,39 +290,52 @@ public class SimpleQueryBus implements QueryBus {
         return runAfterCommitOrImmediately(context, filter, () -> completeSubscriptionsExceptionally(filter, cause));
     }
 
-    private void completeSubscriptionsExceptionally(Predicate<QueryMessage> filter, Throwable cause) {
-        updateHandlers.entrySet()
-                      .stream()
-                      .filter(entry -> filter.test(entry.getKey()))
-                      .forEach(entry -> emitError(entry.getValue(), cause, entry.getKey()));
+    private int completeSubscriptionsExceptionally(Predicate<QueryMessage> filter, Throwable cause) {
+        List<Map.Entry<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>>> matchingHandlers =
+                updateHandlers.entrySet()
+                              .stream()
+                              .filter(entry -> filter.test(entry.getKey()))
+                              .toList();
+
+        matchingHandlers.forEach(entry -> emitError(entry.getValue(), cause, entry.getKey()));
+
+        return matchingHandlers.size();
     }
 
     /**
-     * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits, matching
-     * {@code updateTask}'s matching subscriptions to the given {@code filter}.
+     * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits,
+     * matching {@code updateTask}'s subscriptions to the given {@code filter}.
      * <p>
-     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not for an
-     * already-errored {@code context}, since the update is silently dropped in that case and the {@code filter} must
-     * not observe any side effects.
+     * When run immediately, the returned count reflects the actual outcome of the {@code updateTask} - e.g. the
+     * number of subscribers an update was successfully delivered to, as opposed to the number of subscribers merely
+     * matching the {@code filter} before delivery was attempted.
+     * <p>
+     * When deferred to after commit, the {@code updateTask} itself runs later and its outcome is not available to
+     * this method. In that case, the returned count is a match count against the given {@code filter}, computed at
+     * call time - not the outcome of the eventual {@code updateTask} run - since waiting for that outcome would
+     * require blocking until after the given {@code context} commits, which could deadlock a caller invoking this
+     * from within that same commit pipeline.
+     * <p>
+     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not
+     * for an already-errored {@code context}, since the update is silently dropped in that case and the
+     * {@code filter} must not observe any side effects.
      */
     private CompletableFuture<OptionalInt> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
                                                                        Predicate<QueryMessage> filter,
-                                                                       Runnable updateTask) {
+                                                                       IntSupplier updateTask) {
         if (context == null || context.isCommitted()) {
-            int matchCount = matchCount(filter);
-            updateTask.run();
-            return CompletableFuture.completedFuture(OptionalInt.of(matchCount));
+            return CompletableFuture.completedFuture(OptionalInt.of(updateTask.getAsInt()));
         } else if (!context.isCompleted()) {
             int matchCount = matchCount(filter);
             context.computeResourceIfAbsent(
                            UPDATE_TASKS_KEY,
                            () -> {
-                               List<Runnable> subscriptionQueryTask = new ArrayList<>();
-                               context.runOnAfterCommit(c -> subscriptionQueryTask.forEach(Runnable::run));
-                               return subscriptionQueryTask;
+                               List<Runnable> subscriptionQueryTasks = new ArrayList<>();
+                               context.runOnAfterCommit(c -> subscriptionQueryTasks.forEach(Runnable::run));
+                               return subscriptionQueryTasks;
                            }
                    )
-                   .add(updateTask);
+                   .add(updateTask::getAsInt);
             return CompletableFuture.completedFuture(OptionalInt.of(matchCount));
         }
         // else: context completed with error - drop the update

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -717,6 +717,33 @@ class SimpleQueryBusTest {
             // then...
             assertThat(matchCountRef.get()).isEqualTo(1);
         }
+
+        @Test
+        void emitUpdateReturningCountExcludesSubscriptionsWhoseUpdateBufferOverflowed() {
+            // given...
+            QueryMessage testQueryWithFullBuffer = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryWithRoom = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryWithFullBuffer.identifier())
+                            || query.identifier().equals(testQueryWithRoom.identifier());
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            SubscriptionQueryUpdateMessage updateMessage =
+                    new GenericSubscriptionQueryUpdateMessage(UPDATE_PAYLOAD_TYPE, UPDATE_PAYLOAD);
+            testSubject.subscriptionQuery(testQueryWithFullBuffer, null, 1);
+            testSubject.subscriptionQuery(testQueryWithRoom, null, Queues.SMALL_BUFFER_SIZE);
+            // Fill the single-slot buffer so the next update to it overflows.
+            testSubject.emitUpdate(query -> query.identifier().equals(testQueryWithFullBuffer.identifier()),
+                                   () -> updateMessage,
+                                   null)
+                       .join();
+            // when...
+            Integer deliveredCount = testSubject.emitUpdateAndCount(queryFilter, () -> updateMessage, null)
+                                                .orTimeout(1, TimeUnit.SECONDS)
+                                                .join()
+                                                .orElseThrow();
+            // then only the subscription with buffer room actually received the update...
+            assertThat(deliveredCount).isEqualTo(1);
+        }
     }
 
     @Nested

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.QueueMessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.TransactionalUnitOfWorkFactory;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -33,6 +34,7 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -903,6 +906,30 @@ class SimpleQueryBusTest {
             // then...
             assertThat(matchCount).isZero();
         }
+
+        @Test
+        void completeSubscriptionsReturningCountExcludesSubscriptionsWhoseSealFailed() {
+            // given...
+            QueryMessage testQueryThatFailsToSeal = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryThatSealsFine = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryThatFailsToSeal.identifier())
+                            || query.identifier().equals(testQueryThatSealsFine.identifier());
+            testSubject.subscriptionQuery(testQueryThatFailsToSeal, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryThatSealsFine, null, Queues.SMALL_BUFFER_SIZE);
+            QueueMessageStream<SubscriptionQueryUpdateMessage> failingHandler =
+                    spyOnUpdateHandlerFor(testQueryThatFailsToSeal);
+            doThrow(new MockException("Sealing failed")).when(failingHandler).seal();
+            // when...
+            Integer completedCount = testSubject.completeSubscriptionsAndCount(queryFilter, null)
+                                                 .orTimeout(1, TimeUnit.SECONDS)
+                                                 .join()
+                                                 .orElseThrow();
+            // then only the subscription whose seal() succeeded is counted...
+            assertThat(completedCount).isEqualTo(1);
+            // and the failing subscription is still terminated, just exceptionally instead...
+            verify(failingHandler).sealExceptionally(any(MockException.class));
+        }
     }
 
     @Nested
@@ -1076,6 +1103,54 @@ class SimpleQueryBusTest {
                                .orElseThrow();
             // then...
             assertThat(matchCount).isZero();
+        }
+
+        @Test
+        void completeSubscriptionsExceptionallyReturningCountExcludesSubscriptionsWhoseSealExceptionallyFailed() {
+            // given...
+            QueryMessage testQueryThatFailsToSeal = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage testQueryThatSealsFine = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            Predicate<QueryMessage> queryFilter = query ->
+                    query.identifier().equals(testQueryThatFailsToSeal.identifier())
+                            || query.identifier().equals(testQueryThatSealsFine.identifier());
+            testSubject.subscriptionQuery(testQueryThatFailsToSeal, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(testQueryThatSealsFine, null, Queues.SMALL_BUFFER_SIZE);
+            QueueMessageStream<SubscriptionQueryUpdateMessage> failingHandler =
+                    spyOnUpdateHandlerFor(testQueryThatFailsToSeal);
+            doThrow(new MockException("Sealing exceptionally failed")).when(failingHandler)
+                                                                       .sealExceptionally(any(Throwable.class));
+            MockException cause = new MockException("Mock");
+            // when...
+            Integer completedCount =
+                    testSubject.completeSubscriptionsExceptionallyAndCount(queryFilter, cause, null)
+                               .orTimeout(1, TimeUnit.SECONDS)
+                               .join()
+                               .orElseThrow();
+            // then only the subscription whose sealExceptionally() succeeded is counted...
+            assertThat(completedCount).isEqualTo(1);
+        }
+    }
+
+    /**
+     * Replaces the internal update handler registered for the given {@code query} with a spy wrapping the original,
+     * so that {@link QueueMessageStream#seal()} or {@link QueueMessageStream#sealExceptionally(Throwable)} can be
+     * stubbed to fail. There is no production seam for this - the update handler is a concrete
+     * {@code QueueMessageStream} instantiated internally by {@link SimpleQueryBus} - so reflection is used to reach
+     * into the otherwise-private {@code updateHandlers} map for test purposes only.
+     */
+    @SuppressWarnings("unchecked")
+    private QueueMessageStream<SubscriptionQueryUpdateMessage> spyOnUpdateHandlerFor(QueryMessage query) {
+        try {
+            Field updateHandlersField = SimpleQueryBus.class.getDeclaredField("updateHandlers");
+            updateHandlersField.setAccessible(true);
+            ConcurrentMap<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> updateHandlers =
+                    (ConcurrentMap<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>>)
+                            updateHandlersField.get(testSubject);
+            QueueMessageStream<SubscriptionQueryUpdateMessage> spiedHandler = spy(updateHandlers.get(query));
+            updateHandlers.put(query, spiedHandler);
+            return spiedHandler;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to spy on the update handler for test purposes", e);
         }
     }
 }


### PR DESCRIPTION
This pull request adjusts two things to the emit-and-count logic introduced with #4764, which are:

1. A typo in the documentation of the `QueryUpdateEmitter`, which still mentioned a constant in the `QueryBus` that was replaced for an `OptionalInt` solution.
2. Counting changes is **only** done for successful tasks. Hence if an emit fails, that is not counted towards the total.

In doing the above, this pull request resolves #4884 and #4885.